### PR TITLE
Set Textdirection based on input language

### DIFF
--- a/super_editor/example/lib/demos/demo_RTL.dart
+++ b/super_editor/example/lib/demos/demo_RTL.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// Example of a rich text editor.
+///
+/// This editor will expand in functionality as the rich text
+/// package expands.
+class RTLDemo extends StatefulWidget {
+  @override
+  _RTLDemoState createState() => _RTLDemoState();
+}
+
+class _RTLDemoState extends State<RTLDemo> {
+  late MutableDocument _doc;
+  late DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createInitialDocument();
+    _docEditor = DocumentEditor(document: _doc);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor.standard(
+      editor: _docEditor,
+      maxWidth: 600,
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+    );
+  }
+}
+
+MutableDocument _createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Example Document',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'مثال',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+            text:
+                'لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.'),
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'فقرة رقم ١ في القائمة.',
+        ),
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'فقرة رقم ٢ في القائمة.',
+        ),
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'فقرة رقم ٣ في القائمة.',
+        ),
+      ),
+    ],
+  );
+}

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/demo_RTL.dart';
 import 'package:example/demos/demo_markdown_serialization.dart';
 import 'package:example/demos/demo_paragraphs.dart';
 import 'package:example/demos/demo_selectable_text.dart';
@@ -173,6 +174,13 @@ final _menu = <_MenuGroup>[
         title: 'Markdown Serialization Demo',
         pageBuilder: (context) {
           return MarkdownSerializationDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.description,
+        title: 'RTL Demo',
+        pageBuilder: (context) {
+          return RTLDemo();
         },
       ),
     ],

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -14,6 +14,7 @@ import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 
 import 'styles.dart';
+import 'text_tools.dart';
 
 final _log = Logger(scope: 'paragraph.dart');
 
@@ -312,7 +313,9 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
   _log.log('paragraphBuilder', '   - base: ${textSelection?.base}');
   _log.log('paragraphBuilder', '   - extent: ${textSelection?.extent}');
 
-  TextAlign textAlign = TextAlign.left;
+  final textDirection = getParagraphDirection((componentContext.documentNode as TextNode).text.text);
+
+  TextAlign textAlign =  (textDirection == TextDirection.ltr) ? TextAlign.left : TextAlign.right;
   final textAlignName = (componentContext.documentNode as TextNode).metadata['textAlign'];
   switch (textAlignName) {
     case 'left':
@@ -335,6 +338,7 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
     textStyleBuilder: componentContext.extensions[textStylesExtensionKey],
     metadata: (componentContext.documentNode as TextNode).metadata,
     textAlign: textAlign,
+    textDirection: textDirection,
     textSelection: textSelection,
     selectionColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).selectionColor,
     showCaret: showCaret,

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -315,7 +315,7 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
 
   final textDirection = getParagraphDirection((componentContext.documentNode as TextNode).text.text);
 
