### PR TITLE
Use control key for shortcuts on Windows and Linux. (#172)

### DIFF
--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -3,11 +3,12 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:super_editor/src/default_editor/attributions.dart';
-import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/keyboard.dart';
+import 'package:super_editor/super_editor.dart';
 
 import 'document_interaction.dart';
 import 'multi_node_editing.dart';
@@ -35,7 +36,7 @@ ExecutionInstruction collapseSelectionWhenDirectionalKeyIsPressed({
   if (keyEvent.isShiftPressed) {
     return ExecutionInstruction.continueExecution;
   }
-  if (keyEvent.isMetaPressed) {
+  if (keyEvent.isMetaPressed || keyEvent.isControlPressed) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null || editContext.composer.selection!.isCollapsed) {
@@ -60,7 +61,7 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isMetaPressed || keyEvent.character?.toLowerCase() != 'v') {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'v') {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -101,7 +102,7 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isMetaPressed || keyEvent.character?.toLowerCase() != 'a') {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'a') {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -260,7 +261,7 @@ ExecutionInstruction copyWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isMetaPressed || keyEvent.character?.toLowerCase() != 'c') {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'c') {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -346,7 +347,7 @@ ExecutionInstruction applyBoldWhenCmdBIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (keyEvent.character?.toLowerCase() != 'b' || !keyEvent.isMetaPressed) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'b') {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -375,7 +376,7 @@ ExecutionInstruction applyItalicsWhenCmdIIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (keyEvent.character?.toLowerCase() != 'i' || !keyEvent.isMetaPressed) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'i') {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -636,7 +637,7 @@ ExecutionInstruction moveUpDownLeftAndRightWithArrowKeys({
     final movementModifiers = <String, dynamic>{
       'movement_unit': 'character',
     };
-    if (keyEvent.isMetaPressed) {
+    if (keyEvent.isPrimaryShortcutKeyPressed) {
       movementModifiers['movement_unit'] = 'line';
     } else if (keyEvent.isAltPressed) {
       movementModifiers['movement_unit'] = 'word';
@@ -654,7 +655,7 @@ ExecutionInstruction moveUpDownLeftAndRightWithArrowKeys({
     final movementModifiers = <String, dynamic>{
       'movement_unit': 'character',
     };
-    if (keyEvent.isMetaPressed) {
+    if (keyEvent.isPrimaryShortcutKeyPressed) {
       movementModifiers['movement_unit'] = 'line';
     } else if (keyEvent.isAltPressed) {
       movementModifiers['movement_unit'] = 'word';

--- a/super_editor/lib/src/infrastructure/_platform_detector_io.dart
+++ b/super_editor/lib/src/infrastructure/_platform_detector_io.dart
@@ -1,0 +1,3 @@
+import 'dart:io';
+
+final isMac = Platform.isMacOS;

--- a/super_editor/lib/src/infrastructure/_platform_detector_unsupported.dart
+++ b/super_editor/lib/src/infrastructure/_platform_detector_unsupported.dart
@@ -1,0 +1,1 @@
+const isMac = false;

--- a/super_editor/lib/src/infrastructure/_platform_detector_web.dart
+++ b/super_editor/lib/src/infrastructure/_platform_detector_web.dart
@@ -1,0 +1,4 @@
+import 'dart:html';
+
+final _platform = window.navigator.platform ?? '';
+final isMac = _platform.startsWith('Mac');

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -1,3 +1,12 @@
+import 'package:flutter/services.dart';
+
+import 'platform_detector.dart';
+
+extension PrimaryShortcutKey on RawKeyEvent {
+  bool get isPrimaryShortcutKeyPressed =>
+      (Platform.instance.isMac && isMetaPressed) || (!Platform.instance.isMac && isControlPressed);
+}
+
 /// On web, Flutter reports control character labels as
 /// the [RawKeyEvent.character], which we don't want.
 /// Until Flutter fixes the problem, this blacklist

--- a/super_editor/lib/src/infrastructure/platform_detector.dart
+++ b/super_editor/lib/src/infrastructure/platform_detector.dart
@@ -1,0 +1,19 @@
+import '_platform_detector_unsupported.dart'
+    if (dart.library.html) '_platform_detector_web.dart'
+    if (dart.library.io) '_platform_detector_io.dart' as impl;
+
+/// Interrogates the current platform this app is running on
+/// and provides information that is relevant to Super Editor.
+class Platform {
+  static var _instance = Platform();
+  static Platform get instance => _instance;
+
+  /// Sets the [Platform] singleton so that tests can pretend
+  /// to run on platforms other than the host machine that
+  /// executes the tests.
+  static void setTestInstance(Platform? testPlatform) {
+    _instance = testPlatform ?? Platform();
+  }
+
+  bool get isMac => impl.isMac;
+}

--- a/super_editor/lib/src/infrastructure/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:super_editor/src/default_editor/editor.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/src/infrastructure/selectable_text.dart';
 import 'package:super_editor/src/infrastructure/text_layout.dart';
 
@@ -1191,7 +1192,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
     SelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
-    if (!keyEvent.isMetaPressed) {
+    if (!keyEvent.isPrimaryShortcutKeyPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
     if (keyEvent.logicalKey != LogicalKeyboardKey.keyC) {
@@ -1208,7 +1209,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
     SelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
-    if (!keyEvent.isMetaPressed) {
+    if (!keyEvent.isPrimaryShortcutKeyPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
     if (keyEvent.logicalKey != LogicalKeyboardKey.keyV) {
@@ -1229,7 +1230,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
     SelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
-    if (!keyEvent.isMetaPressed) {
+    if (!keyEvent.isPrimaryShortcutKeyPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
     if (keyEvent.logicalKey != LogicalKeyboardKey.keyA) {
@@ -1268,7 +1269,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
       final movementModifiers = <String, dynamic>{
         'movement_unit': 'character',
       };
-      if (keyEvent.isMetaPressed) {
+      if (keyEvent.isPrimaryShortcutKeyPressed) {
         movementModifiers['movement_unit'] = 'line';
       } else if (keyEvent.isAltPressed) {
         movementModifiers['movement_unit'] = 'word';
@@ -1286,7 +1287,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
       final movementModifiers = <String, dynamic>{
         'movement_unit': 'character',
       };
-      if (keyEvent.isMetaPressed) {
+      if (keyEvent.isPrimaryShortcutKeyPressed) {
         movementModifiers['movement_unit'] = 'line';
       } else if (keyEvent.isAltPressed) {
         movementModifiers['movement_unit'] = 'word';

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -8,9 +8,11 @@ import 'package:super_editor/src/default_editor/document_keyboard_actions.dart';
 import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
+import 'package:super_editor/src/infrastructure/platform_detector.dart';
 
 import '../_document_test_tools.dart';
 import '../_text_entry_test_tools.dart';
+import '../infrastructure/_platform_test_tools.dart';
 
 void main() {
   group(
@@ -22,6 +24,8 @@ void main() {
           test(
             'it does nothing when meta key is pressed but A-key is not pressed',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: _editContext,
@@ -38,12 +42,16 @@ void main() {
 
               // The handler should pass on handling the key.
               expect(result, ExecutionInstruction.continueExecution);
+
+              Platform.setTestInstance(null);
             },
           );
 
           test(
             'it does nothing when A-key is pressed but meta key is not pressed',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: _editContext,
@@ -60,12 +68,16 @@ void main() {
 
               // The handler should pass on handling the key.
               expect(result, ExecutionInstruction.continueExecution);
+
+              Platform.setTestInstance(null);
             },
           );
 
           test(
             'it does nothing when CMD+A is pressed but the document is empty',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: _editContext,
@@ -81,12 +93,16 @@ void main() {
 
               // The handler should pass on handling the key.
               expect(result, ExecutionInstruction.continueExecution);
+
+              Platform.setTestInstance(null);
             },
           );
 
           test(
             'it selects all when CMD+A is pressed with a single-node document',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(
                 document: MutableDocument(
                   nodes: [
@@ -125,11 +141,15 @@ void main() {
                   nodePosition: TextPosition(offset: 'This is some text'.length),
                 ),
               );
+
+              Platform.setTestInstance(null);
             },
           );
           test(
             'it selects all when CMD+A is pressed with a two-node document',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(
                 document: MutableDocument(
                   nodes: [
@@ -172,11 +192,15 @@ void main() {
                   nodePosition: TextPosition(offset: 'This is some text'.length),
                 ),
               );
+
+              Platform.setTestInstance(null);
             },
           );
           test(
             'it selects all when CMD+A is pressed with a three-node document',
             () {
+              Platform.setTestInstance(MacPlatform());
+
               final _editContext = createEditContext(
                 document: MutableDocument(
                   nodes: [
@@ -223,6 +247,8 @@ void main() {
                   nodePosition: BinaryPosition.included(),
                 ),
               );
+
+              Platform.setTestInstance(null);
             },
           );
         },

--- a/super_editor/test/src/infrastructure/_platform_test_tools.dart
+++ b/super_editor/test/src/infrastructure/_platform_test_tools.dart
@@ -1,0 +1,11 @@
+import 'package:super_editor/src/infrastructure/platform_detector.dart';
+
+class MacPlatform implements Platform {
+  @override
+  bool get isMac => true;
+}
+
+class WindowsPlatform implements Platform {
+  @override
+  bool get isMac => false;
+}


### PR DESCRIPTION
Use control key for shortcuts on Windows and Linux. (#172)