### PR TITLE
Fix bugs: auto-scroll not working, styled text not combining spans

### DIFF
--- a/lib/src/default_editor/document_interaction.dart
+++ b/lib/src/default_editor/document_interaction.dart
@@ -139,11 +139,17 @@ class _DocumentInteractorState extends State<DocumentInteractor> with SingleTick
   void _onSelectionChange() {
     _log.log('_onSelectionChange', 'EditableDocument: _onSelectionChange()');
     setState(() {
-      _ensureSelectionExtentIsVisible();
+      // Use a post-frame callback to "ensure selection extent is visible"
+      // so that any pending visual document changes can happen before
+      // attempting to calculate the visual position of the selection extent.
+      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+        _ensureSelectionExtentIsVisible();
+      });
     });
   }
 
   void _ensureSelectionExtentIsVisible() {
+    _log.log('_ensureSelectionExtentIsVisible', 'selection: ${widget.editContext.composer.selection}');
     final selection = widget.editContext.composer.selection;
     if (selection == null) {
       return;

--- a/lib/src/infrastructure/attributed_spans.dart
+++ b/lib/src/infrastructure/attributed_spans.dart
@@ -393,7 +393,9 @@ class AttributedSpans {
     // Combine `this` and `other` attributions into one list.
     final List<SpanMarker> combinedAttributions = List.from(_attributions)..addAll(pushedSpans._attributions);
     _log.log('addAt', 'combined attributions before merge:');
-    _log.log('addAt', combinedAttributions.toString());
+    for (final marker in combinedAttributions) {
+      _log.log('addAt', '   - $marker');
+    }
 
     // Clean up the boundary between the two lists of attributions
     // by merging compatible attributions that meet at the boundary.
@@ -415,21 +417,26 @@ class AttributedSpans {
   void _mergeBackToBackAttributions(List<SpanMarker> attributions, int mergePoint) {
     _log.log('_mergeBackToBackAttributions', 'merging attributions at $mergePoint');
     // Look for any compatible attributions at
-    // `mergePoint` and `mergePoint+1` and combine them.
-    final startEdgeMarkers = attributions.where((marker) => marker.offset == mergePoint).toList();
-    final endEdgeMarkers = attributions.where((marker) => marker.offset == mergePoint + 1).toList();
-    for (final startEdgeMarker in startEdgeMarkers) {
-      _log.log('_mergeBackToBackAttributions', 'marker on left side: $startEdgeMarker');
-      final matchingEndEdgeMarker = endEdgeMarkers.firstWhereOrNull(
-        (marker) => marker.attribution == startEdgeMarker.attribution && marker.isStart,
+    // `mergePoint - 1` and `mergePoint` and combine them.
+    final endAtMergePointMarkers =
+        attributions.where((marker) => marker.isEnd && marker.offset == mergePoint - 1).toList();
+    final startAtMergePointMarkers =
+        attributions.where((marker) => marker.isStart && marker.offset == mergePoint).toList();
+    for (final startMarker in startAtMergePointMarkers) {
+      _log.log('_mergeBackToBackAttributions', 'marker on right side: $startMarker');
+      final endMarker = endAtMergePointMarkers.firstWhereOrNull(
+        (marker) => marker.attribution == startMarker.attribution,
       );
-      _log.log('_mergeBackToBackAttributions', 'matching marker on right side? $matchingEndEdgeMarker');
-      if (startEdgeMarker.isEnd && matchingEndEdgeMarker != null) {
+      _log.log('_mergeBackToBackAttributions', 'matching marker on left side? $endMarker');
+      if (endMarker != null) {
         // These two attributions should be combined into one.
         // To do this, delete these two markers from the original
         // attribution list.
-        _log.log('_mergeBackToBackAttributions', 'removing both markers because they offset each other');
-        attributions..remove(startEdgeMarker)..remove(matchingEndEdgeMarker);
+        _log.log('_mergeBackToBackAttributions', 'combining left/right spans at edge at index $mergePoint');
+        _log.log('_mergeBackToBackAttributions', 'Removing markers:');
+        _log.log('_mergeBackToBackAttributions', ' - $startMarker');
+        _log.log('_mergeBackToBackAttributions', ' - $endMarker');
+        attributions..remove(startMarker)..remove(endMarker);
       }
     }
   }
@@ -635,7 +642,7 @@ class AttributedSpans {
       ..addAll(contractedAttributions);
   }
 
-  /// Returns a copy of this `AttributedSpans`.
+  /// Returns a copy of this [AttributedSpans].
   AttributedSpans copy() {
     return AttributedSpans(
       attributions: List.from(_attributions),

--- a/test/serialization/markdown_test.dart
+++ b/test/serialization/markdown_test.dart
@@ -381,8 +381,10 @@ This is some code
           ),
         ]);
 
+        // Ensure that the document serializes. We don't bother with
+        // validating the output because other tests should validate
+        // the per-node serializations.
         final markdown = serializeDocumentToMarkdown(doc);
-        print(markdown);
       });
     });
 

--- a/test/src/infrastructure/attributed_text_test.dart
+++ b/test/src/infrastructure/attributed_text_test.dart
@@ -111,6 +111,41 @@ void main() {
       expect(textSpan.children![2].toPlainText(), 'ij');
     });
 
+    test('add styled character to existing styled text', () {
+      final initialText = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
+
+      final newText = initialText.copyAndAppend(AttributedText(
+        text: 'k',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.end),
+          ],
+        ),
+      ));
+
+      final textSpan = newText.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 2);
+      expect(textSpan.children![0].toPlainText(), 'abcdefghi');
+
+      // Ensures that typing a styled character at the end of text
+      // results in a single expanded span, rather than 2 independent
+      // spans with the same style.
+      expect(textSpan.children![1].toPlainText(), 'jk');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![1].style!.fontStyle, null);
+    });
+
     test('non-mingled varying styles', () {
       final text = AttributedText(
         text: 'abcdefghij',


### PR DESCRIPTION
Fixes a couple bugs:

Bug #99 - when adding new list items or new lines that go offscreen, auto-scroll does not move the viewport down to show the extent.

Bug #100 - when typing individual characters with a style, the style of the new character does not combine with the matching style of the character before it.