-  TextAlign textAlign =  (textDirection == TextDirection.ltr) ? TextAlign.left : TextAlign.right;
+  TextAlign textAlign = (textDirection == TextDirection.ltr) ? TextAlign.left : TextAlign.right;
   final textAlignName = (componentContext.documentNode as TextNode).metadata['textAlign'];
   switch (textAlignName) {
     case 'left':

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -177,6 +177,7 @@ class TextComponent extends StatefulWidget {
     Key? key,
     required this.text,
     this.textAlign,
+    this.textDirection,
     required this.textStyleBuilder,
     this.metadata = const {},
     this.textSelection,
@@ -189,6 +190,7 @@ class TextComponent extends StatefulWidget {
 
   final AttributedText text;
   final TextAlign? textAlign;
+  final TextDirection? textDirection;
   final AttributionStyleBuilder textStyleBuilder;
   final Map<String, dynamic> metadata;
   final TextSelection? textSelection;
@@ -526,6 +528,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
       key: _selectableTextKey,
       textSpan: richText,
       textAlign: widget.textAlign ?? TextAlign.left,
+      textDirection: widget.textDirection ?? TextDirection.ltr,
       textSelection: widget.textSelection ?? const TextSelection.collapsed(offset: -1),
       textSelectionDecoration: TextSelectionDecoration(selectionColor: widget.selectionColor),
       showCaret: widget.showCaret,

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -1,5 +1,5 @@
 import 'dart:math';
-
+import 'dart:ui';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
@@ -136,4 +136,22 @@ TextSelection expandPositionToParagraph({
     baseOffset: start,
     extentOffset: end,
   );
+}
+
+// copied from: flutter/lib/src/widgets/editable_text.dart
+// RTL covers Arabic, Hebrew, and other RTL languages such as Urdu,
+// Aramic, Farsi, Dhivehi.
+final RegExp _rtlRegExp = RegExp(r'[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]');
+
+/// Returns the [TextDirection] of the text based on its first non-whitespace character.
+/// 
+/// The default value is [TextDirection.ltr] for any character that is not from an RTL language. 
+TextDirection getParagraphDirection(String text) {
+  text = text.trim();
+
+  if (text.isNotEmpty && _rtlRegExp.hasMatch(String.fromCharCode(text.runes.first))) {
+    return TextDirection.rtl;
+  } else {
+    return TextDirection.ltr;
+  }
 }

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -144,8 +144,8 @@ TextSelection expandPositionToParagraph({
 final RegExp _rtlRegExp = RegExp(r'[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]');
 
 /// Returns the [TextDirection] of the text based on its first non-whitespace character.
-/// 
-/// The default value is [TextDirection.ltr] for any character that is not from an RTL language. 
+///
+/// The default value is [TextDirection.ltr] for any character that is not from an RTL language.
 TextDirection getParagraphDirection(String text) {
   text = text.trim();
 

--- a/super_editor/lib/src/infrastructure/super_selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/super_selectable_text.dart
@@ -36,6 +36,7 @@ class SuperSelectableText extends StatefulWidget {
     required String text,
     required TextStyle style,
     this.textAlign = TextAlign.left,
+    this.textDirection = TextDirection.ltr,
     this.textSelection = const TextSelection.collapsed(offset: -1),
     this.textSelectionDecoration = const TextSelectionDecoration(
       selectionColor: Color(0xFFACCEF7),
@@ -55,6 +56,7 @@ class SuperSelectableText extends StatefulWidget {
     Key? key,
     required TextSpan textSpan,
     this.textAlign = TextAlign.left,
+    this.textDirection = TextDirection.ltr,
     this.textSelection = const TextSelection.collapsed(offset: -1),
     this.textSelectionDecoration = const TextSelectionDecoration(
       selectionColor: Color(0xFFACCEF7),
@@ -74,6 +76,9 @@ class SuperSelectableText extends StatefulWidget {
 
   /// The alignment to use for [richText] display.
   final TextAlign textAlign;
+
+  /// The text direction to use for [richText] display.
+  final TextDirection textDirection;
 
   /// The portion of [richText] to display with the
   /// [textSelectionDecoration].
@@ -445,6 +450,7 @@ class SuperSelectableTextState extends State<SuperSelectableText> implements Tex
       key: _textKey,
       text: widget.richText,
       textAlign: widget.textAlign,
+      textDirection: widget.textDirection,
     );
   }
 


### PR DESCRIPTION
- closes #124 
  - Exposes textDirection property of `SelectableText`. 
  - In `paragraphBuilder`, textDirection is set to `TextDirection.rtl` if the first non-whitespace character of a paragraph is from an RTL language. Everything else is `TextDirection.ltr`.


Result as seen in the added demo:


<img width="702" alt="Screen Shot 2021-04-14 at 5 50 05 PM" src="https://user-images.githubusercontent.com/46427323/114731407-66a28600-9d4a-11eb-879b-452cee5ef498.png">
