### PR TITLE
Bug fixes for #115, #118, #123, #126

### DIFF
--- a/super_editor/example/lib/demos/demo_paragraphs.dart
+++ b/super_editor/example/lib/demos/demo_paragraphs.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// Example of various paragraph configurations in an editor.
+class ParagraphsDemo extends StatefulWidget {
+  @override
+  _ParagraphsDemoState createState() => _ParagraphsDemoState();
+}
+
+class _ParagraphsDemoState extends State<ParagraphsDemo> {
+  Document _doc;
+  DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createInitialDocument();
+    _docEditor = DocumentEditor(document: _doc);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Editor.standard(
+      editor: _docEditor,
+      maxWidth: 600,
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+    );
+  }
+}
+
+Document _createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Various paragraph formations',
+        ),
+        metadata: {
+          'blockType': 'header1',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is a short\nparagraph of text\nthat is left aligned',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is a short\nparagraph of text\nthat is center aligned',
+        ),
+        metadata: {
+          'textAlign': 'center',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is a short\nparagraph of text\nthat is right aligned',
+        ),
+        metadata: {
+          'textAlign': 'right',
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+    ],
+  );
+}

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/demos/demo_markdown_serialization.dart';
+import 'package:example/demos/demo_paragraphs.dart';
 import 'package:example/demos/demo_selectable_text.dart';
 import 'package:example/demos/example_editor.dart';
 import 'package:example/demos/sliver_example_editor.dart';
@@ -159,6 +160,18 @@ final _menu = <_MenuGroup>[
         title: 'Markdown Serialization Demo',
         pageBuilder: (context) {
           return MarkdownSerializationDemo();
+        },
+      ),
+    ],
+  ),
+  _MenuGroup(
+    title: 'PIECES',
+    items: [
+      _MenuItem(
+        icon: Icons.text_snippet,
+        title: 'Paragraphs',
+        pageBuilder: (context) {
+          return ParagraphsDemo();
         },
       ),
     ],

--- a/super_editor/example/lib/spikes/editor_abstractions/default_editor/box_component.dart
+++ b/super_editor/example/lib/spikes/editor_abstractions/default_editor/box_component.dart
@@ -1,6 +1,5 @@
 import 'package:example/spikes/editor_abstractions/core/edit_context.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/src/rendering/mouse_cursor.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/document.dart';

--- a/super_editor/example/pubspec.lock
+++ b/super_editor/example/pubspec.lock
@@ -267,7 +267,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/services.dart';
-import 'package:flutter/src/rendering/mouse_cursor.dart';
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -145,7 +145,7 @@ class _PasteEditorCommand implements EditorCommand {
     required String content,
     required DocumentPosition pastePosition,
     required DocumentComposer composer,
-  })   : _content = content,
+  })  : _content = content,
         _pastePosition = pastePosition,
         _composer = composer;
 
@@ -295,13 +295,16 @@ Future<void> _copy({
 
     if (i == 0) {
       // This is the first node and it may be partially selected.
-      final nodePosition = selectedNode.id == documentSelection.base.nodeId
+      final baseSelectionPosition = selectedNode.id == documentSelection.base.nodeId
           ? documentSelection.base.nodePosition
           : documentSelection.extent.nodePosition;
 
+      final extentSelectionPosition =
+          selectedNodes.length > 1 ? selectedNode.endPosition : documentSelection.extent.nodePosition;
+
       nodeSelection = selectedNode.computeSelection(
-        base: nodePosition,
-        extent: selectedNode.endPosition,
+        base: baseSelectionPosition,
+        extent: extentSelectionPosition,
       );
     } else if (i == selectedNodes.length - 1) {
       // This is the last node and it may be partially selected.
@@ -323,7 +326,7 @@ Future<void> _copy({
 
     final nodeContent = selectedNode.copyContent(nodeSelection);
     if (nodeContent != null) {
-      buffer.writeln(nodeContent);
+      buffer.write(nodeContent);
       if (i < selectedNodes.length - 1) {
         buffer.writeln();
       }

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -251,7 +251,7 @@ bool _convertParagraphIfDesired({
       }),
     );
 
-    node.text = AttributedText();
+    node.text = node.text.removeRegion(startOffset: 0, endOffset: hrMatch.firstMatch(textBeforeCaret)!.end);
 
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(

--- a/super_editor/lib/src/infrastructure/selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/selectable_text.dart
@@ -547,7 +547,9 @@ class _TextSelectionPainter extends CustomPainter {
     final selectionBoxes = renderParagraph.getBoxesForSelection(selection);
 
     for (final box in selectionBoxes) {
-      final rect = box.toRect();
+      final rawRect = box.toRect();
+      final rect = Rect.fromLTWH(rawRect.left, rawRect.top - 2, rawRect.width, rawRect.height + 4);
+
       canvas.drawRect(
         // Note: If the rect has no width then we've selected an empty line. Give
         //       that line a slight width for visibility.

--- a/super_editor/lib/src/infrastructure/selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/selectable_text.dart
@@ -428,9 +428,18 @@ class SelectableTextState extends State<SelectableText> implements TextLayout {
 
     return Stack(
       children: [
-        _buildTextSelection(),
-        _buildText(),
-        _buildTextCaret(),
+        SizedBox(
+          width: double.infinity,
+          child: _buildTextSelection(),
+        ),
+        SizedBox(
+          width: double.infinity,
+          child: _buildText(),
+        ),
+        SizedBox(
+          width: double.infinity,
+          child: _buildTextCaret(),
+        ),
       ],
     );
   }
@@ -668,7 +677,7 @@ class _CursorPainter extends CustomPainter {
     required this.caretColor,
     required this.isTextEmpty,
     required this.showCaret,
-  })   : caretPaint = Paint()..color = caretColor,
+  })  : caretPaint = Paint()..color = caretColor,
         super(repaint: blinkController);
 
   final _CaretBlinkController blinkController;


### PR DESCRIPTION
Fixes bug where selection rectangles leave gaps between lines. This problem comes from Flutter's text box calculations, so the solution for now is a hard-coded height adjustment.

Fixes bug where inserting an HR with "---" before some text would delete all following text.

Fixes bug where copying text within a single node would copy everything from the selected content to the end of the node.

Fixes bug where paragraphs that don't require full width will shrink their widget, resulting in incorrect layout for center and right aligned text that doesn't fill all available width.