### PR TITLE
Fix doc switching bug and caret focus bug

### DIFF
--- a/example/lib/demos/demo_document_loses_focus.dart
+++ b/example/lib/demos/demo_document_loses_focus.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_richtext/flutter_richtext.dart';
+
+/// Demo of an [Editor] widget that can lose focus to a nearby
+/// [TextField] to ensure that the [Editor] correctly removes
+/// its caret.
+// TODO: Add widget tests for focus interaction verifications
+class LoseFocusDemo extends StatefulWidget {
+  @override
+  _LoseFocusDemoState createState() => _LoseFocusDemoState();
+}
+
+class _LoseFocusDemoState extends State<LoseFocusDemo> {
+  Document _doc;
+  DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createDocument1();
+    _docEditor = DocumentEditor(document: _doc);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          _buildDocSelector(),
+          Expanded(
+            child: Editor.standard(
+              editor: _docEditor,
+              maxWidth: 600,
+              padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDocSelector() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 48.0),
+      child: TextField(
+        decoration: InputDecoration(
+          hintText: 'tap to give focus to this TextField',
+        ),
+      ),
+    );
+  }
+}
+
+Document _createDocument1() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Document #1',
+        ),
+        metadata: {
+          'blockType': 'header1',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+    ],
+  );
+}

--- a/example/lib/demos/demo_switch_document_content.dart
+++ b/example/lib/demos/demo_switch_document_content.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_richtext/flutter_richtext.dart';
+
+/// Demo of an [Editor] widget where the [DocumentEditor] changes.
+///
+/// This demo ensures that [Editor] state resets where appropriate
+/// when its content is replaced.
+class SwitchDocumentDemo extends StatefulWidget {
+  @override
+  _SwitchDocumentDemoState createState() => _SwitchDocumentDemoState();
+}
+
+class _SwitchDocumentDemoState extends State<SwitchDocumentDemo> {
+  Document _doc1;
+  DocumentEditor _docEditor1;
+
+  Document _doc2;
+  DocumentEditor _docEditor2;
+
+  DocumentEditor _activeDocumentEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc1 = _createDocument1();
+    _docEditor1 = DocumentEditor(document: _doc1);
+
+    _doc2 = _createDocument2();
+    _docEditor2 = DocumentEditor(document: _doc2);
+
+    _activeDocumentEditor = _docEditor1;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          _buildDocSelector(),
+          Expanded(
+            child: Editor.standard(
+              editor: _activeDocumentEditor,
+              maxWidth: 600,
+              padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDocSelector() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        TextButton(
+          onPressed: () {
+            setState(() {
+              _activeDocumentEditor = _docEditor1;
+            });
+          },
+          child: Text('Document 1'),
+        ),
+        SizedBox(width: 24),
+        TextButton(
+          onPressed: () {
+            setState(() {
+              _activeDocumentEditor = _docEditor2;
+            });
+          },
+          child: Text('Document 2'),
+        ),
+      ],
+    );
+  }
+}
+
+Document _createDocument1() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Document #1',
+        ),
+        metadata: {
+          'blockType': 'header1',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+    ],
+  );
+}
+
+Document _createDocument2() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Document #2',
+        ),
+        metadata: {
+          'blockType': 'header1',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+            text:
+                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+      ),
+    ],
+  );
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,7 @@
+import 'package:example/demos/demo_document_loses_focus.dart';
 import 'package:example/demos/demo_markdown_serialization.dart';
 import 'package:example/demos/demo_selectable_text.dart';
+import 'package:example/demos/demo_switch_document_content.dart';
 import 'package:example/demos/example_editor.dart';
 import 'package:example/demos/sliver_example_editor.dart';
 import 'package:flutter/material.dart';
@@ -143,6 +145,20 @@ final _menu = <_MenuGroup>[
         title: 'Markdown Serialization Demo',
         pageBuilder: (context) {
           return MarkdownSerializationDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.description,
+        title: 'Switch Docs Demo',
+        pageBuilder: (context) {
+          return SwitchDocumentDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.description,
+        title: 'Lose Focus Demo',
+        pageBuilder: (context) {
+          return LoseFocusDemo();
         },
       ),
     ],

--- a/lib/src/core/document_layout.dart
+++ b/lib/src/core/document_layout.dart
@@ -279,6 +279,7 @@ class ComponentContext {
     required this.document,
     required this.documentNode,
     required this.componentKey,
+    required this.showCaret,
     this.nodeSelection,
     this.extensions = const {},
   });
@@ -299,6 +300,14 @@ class ComponentContext {
   /// The `componentKey` is used by the `DocumentLayout` to query for
   /// node-specific information, like node positions and selections.
   final GlobalKey componentKey;
+
+  /// [true] if the extent component should display a caret,
+  /// [false] otherwise.
+  ///
+  /// Not every component has a caret to display, e.g., an
+  /// image, but the components that do have a caret, e.g.,
+  /// a paragraph, should respect this property.
+  final bool showCaret;
 
   /// The current selected region within the `documentNode`.
   ///

--- a/lib/src/default_editor/document_interaction.dart
+++ b/lib/src/default_editor/document_interaction.dart
@@ -134,7 +134,6 @@ class _DocumentInteractorState extends State<DocumentInteractor> with SingleTick
     super.dispose();
   }
 
