### PR TITLE
Feature/Update to use pedantic 1.11

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.8.0.yaml
+include: package:pedantic/analysis_options.1.11.0.yaml
 
 analyzer:
     exclude: [build/**]

--- a/example/lib/spikes/editor_abstractions/default_editor/paragraph.dart
+++ b/example/lib/spikes/editor_abstractions/default_editor/paragraph.dart
@@ -276,7 +276,7 @@ Future<void> _processUrlNode({
   @required String originalText,
   @required String url,
 }) async {
-  final response = await http.get(url);
+  final response = await http.get(Uri.parse(url));
 
   if (response.statusCode < 200 || response.statusCode >= 300) {
     print('Failed to load URL: ${response.statusCode} - ${response.reasonPhrase}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic: ^1.9.2
+  pedantic: ^1.11.0
 
 #  uuid: ^2.2.2
   uuid: ^3.0.3


### PR DESCRIPTION
Updates to use pedantic version 1.11.0 over 1.8.0. This will result in more analyzer warnings that will need to be fixed, but is worth considering as the package supports dart 2.12+.