### PR TITLE
Bugfix: Resolved a race condition with paste functionality. (#151)

### DIFF
--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -81,6 +81,8 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
     editContext.editor.executeCommand(
       DeleteSelectionCommand(documentSelection: editContext.composer.selection!),
     );
+
+    editContext.composer.selection = DocumentSelection.collapsed(position: pastePosition);
   }
 
   // TODO: figure out a general approach for asynchronous behaviors that
@@ -129,7 +131,7 @@ Future<void> _paste({
   required DocumentPosition pastePosition,
 }) async {
   final content = (await Clipboard.getData('text/plain'))?.text ?? '';
-  _log.log('_paste', 'Content from clipboard:');
+  _log.log('_paste', 'Content from clipboard: $content');
 
   editor.executeCommand(
     _PasteEditorCommand(


### PR DESCRIPTION
Bugfix: Resolved a race condition with paste functionality. (#151)

The initial bug was very difficult to reproduce, however, adding a forced delay immediately after the clipboard query and before the insertion of the content was able to reproduce the error every time.

To fix the race condition, I update the document selection to its final location before attempting to paste any content. If paste took a very long time, this would result in seeing the content deleted, seeing the caret where the deleted text used to be, and then seeing the new content pasted into place. Paste should never take long enough to notice this series of events.