-  // DocumentLayout get _layout => widget.documentLayoutKey.currentState as DocumentLayout;
   DocumentLayout get _layout => widget.editContext.documentLayout;
 
   void _onSelectionChange() {

--- a/lib/src/default_editor/editor.dart
+++ b/lib/src/default_editor/editor.dart
@@ -205,6 +205,12 @@ class _EditorState extends State<Editor> {
       _composer = widget.composer ?? DocumentComposer();
       _composer.addListener(_updateComposerPreferencesAtSelection);
     }
+    if (widget.editor != oldWidget.editor) {
+      // The content displayed in this Editor was switched
+      // out. Remove any content selection from the previous
+      // document.
+      _composer.selection = null;
+    }
     if (widget.focusNode != oldWidget.focusNode) {
       _focusNode = widget.focusNode ?? FocusNode();
     }
@@ -269,6 +275,7 @@ class _EditorState extends State<Editor> {
           padding: widget.padding,
           child: MultiListenableBuilder(
             listenables: {
+              _focusNode,
               _composer,
               widget.editor.document,
             },
@@ -277,6 +284,7 @@ class _EditorState extends State<Editor> {
                 key: _docLayoutKey,
                 document: widget.editor.document,
                 documentSelection: _composer.selection,
+                showCaret: _focusNode.hasFocus,
                 componentBuilders: widget.componentBuilders,
                 extensions: {
                   textStylesExtensionKey: widget.textStyleBuilder,

--- a/lib/src/default_editor/layout.dart
+++ b/lib/src/default_editor/layout.dart
@@ -24,6 +24,7 @@ class DefaultDocumentLayout extends StatefulWidget {
     Key? key,
     required this.document,
     this.documentSelection,
+    required this.showCaret,
     required this.componentBuilders,
     this.componentVerticalSpacing = 16,
     this.extensions = const {},
@@ -36,6 +37,10 @@ class DefaultDocumentLayout extends StatefulWidget {
   /// The selection of a region of a `Document`, used when
   /// rendering document content, e.g., painting a text selection.
   final DocumentSelection? documentSelection;
+
+  /// [true] if the document UI should display a caret at the
+  /// selection extent.
+  final bool showCaret;
 
   /// Builders for every type of component that this layout displays.
   ///
@@ -118,10 +123,6 @@ class _DefaultDocumentLayoutState extends State<DefaultDocumentLayout> implement
       return null;
     }
     final componentRect = component.getRectForPosition(position.nodePosition);
-    if (componentRect == null) {
-      return null;
-    }
-
     final componentBox = component.context.findRenderObject() as RenderBox;
     final docOffset = componentBox.localToGlobal(Offset.zero, ancestor: context.findRenderObject());
 
@@ -362,6 +363,7 @@ class _DefaultDocumentLayoutState extends State<DefaultDocumentLayout> implement
         document: widget.document,
         documentNode: docNode,
         componentKey: componentKey,
+        showCaret: widget.showCaret,
         nodeSelection: nodeSelection,
         extensions: widget.extensions,
       ));

--- a/lib/src/default_editor/list_items.dart
+++ b/lib/src/default_editor/list_items.dart
@@ -475,7 +475,7 @@ Widget? unorderedListItemBuilder(ComponentContext componentContext) {
   }
 
   final textSelection = componentContext.nodeSelection?.nodeSelection as TextSelection;
-  final hasCaret = componentContext.nodeSelection?.isExtent ?? false;
+  final showCaret = componentContext.showCaret && (componentContext.nodeSelection?.isExtent ?? false);
 
   return UnorderedListItemComponent(
     textKey: componentContext.componentKey,
@@ -484,7 +484,7 @@ Widget? unorderedListItemBuilder(ComponentContext componentContext) {
     indent: listItemNode.indent,
     textSelection: textSelection,
     selectionColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).selectionColor,
-    showCaret: hasCaret,
+    showCaret: showCaret,
     caretColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).textCaretColor,
   );
 }
@@ -512,7 +512,7 @@ Widget? orderedListItemBuilder(ComponentContext componentContext) {
   }
 
   final textSelection = componentContext.nodeSelection?.nodeSelection as TextSelection;
-  final hasCaret = componentContext.nodeSelection?.isExtent ?? false;
+  final showCaret = componentContext.showCaret && (componentContext.nodeSelection?.isExtent ?? false);
 
   return OrderedListItemComponent(
     textKey: componentContext.componentKey,
@@ -521,7 +521,7 @@ Widget? orderedListItemBuilder(ComponentContext componentContext) {
     styleBuilder: componentContext.extensions[textStylesExtensionKey],
     textSelection: textSelection,
     selectionColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).selectionColor,
-    showCaret: hasCaret,
+    showCaret: showCaret,
     caretColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).textCaretColor,
     indent: listItemNode.indent,
   );

--- a/lib/src/default_editor/paragraph.dart
+++ b/lib/src/default_editor/paragraph.dart
@@ -503,7 +503,9 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
     _log.log('paragraphBuilder',
         'ERROR: Building a paragraph component but the selection is not a TextSelection: ${componentContext.documentNode.id}');
   }
-  final showCaret = componentContext.nodeSelection != null ? componentContext.nodeSelection!.isExtent : false;
+  final showCaret = componentContext.showCaret && componentContext.nodeSelection != null
+      ? componentContext.nodeSelection!.isExtent
+      : false;
   final highlightWhenEmpty =
       componentContext.nodeSelection == null ? false : componentContext.nodeSelection!.highlightWhenEmpty;
 


### PR DESCRIPTION
Fixed: switching from one document to another document when a content selection is present no longer results in an error UI.

Fixed: removing focus from the editor now makes the caret disappear.