### PR TITLE
Ignore characters on web that are reported as 'Dead'. (#119)

### DIFF
--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -13,6 +13,7 @@ extension PrimaryShortcutKey on RawKeyEvent {
 /// identifies the keys that we should ignore for the
 /// purpose of text/character entry.
 const webBugBlacklistCharacters = {
+  'Dead',
   'Shift',
   'Alt',
   'Escape',


### PR DESCRIPTION
Ignore characters on web that are reported as 'Dead'. (#119)

On web, some keys report a `character` value of "Dead". This is a Flutter bug/incomplete feature issue. I don't think there is much we can do, so I've opted to ignore any character with that value.