### PR TITLE
Added codeowners configuration in .github file

### DIFF
--- a/.github
+++ b/.github
@@ -1,0 +1,1 @@
+* @matthew-carroll


### PR DESCRIPTION
I added a `.github` file to configure code owners.

For now, I've defined myself as the sole code owner so that I have to be added to all PRs and approve all PRs. I think this is important until we have a proven track record of PRs reviewed by other developers. Once we do, we can expand the set of code owners.