### PR TITLE
Example editor toolbar links

### DIFF
--- a/super_editor/README.md
+++ b/super_editor/README.md
@@ -67,7 +67,7 @@ final myDoc = MutableDocument(
       id: DocumentEditor.createNodeId(),
       text: AttributedText(text: 'This is a header'),
       metadata: {
-        'blockType': 'header1',
+        'blockType': header1Attribution,
       },
     ),
     ParagraphNode(

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -25,13 +25,13 @@ class _AttributedTextDemoState extends State<AttributedTextDemo> {
     );
 
     for (final range in _boldRanges) {
-      _text.addAttribution('bold', range);
+      _text.addAttribution(boldAttribution, range);
     }
     for (final range in _italicsRanges) {
-      _text.addAttribution('italics', range);
+      _text.addAttribution(italicsAttribution, range);
     }
     for (final range in _strikethroughRanges) {
-      _text.addAttribution('strikethrough', range);
+      _text.addAttribution(strikethroughAttribution, range);
     }
 
     setState(() {

--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -66,7 +66,7 @@ Document _createDocument1() {
           text: 'Document #1',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       ParagraphNode(

--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -105,7 +105,7 @@ Document _createInitialDocument() {
           text: 'Example Document',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       HorizontalRuleNode(id: DocumentEditor.createNodeId()),

--- a/super_editor/example/lib/demos/demo_paragraphs.dart
+++ b/super_editor/example/lib/demos/demo_paragraphs.dart
@@ -43,7 +43,7 @@ Document _createInitialDocument() {
           text: 'Various paragraph formations',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       ParagraphNode(

--- a/super_editor/example/lib/demos/demo_switch_document_content.dart
+++ b/super_editor/example/lib/demos/demo_switch_document_content.dart
@@ -90,7 +90,7 @@ Document _createDocument1() {
           text: 'Document #1',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       ParagraphNode(
@@ -113,7 +113,7 @@ Document _createDocument2() {
           text: 'Document #2',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       ParagraphNode(

--- a/super_editor/example/lib/demos/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor.dart
@@ -37,6 +37,10 @@ class _ExampleEditorState extends State<ExampleEditor> {
 
   @override
   void dispose() {
+    if (_formatBarOverlayEntry != null) {
+      _formatBarOverlayEntry.remove();
+    }
+
     _scrollController.dispose();
     _composer.dispose();
     super.dispose();
@@ -161,17 +165,16 @@ class _TextFormatBarState extends State<TextFormatBar> {
     if (selectedNode is ParagraphNode) {
       final type = selectedNode.metadata['blockType'];
 
-      switch (type) {
-        case 'header1':
-          return TextType.header1;
-        case 'header2':
-          return TextType.header2;
-        case 'header3':
-          return TextType.header3;
-        case 'blockquote':
-          return TextType.blockquote;
-        default:
-          return TextType.paragraph;
+      if (type == header1Attribution) {
+        return TextType.header1;
+      } else if (type == header2Attribution) {
+        return TextType.header2;
+      } else if (type == header3Attribution) {
+        return TextType.header3;
+      } else if (type == blockquoteAttribution) {
+        return TextType.blockquote;
+      } else {
+        return TextType.paragraph;
       }
     } else if (selectedNode is ListItemNode) {
       return selectedNode.type == ListItemType.ordered ? TextType.orderedListItem : TextType.unorderedListItem;
@@ -231,7 +234,7 @@ class _TextFormatBarState extends State<TextFormatBar> {
         ConvertListItemToParagraphCommand(
           nodeId: widget.composer.selection.extent.nodeId,
           paragraphMetadata: {
-            'blockType': _getBlockTypeName(newType),
+            'blockType': _getBlockTypeAttribution(newType),
           },
         ),
       );
@@ -245,7 +248,7 @@ class _TextFormatBarState extends State<TextFormatBar> {
     } else {
       // Apply a new block type to an existing paragraph node.
       final existingNode = widget.editor.document.getNodeById(widget.composer.selection.extent.nodeId);
-      (existingNode as ParagraphNode).metadata['blockType'] = _getBlockTypeName(newType);
+      (existingNode as ParagraphNode).metadata['blockType'] = _getBlockTypeAttribution(newType);
     }
   }
 
@@ -253,16 +256,16 @@ class _TextFormatBarState extends State<TextFormatBar> {
     return type == TextType.orderedListItem || type == TextType.unorderedListItem;
   }
 
-  String _getBlockTypeName(TextType newType) {
+  Attribution _getBlockTypeAttribution(TextType newType) {
     switch (newType) {
       case TextType.header1:
-        return 'header1';
+        return header1Attribution;
       case TextType.header2:
-        return 'header2';
+        return header2Attribution;
       case TextType.header3:
-        return 'header3';
+        return header3Attribution;
       case TextType.blockquote:
-        return 'blockquote';
+        return blockquoteAttribution;
       case TextType.paragraph:
       default:
         return null;
@@ -273,7 +276,7 @@ class _TextFormatBarState extends State<TextFormatBar> {
     widget.editor.executeCommand(
       ToggleTextAttributionsCommand(
         documentSelection: widget.composer.selection,
-        attributions: {'bold'},
+        attributions: {boldAttribution},
       ),
     );
   }
@@ -282,7 +285,7 @@ class _TextFormatBarState extends State<TextFormatBar> {
     widget.editor.executeCommand(
       ToggleTextAttributionsCommand(
         documentSelection: widget.composer.selection,
-        attributions: {'italics'},
+        attributions: {italicsAttribution},
       ),
     );
   }
@@ -291,7 +294,7 @@ class _TextFormatBarState extends State<TextFormatBar> {
     widget.editor.executeCommand(
       ToggleTextAttributionsCommand(
         documentSelection: widget.composer.selection,
-        attributions: {'strikethrough'},
+        attributions: {strikethroughAttribution},
       ),
     );
   }
@@ -517,7 +520,7 @@ Document _createInitialDocument() {
           text: 'Example Document',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       HorizontalRuleNode(id: DocumentEditor.createNodeId()),
@@ -534,7 +537,7 @@ Document _createInitialDocument() {
           text: 'This is a blockquote!',
         ),
         metadata: {
-          'blockType': 'blockquote',
+          'blockType': blockquoteAttribution,
         },
       ),
       ListItemNode.unordered(

--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -1,0 +1,94 @@
+import 'package:super_editor/super_editor.dart';
+
+Document createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      ImageNode(
+        id: DocumentEditor.createNodeId(),
+        imageUrl: 'https://i.ytimg.com/vi/fq4N0hgOWzU/maxresdefault.jpg',
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Example Document',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is a blockquote!',
+        ),
+        metadata: {
+          'blockType': blockquoteAttribution,
+        },
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is an unordered list item',
+        ),
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is another list item',
+        ),
+      ),
+      ListItemNode.unordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'This is a 3rd list item',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+            text:
+                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+      ),
+      ListItemNode.ordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'First thing to do',
+        ),
+      ),
+      ListItemNode.ordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Second thing to do',
+        ),
+      ),
+      ListItemNode.ordered(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Third thing to do',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+        ),
+      ),
+    ],
+  );
+}

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -584,14 +584,33 @@ class _EditorToolbarState extends State<EditorToolbar> {
         width: 400,
         height: 40,
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: TextField(
-          focusNode: _urlFocusNode,
-          controller: _urlController,
-          decoration: InputDecoration(
-            hintText: 'enter url...',
-            border: InputBorder.none,
-          ),
-          onSubmitted: (newValue) => _applyLink(),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                focusNode: _urlFocusNode,
+                controller: _urlController,
+                decoration: InputDecoration(
+                  hintText: 'enter url...',
+                  border: InputBorder.none,
+                ),
+                onSubmitted: (newValue) => _applyLink(),
+              ),
+            ),
+            IconButton(
+              icon: Icon(Icons.close),
+              iconSize: 20,
+              splashRadius: 16,
+              padding: EdgeInsets.zero,
+              onPressed: () {
+                setState(() {
+                  _urlFocusNode.unfocus();
+                  _showUrlField = false;
+                  _urlController.clear();
+                });
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -1,0 +1,162 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '_example_document.dart';
+import '_toolbar.dart';
+
+/// Example of a rich text editor.
+///
+/// This editor will expand in functionality as package
+/// capabilities expand.
+class ExampleEditor extends StatefulWidget {
+  @override
+  _ExampleEditorState createState() => _ExampleEditorState();
+}
+
+class _ExampleEditorState extends State<ExampleEditor> {
+  final GlobalKey _docLayoutKey = GlobalKey();
+
+  Document _doc;
+  DocumentEditor _docEditor;
+  DocumentComposer _composer;
+
+  FocusNode _editorFocusNode;
+
+  ScrollController _scrollController;
+
+  OverlayEntry _formatBarOverlayEntry;
+  final _selectionAnchor = ValueNotifier<Offset>(null);
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = createInitialDocument()..addListener(_updateToolbarDisplay);
+    _docEditor = DocumentEditor(document: _doc);
+    _composer = DocumentComposer()..addListener(_updateToolbarDisplay);
+    _editorFocusNode = FocusNode();
+    _scrollController = ScrollController()..addListener(_updateToolbarDisplay);
+  }
+
+  @override
+  void dispose() {
+    if (_formatBarOverlayEntry != null) {
+      _formatBarOverlayEntry.remove();
+    }
+
+    _scrollController.dispose();
+    _editorFocusNode.dispose();
+    _composer.dispose();
+    super.dispose();
+  }
+
+  void _updateToolbarDisplay() {
+    final selection = _composer.selection;
+    if (selection == null) {
+      // Nothing is selected. We don't want to show a toolbar
+      // in this case.
+      _hideEditorToolbar();
+
+      return;
+    }
+    if (selection.base.nodeId != selection.extent.nodeId) {
+      // More than one node is selected. We don't want to show
+      // a toolbar in this case.
+      _hideEditorToolbar();
+
+      return;
+    }
+    if (selection.isCollapsed) {
+      // We only want to show the toolbar when a span of text
+      // is selected. Therefore, we ignore collapsed selections.
+      _hideEditorToolbar();
+
+      return;
+    }
+
+    final textNode = _doc.getNodeById(selection.extent.nodeId);
+    if (textNode is! TextNode) {
+      // The currently selected content is not a paragraph. We don't
+      // want to show a toolbar in this case.
+      _hideEditorToolbar();
+
+      return;
+    }
+
+    // Show the editor's toolbar for text styling.
+    _showEditorToolbar();
+  }
+
+  void _showEditorToolbar() {
+    if (_formatBarOverlayEntry == null) {
+      // Create an overlay entry to build the editor toolbar.
+      // TODO: add an overlay to the Editor widget to avoid using the
+      //       application overlay
+      _formatBarOverlayEntry ??= OverlayEntry(builder: (context) {
+        return EditorToolbar(
+          anchor: _selectionAnchor,
+          editor: _docEditor,
+          composer: _composer,
+          closeToolbar: _hideEditorToolbar,
+        );
+      });
+
+      // Display the toolbar in the application overlay.
+      final overlay = Overlay.of(context);
+      overlay.insert(_formatBarOverlayEntry);
+
+      // Schedule a callback after this frame to locate the selection
+      // bounds on the screen and display the toolbar near the selected
+      // text.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        final docBoundingBox = (_docLayoutKey.currentState as DocumentLayout)
+            .getRectForSelection(_composer.selection.base, _composer.selection.extent);
+        final docBox = _docLayoutKey.currentContext.findRenderObject() as RenderBox;
+        final overlayBoundingBox = Rect.fromPoints(
+          docBox.localToGlobal(docBoundingBox.topLeft, ancestor: context.findRenderObject()),
+          docBox.localToGlobal(docBoundingBox.bottomRight, ancestor: context.findRenderObject()),
+        );
+
+        _selectionAnchor.value = overlayBoundingBox.topCenter;
+      });
+    }
+  }
+
+  void _hideEditorToolbar() {
+    // Null out the selection anchor so that when it re-appears,
+    // the bar doesn't momentarily "flash" at its old anchor position.
+    _selectionAnchor.value = null;
+
+    if (_formatBarOverlayEntry != null) {
+      // Remove the toolbar overlay and null-out the entry.
+      // We null out the entry because we can't query whether
+      // or not the entry exists in the overlay, so in our
+      // case, null implies the entry is not in the overlay,
+      // and non-null implies the entry is in the overlay.
+      _formatBarOverlayEntry.remove();
+      _formatBarOverlayEntry = null;
+    }
+
+    // Ensure that focus returns to the editor.
+    //
+    // I tried explicitly unfocus()'ing the URL textfield
+    // in the toolbar but it didn't return focus to the
+    // editor. I'm not sure why.
+    _editorFocusNode.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Editor.standard(
+      editor: _docEditor,
+      composer: _composer,
+      focusNode: _editorFocusNode,
+      scrollController: _scrollController,
+      documentLayoutKey: _docLayoutKey,
+      maxWidth: 600, // arbitrary choice for maximum width
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+    );
+  }
+}

--- a/super_editor/example/lib/demos/sliver_example_editor.dart
+++ b/super_editor/example/lib/demos/sliver_example_editor.dart
@@ -101,7 +101,7 @@ Document _createInitialDocument() {
           text: 'Example Document',
         ),
         metadata: {
-          'blockType': 'header1',
+          'blockType': header1Attribution,
         },
       ),
       HorizontalRuleNode(id: DocumentEditor.createNodeId()),

--- a/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/super_editor.dart';
 
+const brandAttribution = NamedAttribution('brand');
+const flutterAttribution = NamedAttribution('flutter');
+
 class InteractiveTextFieldDemo extends StatefulWidget {
   @override
   _InteractiveTextFieldDemoState createState() => _InteractiveTextFieldDemoState();
@@ -12,10 +15,10 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
     text: AttributedText(
         text: 'Super Editor is an open source text editor for Flutter projects.',
         spans: AttributedSpans(attributions: [
-          SpanMarker(attribution: 'brand', offset: 0, markerType: SpanMarkerType.start),
-          SpanMarker(attribution: 'brand', offset: 11, markerType: SpanMarkerType.end),
-          SpanMarker(attribution: 'flutter', offset: 47, markerType: SpanMarkerType.start),
-          SpanMarker(attribution: 'flutter', offset: 53, markerType: SpanMarkerType.end),
+          SpanMarker(attribution: brandAttribution, offset: 0, markerType: SpanMarkerType.start),
+          SpanMarker(attribution: brandAttribution, offset: 11, markerType: SpanMarkerType.end),
+          SpanMarker(attribution: flutterAttribution, offset: 47, markerType: SpanMarkerType.start),
+          SpanMarker(attribution: flutterAttribution, offset: 53, markerType: SpanMarkerType.end),
         ])),
   );
 
@@ -166,19 +169,19 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
     );
   }
 
-  TextStyle _textStyleBuilder(Set<dynamic> attributions) {
+  TextStyle _textStyleBuilder(Set<Attribution> attributions) {
     TextStyle textStyle = TextStyle(
       color: Colors.black,
       fontSize: 14,
     );
 
-    if (attributions.contains('brand')) {
+    if (attributions.contains(brandAttribution)) {
       textStyle = textStyle.copyWith(
         color: Colors.red,
         fontWeight: FontWeight.bold,
       );
     }
-    if (attributions.contains('flutter')) {
+    if (attributions.contains(flutterAttribution)) {
       textStyle = textStyle.copyWith(
         color: Colors.blue,
       );

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:example/demos/demo_markdown_serialization.dart';
 import 'package:example/demos/demo_paragraphs.dart';
 import 'package:example/demos/demo_selectable_text.dart';
 import 'package:example/demos/supertextfield/demo_textfield.dart';
-import 'package:example/demos/example_editor.dart';
+import 'package:example/demos/example_editor/example_editor.dart';
 import 'package:example/demos/sliver_example_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 
 import 'document_selection.dart';
 
@@ -53,11 +54,11 @@ class DocumentComposer with ChangeNotifier {
 /// like a "bold mode" or "italics mode" when there is no
 /// bold or italics text around the caret.
 class ComposerPreferences with ChangeNotifier {
-  final Set<dynamic> _currentStyles = {};
+  final Set<Attribution> _currentStyles = {};
 
   /// Returns the styles that should be applied to the next
   /// character that is entered in a `Document`.
-  Set<dynamic> get currentStyles => _currentStyles;
+  Set<Attribution> get currentStyles => _currentStyles;
 
   /// Adds `name` to `currentStyles`.
   void addStyle(dynamic name) {
@@ -65,15 +66,15 @@ class ComposerPreferences with ChangeNotifier {
     notifyListeners();
   }
 
-  /// Adds all `names` to `currentStyles`.
-  void addStyles(Set<dynamic> names) {
-    _currentStyles.addAll(names);
+  /// Adds all [attributions] to [currentStyles].
+  void addStyles(Set<Attribution> attributions) {
+    _currentStyles.addAll(attributions);
     notifyListeners();
   }
 
-  /// Removes `name` from `currentStyles`.
-  void removeStyle(dynamic name) {
-    _currentStyles.remove(name);
+  /// Removes [attributions] from [currentStyles].
+  void removeStyle(Attribution attributions) {
+    _currentStyles.remove(attributions);
     notifyListeners();
   }
 

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -55,7 +55,9 @@ class LinkAttribution implements Attribution {
   final Uri url;
 
   @override
-  bool canMergeWith(Attribution other) => this == other;
+  bool canMergeWith(Attribution other) {
+    return this == other;
+  }
 
   @override
   bool operator ==(Object other) =>
@@ -63,4 +65,9 @@ class LinkAttribution implements Attribution {
 
   @override
   int get hashCode => url.hashCode;
+
+  @override
+  String toString() {
+    return '[LinkAttribution]: $url';
+  }
 }

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -1,0 +1,66 @@
+import 'package:super_editor/src/infrastructure/attributed_spans.dart';
+
+/// Header 1 style attribution.
+const header1Attribution = NamedAttribution('header1');
+
+/// Header 2 style attribution.
+const header2Attribution = NamedAttribution('header2');
+
+/// Header 3 style attribution.
+const header3Attribution = NamedAttribution('header3');
+
+/// Header 4 style attribution.
+const header4Attribution = NamedAttribution('header4');
+
+/// Header 5 style attribution.
+const header5Attribution = NamedAttribution('header5');
+
+/// Header 6 style attribution.
+const header6Attribution = NamedAttribution('header6');
+
+/// Blockquote attribution
+const blockquoteAttribution = NamedAttribution('blockquote');
+
+/// Bold style attribution.
+const boldAttribution = NamedAttribution('bold');
+
+/// Italics style attribution.
+const italicsAttribution = NamedAttribution('italics');
+
+/// Strikethrough style attribution.
+const strikethroughAttribution = NamedAttribution('strikethrough');
+
+/// Code style attribution.
+const codeAttribution = NamedAttribution('code');
+
+/// Attribution to be used within [AttributedText] to
+/// represent a link.
+///
+/// Every [LinkAttribution] is considered equivalent so
+/// that [AttributedText] prevents multiple [LinkAttribution]s
+/// from overlapping.
+///
+/// If [LinkAttribution] does not meet your development needs,
+/// a different class or value can be used to implement links
+/// within [AttributedText]. This class doesn't have a special
+/// relationship with [AttributedText].
+class LinkAttribution implements Attribution {
+  LinkAttribution({
+    required this.url,
+  });
+
+  @override
+  String get id => 'link';
+
+  final Uri url;
+
+  @override
+  bool canMergeWith(Attribution other) => this == other;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is LinkAttribution && runtimeType == other.runtimeType && url == other.url;
+
+  @override
+  int get hashCode => url.hashCode;
+}

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 
@@ -79,7 +80,7 @@ ExecutionInstruction convertBlockquoteToParagraphWhenBackspaceIsPressed({
   if (node is! ParagraphNode) {
     return ExecutionInstruction.continueExecution;
   }
-  if (node.metadata['blockType'] != 'blockquote') {
+  if (node.metadata['blockType'] != blockquoteAttribution) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -145,7 +146,7 @@ ExecutionInstruction insertNewlineInBlockquote({
   if (node is! ParagraphNode) {
     return ExecutionInstruction.continueExecution;
   }
-  if (node.metadata['blockType'] != 'blockquote') {
+  if (node.metadata['blockType'] != blockquoteAttribution) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -192,7 +193,7 @@ ExecutionInstruction splitBlockquoteWhenEnterPressed({
   if (node is! ParagraphNode) {
     return ExecutionInstruction.continueExecution;
   }
-  if (node.metadata['blockType'] != 'blockquote') {
+  if (node.metadata['blockType'] != blockquoteAttribution) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -247,7 +248,7 @@ class SplitBlockquoteCommand implements EditorCommand {
     final newNode = ParagraphNode(
       id: newNodeId,
       text: endText,
-      metadata: isNewNodeABlockquote ? {'blockType': 'blockquote'} : {},
+      metadata: isNewNodeABlockquote ? {'blockType': blockquoteAttribution} : {},
     );
 
     // Insert the new node after the current node.
@@ -263,7 +264,7 @@ Widget? blockquoteBuilder(ComponentContext componentContext) {
   if (blockquoteNode is! ParagraphNode) {
     return null;
   }
-  if (blockquoteNode.metadata['blockType'] != 'blockquote') {
+  if (blockquoteNode.metadata['blockType'] != blockquoteAttribution) {
     return null;
   }
 

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -3,12 +3,12 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
-import 'text_tools.dart';
 import 'document_interaction.dart';
 import 'multi_node_editing.dart';
 import 'paragraph.dart';
@@ -360,7 +360,7 @@ ExecutionInstruction applyBoldWhenCmdBIsPressed({
   editContext.editor.executeCommand(
     ToggleTextAttributionsCommand(
       documentSelection: editContext.composer.selection!,
-      attributions: {'bold'},
+      attributions: {boldAttribution},
     ),
   );
 
@@ -389,7 +389,7 @@ ExecutionInstruction applyItalicsWhenCmdIIsPressed({
   editContext.editor.executeCommand(
     ToggleTextAttributionsCommand(
       documentSelection: editContext.composer.selection!,
-      attributions: {'italics'},
+      attributions: {italicsAttribution},
     ),
   );
 

--- a/super_editor/lib/src/default_editor/editor.dart
+++ b/super_editor/lib/src/default_editor/editor.dart
@@ -5,11 +5,13 @@ import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_editor.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/blockquote.dart';
 import 'package:super_editor/src/default_editor/horizontal_rule.dart';
 import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
+import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 
 import 'box_component.dart';
@@ -330,7 +332,7 @@ final defaultSelectionStyle = const SelectionStyle(
 );
 
 /// Creates `TextStyles` for the standard `Editor`.
-TextStyle defaultStyleBuilder(Set<dynamic> attributions) {
+TextStyle defaultStyleBuilder(Set<Attribution> attributions) {
   TextStyle newStyle = TextStyle(
     color: Colors.black,
     fontSize: 13,
@@ -338,49 +340,38 @@ TextStyle defaultStyleBuilder(Set<dynamic> attributions) {
   );
 
   for (final attribution in attributions) {
-    if (attribution is! String) {
-      continue;
-    }
-
-    switch (attribution) {
-      case 'header1':
-        newStyle = newStyle.copyWith(
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-          height: 1.0,
-        );
-        break;
-      case 'header2':
-        newStyle = newStyle.copyWith(
-          fontSize: 18,
-          fontWeight: FontWeight.bold,
-          color: const Color(0xFF888888),
-          height: 1.0,
-        );
-        break;
-      case 'blockquote':
-        newStyle = newStyle.copyWith(
-          fontSize: 20,
-          fontWeight: FontWeight.bold,
-          height: 1.4,
-          color: Colors.grey,
-        );
-        break;
-      case 'bold':
-        newStyle = newStyle.copyWith(
-          fontWeight: FontWeight.bold,
-        );
-        break;
-      case 'italics':
-        newStyle = newStyle.copyWith(
-          fontStyle: FontStyle.italic,
-        );
-        break;
-      case 'strikethrough':
-        newStyle = newStyle.copyWith(
-          decoration: TextDecoration.lineThrough,
-        );
-        break;
+    if (attribution == header1Attribution) {
+      newStyle = newStyle.copyWith(
+        fontSize: 24,
+        fontWeight: FontWeight.bold,
+        height: 1.0,
+      );
+    } else if (attribution == header2Attribution) {
+      newStyle = newStyle.copyWith(
+        fontSize: 18,
+        fontWeight: FontWeight.bold,
+        color: const Color(0xFF888888),
+        height: 1.0,
+      );
+    } else if (attribution == blockquoteAttribution) {
+      newStyle = newStyle.copyWith(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        height: 1.4,
+        color: Colors.grey,
+      );
+    } else if (attribution == boldAttribution) {
+      newStyle = newStyle.copyWith(
+        fontWeight: FontWeight.bold,
+      );
+    } else if (attribution == italicsAttribution) {
+      newStyle = newStyle.copyWith(
+        fontStyle: FontStyle.italic,
+      );
+    } else if (attribution == strikethroughAttribution) {
+      newStyle = newStyle.copyWith(
+        decoration: TextDecoration.lineThrough,
+      );
     }
   }
   return newStyle;

--- a/super_editor/lib/src/default_editor/editor.dart
+++ b/super_editor/lib/src/default_editor/editor.dart
@@ -372,6 +372,11 @@ TextStyle defaultStyleBuilder(Set<Attribution> attributions) {
       newStyle = newStyle.copyWith(
         decoration: TextDecoration.lineThrough,
       );
+    } else if (attribution is LinkAttribution) {
+      newStyle = newStyle.copyWith(
+        color: Colors.lightBlue,
+        decoration: TextDecoration.underline,
+      );
     }
   }
   return newStyle;

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/src/core/document_editor.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -274,7 +275,7 @@ bool _convertParagraphIfDesired({
     final newNode = ParagraphNode(
       id: node.id,
       text: adjustedText,
-      metadata: {'blockType': 'blockquote'},
+      metadata: {'blockType': blockquoteAttribution},
     );
     final nodeIndex = document.getNodeIndex(node);
 

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -13,6 +13,7 @@ import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
 import 'package:super_editor/src/infrastructure/selectable_text.dart';
@@ -451,7 +452,7 @@ class ToggleTextAttributionsCommand implements EditorCommand {
   });
 
   final DocumentSelection documentSelection;
-  final Set<String> attributions;
+  final Set<Attribution> attributions;
 
   @override
   void execute(Document document, DocumentEditorTransaction transaction) {
@@ -523,7 +524,7 @@ class ToggleTextAttributionsCommand implements EditorCommand {
 
     // Toggle attributions.
     for (final entry in nodesAndSelections.entries) {
-      for (String attribution in attributions) {
+      for (Attribution attribution in attributions) {
         final node = entry.key;
         final range = entry.value;
         _log.log('ToggleTextAttributionsCommand', ' - toggling attribution: $attribution. Range: $range');
@@ -547,7 +548,7 @@ class InsertTextCommand implements EditorCommand {
 
   final DocumentPosition documentPosition;
   final String textToInsert;
-  final Set<dynamic> attributions;
+  final Set<Attribution> attributions;
 
   @override
   void execute(Document document, DocumentEditorTransaction transaction) {

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -418,14 +418,16 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
   Widget build(BuildContext context) {
     _log.log('build', 'Building a TextComponent with key: ${widget.key}');
 
-    final blockType = widget.metadata['blockType'];
+    Attribution? blockType = widget.metadata['blockType'];
 
     // Surround the text with block level attributions.
-    final blockText = widget.text.copyText(0)
-      ..addAttribution(
+    final blockText = widget.text.copyText(0);
+    if (blockType != null) {
+      blockText.addAttribution(
         blockType,
         TextRange(start: 0, end: widget.text.text.length - 1),
       );
+    }
     final richText = blockText.computeTextSpan(widget.textStyleBuilder);
 
     return SelectableText(

--- a/super_editor/lib/src/infrastructure/attributed_text.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text.dart
@@ -8,21 +8,19 @@ final _log = Logger(scope: 'AttributedText');
 
 /// Text with attributions applied to desired spans of text.
 ///
-/// An attribution can be any object as long as each attribution
-/// object implements equality. A `String` is typically a good
-/// choice to use as an attribution type.
+/// An attribution can be any subclass of [Attribution].
 ///
-/// `AttributedText` is a convenient way to store and manipulate
+/// [AttributedText] is a convenient way to store and manipulate
 /// text that might have overlapping styles and/or non-style
-/// attributions. A common Flutter alternative is `TextSpan`, but
-/// `TextSpan` does not support overlapping styles, and `TextSpan`
+/// attributions. A common Flutter alternative is [TextSpan], but
+/// [TextSpan] does not support overlapping styles, and [TextSpan]
 /// is exclusively intended for visual text styles.
 ///
-/// To style Flutter text, `AttributedText` produces a
-/// corresponding `TextSpan` with `computeTextSpan()`. Clients
-/// style the text by providing an `AttributionStyleBuilder`,
+/// To style Flutter text, [AttributedText] produces a
+/// corresponding [TextSpan] with [computeTextSpan()]. Clients
+/// style the text by providing an [AttributionStyleBuilder],
 /// which is responsible for interpreting the meaning of all
-/// attributions applied to this `AttributedText`.
+/// attributions applied to this [AttributedText].
 // TODO: there is a mixture of mutable and immutable behavior in this class.
 //       Pick one or the other, or offer 2 classes: mutable and immutable (#113)
 class AttributedText with ChangeNotifier {
@@ -31,28 +29,28 @@ class AttributedText with ChangeNotifier {
     AttributedSpans? spans,
   }) : spans = spans ?? AttributedSpans();
 
-  /// The text that this `AttributedText` attributes.
+  /// The text that this [AttributedText] attributes.
   final String text;
 
-  /// The attributes applied to `text`.
+  /// The attributes applied to [text].
   final AttributedSpans spans;
 
-  /// Returns true if the given `attribution` is applied at `offset`.
+  /// Returns true if the given [attribution] is applied at [offset].
   ///
-  /// If the given `attribution` is null, returns `true` if any attribution
-  /// exists at the given `offset`.
+  /// If the given [attribution] is [null], returns [true] if any attribution
+  /// exists at the given [offset].
   bool hasAttributionAt(
     int offset, {
-    dynamic attribution,
+    Attribution? attribution,
   }) {
     return spans.hasAttributionAt(offset, attribution: attribution);
   }
 
-  /// Returns true if this `AttributedText` contains at least one
-  /// character with each of the given `attributions` within the
-  /// given `range` (inclusive).
+  /// Returns true if this [AttributedText] contains at least one
+  /// character with each of the given [attributions] within the
+  /// given [range] (inclusive).
   bool hasAttributionsWithin({
-    required Set<dynamic> attributions,
+    required Set<Attribution> attributions,
     required TextRange range,
   }) {
     return spans.hasAttributionsWithin(
@@ -62,35 +60,35 @@ class AttributedText with ChangeNotifier {
     );
   }
 
-  /// Returns all attributions applied to the given `offset`.
-  Set<dynamic> getAllAttributionsAt(int offset) {
+  /// Returns all attributions applied to the given [offset].
+  Set<Attribution> getAllAttributionsAt(int offset) {
     return spans.getAllAttributionsAt(offset);
   }
 
-  /// Adds the given attribution to all characters within the given
-  /// `range`, inclusive.
-  void addAttribution(dynamic attribution, TextRange range) {
+  /// Adds the given [attribution] to all characters within the given
+  /// [range], inclusive.
+  void addAttribution(Attribution attribution, TextRange range) {
     spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
     notifyListeners();
   }
 
-  /// Removes the given attribution from all characters within the
-  /// given `range`, inclusive.
-  void removeAttribution(dynamic attribution, TextRange range) {
+  /// Removes the given [attribution] from all characters within the
+  /// given [range], inclusive.
+  void removeAttribution(Attribution attribution, TextRange range) {
     spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
     notifyListeners();
   }
 
-  /// If ALL of the text in `range`, inclusive, contains the given `attribution`,
-  /// that attribution is removed from the text in `range`, inclusive.
-  /// Otherwise, all of the text in `range`, inclusive, is given the `attribution`.
-  void toggleAttribution(dynamic attribution, TextRange range) {
+  /// If ALL of the text in [range], inclusive, contains the given [attribution],
+  /// that [attribution] is removed from the text in [range], inclusive.
+  /// Otherwise, all of the text in [range], inclusive, is given the [attribution].
+  void toggleAttribution(Attribution attribution, TextRange range) {
     spans.toggleAttribution(attribution: attribution, start: range.start, end: range.end);
     notifyListeners();
   }
 
-  /// Copies all text and attributions from `startOffset` to
-  /// `endOffset`, inclusive, and returns them as a new `AttributedText`.
+  /// Copies all text and attributions from [startOffset] to
+  /// [endOffset], inclusive, and returns them as a new [AttributedText].
   AttributedText copyText(int startOffset, [int? endOffset]) {
     _log.log('copyText', 'start: $startOffset, end: $endOffset');
 
@@ -113,7 +111,7 @@ class AttributedText with ChangeNotifier {
     );
   }
 
-  /// Returns a copy of this `AttributedText` with the `other` text
+  /// Returns a copy of this [AttributedText] with the [other] text
   /// and attributions appended to the end.
   AttributedText copyAndAppend(AttributedText other) {
     _log.log('copyAndAppend', 'our attributions before pushing them:');
@@ -140,16 +138,16 @@ class AttributedText with ChangeNotifier {
     );
   }
 
-  /// Returns a copy of this `AttributedText` with `textToInsert`
-  /// inserted at `startOffset`.
+  /// Returns a copy of this [AttributedText] with [textToInsert]
+  /// inserted at [startOffset].
   ///
-  /// Any attributions that span `startOffset` are applied to all
-  /// of the inserted text. All spans that start after `startOffset`
-  /// are pushed back by the length of `textToInsert`.
+  /// Any attributions that span [startOffset] are applied to all
+  /// of the inserted text. All spans that start after [startOffset]
+  /// are pushed back by the length of [textToInsert].
   AttributedText insertString({
     required String textToInsert,
     required int startOffset,
-    Set<dynamic> applyAttributions = const {},
+    Set<Attribution> applyAttributions = const {},
   }) {
     _log.log('insertString', 'text: "$textToInsert", start: $startOffset, attributions: $applyAttributions');
 
@@ -175,9 +173,9 @@ class AttributedText with ChangeNotifier {
     return startText.copyAndAppend(insertedText).copyAndAppend(endText);
   }
 
-  /// Copies this `AttributedText` and removes  a region of text
-  /// and attributions from `startOffset`, inclusive,
-  /// to `endOffset`, exclusive.
+  /// Copies this [AttributedText] and removes  a region of text
+  /// and attributions from [startOffset], inclusive,
+  /// to [endOffset], exclusive.
   AttributedText removeRegion({
     required int startOffset,
     required int endOffset,
@@ -211,11 +209,11 @@ class AttributedText with ChangeNotifier {
     }
   }
 
-  /// Returns a Flutter `TextSpan` that is styled based on the
-  /// attributions within this `AttributedText`.
+  /// Returns a Flutter [TextSpan] that is styled based on the
+  /// attributions within this [AttributedText].
   ///
-  /// The given `styleBuilder` interprets the meaning of every
-  /// attribution and constructs `TextStyle`s accordingly.
+  /// The given [styleBuilder] interprets the meaning of every
+  /// attribution and constructs [TextStyle]s accordingly.
   // TODO: remove this method and use [visitAttributions()] to compute TextSpan
   TextSpan computeTextSpan(AttributionStyleBuilder styleBuilder) {
     _log.log('computeTextSpan', 'text length: ${text.length}');
@@ -258,15 +256,15 @@ class AttributedText with ChangeNotifier {
 /// closing index to be exclusive, but that is not how this callback
 /// works. Both the [start] and [end] [index]es are inclusive.
 typedef AttributionVisitor = void Function(
-    AttributedText fullText, int index, Set<dynamic> attributions, AttributionVisitEvent event);
+    AttributedText fullText, int index, Set<Attribution> attributions, AttributionVisitEvent event);
 
 enum AttributionVisitEvent {
   start,
   end,
 }
 
-/// Creates the desired `TextStyle` given the `attributions` associated
+/// Creates the desired [TextStyle] given the [attributions] associated
 /// with a span of text.
 ///
-/// The `attributions` set may be empty.
-typedef AttributionStyleBuilder = TextStyle Function(Set<dynamic> attributions);
+/// The [attributions] set may be empty.
+typedef AttributionStyleBuilder = TextStyle Function(Set<Attribution> attributions);

--- a/super_editor/lib/src/infrastructure/attributed_text.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text.dart
@@ -65,6 +65,31 @@ class AttributedText with ChangeNotifier {
     return spans.getAllAttributionsAt(offset);
   }
 
+  /// Returns spans for each attribution that (at least partially) appear
+  /// within the given [range], as selected by [attributionFilter].
+  ///
+  /// By default, the returned spans represent the full, contiguous span
+  /// of each attribution. This means that if a portion of an attribution
+  /// appears within the given [range], the entire attribution span is
+  /// returned, including the area that sits outside the given [range].
+  ///
+  /// To obtain attribution spans that are cut down and limited to the
+  /// given [range], pass [true] for [resizeSpansToFitInRange]. This setting
+  /// only effects the returned spans, it does not alter the attributions
+  /// within this [AttributedText].
+  Set<AttributionSpan> getAttributionSpansInRange({
+    required AttributionFilter attributionFilter,
+    required TextRange range,
+    bool resizeSpansToFitInRange = false,
+  }) {
+    return spans.getAttributionSpansInRange(
+      attributionFilter: attributionFilter,
+      start: range.start,
+      end: range.end,
+      resizeSpansToFitInRange: resizeSpansToFitInRange,
+    );
+  }
+
   /// Adds the given [attribution] to all characters within the given
   /// [range], inclusive.
   void addAttribution(Attribution attribution, TextRange range) {
@@ -75,7 +100,7 @@ class AttributedText with ChangeNotifier {
   /// Removes the given [attribution] from all characters within the
   /// given [range], inclusive.
   void removeAttribution(Attribution attribution, TextRange range) {
-    spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
+    spans.removeAttribution(attributionToRemove: attribution, start: range.start, end: range.end);
     notifyListeners();
   }
 

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -12,6 +12,7 @@ export 'src/core/document_editor.dart';
 export 'src/core/document_layout.dart';
 export 'src/core/document_selection.dart';
 export 'src/core/edit_context.dart';
+export 'src/default_editor/attributions.dart';
 export 'src/default_editor/blockquote.dart';
 export 'src/default_editor/box_component.dart';
 export 'src/default_editor/document_interaction.dart';

--- a/super_editor/test/serialization/markdown_test.dart
+++ b/super_editor/test/serialization/markdown_test.dart
@@ -1,3 +1,4 @@
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/serialization/markdown.dart';
@@ -14,22 +15,22 @@ void main() {
           ),
         ]);
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header1';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header1Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '# My Header');
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header2';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header2Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '## My Header');
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header3';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header3Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '### My Header');
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header4';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header4Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '#### My Header');
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header5';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header5Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '##### My Header');
 
-        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = 'header6';
+        (doc.nodes[0] as ParagraphNode).metadata['blockType'] = header6Attribution;
         expect(serializeDocumentToMarkdown(doc).trim(), '###### My Header');
       });
 
@@ -41,12 +42,12 @@ void main() {
               text: 'My Header',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 3, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 3, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
-            metadata: {'blockType': 'header1'},
+            metadata: {'blockType': header1Attribution},
           ),
         ]);
 
@@ -58,7 +59,7 @@ void main() {
           ParagraphNode(
             id: '1',
             text: AttributedText(text: 'This is a blockquote'),
-            metadata: {'blockType': 'blockquote'},
+            metadata: {'blockType': blockquoteAttribution},
           ),
         ]);
 
@@ -73,12 +74,12 @@ void main() {
               text: 'This is a blockquote',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 10, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 19, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 19, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
-            metadata: {'blockType': 'blockquote'},
+            metadata: {'blockType': blockquoteAttribution},
           ),
         ]);
 
@@ -90,7 +91,7 @@ void main() {
           ParagraphNode(
             id: '1',
             text: AttributedText(text: 'This is some code'),
-            metadata: {'blockType': 'code'},
+            metadata: {'blockType': codeAttribution},
           ),
         ]);
 
@@ -122,8 +123,8 @@ This is some code
               text: 'This is a paragraph.',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -141,10 +142,10 @@ This is some code
               text: 'This is a paragraph.',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.end),
-                  SpanMarker(attribution: 'italics', offset: 5, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'italics', offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: italicsAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -162,10 +163,10 @@ This is some code
               text: 'This is a paragraph.',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.end),
-                  SpanMarker(attribution: 'code', offset: 5, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'code', offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: codeAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: codeAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -248,8 +249,8 @@ This is some code
               text: 'Unordered 1',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -310,8 +311,8 @@ This is some code
               text: 'Ordered 1',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: 'bold', offset: 6, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -330,7 +331,7 @@ This is some code
           ParagraphNode(
             id: DocumentEditor.createNodeId(),
             text: AttributedText(text: 'Example Doc'),
-            metadata: {'blockType': 'header1'},
+            metadata: {'blockType': header1Attribution},
           ),
           HorizontalRuleNode(id: DocumentEditor.createNodeId()),
           ParagraphNode(
@@ -368,7 +369,7 @@ This is some code
           ParagraphNode(
             id: DocumentEditor.createNodeId(),
             text: AttributedText(text: 'This is a blockquote.'),
-            metadata: {'blockType': 'blockquote'},
+            metadata: {'blockType': blockquoteAttribution},
           ),
           ParagraphNode(
             id: DocumentEditor.createNodeId(),
@@ -377,7 +378,7 @@ This is some code
           ParagraphNode(
             id: DocumentEditor.createNodeId(),
             text: AttributedText(text: '{\n  // This is some code.\n}'),
-            metadata: {'blockType': 'code'},
+            metadata: {'blockType': codeAttribution},
           ),
         ]);
 
@@ -391,29 +392,29 @@ This is some code
     group('deserialization', () {
       test('headers', () {
         final header1Doc = deserializeMarkdownToDocument('# Header 1');
-        expect((header1Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header1');
+        expect((header1Doc.nodes.first as ParagraphNode).metadata['blockType'], header1Attribution);
 
         final header2Doc = deserializeMarkdownToDocument('## Header 2');
-        expect((header2Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header2');
+        expect((header2Doc.nodes.first as ParagraphNode).metadata['blockType'], header2Attribution);
 
         final header3Doc = deserializeMarkdownToDocument('### Header 3');
-        expect((header3Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header3');
+        expect((header3Doc.nodes.first as ParagraphNode).metadata['blockType'], header3Attribution);
 
         final header4Doc = deserializeMarkdownToDocument('#### Header 4');
-        expect((header4Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header4');
+        expect((header4Doc.nodes.first as ParagraphNode).metadata['blockType'], header4Attribution);
 
         final header5Doc = deserializeMarkdownToDocument('##### Header 5');
-        expect((header5Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header5');
+        expect((header5Doc.nodes.first as ParagraphNode).metadata['blockType'], header5Attribution);
 
         final header6Doc = deserializeMarkdownToDocument('###### Header 6');
-        expect((header6Doc.nodes.first as ParagraphNode).metadata['blockType'], 'header6');
+        expect((header6Doc.nodes.first as ParagraphNode).metadata['blockType'], header6Attribution);
       });
 
       test('blockquote', () {
         final blockquoteDoc = deserializeMarkdownToDocument('> This is a blockquote');
 
         final blockquote = blockquoteDoc.nodes.first as ParagraphNode;
-        expect(blockquote.metadata['blockType'], 'blockquote');
+        expect(blockquote.metadata['blockType'], blockquoteAttribution);
         expect(blockquote.text.text, 'This is a blockquote');
       });
 
@@ -424,7 +425,7 @@ This is some code
 ```''');
 
         final code = codeBlockDoc.nodes.first as ParagraphNode;
-        expect(code.metadata['blockType'], 'code');
+        expect(code.metadata['blockType'], codeAttribution);
         expect(code.text.text, 'This is some code\n');
       });
 
@@ -461,8 +462,8 @@ This is some code
         expect(styledText.text, 'This is some styled text to parse as markdown');
 
         expect(styledText.getAllAttributionsAt(0).isEmpty, true);
-        expect(styledText.getAllAttributionsAt(8).contains('bold'), true);
-        expect(styledText.getAllAttributionsAt(13).containsAll(['bold', 'italics']), true);
+        expect(styledText.getAllAttributionsAt(8).contains(boldAttribution), true);
+        expect(styledText.getAllAttributionsAt(13).containsAll([boldAttribution, italicsAttribution]), true);
         expect(styledText.getAllAttributionsAt(19).isEmpty, true);
       });
 
@@ -518,7 +519,7 @@ This is some code
         expect(document.nodes.length, 18);
 
         expect(document.nodes[0], isA<ParagraphNode>());
-        expect((document.nodes[0] as ParagraphNode).metadata['blockType'], 'header1');
+        expect((document.nodes[0] as ParagraphNode).metadata['blockType'], header1Attribution);
 
         expect(document.nodes[1], isA<HorizontalRuleNode>());
 

--- a/super_editor/test/src/default_editor/attributions_test.dart
+++ b/super_editor/test/src/default_editor/attributions_test.dart
@@ -1,0 +1,54 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/infrastructure/attributed_spans.dart';
+import 'package:super_editor/src/infrastructure/attributed_text.dart';
+
+void main() {
+  group('Default editor attributions', () {
+    group('links', () {
+      test('different link attributions cannot overlap', () {
+        final text = AttributedText(
+          text: 'one two three',
+        );
+
+        // Add link across "one two"
+        text.addAttribution(
+          LinkAttribution(url: Uri.parse('https://flutter.dev')),
+          TextRange(start: 0, end: 6),
+        );
+
+        // Try to add a different link across "two three" and expect
+        // an exception
+        expect(() {
+          text.addAttribution(
+            LinkAttribution(url: Uri.parse('https://pub.dev')),
+            TextRange(start: 4, end: 12),
+          );
+        }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
+      });
+
+      test('identical link attributions can overlap', () {
+        final text = AttributedText(
+          text: 'one two three',
+        );
+
+        final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
+
+        // Add link across "one two"
+        text.addAttribution(
+          linkAttribution,
+          TextRange(start: 0, end: 6),
+        );
+
+        text.addAttribution(
+          LinkAttribution(url: Uri.parse('https://flutter.dev')),
+          TextRange(start: 4, end: 12),
+        );
+
+        expect(text.spans.hasAttributionsWithin(attributions: {linkAttribution}, start: 0, end: 12), true);
+      });
+    });
+  });
+}

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -6,6 +6,7 @@ import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_editor.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/box_component.dart';
 import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/default_editor/horizontal_rule.dart';
@@ -46,15 +47,15 @@ void main() {
               nodePosition: TextPosition(offset: 13),
             ),
           ),
-          attributions: {'bold'},
+          attributions: {boldAttribution},
         );
 
         editor.executeCommand(command);
 
         final boldedText = (document.nodes.first as ParagraphNode).text;
         expect(boldedText.getAllAttributionsAt(0), <dynamic>{});
-        expect(boldedText.getAllAttributionsAt(1), {'bold'});
-        expect(boldedText.getAllAttributionsAt(12), {'bold'});
+        expect(boldedText.getAllAttributionsAt(1), {boldAttribution});
+        expect(boldedText.getAllAttributionsAt(12), {boldAttribution});
         expect(boldedText.getAllAttributionsAt(13), <dynamic>{});
       });
     });

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -8,6 +8,157 @@ final strikethrough = NamedAttribution('strikethrough');
 
 void main() {
   group('Spans', () {
+    group('attribution queries', () {
+      test('it expands a span from a given offset', () {
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 3, end: 16);
+        final expandedSpan = spans.expandAttributionToSpan(attribution: bold, offset: 6);
+
+        expect(
+          expandedSpan,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 3,
+              end: 16,
+            ),
+          ),
+        );
+      });
+
+      test('it returns spans that fit within a range', () {
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: bold, start: 0, end: 2)
+          ..addAttribution(newAttribution: bold, start: 5, end: 10);
+        final attributionSpans = spans.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == bold,
+          start: 3,
+          end: 15,
+        );
+
+        expect(attributionSpans.length, 1);
+        expect(
+          attributionSpans.first,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 5,
+              end: 10,
+            ),
+          ),
+        );
+      });
+
+      test('it returns spans that partially overlap range', () {
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: bold, start: 3, end: 7)
+          ..addAttribution(newAttribution: bold, start: 10, end: 15);
+        final attributionSpans = spans.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == bold,
+          start: 5,
+          end: 12,
+        );
+
+        expect(attributionSpans.length, 2);
+        expect(
+          attributionSpans.first,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 3,
+              end: 7,
+            ),
+          ),
+        );
+        expect(
+          attributionSpans.last,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 10,
+              end: 15,
+            ),
+          ),
+        );
+      });
+
+      test('it returns spans that completely cover the range', () {
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 0, end: 10);
+        final attributionSpans = spans.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == bold,
+          start: 3,
+          end: 8,
+        );
+
+        expect(attributionSpans.length, 1);
+        expect(
+          attributionSpans.first,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 0,
+              end: 10,
+            ),
+          ),
+        );
+      });
+
+      test('it resizes spans that partially overlap range', () {
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: bold, start: 3, end: 7)
+          ..addAttribution(newAttribution: bold, start: 10, end: 15);
+        final attributionSpans = spans.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == bold,
+          start: 5,
+          end: 12,
+          resizeSpansToFitInRange: true,
+        );
+
+        expect(attributionSpans.length, 2);
+        expect(
+          attributionSpans.first,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 5,
+              end: 7,
+            ),
+          ),
+        );
+        expect(
+          attributionSpans.last,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 10,
+              end: 12,
+            ),
+          ),
+        );
+      });
+
+      test('it resizes spans that completely cover the range', () {
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 0, end: 10);
+        final attributionSpans = spans.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == bold,
+          start: 3,
+          end: 8,
+          resizeSpansToFitInRange: true,
+        );
+
+        expect(attributionSpans.length, 1);
+        expect(
+          attributionSpans.first,
+          equals(
+            AttributionSpan(
+              attribution: bold,
+              start: 3,
+              end: 8,
+            ),
+          ),
+        );
+      });
+    });
+
     group('single attribution', () {
       test('applies attribution to full span', () {
         final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 0, end: 16);

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -182,6 +182,47 @@ void main() {
           '____ss____',
         ]).expectSpans(spans);
       });
+
+      test('incompatible attributions cannot overlap', () {
+        final spans = AttributedSpans();
+
+        // Add link at beginning
+        spans.addAttribution(
+          newAttribution: _LinkAttribution(url: 'https://flutter.dev'),
+          start: 0,
+          end: 6,
+        );
+
+        // Try to add a different link at the end but overlapping
+        // the first link. Expect an exception.
+        expect(() {
+          spans.addAttribution(
+            newAttribution: _LinkAttribution(url: 'https://pub.dev'),
+            start: 4,
+            end: 12,
+          );
+        }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
+      });
+
+      test('compatible attributions are merged', () {
+        final spans = AttributedSpans();
+
+        // Add bold at beginning
+        spans.addAttribution(
+          newAttribution: bold,
+          start: 0,
+          end: 6,
+        );
+
+        // Add bold at end but overlapping earlier bold
+        spans.addAttribution(
+          newAttribution: bold,
+          start: 4,
+          end: 12,
+        );
+
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 12), true);
+      });
     });
 
     group('collapse spans', () {

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -1,37 +1,42 @@
 import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Attributions used throughout this test suite.
+final bold = NamedAttribution('bold');
+final italics = NamedAttribution('italics');
+final strikethrough = NamedAttribution('strikethrough');
+
 void main() {
   group('Spans', () {
     group('single attribution', () {
       test('applies attribution to full span', () {
-        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 0, end: 16);
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 0, end: 16);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 16), true);
       });
 
       test('applies attribution to beginning of span', () {
-        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 0, end: 7);
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 0, end: 7);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 7), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 7), true);
       });
 
       test('applies attribution to inner span', () {
-        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 2, end: 7);
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 2, end: 7);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 2, end: 7), true);
       });
 
       test('applies attribution to end of span', () {
-        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 7, end: 16);
+        final spans = AttributedSpans()..addAttribution(newAttribution: bold, start: 7, end: 16);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 7, end: 16), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 7, end: 16), true);
       });
 
       test('applies exotic span', () {
-        final linkAttribution = {
-          'url': 'https://youtube.com/c/superdeclarative',
-        };
+        final linkAttribution = _LinkAttribution(
+          url: 'https://youtube.com/c/superdeclarative',
+        );
         final spans = AttributedSpans()..addAttribution(newAttribution: linkAttribution, start: 2, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {linkAttribution}, start: 2, end: 7), true);
@@ -40,87 +45,87 @@ void main() {
       test('removes attribution from full span', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 16, markerType: SpanMarkerType.end)
           ],
-        )..removeAttribution(attributionToRemove: 'bold', start: 0, end: 16);
+        )..removeAttribution(attributionToRemove: bold, start: 0, end: 16);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 16), false);
       });
 
       test('removes attribution from inner text span', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.end)
           ],
-        )..removeAttribution(attributionToRemove: 'bold', start: 2, end: 7);
+        )..removeAttribution(attributionToRemove: bold, start: 2, end: 7);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), false);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 2, end: 7), false);
       });
 
       test('removes attribution from partial beginning span', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.end)
           ],
-        )..removeAttribution(attributionToRemove: 'bold', start: 2, end: 4);
+        )..removeAttribution(attributionToRemove: bold, start: 2, end: 4);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 5, end: 7), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 5, end: 7), true);
       });
 
       test('removes attribution from partial inner span', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.end)
           ],
-        )..removeAttribution(attributionToRemove: 'bold', start: 4, end: 5);
+        )..removeAttribution(attributionToRemove: bold, start: 4, end: 5);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 3), true);
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 6, end: 7), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 2, end: 3), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 6, end: 7), true);
       });
 
       test('removes attribution from partial ending span', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.end)
           ],
-        )..removeAttribution(attributionToRemove: 'bold', start: 5, end: 7);
+        )..removeAttribution(attributionToRemove: bold, start: 5, end: 7);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 4), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 2, end: 4), true);
       });
 
       test('applies attribution when mixed span is toggled', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 8, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 16, markerType: SpanMarkerType.end)
           ],
-        )..toggleAttribution(attribution: 'bold', start: 0, end: 16);
+        )..toggleAttribution(attribution: bold, start: 0, end: 16);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 16), true);
       });
 
       test('removes attribution when contiguous span is toggled', () {
         final spans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 16, markerType: SpanMarkerType.end)
           ],
-        )..toggleAttribution(attribution: 'bold', start: 0, end: 16);
+        )..toggleAttribution(attribution: bold, start: 0, end: 16);
 
-        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
+        expect(spans.hasAttributionsWithin(attributions: {bold}, start: 0, end: 16), false);
       });
     });
 
     group('multiple attributions', () {
       test('full length overlap', () {
         final spans = AttributedSpans()
-          ..addAttribution(newAttribution: 'b', start: 0, end: 9)
-          ..addAttribution(newAttribution: 'i', start: 0, end: 9);
+          ..addAttribution(newAttribution: bold, start: 0, end: 9)
+          ..addAttribution(newAttribution: italics, start: 0, end: 9);
 
         _ExpectedSpans([
           'bbbbbbbbbb',
@@ -130,8 +135,8 @@ void main() {
 
       test('half and half', () {
         final spans = AttributedSpans()
-          ..addAttribution(newAttribution: 'b', start: 5, end: 9)
-          ..addAttribution(newAttribution: 'i', start: 0, end: 4);
+          ..addAttribution(newAttribution: bold, start: 5, end: 9)
+          ..addAttribution(newAttribution: italics, start: 0, end: 4);
 
         _ExpectedSpans([
           '_____bbbbb',
@@ -141,8 +146,8 @@ void main() {
 
       test('two partial overlap', () {
         final spans = AttributedSpans()
-          ..addAttribution(newAttribution: 'b', start: 4, end: 8)
-          ..addAttribution(newAttribution: 'i', start: 1, end: 5);
+          ..addAttribution(newAttribution: bold, start: 4, end: 8)
+          ..addAttribution(newAttribution: italics, start: 1, end: 5);
 
         _ExpectedSpans([
           '____bbbbb_',
@@ -152,9 +157,9 @@ void main() {
 
       test('three partial overlap', () {
         final spans = AttributedSpans()
-          ..addAttribution(newAttribution: 'b', start: 4, end: 8)
-          ..addAttribution(newAttribution: 'i', start: 1, end: 5)
-          ..addAttribution(newAttribution: 's', start: 5, end: 9);
+          ..addAttribution(newAttribution: bold, start: 4, end: 8)
+          ..addAttribution(newAttribution: italics, start: 1, end: 5)
+          ..addAttribution(newAttribution: strikethrough, start: 5, end: 9);
 
         _ExpectedSpans([
           '____bbbbb_',
@@ -165,11 +170,11 @@ void main() {
 
       test('many small segments', () {
         final spans = AttributedSpans()
-          ..addAttribution(newAttribution: 'b', start: 0, end: 1)
-          ..addAttribution(newAttribution: 'i', start: 2, end: 3)
-          ..addAttribution(newAttribution: 's', start: 4, end: 5)
-          ..addAttribution(newAttribution: 'b', start: 6, end: 7)
-          ..addAttribution(newAttribution: 'i', start: 8, end: 9);
+          ..addAttribution(newAttribution: bold, start: 0, end: 1)
+          ..addAttribution(newAttribution: italics, start: 2, end: 3)
+          ..addAttribution(newAttribution: strikethrough, start: 4, end: 5)
+          ..addAttribution(newAttribution: bold, start: 6, end: 7)
+          ..addAttribution(newAttribution: italics, start: 8, end: 9);
 
         _ExpectedSpans([
           'bb____bb__',
@@ -189,8 +194,8 @@ void main() {
       test('single continuous attribution', () {
         final collapsedSpans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'b', offset: 16, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 16, markerType: SpanMarkerType.end),
           ],
         ).collapseSpans(contentLength: 17);
 
@@ -198,16 +203,16 @@ void main() {
         expect(collapsedSpans.first.start, 0);
         expect(collapsedSpans.first.end, 16);
         expect(collapsedSpans.first.attributions.length, 1);
-        expect(collapsedSpans.first.attributions.first, 'b');
+        expect(collapsedSpans.first.attributions.first, bold);
       });
 
       test('single fractured attribution', () {
         final collapsedSpans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'b', offset: 3, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'b', offset: 7, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'b', offset: 10, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 3, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 10, markerType: SpanMarkerType.end),
           ],
         ).collapseSpans(contentLength: 17);
 
@@ -215,14 +220,14 @@ void main() {
         expect(collapsedSpans[0].start, 0);
         expect(collapsedSpans[0].end, 3);
         expect(collapsedSpans[0].attributions.length, 1);
-        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[0].attributions.first, bold);
         expect(collapsedSpans[1].start, 4);
         expect(collapsedSpans[1].end, 6);
         expect(collapsedSpans[1].attributions.length, 0);
         expect(collapsedSpans[2].start, 7);
         expect(collapsedSpans[2].end, 10);
         expect(collapsedSpans[2].attributions.length, 1);
-        expect(collapsedSpans[2].attributions.first, 'b');
+        expect(collapsedSpans[2].attributions.first, bold);
         expect(collapsedSpans[3].start, 11);
         expect(collapsedSpans[3].end, 16);
         expect(collapsedSpans[3].attributions.length, 0);
@@ -231,10 +236,10 @@ void main() {
       test('multiple non-overlapping attributions', () {
         final collapsedSpans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'b', offset: 3, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'i', offset: 7, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'i', offset: 10, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 3, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: italics, offset: 7, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: italics, offset: 10, markerType: SpanMarkerType.end),
           ],
         ).collapseSpans(contentLength: 17);
 
@@ -242,14 +247,14 @@ void main() {
         expect(collapsedSpans[0].start, 0);
         expect(collapsedSpans[0].end, 3);
         expect(collapsedSpans[0].attributions.length, 1);
-        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[0].attributions.first, bold);
         expect(collapsedSpans[1].start, 4);
         expect(collapsedSpans[1].end, 6);
         expect(collapsedSpans[1].attributions.length, 0);
         expect(collapsedSpans[2].start, 7);
         expect(collapsedSpans[2].end, 10);
         expect(collapsedSpans[2].attributions.length, 1);
-        expect(collapsedSpans[2].attributions.first, 'i');
+        expect(collapsedSpans[2].attributions.first, italics);
         expect(collapsedSpans[3].start, 11);
         expect(collapsedSpans[3].end, 16);
         expect(collapsedSpans[3].attributions.length, 0);
@@ -258,10 +263,10 @@ void main() {
       test('multiple overlapping attributions', () {
         final collapsedSpans = AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'b', offset: 8, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'i', offset: 6, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'i', offset: 16, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 8, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: italics, offset: 6, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: italics, offset: 16, markerType: SpanMarkerType.end),
           ],
         ).collapseSpans(contentLength: 17);
 
@@ -269,15 +274,15 @@ void main() {
         expect(collapsedSpans[0].start, 0);
         expect(collapsedSpans[0].end, 5);
         expect(collapsedSpans[0].attributions.length, 1);
-        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[0].attributions.first, bold);
         expect(collapsedSpans[1].start, 6);
         expect(collapsedSpans[1].end, 8);
         expect(collapsedSpans[1].attributions.length, 2);
-        expect(collapsedSpans[1].attributions, equals({'b', 'i'}));
+        expect(collapsedSpans[1].attributions, equals({bold, italics}));
         expect(collapsedSpans[2].start, 9);
         expect(collapsedSpans[2].end, 16);
         expect(collapsedSpans[2].attributions.length, 1);
-        expect(collapsedSpans[2].attributions.first, 'i');
+        expect(collapsedSpans[2].attributions.first, italics);
       });
     });
   });
@@ -320,8 +325,46 @@ class _ExpectedSpans {
           continue;
         }
 
-        expect(spans.hasAttributionAt(characterIndex, attribution: attributionName), true);
+        Attribution namedAttribution;
+        switch (attributionName) {
+          case 'b':
+            namedAttribution = bold;
+            break;
+          case 'i':
+            namedAttribution = italics;
+            break;
+          case 's':
+            namedAttribution = strikethrough;
+            break;
+          default:
+            throw Exception('Unknown span template character: $attributionName');
+        }
+
+        expect(spans.hasAttributionAt(characterIndex, attribution: namedAttribution), true);
       }
     }
   }
+}
+
+class _LinkAttribution implements Attribution {
+  _LinkAttribution({
+    required this.url,
+  });
+
+  @override
+  String get id => 'link';
+
+  final String url;
+
+  @override
+  bool canMergeWith(Attribution other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is _LinkAttribution && runtimeType == other.runtimeType && url == other.url;
+
+  @override
+  int get hashCode => url.hashCode;
 }

--- a/super_editor/test/src/infrastructure/attributed_text_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_text_test.dart
@@ -3,6 +3,11 @@ import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Attributions used throughout this test suite.
+final bold = NamedAttribution('bold');
+final italics = NamedAttribution('italics');
+final strikethrough = NamedAttribution('strikethrough');
+
 void main() {
   group('Attributed Text', () {
     test('no styles', () {
@@ -20,8 +25,8 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 9, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -37,8 +42,8 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 1, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 1, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -61,8 +66,8 @@ void main() {
             // Notice that the markers are provided in reverse order:
             // end then start. Order shouldn't matter within a single
             // position index. This test ensures that.
-            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 1, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 1, markerType: SpanMarkerType.start),
           ],
         ),
       );
@@ -79,7 +84,7 @@ void main() {
 
     test('add single character style', () {
       final text = AttributedText(text: 'abcdefghij');
-      text.addAttribution('bold', TextRange(start: 1, end: 1));
+      text.addAttribution(bold, TextRange(start: 1, end: 1));
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -96,8 +101,8 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 7, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -116,8 +121,8 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 9, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 9, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -126,8 +131,8 @@ void main() {
         text: 'k',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.end),
           ],
         ),
       ));
@@ -151,8 +156,8 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 9, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -160,12 +165,12 @@ void main() {
       final newText = initialText.insertString(
         textToInsert: 'a',
         startOffset: 0,
-        applyAttributions: {'bold'},
+        applyAttributions: {bold},
       );
 
       expect(newText.text, 'aabcdefghij');
       expect(
-        newText.hasAttributionsWithin(attributions: {'bold'}, range: TextRange(start: 0, end: 10)),
+        newText.hasAttributionsWithin(attributions: {bold}, range: TextRange(start: 0, end: 10)),
         true,
       );
     });
@@ -175,10 +180,10 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 4, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'italics', offset: 5, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'italics', offset: 9, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 4, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: italics, offset: 5, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: italics, offset: 9, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -199,10 +204,10 @@ void main() {
         text: 'abcdefghij',
         spans: AttributedSpans(
           attributions: [
-            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'italics', offset: 4, markerType: SpanMarkerType.start),
-            SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.end),
-            SpanMarker(attribution: 'italics', offset: 7, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: bold, offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: italics, offset: 4, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: bold, offset: 5, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: italics, offset: 7, markerType: SpanMarkerType.end),
           ],
         ),
       );
@@ -239,7 +244,7 @@ void main() {
         listenerCalled = true;
       });
 
-      text.addAttribution('bold', TextRange(start: 1, end: 1));
+      text.addAttribution(bold, TextRange(start: 1, end: 1));
 
       expect(listenerCalled, isTrue);
     });
@@ -247,29 +252,21 @@ void main() {
 }
 
 /// Creates styles based on the given `attributions`.
-TextStyle _styleBuilder(Set<dynamic> attributions) {
+TextStyle _styleBuilder(Set<Attribution> attributions) {
   TextStyle newStyle = const TextStyle();
   for (final attribution in attributions) {
-    if (attribution is! String) {
-      continue;
-    }
-
-    switch (attribution) {
-      case 'bold':
-        newStyle = newStyle.copyWith(
-          fontWeight: FontWeight.bold,
-        );
-        break;
-      case 'italics':
-        newStyle = newStyle.copyWith(
-          fontStyle: FontStyle.italic,
-        );
-        break;
-      case 'strikethrough':
-        newStyle = newStyle.copyWith(
-          decoration: TextDecoration.lineThrough,
-        );
-        break;
+    if (attribution == bold) {
+      newStyle = newStyle.copyWith(
+        fontWeight: FontWeight.bold,
+      );
+    } else if (attribution == italics) {
+      newStyle = newStyle.copyWith(
+        fontStyle: FontStyle.italic,
+      );
+    } else if (attribution == strikethrough) {
+      newStyle = newStyle.copyWith(
+        decoration: TextDecoration.lineThrough,
+      );
     }
   }
   return newStyle;


### PR DESCRIPTION
This PR implements link attributions for the example editor.

To better facilitate link-style behavior, I changed the concept of text attributions from `dynamic` to a dedicated base class called `Attribution`. This required updating lots of codes and tests to use the new type.

I also added some new behavior to `AttributedSpans` based on the type of queries that we need to do in the example app when we select no link vs one link vs 2+ links.