### PR TITLE
Bugfix: jumping to start/end of lines was off by a line on web

### DIFF
--- a/super_editor/lib/src/infrastructure/selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/selectable_text.dart
@@ -217,7 +217,9 @@ class SelectableTextState extends State<SelectableText> implements TextLayout {
     }
 
     final renderParagraph = _renderParagraph!;
-    final positionOffset = renderParagraph.getOffsetForCaret(currentPosition, Rect.zero);
+    // Note: add half the line height to the current offset to help deal with
+    //       line heights that aren't accurate.
+    final positionOffset = renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, _lineHeight / 2);
     final endOfLineOffset = Offset(0, positionOffset.dy);
     return renderParagraph.getPositionForOffset(endOfLineOffset);
   }
@@ -229,7 +231,9 @@ class SelectableTextState extends State<SelectableText> implements TextLayout {
     }
 
     final renderParagraph = _renderParagraph!;
-    final positionOffset = renderParagraph.getOffsetForCaret(currentPosition, Rect.zero);
+    // Note: add half the line height to the current offset to help deal with
+    //       line heights that aren't accurate.
+    final positionOffset = renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, _lineHeight / 2);
     final endOfLineOffset = Offset(renderParagraph.size.width, positionOffset.dy);
     return renderParagraph.getPositionForOffset(endOfLineOffset);
   }


### PR DESCRIPTION
Bugfix: jumping to start/end of lines was off by a line on web due to inaccurate position calculations in the text system. Added half a line height to the calculations to sit definitively within the current line. (#170)