### PR TITLE
Downgrade libraries to prevent clash.

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 import FlutterMacOS
 import Foundation
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -50,13 +50,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -108,35 +115,35 @@ packages:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.1.2"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "0.12.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.1.4"
   linkify:
     dependency: "direct main"
     description:
       name: linkify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.0.0"
   markdown:
     dependency: transitive
     description:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
@@ -232,7 +239,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -281,7 +288,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,16 +31,16 @@ dependencies:
 
   charcode: ^1.1.3
 
-#  linkify: ^3.0.0
-  linkify: ^4.0.0
-#  http: ^0.12.2
-  http: ^0.13.1
+  linkify: ^3.0.0
+#  linkify: ^4.0.0
+  http: ^0.12.2
+#  http: ^0.13.1
 
-#  google_fonts: ^1.1.2
-  google_fonts: ^2.0.0
+  google_fonts: ^1.1.2
+#  google_fonts: ^2.0.0
 
-#  uuid: ^2.2.2
-  uuid: ^3.0.3
+  uuid: ^2.2.2
+#  uuid: ^3.0.3
 
   flutter_richtext:
     path: ../

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -50,13 +50,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -80,28 +87,28 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "0.12.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.1.4"
   linkify:
     dependency: "direct main"
     description:
       name: linkify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.0.0"
   markdown:
     dependency: "direct main"
     description:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
@@ -141,7 +148,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -190,7 +197,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,18 +13,18 @@ dependencies:
 
   pedantic: ^1.9.2
 
-#  uuid: ^2.2.2
-  uuid: ^3.0.3
+  uuid: ^2.2.2
+#  uuid: ^3.0.3
 
-#  http: ^0.12.2
-  http: ^0.13.1
+  http: ^0.12.2
+#  http: ^0.13.1
 
-#  linkify: ^3.0.0
-  linkify: ^4.0.0
+  linkify: ^3.0.0
+#  linkify: ^4.0.0
 
   # TODO: move markdown serialization to a separate package and
   #       then remove this dependency.
-  markdown: ^4.0.0
+  markdown: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR is not necessarily for merging. But this changes were required to make the RTE working on Superlist.

As the stream_chat library can not work with uuid right now, we need to lower down the versions of the libraries. 

After all the necessary downgrades, I was able to run the tests by running the following command:

```
flutter test --no-sound-null-safety
```

All 55 tests passed with this approach.