### PR TITLE
Cmd + backspace deletes the entire line before the caret. (#176)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield.dart
@@ -10,7 +10,6 @@ import 'package:flutter/services.dart';
 import 'package:super_editor/src/default_editor/editor.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
-import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/src/infrastructure/selectable_text.dart';
 import 'package:super_editor/src/infrastructure/text_layout.dart';
 
@@ -1181,6 +1180,7 @@ const defaultTextFieldKeyboardHandlers = <TextFieldKeyboardHandler>[
   DefaultSuperTextFieldKeyboardHandlers.pasteTextWhenCmdVIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.selectAllTextFieldWhenCmdAIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.moveUpDownLeftAndRightWithArrowKeys,
+  DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.deleteTextWhenBackspaceOrDeleteIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.insertNewlineWhenEnterIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.insertCharacterWhenKeyIsPressed,
@@ -1347,6 +1347,30 @@ class DefaultSuperTextFieldKeyboardHandlers {
     }
 
     controller.insertCharacter(keyEvent.character!);
+
+    return TextFieldKeyboardHandlerResult.handled;
+  }
+
+  static TextFieldKeyboardHandlerResult deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed({
+    required AttributedTextEditingController controller,
+    required SelectableTextState selectableTextState,
+    required RawKeyEvent keyEvent,
+  }) {
+    if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
+      return TextFieldKeyboardHandlerResult.notHandled;
+    }
+    if (!controller.selection.isCollapsed) {
+      return TextFieldKeyboardHandlerResult.notHandled;
+    }
+    if (controller.selection.extentOffset < 0) {
+      return TextFieldKeyboardHandlerResult.notHandled;
+    }
+    if (selectableTextState.getPositionAtStartOfLine(controller.selection.extent).offset ==
+        controller.selection.extentOffset) {
+      return TextFieldKeyboardHandlerResult.notHandled;
+    }
+
+    controller.deleteTextOnLineBeforeCaret(selectableTextState: selectableTextState);
 
     return TextFieldKeyboardHandlerResult.handled;
   }
@@ -1640,6 +1664,22 @@ extension DefaultSuperTextFieldActions on AttributedTextEditingController {
       endOffset: deleteEndIndex,
     );
     selection = TextSelection.collapsed(offset: deleteStartIndex);
+  }
+
+  void deleteTextOnLineBeforeCaret({
+    required SelectableTextState selectableTextState,
+  }) {
+    assert(selection.isCollapsed);
+
+    final startOfLinePosition = selectableTextState.getPositionAtStartOfLine(selection.extent);
+    selection = TextSelection(
+      baseOffset: selection.extentOffset,
+      extentOffset: startOfLinePosition.offset,
+    );
+
+    if (!selection.isCollapsed) {
+      deleteSelectedText();
+    }
   }
 
   void deleteSelectedText() {

--- a/super_editor/test/src/infrastructure/super_textfield_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield_test.dart
@@ -1648,6 +1648,460 @@ void main() {
         });
       });
 
