### PR TITLE
Fix: bold/italics style toggling was adding an extra character to the styled text at the end. (#107)

### DIFF
--- a/super_editor/.run/Example.run.xml
+++ b/super_editor/.run/Example.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Example" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="filePath" value="$PROJECT_DIR$/super_editor/example/lib/main.dart" />
+    <option name="filePath" value="$PROJECT_DIR$/example/lib/main.dart" />
     <method v="2" />
   </configuration>
 </component>

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -468,6 +468,10 @@ class ToggleTextAttributionsCommand implements EditorCommand {
         final extentOffset = (documentSelection.extent.nodePosition as TextPosition).offset;
         startOffset = baseOffset < extentOffset ? baseOffset : extentOffset;
         endOffset = baseOffset < extentOffset ? extentOffset : baseOffset;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset -= 1;
       } else if (textNode == nodes.first) {
         // Handle partial node selection in first node.
         _log.log('ToggleTextAttributionsCommand', ' - selecting part of the first node: ${textNode.id}');
@@ -477,19 +481,15 @@ class ToggleTextAttributionsCommand implements EditorCommand {
         // Handle partial node selection in last node.
         _log.log('ToggleTextAttributionsCommand', ' - toggling part of the last node: ${textNode.id}');
         startOffset = 0;
-        endOffset = (nodeRange.end.nodePosition as TextPosition).offset;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset = (nodeRange.end.nodePosition as TextPosition).offset - 1;
       } else {
         // Handle full node selection.
         _log.log('ToggleTextAttributionsCommand', ' - toggling full node: ${textNode.id}');
         startOffset = 0;
         endOffset = max(textNode.text.text.length - 1, 0);
-      }
-
-      // The attribution range needs the `start` and `end` to
-      // be inclusive. Make sure the `endOffset` isn't equal
-      // to the text length.
-      if (endOffset == textNode.text.text.length) {
-        endOffset = textNode.text.text.length - 1;
       }
 
       final selectionRange = TextRange(start: startOffset, end: endOffset);

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -18,6 +18,47 @@ import '_text_entry_test_tools.dart';
 
 void main() {
   group('text.dart', () {
+    group('ToggleTextAttributionsCommand', () {
+      test('it toggles selected text and nothing more', () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(
+              id: 'paragraph',
+              text: AttributedText(text: ' make me bold '),
+            )
+          ],
+        );
+        final editor = DocumentEditor(document: document);
+
+        final command = ToggleTextAttributionsCommand(
+          documentSelection: DocumentSelection(
+            base: DocumentPosition(
+              nodeId: 'paragraph',
+              nodePosition: TextPosition(offset: 1),
+            ),
+            extent: DocumentPosition(
+              nodeId: 'paragraph',
+              // IMPORTANT: we want to end the bold at the 'd' character but
+              // the TextPosition indexes the ' ' after the 'd'. This is because
+              // TextPosition references the character after the selection, not
+              // the last character in the selection. See the TextPosition class
+              // definition for more information.
+              nodePosition: TextPosition(offset: 13),
+            ),
+          ),
+          attributions: {'bold'},
+        );
+
+        editor.executeCommand(command);
+
+        final boldedText = (document.nodes.first as ParagraphNode).text;
+        expect(boldedText.getAllAttributionsAt(0), <dynamic>{});
+        expect(boldedText.getAllAttributionsAt(1), {'bold'});
+        expect(boldedText.getAllAttributionsAt(12), {'bold'});
+        expect(boldedText.getAllAttributionsAt(13), <dynamic>{});
+      });
+    });
+
     group('TextComposable text entry', () {
       test('it does nothing when meta is pressed', () {
         final editContext = _createEditContext();


### PR DESCRIPTION
Fix: bold/italics style toggling was adding an extra character to the styled text at the end. (#107)