+      group('delete line before caret', () {
+        group('Mac', () {
+          testWidgets('cmd + backspace deletes partial line before caret (flowed multiline)', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 28), // midway through 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 18);
+            expect(controller.text.text, 'this text is long be multiline in the available space');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('cmd + backspace deletes entire line (flowed multiline)', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 31, affinity: TextAffinity.upstream), // end of 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 18);
+            expect(controller.text.text, 'this text is long multiline in the available space');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('cmd + backspace deletes partial line before caret (explicit newlines)', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is line 1\nThis is line 2\nThis is line 3'),
+              selection: TextSelection.collapsed(offset: 23), // midway through 2nd line
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 15);
+            expect(controller.text.text, 'This is line 1\nline 2\nThis is line 3');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('cmd + backspace deletes entire line (explicit newlines)', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is line 1\nThis is line 2\nThis is line 3'),
+              selection: TextSelection.collapsed(offset: 29, affinity: TextAffinity.upstream), // end of 2nd line
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 15);
+            expect(controller.text.text, 'This is line 1\n\nThis is line 3');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection is expanded', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is some text that doesn\'t matter for this test.'),
+              selection: TextSelection(
+                baseOffset: 0,
+                extentOffset: 10,
+              ),
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection extent is < 0', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is some text that doesn\'t matter for this test.'),
+              selection: TextSelection.collapsed(offset: -1),
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection is at start of line', (tester) async {
+            Platform.setTestInstance(MacPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 18), // start of 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isMetaPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+        });
+
+        group('Windows + Linux', () {
+          testWidgets('control + backspace deletes partial line before caret (flowed multiline)', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 28), // midway through 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 18);
+            expect(controller.text.text, 'this text is long be multiline in the available space');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('control + backspace deletes entire line (flowed multiline)', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 31, affinity: TextAffinity.upstream), // end of 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 18);
+            expect(controller.text.text, 'this text is long multiline in the available space');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('control + backspace deletes partial line before caret (explicit newlines)', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is line 1\nThis is line 2\nThis is line 3'),
+              selection: TextSelection.collapsed(offset: 23), // midway through 2nd line
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 15);
+            expect(controller.text.text, 'This is line 1\nline 2\nThis is line 3');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('control + backspace deletes entire line (explicit newlines)', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is line 1\nThis is line 2\nThis is line 3'),
+              selection: TextSelection.collapsed(offset: 29, affinity: TextAffinity.upstream), // end of 2nd line
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.handled);
+            expect(controller.selection.isCollapsed, true);
+            expect(controller.selection.extentOffset, 15);
+            expect(controller.text.text, 'This is line 1\n\nThis is line 3');
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection is expanded', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is some text that doesn\'t matter for this test.'),
+              selection: TextSelection(
+                baseOffset: 0,
+                extentOffset: 10,
+              ),
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection extent is < 0', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: 'This is some text that doesn\'t matter for this test.'),
+              selection: TextSelection.collapsed(offset: -1),
+            );
+
+            final selectableTextState = await _pumpAndReturnSelectableText(tester, controller.text.text);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+
+          testWidgets('it does nothing when selection is at start of line', (tester) async {
+            Platform.setTestInstance(WindowsPlatform());
+
+            // Note: this test depends on a multi-line text layout, therefore
+            // the layout width and the text content must be precise.
+            final controller = AttributedTextEditingController(
+              text: AttributedText(text: _multilineLayoutText),
+              selection: TextSelection.collapsed(offset: 18), // start of 2nd line
+            );
+
+            final selectableTextState = await _pumpMultilineLayout(tester);
+
+            final result =
+                DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed(
+              controller: controller,
+              selectableTextState: selectableTextState,
+              keyEvent: FakeRawKeyEvent(
+                data: FakeRawKeyEventData(
+                  logicalKey: LogicalKeyboardKey.backspace,
+                  physicalKey: PhysicalKeyboardKey.backspace,
+                  isControlPressed: true,
+                ),
+                character: null,
+              ),
+            );
+
+            expect(result, TextFieldKeyboardHandlerResult.notHandled);
+
+            Platform.setTestInstance(null);
+          });
+        });
+      });
+
       group('backspace pressed', () {
         test('it does nothing when text is empty', () {
           final controller = AttributedTextEditingController(
@@ -2014,10 +2468,10 @@ final _multilineLayoutText = 'this text is long enough to be multiline in the av
 
 // Based on experiments, the text is laid out as follows:
 //
-//  (0)this text is long (17)
-// (18)enough to be (31)
-// (32)multiline in the (49)
-// (50)available space(65)
+//  (0)this text is long (18 - upstream)
+// (18)enough to be (31 - upstream)
+// (31)multiline in the (48 - upstream)
+// (48)available space(63)
 Future<SelectableTextState> _pumpMultilineLayout(
   WidgetTester tester,
 ) async {


### PR DESCRIPTION
Cmd + backspace deletes the entire line before the caret. (#176)