### PR TITLE
197 make document interaction reusable

### DIFF
--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -61,6 +61,13 @@ abstract class Document with ChangeNotifier {
   /// Returns all `DocumentNode`s from `position1` to `position2`, including
   /// the nodes at `position1` and `position2`.
   List<DocumentNode> getNodesInside(DocumentPosition position1, DocumentPosition position2);
+
+  /// Returns [true] if the content in the [other] document is equivalent to
+  /// the content in this document, ignoring any details that are unrelated
+  /// to content, such as individual node IDs.
+  ///
+  /// To compare [Document] equality, use the standard [==] operator.
+  bool hasEquivalentContent(Document other);
 }
 
 /// A span within a `Document` that begins at `start` and
@@ -159,4 +166,10 @@ abstract class DocumentNode implements ChangeNotifier {
   /// within `selection`, or null if the given selection does
   /// not make sense as plain-text.
   String? copyContent(dynamic selection);
+
+  /// Returns true of the [other] node is the same type as this
+  /// node, and contains the same content.
+  ///
+  /// Content equivalency ignores the node ID.
+  bool hasEquivalentContent(DocumentNode other);
 }

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -54,50 +54,63 @@ class DocumentComposer with ChangeNotifier {
 /// like a "bold mode" or "italics mode" when there is no
 /// bold or italics text around the caret.
 class ComposerPreferences with ChangeNotifier {
-  final Set<Attribution> _currentStyles = {};
+  final Set<Attribution> _currentAttributions = {};
 
   /// Returns the styles that should be applied to the next
   /// character that is entered in a `Document`.
-  Set<Attribution> get currentStyles => _currentStyles;
+  Set<Attribution> get currentAttributions => _currentAttributions;
 
-  /// Adds `name` to `currentStyles`.
-  void addStyle(dynamic name) {
-    _currentStyles.add(name);
+  /// Adds [attribution] to [currentAttributions].
+  void addStyle(Attribution attribution) {
+    _currentAttributions.add(attribution);
     notifyListeners();
   }
 
-  /// Adds all [attributions] to [currentStyles].
+  /// Adds all [attributions] to [currentAttributions].
   void addStyles(Set<Attribution> attributions) {
-    _currentStyles.addAll(attributions);
+    _currentAttributions.addAll(attributions);
     notifyListeners();
   }
 
-  /// Removes [attributions] from [currentStyles].
+  /// Removes [attributions] from [currentAttributions].
   void removeStyle(Attribution attributions) {
-    _currentStyles.remove(attributions);
+    _currentAttributions.remove(attributions);
     notifyListeners();
   }
 
-  /// Removes all `names` from `currentStyles`.
-  void removeStyles(Set<dynamic> names) {
-    _currentStyles.removeAll(names);
+  /// Removes all [attributions] from [currentAttributions].
+  void removeStyles(Set<Attribution> attributions) {
+    _currentAttributions.removeAll(attributions);
     notifyListeners();
   }
 
-  /// Adds or removes `name` to/from `currentStyles` depending
-  /// on whether `name` is already in `currentStyles`.
-  void toggleStyle(dynamic name) {
-    if (_currentStyles.contains(name)) {
-      _currentStyles.remove(name);
+  /// Adds or removes [attribution] to/from [currentAttributions] depending
+  /// on whether [attribution] is already in [currentAttributions].
+  void toggleStyle(Attribution attribution) {
+    if (_currentAttributions.contains(attribution)) {
+      _currentAttributions.remove(attribution);
     } else {
-      _currentStyles.add(name);
+      _currentAttributions.add(attribution);
+    }
+    notifyListeners();
+  }
+
+  /// Adds or removes all [attributions] to/from [currentAttributions] depending
+  /// on whether each attribution is already in [currentAttributions].
+  void toggleStyles(Set<Attribution> attributions) {
+    for (final attribution in attributions) {
+      if (_currentAttributions.contains(attribution)) {
+        _currentAttributions.remove(attribution);
+      } else {
+        _currentAttributions.add(attribution);
+      }
     }
     notifyListeners();
   }
 
   /// Removes all styles from `currentStyles`.
   void clearStyles() {
-    _currentStyles.clear();
+    _currentAttributions.clear();
     notifyListeners();
   }
 }

--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
 import 'document.dart';
@@ -234,4 +234,33 @@ class MutableDocument with ChangeNotifier implements Document {
   void _forwardNodeChange() {
     notifyListeners();
   }
+
+  /// Returns [true] if the content of the [other] [Document] is equivalent
+  /// to the content of this [Document].
+  ///
+  /// Content equivalency compares types of content nodes, and the content
+  /// within them, like the text of a paragraph, but ignores node IDs and
+  /// ignores the runtime type of the [Document], itself.
+  @override
+  bool hasEquivalentContent(Document other) {
+    if (_nodes.length != other.nodes.length) {
+      return false;
+    }
+
+    for (int i = 0; i < _nodes.length; ++i) {
+      if (!_nodes[i].hasEquivalentContent(other.nodes[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MutableDocument && runtimeType == other.runtimeType && DeepCollectionEquality().equals(_nodes, nodes);
+
+  @override
+  int get hashCode => _nodes.hashCode;
 }

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -4,6 +4,15 @@ import 'package:flutter/rendering.dart';
 import 'document_selection.dart';
 import 'document.dart';
 
+/// Obtains a [DocumentLayout].
+///
+/// This typedef is provided because a [DocumentLayout] typically
+/// comes from a [State] object, which can change over time, and must
+/// be obtained via [GlobalKey]. Therefore, a resolver function like
+/// this is passed around, instead of a direct reference to a
+/// [DocumentLayout].
+typedef DocumentLayoutResolver = DocumentLayout Function();
+
 /// Abstract representation of a document layout.
 ///
 /// Regardless of how a document is displayed, a `DocumentLayout` needs
@@ -136,7 +145,7 @@ mixin DocumentComponent<T extends StatefulWidget> on State<T> {
   /// Returns `null` if there is nowhere to move left within this
   /// component, such as when the `currentPosition` is the first
   /// character within a paragraph.
-  dynamic? movePositionLeft(dynamic currentPosition, [Map<String, dynamic> movementModifiers]);
+  dynamic? movePositionLeft(dynamic currentPosition, [Set<MovementModifier> movementModifiers]);
 
   /// Returns a new position within this component's node that
   /// corresponds to the `currentPosition` moved right one unit,
@@ -152,7 +161,7 @@ mixin DocumentComponent<T extends StatefulWidget> on State<T> {
   /// Returns null if there is nowhere to move right within this
   /// component, such as when the `currentPosition` refers to the
   /// last character in a paragraph.
-  dynamic? movePositionRight(dynamic currentPosition, [Map<String, dynamic> movementModifiers]);
+  dynamic? movePositionRight(dynamic currentPosition, [Set<MovementModifier> movementModifiers]);
 
   /// Returns a new position within this component's node that
   /// corresponds to the `currentPosition` moved up one unit,
@@ -224,6 +233,32 @@ mixin DocumentComponent<T extends StatefulWidget> on State<T> {
   /// Returns the desired `MouseCursor` at the given (x,y) `localOffset`, or
   /// `null` if this component has no preference for the cursor style.
   MouseCursor? getDesiredCursorAtOffset(Offset localOffset);
+}
+
+/// Preferences for how the document selection should change, e.g.,
+/// move word-by-word instead of character-by-character.
+///
+/// Default values are provided, such as [MovementModifier.word]. These
+/// defaults are understood by the default node implementations. If you
+/// introduce custom nodes/content, you can create your own
+/// [MovementModifier]s by instantiating them with [id]s of your choice,
+/// so long as those [id]s don't conflict with existing [id]s. You're
+/// responsible for implementing whatever behavior those custom
+/// [MovementModifier]s represent.
+class MovementModifier {
+  static const word = MovementModifier('word');
+  static const line = MovementModifier('line');
+
+  const MovementModifier(this.id);
+
+  final String id;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is MovementModifier && runtimeType == other.runtimeType && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
 }
 
 /// Builds a widget that renders the desired UI for one or

--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -1,3 +1,5 @@
+import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+
 import 'document_composer.dart';
 import 'document_editor.dart';
 import 'document_layout.dart';
@@ -8,6 +10,7 @@ class EditContext {
     required this.editor,
     required DocumentLayout Function() getDocumentLayout,
     required this.composer,
+    required this.commonOps,
   }) : _getDocumentLayout = getDocumentLayout;
 
   final DocumentEditor editor;
@@ -16,4 +19,6 @@ class EditContext {
   DocumentLayout get documentLayout => _getDocumentLayout();
 
   final DocumentComposer composer;
+
+  final CommonEditorOperations commonOps;
 }

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -64,39 +64,6 @@ class BlockquoteComponent extends StatelessWidget {
   }
 }
 
-ExecutionInstruction convertBlockquoteToParagraphWhenBackspaceIsPressed({
-  required EditContext editContext,
-  required RawKeyEvent keyEvent,
-}) {
-  if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ParagraphNode) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (node.metadata['blockType'] != blockquoteAttribution) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final textPosition = editContext.composer.selection!.extent.nodePosition;
-  if (textPosition is! TextPosition || textPosition.offset > 0) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final didConvertToParagraph = editContext.commonOps.convertToParagraph();
-  return didConvertToParagraph ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
-}
-
 class ConvertBlockquoteToParagraphCommand implements EditorCommand {
   ConvertBlockquoteToParagraphCommand({
     required this.nodeId,

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -193,30 +193,3 @@ class BinarySelection {
   @override
   int get hashCode => position.hashCode;
 }
-
-/// Deletes the [DocumentNode] behind a selected [BoxComponent], if the
-/// current [DocumentSelection] is collapsed on a [BinarySelection].
-ExecutionInstruction deleteBoxWhenBackspaceOrDeleteIsPressed({
-  required EditContext editContext,
-  required RawKeyEvent keyEvent,
-}) {
-  if (keyEvent.logicalKey != LogicalKeyboardKey.backspace && keyEvent.logicalKey != LogicalKeyboardKey.delete) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (editContext.composer.selection!.extent.nodePosition is! BinaryPosition) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!(editContext.composer.selection!.extent.nodePosition as BinaryPosition).isIncluded) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final didDeleteSelection = editContext.commonOps.deleteSelection();
-
-  return didDeleteSelection ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
-}

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1,0 +1,1922 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:http/http.dart' as http;
+import 'package:linkify/linkify.dart';
+import 'package:super_editor/src/core/document_editor.dart';
+import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/super_editor.dart';
+
+final _log = Logger(scope: 'common_editor_operations.dart');
+
+/// Performs common, high-level editing and composition tasks
+/// with a simplified API.
+///
+/// [CommonEditorOperations] is intended to provide a simple and
+/// easy to use API for common tasks; it is not intended to operate
+/// as a fundamental document manipulation tool. [CommonEditorOperations]
+/// is built on top of [DocumentEditor], [DocumentLayout], and
+/// [DocumentComposer]. Use those core artifacts to implement any
+/// operations that are not supported by [CommonEditorOperations].
+///
+/// For example, compare the following [CommonEditorOperations] calls
+/// to their respective implementation:
+/// TODO: show 2-3 examples that compare the [CommonEditorOperations]
+///       call with the comparable implementation to make it clear
+///       that anything this class does, the developer can do directly.
+///
+/// If you implement operations for your editor that are not provided
+/// by [CommonEditorOperations], consider implementing those operations
+/// as extension methods on top of [CommonEditorOperations] so that the
+/// rest of your editor can use those behaviors as if they were
+/// implemented within [CommonEditorOperations].
+class CommonEditorOperations {
+  CommonEditorOperations({
+    required DocumentEditor editor,
+    required DocumentComposer composer,
+    required DocumentLayoutResolver documentLayoutResolver,
+  })  : editor = editor,
+        composer = composer,
+        documentLayoutResolver = documentLayoutResolver;
+
+  // Marked as protected for extension methods and subclasses
+  @protected
+  final DocumentEditor editor;
+  // Marked as protected for extension methods and subclasses
+  @protected
+  final DocumentComposer composer;
+  // Marked as protected for extension methods and subclasses
+  @protected
+  final DocumentLayoutResolver documentLayoutResolver;
+
+  /// Clears the [DocumentComposer]'s current selection and sets
+  /// the selection to the given collapsed [documentPosition].
+  ///
+  /// Returns [true] if the selection was set to the given [documentPosition],
+  /// or [false] if the given [documentPosition] could not be
+  /// resolved to a location within the [Document].
+  bool insertCaretAtPosition(DocumentPosition documentPosition) {
+    if (editor.document.getNodeById(documentPosition.nodeId) == null) {
+      return false;
+    }
+
+    composer.selection = DocumentSelection.collapsed(position: documentPosition);
+    return true;
+  }
+
+  /// Locates the [DocumentPosition] at the given [documentOffset] and
+  /// sets the [DocumentComposer]'s selection to that collapsed position.
+  ///
+  /// If [findNearestPosition] is [true] (the default), then the [DocumentPosition]
+  /// nearest the given [documentOffset] is used. If [findNearestPosition] is
+  /// [false] then the selection is only changed if the given [documentOffset]
+  /// sits directly on top of a valid [DocumentPosition], e.g., within the
+  /// bounding box of a line of text, or within the bounds of an image.
+  ///
+  /// Returns [true] if the selection is set based on the given [documentOffset],
+  /// or [false] if no relevant [DocumentPosition could be located.
+  bool insertCaretAtOffset(
+    Offset documentOffset, {
+    findNearestPosition = true,
+  }) {
+    DocumentPosition? position;
+    if (findNearestPosition) {
+      position = documentLayoutResolver().getDocumentPositionNearestToOffset(documentOffset);
+    } else {
+      position = documentLayoutResolver().getDocumentPositionAtOffset(documentOffset);
+    }
+
+    if (position != null) {
+      composer.selection = DocumentSelection.collapsed(position: position);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// Sets the [DocumentComposer]'s selection to a [DocumentSelection]
+  /// that spans from [baseDocumentPosition] to [extentDocumentPosition]
+  /// with the selection direction going from the base position to the
+  /// extent position.
+  ///
+  /// Returns [true] if the selection is successfully changed. Returns
+  /// [false] if either [DocumentPosition] could not be mapped to locations
+  /// within the [Document], and therefore the selection could not be set.
+  bool selectRegion({
+    required DocumentPosition baseDocumentPosition,
+    required DocumentPosition extentDocumentPosition,
+  }) {
+    if (editor.document.getNodeById(baseDocumentPosition.nodeId) == null) {
+      return false;
+    }
+    if (editor.document.getNodeById(extentDocumentPosition.nodeId) == null) {
+      return false;
+    }
+
+    composer.selection = DocumentSelection(
+      base: baseDocumentPosition,
+      extent: extentDocumentPosition,
+    );
+
+    return true;
+  }
+
+  /// Given a collapsed selection in a [TextNode], expands the
+  /// [DocumentComposer]'s selection to include the entire word in
+  /// which the current selection sits.
+  ///
+  /// Returns [true] if a word was selected. Returns [false] if no
+  /// selection could be computed, e.g., the selection was not collapsed,
+  /// the selection was not in a [TextNode].
+  bool selectSurroundingWord() {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final selectedNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (selectedNode is! TextNode) {
+      return false;
+    }
+
+    final docSelection = composer.selection!;
+    final currentSelection = TextSelection(
+      baseOffset: (docSelection.base.nodePosition as TextPosition).offset,
+      extentOffset: (docSelection.extent.nodePosition as TextPosition).offset,
+    );
+    final selectedText = currentSelection.textInside(selectedNode.text.text);
+
+    if (selectedText.contains(' ')) {
+      // The selection already spans multiple paragraphs. Nothing to do.
+      return false;
+    }
+
+    final wordSelection = expandPositionToWord(
+      text: selectedNode.text.text,
+      textPosition: TextPosition(offset: (docSelection.extent.nodePosition as TextPosition).offset),
+    );
+
+    composer.selection = DocumentSelection(
+      base: DocumentPosition(
+        nodeId: selectedNode.id,
+        nodePosition: wordSelection.base,
+      ),
+      extent: DocumentPosition(
+        nodeId: selectedNode.id,
+        nodePosition: wordSelection.extent,
+      ),
+    );
+
+    return true;
+  }
+
+  /// Given a selection in a [TextNode], expands the [DocumentComposer]'s
+  /// selection to include the entire paragraph in which the current
+  /// selection sits.
+  ///
+  /// Returns [true] if a paragraph was selected. Returns [false] if no
+  /// selection could be computed, e.g., the existing selection spanned
+  /// more than one paragraph, the selection spanned multiple nodes,
+  /// the selection was not in a [TextNode].
+  bool selectSurroundingParagraph() {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final selectedNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (selectedNode is! TextNode) {
+      return false;
+    }
+
+    final docSelection = composer.selection!;
+    final currentSelection = TextSelection(
+      baseOffset: (docSelection.base.nodePosition as TextPosition).offset,
+      extentOffset: (docSelection.extent.nodePosition as TextPosition).offset,
+    );
+    final selectedText = currentSelection.textInside(selectedNode.text.text);
+
+    if (selectedText.contains('\n')) {
+      // The selection already spans multiple paragraphs. Nothing to do.
+      return false;
+    }
+
+    final paragraphSelection = expandPositionToParagraph(
+      text: selectedNode.text.text,
+      textPosition: TextPosition(offset: (docSelection.extent.nodePosition as TextPosition).offset),
+    );
+
+    composer.selection = DocumentSelection(
+      base: DocumentPosition(
+        nodeId: selectedNode.id,
+        nodePosition: paragraphSelection.base,
+      ),
+      extent: DocumentPosition(
+        nodeId: selectedNode.id,
+        nodePosition: paragraphSelection.extent,
+      ),
+    );
+
+    return true;
+  }
+
+  /// Sets the [DocumentComposer]'s selection to include the entire
+  /// [Document].
+  ///
+  /// Always returns [true].
+  bool selectAll() {
+    final nodes = editor.document.nodes;
+    if (nodes.isEmpty) {
+      return false;
+    }
+
+    composer.selection = DocumentSelection(
+      base: DocumentPosition(
+        nodeId: nodes.first.id,
+        nodePosition: nodes.first.beginningPosition,
+      ),
+      extent: DocumentPosition(
+        nodeId: nodes.last.id,
+        nodePosition: nodes.last.endPosition,
+      ),
+    );
+
+    return true;
+  }
+
+  /// Collapses the [DocumentComposer]'s selection at the current
+  /// extent [DocumentPosition].
+  ///
+  /// Returns [true] if the selection was collapsed, or [false] if
+  /// there was no selection to collapse.
+  bool collapseSelection() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    composer.selection = composer.selection!.collapse();
+
+    return true;
+  }
+
+  /// Moves the [DocumentComposer]'s selection extent position in the
+  /// upstream direction (to the left for left-to-right languages).
+  ///
+  /// Expands/contracts the selection if [expand] is [true], otherwise
+  /// collapses the selection or keeps it collapsed.
+  ///
+  /// By default, moves one character at a time when the extent sits in
+  /// a [TextNode]. To move word-by-word, pass [MovementModifier.word]
+  /// in [movementModifiers]. To move to the beginning of a line, pass
+  /// [MovementModifier.line] in [movementModifiers].
+  ///
+  /// Returns [true] if the extent moved, or the selection changed, e.g., the
+  /// selection collapsed but the extent stayed in the same place. Returns
+  /// [false] if the extent did not move and the selection did not change.
+  bool moveCaretUpstream({
+    bool expand = false,
+    Set<MovementModifier> movementModifiers = const {},
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final currentExtent = composer.selection!.extent;
+    final nodeId = currentExtent.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node == null) {
+      return false;
+    }
+    final extentComponent = documentLayoutResolver().getComponentByNodeId(nodeId);
+    if (extentComponent == null) {
+      return false;
+    }
+
+    String newExtentNodeId = nodeId;
+    dynamic newExtentNodePosition = extentComponent.movePositionLeft(currentExtent.nodePosition, movementModifiers);
+
+    if (newExtentNodePosition == null) {
+      // Move to next node
+      final nextNode = editor.document.getNodeBefore(node);
+
+      if (nextNode == null) {
+        // We're at the beginning of the document and can't go anywhere.
+        return false;
+      }
+
+      newExtentNodeId = nextNode.id;
+      final nextComponent = documentLayoutResolver().getComponentByNodeId(nextNode.id);
+      if (nextComponent == null) {
+        return false;
+      }
+      newExtentNodePosition = nextComponent.getEndPosition();
+    }
+
+    final newExtent = DocumentPosition(
+      nodeId: newExtentNodeId,
+      nodePosition: newExtentNodePosition,
+    );
+
+    if (expand) {
+      // Selection should be expanded.
+      composer.selection = composer.selection!.expandTo(
+        newExtent,
+      );
+    } else {
+      // Selection should be replaced by new collapsed position.
+      composer.selection = DocumentSelection.collapsed(
+        position: newExtent,
+      );
+    }
+
+    return true;
+  }
+
+  /// Moves the [DocumentComposer]'s selection extent position in the
+  /// downstream direction (to the right for left-to-right languages).
+  ///
+  /// Expands/contracts the selection if [expand] is [true], otherwise
+  /// collapses the selection or keeps it collapsed.
+  ///
+  /// By default, moves one character at a time when the extent sits in
+  /// a [TextNode]. To move word-by-word, pass [MovementModifier.word]
+  /// in [movementModifiers]. To move to the end of a line, pass
+  /// [MovementModifier.line] in [movementModifiers].
+  ///
+  /// Returns [true] if the extent moved, or the selection changed, e.g., the
+  /// selection collapsed but the extent stayed in the same place. Returns
+  /// [false] if the extent did not move and the selection did not change.
+  bool moveCaretDownstream({
+    bool expand = false,
+    Set<MovementModifier> movementModifiers = const {},
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final currentExtent = composer.selection!.extent;
+    final nodeId = currentExtent.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node == null) {
+      return false;
+    }
+    final extentComponent = documentLayoutResolver().getComponentByNodeId(nodeId);
+    if (extentComponent == null) {
+      return false;
+    }
+
+    String newExtentNodeId = nodeId;
+    dynamic newExtentNodePosition = extentComponent.movePositionRight(currentExtent.nodePosition, movementModifiers);
+
+    if (newExtentNodePosition == null) {
+      // Move to next node
+      final nextNode = editor.document.getNodeAfter(node);
+
+      if (nextNode == null) {
+        // We're at the beginning/end of the document and can't go
+        // anywhere.
+        return false;
+      }
+
+      newExtentNodeId = nextNode.id;
+      final nextComponent = documentLayoutResolver().getComponentByNodeId(nextNode.id);
+      if (nextComponent == null) {
+        throw Exception(
+            'Could not find next component to move the selection horizontally. Next node ID: ${nextNode.id}');
+      }
+      newExtentNodePosition = nextComponent.getBeginningPosition();
+    }
+
+    final newExtent = DocumentPosition(
+      nodeId: newExtentNodeId,
+      nodePosition: newExtentNodePosition,
+    );
+
+    if (expand) {
+      // Selection should be expanded.
+      composer.selection = composer.selection!.expandTo(
+        newExtent,
+      );
+    } else {
+      // Selection should be replaced by new collapsed position.
+      composer.selection = DocumentSelection.collapsed(
+        position: newExtent,
+      );
+    }
+
+    return true;
+  }
+
+  /// Moves the [DocumentComposer]'s selection extent position up,
+  /// vertically, either by moving the selection extent up one line of
+  /// text, or by moving the selection extent up to the node above the
+  /// current extent.
+  ///
+  /// If the current selection extent wants to move to the node above,
+  /// but there is no node above the current extent, the extent is moved
+  /// to the "start" position of the current node. For example: the extent
+  /// moves from the middle of the first line of text in a paragraph to
+  /// the beginning of the paragraph.
+  ///
+  /// Expands/contracts the selection if [expand] is [true], otherwise
+  /// collapses the selection or keeps it collapsed.
+  ///
+  /// Returns [true] if the extent moved, or the selection changed, e.g., the
+  /// selection collapsed but the extent stayed in the same place. Returns
+  /// [false] if the extent did not move and the selection did not change.
+  bool moveCaretUp({
+    bool expand = false,
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final currentExtent = composer.selection!.extent;
+    final nodeId = currentExtent.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node == null) {
+      return false;
+    }
+    final extentComponent = documentLayoutResolver().getComponentByNodeId(nodeId);
+    if (extentComponent == null) {
+      return false;
+    }
+
+    String newExtentNodeId = nodeId;
+    dynamic newExtentNodePosition = extentComponent.movePositionUp(currentExtent.nodePosition);
+
+    if (newExtentNodePosition == null) {
+      // Move to next node
+      final nextNode = editor.document.getNodeBefore(node);
+      if (nextNode != null) {
+        newExtentNodeId = nextNode.id;
+        final nextComponent = documentLayoutResolver().getComponentByNodeId(nextNode.id);
+        if (nextComponent == null) {
+          return false;
+        }
+        final offsetToMatch = extentComponent.getOffsetForPosition(currentExtent.nodePosition);
+        newExtentNodePosition = nextComponent.getEndPositionNearX(offsetToMatch.dx);
+      } else {
+        // We're at the top of the document. Move the cursor to the
+        // beginning of the current node.
+        newExtentNodePosition = extentComponent.getBeginningPosition();
+      }
+    }
+
+    final newExtent = DocumentPosition(
+      nodeId: newExtentNodeId,
+      nodePosition: newExtentNodePosition,
+    );
+
+    if (expand) {
+      // Selection should be expanded.
+      composer.selection = composer.selection!.expandTo(
+        newExtent,
+      );
+    } else {
+      // Selection should be replaced by new collapsed position.
+      composer.selection = DocumentSelection.collapsed(
+        position: newExtent,
+      );
+    }
+
+    return true;
+  }
+
+  /// Moves the [DocumentComposer]'s selection extent position down,
+  /// vertically, either by moving the selection extent down one line of
+  /// text, or by moving the selection extent down to the node below the
+  /// current extent.
+  ///
+  /// If the current selection extent wants to move to the node below,
+  /// but there is no node below the current extent, the extent is moved
+  /// to the "end" position of the current node. For example: the extent
+  /// moves from the middle of the last line of text in a paragraph to
+  /// the end of the paragraph.
+  ///
+  /// Expands/contracts the selection if [expand] is [true], otherwise
+  /// collapses the selection or keeps it collapsed.
+  ///
+  /// Returns [true] if the extent moved, or the selection changed, e.g., the
+  /// selection collapsed but the extent stayed in the same place. Returns
+  /// [false] if the extent did not move and the selection did not change.
+  bool moveCaretDown({
+    bool expand = false,
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final currentExtent = composer.selection!.extent;
+    final nodeId = currentExtent.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node == null) {
+      return false;
+    }
+    final extentComponent = documentLayoutResolver().getComponentByNodeId(nodeId);
+    if (extentComponent == null) {
+      return false;
+    }
+
+    String newExtentNodeId = nodeId;
+    dynamic newExtentNodePosition = extentComponent.movePositionDown(currentExtent.nodePosition);
+
+    if (newExtentNodePosition == null) {
+      // Move to next node
+      final nextNode = editor.document.getNodeAfter(node);
+      if (nextNode != null) {
+        newExtentNodeId = nextNode.id;
+        final nextComponent = documentLayoutResolver().getComponentByNodeId(nextNode.id);
+        if (nextComponent == null) {
+          return false;
+        }
+        final offsetToMatch = extentComponent.getOffsetForPosition(currentExtent.nodePosition);
+        newExtentNodePosition = nextComponent.getBeginningPositionNearX(offsetToMatch.dx);
+      } else {
+        // We're at the bottom of the document. Move the cursor to the
+        // end of the current node.
+        newExtentNodePosition = extentComponent.getEndPosition();
+      }
+    }
+
+    final newExtent = DocumentPosition(
+      nodeId: newExtentNodeId,
+      nodePosition: newExtentNodePosition,
+    );
+
+    if (expand) {
+      // Selection should be expanded.
+      composer.selection = composer.selection!.expandTo(
+        newExtent,
+      );
+    } else {
+      // Selection should be replaced by new collapsed position.
+      composer.selection = DocumentSelection.collapsed(
+        position: newExtent,
+      );
+    }
+
+    return true;
+  }
+
+  /// Deletes a unit of content that comes after the [DocumentComposer]'s
+  /// selection extent, or deletes all selected content if the selection
+  /// is not collapsed.
+  ///
+  /// In the case of text editing, deletes the character that appears after
+  /// the caret.
+  ///
+  /// Returns [true] if content was deleted, or [false] if no downstream
+  /// content exists.
+  bool deleteDownstream() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryPosition) {
+      // A span of content is selected. Delete the selection.
+      return deleteSelection();
+    } else if (composer.selection!.extent.nodePosition is TextPosition) {
+      final textPosition = composer.selection!.extent.nodePosition as TextPosition;
+      final text = (editor.document.getNodeById(composer.selection!.extent.nodeId) as TextNode).text.text;
+      if (textPosition.offset == text.length) {
+        final node = editor.document.getNodeById(composer.selection!.extent.nodeId)!;
+        final nodeAfter = editor.document.getNodeAfter(node);
+
+        if (nodeAfter is TextNode) {
+          // The caret is at the end of one TextNode and is followed by
+          // another TextNode. Merge the two TextNodes.
+          return _mergeTextNodeWithDownstreamTextNode();
+        } else {
+          // The caret is at the end of a TextNode, but the next node
+          // is not a TextNode. Move the document selection to the
+          // next node.
+          return _moveSelectionToBeginningOfNextNode();
+        }
+      } else {
+        return _deleteDownstreamCharacter();
+      }
+    }
+
+    return false;
+  }
+
+  bool _moveSelectionToBeginningOfNextNode() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final node = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (node == null) {
+      return false;
+    }
+
+    final nodeAfter = editor.document.getNodeAfter(node);
+    if (nodeAfter == null) {
+      return false;
+    }
+
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: nodeAfter.id,
+        nodePosition: nodeAfter.beginningPosition,
+      ),
+    );
+
+    return true;
+  }
+
+  bool _mergeTextNodeWithDownstreamTextNode() {
+    final node = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (node == null) {
+      return false;
+    }
+    if (node is! TextNode) {
+      return false;
+    }
+
+    final nodeAfter = editor.document.getNodeAfter(node);
+    if (nodeAfter == null) {
+      return false;
+    }
+    if (nodeAfter is! TextNode) {
+      return false;
+    }
+
+    print('Merging node with next text node');
+
+    final firstNodeTextLength = node.text.text.length;
+
+    // Send edit command.
+    editor.executeCommand(
+      CombineParagraphsCommand(
+        firstNodeId: node.id,
+        secondNodeId: nodeAfter.id,
+      ),
+    );
+
+    // Place the cursor at the point where the text came together.
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: node.id,
+        nodePosition: TextPosition(offset: firstNodeTextLength),
+      ),
+    );
+
+    return true;
+  }
+
+  bool _deleteDownstreamCharacter() {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
+      return false;
+    }
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextPosition).offset <= 0) {
+      return false;
+    }
+
+    final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
+    final text = textNode.text;
+    final currentTextPosition = (composer.selection!.extent.nodePosition as TextPosition);
+    if (currentTextPosition.offset >= text.text.length) {
+      return false;
+    }
+
+    final nextCharacterOffset = getCharacterEndBounds(text.text, currentTextPosition.offset);
+
+    // Delete the selected content.
+    editor.executeCommand(
+      DeleteSelectionCommand(
+        documentSelection: DocumentSelection(
+          base: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: currentTextPosition,
+          ),
+          extent: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: TextPosition(offset: nextCharacterOffset),
+          ),
+        ),
+      ),
+    );
+
+    return true;
+  }
+
+  /// Deletes a unit of content that comes before the [DocumentComposer]'s
+  /// selection extent, or deletes all selected content if the selection
+  /// is not collapsed.
+  ///
+  /// In the case of text editing, deletes the character that appears before
+  /// the caret.
+  ///
+  /// Returns [true] if content was deleted, or [false] if no upstream
+  /// content exists.
+  bool deleteUpstream() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryPosition) {
+      // A span of content is selected. Delete the selection.
+      return deleteSelection();
+    } else if (composer.selection!.extent.nodePosition is TextPosition) {
+      final textPosition = composer.selection!.extent.nodePosition as TextPosition;
+      if (textPosition.offset == 0) {
+        final node = editor.document.getNodeById(composer.selection!.extent.nodeId)!;
+        final nodeBefore = editor.document.getNodeBefore(node);
+
+        if (nodeBefore is TextNode) {
+          // The caret is at the beginning of one TextNode and is preceded by
+          // another TextNode. Merge the two TextNodes.
+          return _mergeTextNodeWithUpstreamTextNode();
+        } else {
+          // The caret is at the beginning of a TextNode, but the preceding node
+          // is not a TextNode. Move the document selection to the
+          // preceding node.
+          return _moveSelectionToEndOfPrecedingNode();
+        }
+      } else {
+        return _deleteUpstreamCharacter();
+      }
+    }
+
+    return false;
+  }
+
+  bool _moveSelectionToEndOfPrecedingNode() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final node = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (node == null) {
+      return false;
+    }
+
+    final nodeBefore = editor.document.getNodeBefore(node);
+    if (nodeBefore == null) {
+      return false;
+    }
+
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: nodeBefore.id,
+        nodePosition: nodeBefore.endPosition,
+      ),
+    );
+
+    return true;
+  }
+
+  bool _mergeTextNodeWithUpstreamTextNode() {
+    final node = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (node == null) {
+      return false;
+    }
+
+    final nodeAbove = editor.document.getNodeBefore(node);
+    if (nodeAbove == null) {
+      return false;
+    }
+    if (nodeAbove is! TextNode) {
+      return false;
+    }
+
+    final aboveParagraphLength = nodeAbove.text.text.length;
+
+    // Send edit command.
+    editor.executeCommand(
+      CombineParagraphsCommand(
+        firstNodeId: nodeAbove.id,
+        secondNodeId: node.id,
+      ),
+    );
+
+    // Place the cursor at the point where the text came together.
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: nodeAbove.id,
+        nodePosition: TextPosition(offset: aboveParagraphLength),
+      ),
+    );
+
+    return true;
+  }
+
+  bool _deleteUpstreamCharacter() {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
+      return false;
+    }
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextPosition).offset <= 0) {
+      return false;
+    }
+
+    final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
+    final currentTextPosition = composer.selection!.extent.nodePosition as TextPosition;
+
+    final previousCharacterOffset = getCharacterStartBounds(textNode.text.text, currentTextPosition.offset);
+
+    final newSelectionPosition = DocumentPosition(
+      nodeId: textNode.id,
+      nodePosition: TextPosition(offset: previousCharacterOffset),
+    );
+
+    // Delete the selected content.
+    editor.executeCommand(
+      DeleteSelectionCommand(
+        documentSelection: DocumentSelection(
+          base: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: currentTextPosition,
+          ),
+          extent: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: TextPosition(offset: previousCharacterOffset),
+          ),
+        ),
+      ),
+    );
+
+    composer.selection = DocumentSelection.collapsed(position: newSelectionPosition);
+
+    return true;
+  }
+
+  /// Deletes all selected content.
+  ///
+  /// Returns [true] if content was deleted, or [false] if no content was
+  /// selected.
+  bool deleteSelection() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (composer.selection!.isCollapsed) {
+      if (composer.selection!.extent.nodePosition is! BinaryPosition) {
+        return false;
+      }
+      if (!(composer.selection!.extent.nodePosition as BinaryPosition).isIncluded) {
+        return false;
+      }
+
+      // The document selection is collapsed, but the collapsed selection
+      // currently selects a box node. Delete the box node.
+      _deleteSelectedBox();
+      return true;
+    }
+
+    // The document selection includes a span of content. It may or may not
+    // cross nodes. Either way, delete the selected content.
+    _deleteExpandedSelection();
+    return true;
+  }
+
+  void _deleteSelectedBox() {
+    final node = editor.document.getNode(composer.selection!.extent);
+    if (node == null) {
+      throw Exception(
+          'Tried to delete a node but the selection extent doesn\'t exist in the document. Extent node: ${composer.selection!.extent}');
+    }
+    final deletedNodeIndex = editor.document.getNodeIndex(node);
+
+    editor.executeCommand(
+      DeleteSelectionCommand(
+        documentSelection: composer.selection!,
+      ),
+    );
+
+    final newSelectionPosition = _getAnotherSelectionAfterNodeDeletion(
+      document: editor.document,
+      documentLayout: documentLayoutResolver(),
+      deletedNodeIndex: deletedNodeIndex,
+    );
+
+    composer.selection = newSelectionPosition != null
+        ? DocumentSelection.collapsed(
+            position: newSelectionPosition,
+          )
+        : null;
+  }
+
+  DocumentPosition? _getAnotherSelectionAfterNodeDeletion({
+    required Document document,
+    required DocumentLayout documentLayout,
+    required int deletedNodeIndex,
+  }) {
+    if (deletedNodeIndex > 0) {
+      final newSelectionNodeIndex = deletedNodeIndex - 1;
+      final newSelectionNode = document.getNodeAt(newSelectionNodeIndex);
+      if (newSelectionNode == null) {
+        throw Exception(
+            'Tried to access document node at index $newSelectionNodeIndex but the document returned null.');
+      }
+      final component = documentLayout.getComponentByNodeId(newSelectionNode.id);
+      if (component == null) {
+        throw Exception('Couldn\'t find editor component for node: ${newSelectionNode.id}');
+      }
+      return DocumentPosition(
+        nodeId: newSelectionNode.id,
+        nodePosition: component.getEndPosition(),
+      );
+    } else if (document.nodes.isNotEmpty) {
+      // There is no node above the deleted node. It's at the top
+      // of the document. Try to place the selection in whatever
+      // is now the first node in the document.
+      final newSelectionNode = document.getNodeAt(0);
+      if (newSelectionNode == null) {
+        throw Exception('Could not obtain the first node in a non-empty document.');
+      }
+      final component = documentLayout.getComponentByNodeId(newSelectionNode.id);
+      if (component == null) {
+        throw Exception('Couldn\'t find editor component for node: ${newSelectionNode.id}');
+      }
+      return DocumentPosition(
+        nodeId: newSelectionNode.id,
+        nodePosition: component.getBeginningPosition(),
+      );
+    } else {
+      // The document is empty. Null out the position.
+      return null;
+    }
+  }
+
+  void _deleteExpandedSelection() {
+    final newSelectionPosition = _getDocumentPositionAfterDeletion(
+      document: editor.document,
+      selection: composer.selection!,
+    );
+
+    // Delete the selected content.
+    editor.executeCommand(
+      DeleteSelectionCommand(documentSelection: composer.selection!),
+    );
+
+    composer.selection = DocumentSelection.collapsed(position: newSelectionPosition);
+  }
+
+  DocumentPosition _getDocumentPositionAfterDeletion({
+    required Document document,
+    required DocumentSelection selection,
+  }) {
+    // Figure out where the caret should appear after the
+    // deletion.
+    // TODO: This calculation depends upon the first
+    //       selected node still existing after the deletion. This
+    //       is a fragile expectation and should be revisited.
+    final basePosition = selection.base;
+    final baseNode = document.getNode(basePosition);
+    if (baseNode == null) {
+      throw Exception('Failed to _getDocumentPositionAfterDeletion because the base node no longer exists.');
+    }
+    final baseNodeIndex = document.getNodeIndex(baseNode);
+
+    final extentPosition = selection.extent;
+    final extentNode = document.getNode(extentPosition);
+    if (extentNode == null) {
+      throw Exception('Failed to _getDocumentPositionAfterDeletion because the extent node no longer exists.');
+    }
+    final extentNodeIndex = document.getNodeIndex(extentNode);
+    DocumentPosition newSelectionPosition;
+
+    if (baseNodeIndex != extentNodeIndex) {
+      // Place the caret at the current position within the
+      // first node in the selection.
+      newSelectionPosition = baseNodeIndex <= extentNodeIndex ? selection.base : selection.extent;
+
+      // If it's a binary selection node then that node will
+      // be replaced by a ParagraphNode with the same ID.
+      if (newSelectionPosition.nodePosition is BinaryPosition) {
+        // Assume that the node was replaced with an empty paragraph.
+        newSelectionPosition = DocumentPosition(
+          nodeId: newSelectionPosition.nodeId,
+          nodePosition: TextPosition(offset: 0),
+        );
+      }
+    } else {
+      // Selection is within a single node. If it's a binary
+      // selection node then that node will be replaced by
+      // a ParagraphNode with the same ID. Otherwise, it must
+      // be a TextNode, in which case we need to figure out
+      // which DocumentPosition contains the earlier TextPosition.
+      if (basePosition.nodePosition is BinaryPosition) {
+        // Assume that the node was replace with an empty paragraph.
+        newSelectionPosition = DocumentPosition(
+          nodeId: baseNode.id,
+          nodePosition: TextPosition(offset: 0),
+        );
+      } else if (basePosition.nodePosition is TextPosition) {
+        final baseOffset = (basePosition.nodePosition as TextPosition).offset;
+        final extentOffset = (extentPosition.nodePosition as TextPosition).offset;
+
+        newSelectionPosition = DocumentPosition(
+          nodeId: baseNode.id,
+          nodePosition: TextPosition(offset: min(baseOffset, extentOffset)),
+        );
+      } else {
+        throw Exception(
+            'Unknown selection position type: $basePosition, for node: $baseNode, within document selection: $selection');
+      }
+    }
+
+    return newSelectionPosition;
+  }
+
+  /// Adds the given [attributions] to all [AttributedText] within the
+  /// [DocumentComposer]'s current selection.
+  ///
+  /// Returns [true] if any text exists within the selection, or [false]
+  /// otherwise.
+  bool addAttributionsToSelection(Set<Attribution> attributions) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (composer.selection!.isCollapsed) {
+      return false;
+    }
+
+    editor.executeCommand(
+      AddTextAttributionsCommand(
+        documentSelection: composer.selection!,
+        attributions: attributions,
+      ),
+    );
+
+    return false;
+  }
+
+  /// Removes the given [attributions] from all [AttributedText] within the
+  /// [DocumentComposer]'s current selection.
+  ///
+  /// Returns [true] if any text exists within the selection, or [false]
+  /// otherwise.
+  bool removeAttributionsFromSelection(Set<Attribution> attributions) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (composer.selection!.isCollapsed) {
+      return false;
+    }
+
+    editor.executeCommand(
+      RemoveTextAttributionsCommand(
+        documentSelection: composer.selection!,
+        attributions: attributions,
+      ),
+    );
+
+    return false;
+  }
+
+  /// Toggles the given [attributions] on all [AttributedText] within the
+  /// [DocumentComposer]'s current selection.
+  ///
+  /// Returns [true] if any text exists within the selection, or [false]
+  /// otherwise.
+  bool toggleAttributionsOnSelection(Set<Attribution> attributions) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    if (composer.selection!.isCollapsed) {
+      return false;
+    }
+
+    editor.executeCommand(
+      ToggleTextAttributionsCommand(
+        documentSelection: composer.selection!,
+        attributions: attributions,
+      ),
+    );
+
+    return false;
+  }
+
+  /// Adds the given [attributions] to the [DocumentComposer]'s input
+  /// mode so that any new plain text inserted using [insertPlainText()]
+  /// will contain the given [attributions].
+  ///
+  /// Always returns [true].
+  bool activateComposerAttributions(Set<Attribution> attributions) {
+    composer.preferences.addStyles(attributions);
+    return true;
+  }
+
+  /// Removes the given [attributions] from the [DocumentComposer]'s input
+  /// mode so that any new plain text inserted using [insertPlainText()]
+  /// **doesn't** contain the given [attributions].
+  ///
+  /// Always returns [true].
+  bool deactivateComposerAttributions(Set<Attribution> attributions) {
+    composer.preferences.removeStyles(attributions);
+    return true;
+  }
+
+  /// Toggles the presence of the given [attributions] within the
+  /// [DocumentComposer]'s input mode.
+  ///
+  /// Always returns [true].
+  bool toggleComposerAttributions(Set<Attribution> attributions) {
+    composer.preferences.toggleStyles(attributions);
+    return true;
+  }
+
+  /// Removes all [attributions] within the [DocumentComposer]'s
+  /// input mode.
+  ///
+  /// Always returns [true].
+  bool clearComposerAttributions() {
+    composer.preferences.clearStyles();
+    return true;
+  }
+
+  /// Inserts the given [text] at the [DocumentComposer]'s current
+  /// selection extent, applying any [Attribution]s that are
+  /// currently activated in the [DocumentComposer]'s input mode.
+  ///
+  /// Any selected content is deleted before inserting the new text.
+  ///
+  /// Returns [true] if the [text] was successfully inserted, or [false]
+  /// if it wasn't, e.g., the currently selected node is not a [TextNode].
+  bool insertPlainText(String text) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId)!;
+    final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId)!;
+    if (baseNode.id != extentNode.id) {
+      return false;
+    }
+    if (extentNode is! TextNode) {
+      return false;
+    }
+
+    if (!composer.selection!.isCollapsed) {
+      // The selection is expanded. Delete the selected content
+      // and then insert the new text.
+      deleteSelection();
+    }
+
+    final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
+    final initialTextOffset = (composer.selection!.extent.nodePosition as TextPosition).offset;
+
+    editor.executeCommand(
+      InsertTextCommand(
+        documentPosition: composer.selection!.extent,
+        textToInsert: text,
+        attributions: composer.preferences.currentAttributions,
+      ),
+    );
+
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: textNode.id,
+        nodePosition: TextPosition(
+          offset: initialTextOffset + 1,
+        ),
+      ),
+    );
+
+    return true;
+  }
+
+  /// Inserts the given [character] like [insertPlainText()] except that this
+  /// [character] can contain [Attribution]s.
+  ///
+  /// By default, the current [DocumentComposer] input mode's [Attribution]s
+  /// are added to the given [character]. To insert [character] exactly as it's provided,
+  /// set [ignoreComposerAttributions] to [true].
+  ///
+  /// Returns [true] if the [character] was successfully inserted, or [false]
+  /// if it wasn't, e.g., the currently selected node is not a [TextNode].
+  bool insertCharacter(
+    String character, {
+    bool ignoreComposerAttributions = false,
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final node = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (node is! ParagraphNode) {
+      return false;
+    }
+
+    if (!composer.selection!.isCollapsed) {
+      return false;
+    }
+
+    // Delegate the action to the standard insert-character behavior.
+    final inserted = _insertCharacterInTextComposable(character);
+    if (!inserted) {
+      return false;
+    }
+
+    if (character == ' ') {
+      _convertParagraphIfDesired(
+        document: editor.document,
+        editor: editor,
+        composer: composer,
+        node: node,
+      );
+    }
+
+    return true;
+  }
+
+  // TODO: refactor to make prefix matching extensible (#68)
+  bool _convertParagraphIfDesired({
+    required Document document,
+    required DocumentComposer composer,
+    required ParagraphNode node,
+    required DocumentEditor editor,
+  }) {
+    if (composer.selection == null) {
+      // This method shouldn't be invoked if the given node
+      // doesn't have the caret, but we check just in case.
+      return false;
+    }
+
+    final text = node.text;
+    final textSelection = composer.selection!.extent.nodePosition as TextPosition;
+    final textBeforeCaret = text.text.substring(0, textSelection.offset);
+
+    final unorderedListItemMatch = RegExp(r'^\s*[\*-]\s+$');
+    final hasUnorderedListItemMatch = unorderedListItemMatch.hasMatch(textBeforeCaret);
+
+    final orderedListItemMatch = RegExp(r'^\s*[1].*\s+$');
+    final hasOrderedListItemMatch = orderedListItemMatch.hasMatch(textBeforeCaret);
+
+    _log.log('_convertParagraphIfDesired', ' - text before caret: "$textBeforeCaret"');
+    if (hasUnorderedListItemMatch || hasOrderedListItemMatch) {
+      _log.log('_convertParagraphIfDesired', ' - found unordered list item prefix');
+      int startOfNewText = textBeforeCaret.length;
+      while (startOfNewText < node.text.text.length && node.text.text[startOfNewText] == ' ') {
+        startOfNewText += 1;
+      }
+      final adjustedText = node.text.copyText(startOfNewText);
+      final newNode = hasUnorderedListItemMatch
+          ? ListItemNode.unordered(id: node.id, text: adjustedText)
+          : ListItemNode.ordered(id: node.id, text: adjustedText);
+      final nodeIndex = document.getNodeIndex(node);
+
+      editor.executeCommand(
+        EditorCommandFunction((document, transaction) {
+          transaction
+            ..deleteNodeAt(nodeIndex)
+            ..insertNodeAt(nodeIndex, newNode);
+        }),
+      );
+
+      // We removed some text at the beginning of the list item.
+      // Move the selection back by that same amount.
+      final textPosition = composer.selection!.extent.nodePosition as TextPosition;
+      composer.selection = DocumentSelection.collapsed(
+        position: DocumentPosition(
+          nodeId: node.id,
+          nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
+        ),
+      );
+
+      return true;
+    }
+
+    final hrMatch = RegExp(r'^---*\s$');
+    final hasHrMatch = hrMatch.hasMatch(textBeforeCaret);
+    if (hasHrMatch) {
+      _log.log('_convertParagraphIfDesired', 'Paragraph has an HR match');
+      // Insert an HR before this paragraph and then clear the
+      // paragraph's content.
+      final paragraphNodeIndex = document.getNodeIndex(node);
+
+      editor.executeCommand(
+        EditorCommandFunction((document, transaction) {
+          transaction.insertNodeAt(
+            paragraphNodeIndex,
+            HorizontalRuleNode(
+              id: DocumentEditor.createNodeId(),
+            ),
+          );
+        }),
+      );
+
+      node.text = node.text.removeRegion(startOffset: 0, endOffset: hrMatch.firstMatch(textBeforeCaret)!.end);
+
+      composer.selection = DocumentSelection.collapsed(
+        position: DocumentPosition(
+          nodeId: node.id,
+          nodePosition: TextPosition(offset: 0),
+        ),
+      );
+
+      return true;
+    }
+
+    final blockquoteMatch = RegExp(r'^>\s$');
+    final hasBlockquoteMatch = blockquoteMatch.hasMatch(textBeforeCaret);
+    if (hasBlockquoteMatch) {
+      int startOfNewText = textBeforeCaret.length;
+      while (startOfNewText < node.text.text.length && node.text.text[startOfNewText] == ' ') {
+        startOfNewText += 1;
+      }
+      final adjustedText = node.text.copyText(startOfNewText);
+      final newNode = ParagraphNode(
+        id: node.id,
+        text: adjustedText,
+        metadata: {'blockType': blockquoteAttribution},
+      );
+      final nodeIndex = document.getNodeIndex(node);
+
+      editor.executeCommand(
+        EditorCommandFunction((document, transaction) {
+          transaction
+            ..deleteNodeAt(nodeIndex)
+            ..insertNodeAt(nodeIndex, newNode);
+        }),
+      );
+
+      // We removed some text at the beginning of the list item.
+      // Move the selection back by that same amount.
+      final textPosition = composer.selection!.extent.nodePosition as TextPosition;
+      composer.selection = DocumentSelection.collapsed(
+        position: DocumentPosition(
+          nodeId: node.id,
+          nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
+        ),
+      );
+
+      return true;
+    }
+
+    // URL match, e.g., images, social, etc.
+    _log.log('_convertParagraphIfDesired', 'Looking for URL match...');
+    final extractedLinks = linkify(node.text.text,
+        options: LinkifyOptions(
+          humanize: false,
+        ));
+    final int linkCount = extractedLinks.fold(0, (value, element) => element is UrlElement ? value + 1 : value);
+    final String nonEmptyText =
+        extractedLinks.fold('', (value, element) => element is TextElement ? value + element.text.trim() : value);
+    if (linkCount == 1 && nonEmptyText.isEmpty) {
+      // This node's text is just a URL, try to interpret it
+      // as a known type.
+      final link = extractedLinks.firstWhereOrNull((element) => element is UrlElement)!.text;
+      _processUrlNode(
+        document: document,
+        editor: editor,
+        nodeId: node.id,
+        originalText: node.text.text,
+        url: link,
+      );
+      return true;
+    }
+
+    // No pattern match was found
+    return false;
+  }
+
+  Future<void> _processUrlNode({
+    required Document document,
+    required DocumentEditor editor,
+    required String nodeId,
+    required String originalText,
+    required String url,
+  }) async {
+    final response = await http.get(Uri.parse(url));
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _log.log('_processUrlNode', 'Failed to load URL: ${response.statusCode} - ${response.reasonPhrase}');
+      return;
+    }
+
+    final contentType = response.headers['content-type'];
+    if (contentType == null) {
+      _log.log('_processUrlNode', 'Failed to determine URL content type.');
+      return;
+    }
+    if (!contentType.startsWith('image/')) {
+      _log.log('_processUrlNode', 'URL is not an image. Ignoring');
+      return;
+    }
+
+    // The URL is an image. Convert the node.
+    _log.log('_processUrlNode', 'The URL is an image. Converting the ParagraphNode to an ImageNode.');
+    final node = document.getNodeById(nodeId);
+    if (node is! ParagraphNode) {
+      _log.log(
+          '_processUrlNode', 'The node has become something other than a ParagraphNode ($node). Can\'t convert ndoe.');
+      return;
+    }
+    final currentText = node.text.text;
+    if (currentText.trim() != originalText.trim()) {
+      _log.log('_processUrlNode', 'The node content changed in a non-trivial way. Aborting node conversion.');
+      return;
+    }
+
+    final imageNode = ImageNode(
+      id: node.id,
+      imageUrl: url,
+    );
+    final nodeIndex = document.getNodeIndex(node);
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        transaction
+          ..deleteNodeAt(nodeIndex)
+          ..insertNodeAt(nodeIndex, imageNode);
+      }),
+    );
+  }
+
+  bool _insertCharacterInTextComposable(
+    String character, {
+    bool ignoreComposerAttributions = false,
+  }) {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (!composer.selection!.isCollapsed) {
+      return false;
+    }
+    if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
+      return false;
+    }
+
+    final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
+    final initialTextOffset = (composer.selection!.extent.nodePosition as TextPosition).offset;
+
+    editor.executeCommand(
+      InsertTextCommand(
+        documentPosition: composer.selection!.extent,
+        textToInsert: character,
+        attributions: ignoreComposerAttributions ? {} : composer.preferences.currentAttributions,
+      ),
+    );
+
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: textNode.id,
+        nodePosition: TextPosition(
+          offset: initialTextOffset + character.length,
+        ),
+      ),
+    );
+
+    return true;
+  }
+
+  /// Inserts a new [ParagraphNode], or splits an existing node into two.
+  ///
+  /// If the [DocumentComposer] selection is collapsed, and the extent is
+  /// at the end of a node, such as the end of a paragraph, then a new
+  /// [ParagraphNode] is added after the current node and the selection
+  /// extent is moved to the new [ParagraphNode].
+  ///
+  /// If the [DocumentComposer] selection is collapsed, and the extent is
+  /// in the middle of a node, such as in the middle of a paragraph, list
+  /// item, or blockquote, then the current node is split into two nodes
+  /// of the same type at that position.
+  ///
+  /// If the current selection is not collapsed then the current selection
+  /// is first deleted, then the aforementioned operation takes place.
+  ///
+  /// Returns [true] if a new node was inserted or a node was split into two.
+  /// Returns [false] if there was no selection.
+  bool insertBlockLevelNewline() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    // Ensure that the entire selection sits within the same node.
+    final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId)!;
+    final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId)!;
+    if (baseNode.id != extentNode.id) {
+      return false;
+    }
+
+    if (!composer.selection!.isCollapsed) {
+      // The selection is not collapsed. Delete the selected content first,
+      // then continue the process.
+      deleteSelection();
+    }
+
+    final newNodeId = DocumentEditor.createNodeId();
+
+    if (extentNode is ListItemNode) {
+      // Split the list item into two.
+      editor.executeCommand(
+        SplitListItemCommand(
+          nodeId: extentNode.id,
+          splitPosition: composer.selection!.extent.nodePosition as TextPosition,
+          newNodeId: newNodeId,
+        ),
+      );
+    } else if (extentNode is ParagraphNode) {
+      // Split the paragraph into two. This includes headers, blockquotes, and
+      // any other block-level paragraph.
+      editor.executeCommand(
+        SplitParagraphCommand(
+          nodeId: extentNode.id,
+          splitPosition: composer.selection!.extent.nodePosition as TextPosition,
+          newNodeId: newNodeId,
+        ),
+      );
+    }
+
+    // Place the caret at the beginning of the second node.
+    composer.selection = DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: newNodeId,
+        nodePosition: TextPosition(offset: 0),
+      ),
+    );
+
+    return true;
+  }
+
+  /// Inserts an image at the current selection extent.
+  ///
+  /// If the selection extent sits in an empty paragraph, that paragraph
+  /// is converted into the desired image and a new empty paragraph is inserted
+  /// after the image.
+  ///
+  /// If the selection extent sits at the end of a paragraph, the image is
+  /// inserted as a new node after that paragraph, and then a new empty paragraph
+  /// is inserted after the image.
+  ///
+  /// If the selection extent sits in the middle of a paragraph then the
+  /// paragraph is split into two at that position, an image is inserted between
+  /// the two paragraphs, the selection extent is placed at the beginning of the
+  /// second paragraph.
+  ///
+  /// If the selection extent sits in any other kind of node, nothing happens.
+  ///
+  /// Returns [true] if an image was inserted, [false] if it wasn't.
+  bool insertImage(String url) {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final nodeId = composer.selection!.base.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node is! ParagraphNode) {
+      return false;
+    }
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        final paragraphPosition = composer.selection!.extent.nodePosition as TextPosition;
+        final endOfParagraph = node.endPosition;
+
+        final nodeIndex = editor.document.getNodeIndex(node);
+
+        var newSelection;
+        if (node.text.text.isEmpty) {
+          // Convert empty paragraph to HR.
+          final imageNode = ImageNode(id: nodeId, imageUrl: url);
+
+          transaction
+            ..deleteNodeAt(nodeIndex)
+            ..insertNodeAt(nodeIndex, imageNode);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: imageNode.endPosition,
+            ),
+          );
+        } else if (paragraphPosition == endOfParagraph) {
+          // Insert HR after the paragraph.
+          final imageNode = ImageNode(id: DocumentEditor.createNodeId(), imageUrl: url);
+
+          transaction.insertNodeAfter(previousNode: node, newNode: imageNode);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: imageNode.endPosition,
+            ),
+          );
+        } else {
+          // Split the paragraph and inset HR in between.
+          final textBefore = node.text.copyText(0, paragraphPosition.offset);
+          final textAfter = node.text.copyText(paragraphPosition.offset);
+
+          final imageNode = ImageNode(id: nodeId, imageUrl: url);
+          final newParagraph = ParagraphNode(id: DocumentEditor.createNodeId(), text: textAfter);
+
+          // TODO: node operations need to be a part of a transaction, somehow.
+          node.text = textBefore;
+          transaction
+            ..insertNodeAfter(previousNode: node, newNode: imageNode)
+            ..insertNodeAfter(previousNode: imageNode, newNode: newParagraph);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: newParagraph.beginningPosition,
+            ),
+          );
+        }
+
+        composer.selection = newSelection;
+      }),
+    );
+
+    return true;
+  }
+
+  /// Inserts horizontal rule at the current selection extent.
+  ///
+  /// If the selection extent sits in an empty paragraph, that paragraph
+  /// is converted into the desired horizontal rule and a new empty paragraph
+  /// is inserted after the horizontal rule.
+  ///
+  /// If the selection extent sits at the end of a paragraph, the horizontal
+  /// rule is inserted as a new node after that paragraph, and then a new
+  /// empty paragraph is inserted after the image.
+  ///
+  /// If the selection extent sits in the middle of a paragraph then the
+  /// paragraph is split into two at that position, a horizontal rule is
+  /// inserted between the two paragraphs, the selection extent is placed
+  /// at the beginning of the second paragraph.
+  ///
+  /// If the selection extent sits in any other kind of node, nothing happens.
+  ///
+  /// Returns [true] if a horizontal rule was inserted, [false] if it wasn't.
+  bool insertHorizontalRule() {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final nodeId = composer.selection!.base.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node is! ParagraphNode) {
+      return false;
+    }
+
+    final nodeIndex = editor.document.getNodeIndex(node);
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        final paragraphPosition = composer.selection!.extent.nodePosition as TextPosition;
+        final endOfParagraph = node.endPosition;
+
+        var newSelection;
+        if (node.text.text.isEmpty) {
+          // Convert empty paragraph to HR.
+          final hrNode = HorizontalRuleNode(id: nodeId);
+
+          transaction
+            ..deleteNodeAt(nodeIndex)
+            ..insertNodeAt(nodeIndex, hrNode);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: hrNode.endPosition,
+            ),
+          );
+        } else if (paragraphPosition == endOfParagraph) {
+          // Insert HR after the paragraph.
+          final hrNode = HorizontalRuleNode(id: DocumentEditor.createNodeId());
+
+          transaction.insertNodeAfter(previousNode: node, newNode: hrNode);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: hrNode.endPosition,
+            ),
+          );
+        } else {
+          // Split the paragraph and inset HR in between.
+          final textBefore = node.text.copyText(0, paragraphPosition.offset);
+          final textAfter = node.text.copyText(paragraphPosition.offset);
+
+          final hrNode = HorizontalRuleNode(id: DocumentEditor.createNodeId());
+          final newParagraph = ParagraphNode(id: DocumentEditor.createNodeId(), text: textAfter);
+
+          // TODO: node operations need to be a part of a transaction, somehow.
+          node.text = textBefore;
+          transaction
+            ..insertNodeAfter(previousNode: node, newNode: hrNode)
+            ..insertNodeAfter(previousNode: hrNode, newNode: newParagraph);
+
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: newParagraph.beginningPosition,
+            ),
+          );
+        }
+
+        composer.selection = newSelection;
+      }),
+    );
+
+    return true;
+  }
+
+  /// Indents the list item at the current selection extent, if the entire
+  /// selection sits within a [ListItemNode].
+  ///
+  /// Returns [true] if a list item was indented. Returns [false] if
+  /// the selection extent did not sit in a list item, or if the selection
+  /// included more than just a list item.
+  bool indentListItem() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId);
+    final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (baseNode is! ListItemNode || extentNode is! ListItemNode) {
+      return false;
+    }
+
+    editor.executeCommand(
+      IndentListItemCommand(nodeId: extentNode.id),
+    );
+
+    return true;
+  }
+
+  /// Indents the list item at the current selection extent, if the entire
+  /// selection sits within a [ListItemNode].
+  ///
+  /// If the list item is not indented, the list item is converted to
+  /// a [ParagraphNode].
+  ///
+  /// Returns [true] if a list item was un-indented. Returns [false] if
+  /// the selection extent did not sit in a list item, or if the selection
+  /// included more than just a list item.
+  bool unindentListItem() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId);
+    final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
+    if (baseNode is! ListItemNode || extentNode is! ListItemNode) {
+      return false;
+    }
+
+    editor.executeCommand(
+      UnIndentListItemCommand(nodeId: extentNode.id),
+    );
+
+    return true;
+  }
+
+  /// Converts the [TextNode] with the current [DocumentComposer] selection
+  /// extent to a [ListItemNode] of the given [type], or does nothing if the
+  /// current node is not a [TextNode], or if the current selection spans
+  /// more than one node.
+  ///
+  /// Returns [true] if the selected node was converted to a [ListItemNode],
+  /// or [false] if it wasn't.
+  bool convertToListItem(ListItemType type, AttributedText text) {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final nodeId = composer.selection!.base.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node is! TextNode) {
+      return false;
+    }
+
+    final nodeIndex = editor.document.getNodeIndex(node);
+    final newNode = ListItemNode(id: nodeId, itemType: type, text: text);
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        transaction
+          ..deleteNodeAt(nodeIndex)
+          ..insertNodeAt(nodeIndex, newNode);
+
+        composer.selection = DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: nodeId,
+            nodePosition: newNode.endPosition,
+          ),
+        );
+      }),
+    );
+
+    return true;
+  }
+
+  /// Converts the [TextNode] with the current [DocumentComposer] selection
+  /// extent to a [Paragraph] with a blockquote block type, or does nothing
+  /// if the current node is not a [TextNode], or if the current selection
+  /// spans more than one node.
+  ///
+  /// Returns [true] if the selected node was converted to a blockquote,
+  /// or [false] if it wasn't.
+  bool convertToBlockquote(AttributedText text) {
+    if (composer.selection == null) {
+      return false;
+    }
+    if (composer.selection!.base.nodeId != composer.selection!.extent.nodeId) {
+      return false;
+    }
+
+    final nodeId = composer.selection!.base.nodeId;
+    final node = editor.document.getNodeById(nodeId);
+    if (node is! TextNode) {
+      return false;
+    }
+
+    final nodeIndex = editor.document.getNodeIndex(node);
+    final newNode = ParagraphNode(id: nodeId, metadata: {'blockType': blockquoteAttribution}, text: text);
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        transaction
+          ..deleteNodeAt(nodeIndex)
+          ..insertNodeAt(nodeIndex, newNode);
+
+        composer.selection = DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: nodeId,
+            nodePosition: newNode.endPosition,
+          ),
+        );
+      }),
+    );
+
+    return true;
+  }
+
+  /// Converts the [TextNode] with the current [DocumentComposer] selection
+  /// extent to a [Paragraph], or does nothing if the current node is not
+  /// a [TextNode], or if the current selection spans more than one node.
+  ///
+  /// Returns [true] if the selected node was converted to a [ParagraphNode],
+  /// or [false] if it wasn't.
+  bool convertToParagraph() {
+    if (composer.selection == null) {
+      return false;
+    }
+
+    final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId)!;
+    final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId)!;
+    if (baseNode.id != extentNode.id) {
+      return false;
+    }
+    if (extentNode is! TextNode) {
+      return false;
+    }
+
+    editor.executeCommand(
+      EditorCommandFunction((document, transaction) {
+        final newParagraphNode = ParagraphNode(
+          id: extentNode.id,
+          text: extentNode.text,
+        );
+        final extentNodeIndex = document.getNodeIndex(extentNode);
+
+        transaction
+          ..deleteNodeAt(extentNodeIndex)
+          ..insertNodeAt(extentNodeIndex, newParagraphNode);
+      }),
+    );
+
+    return true;
+  }
+
+  bool _isTextEntryNode({
+    required Document document,
+    required DocumentSelection selection,
+  }) {
+    final extentPosition = selection.extent;
+    final extentNode = document.getNodeById(extentPosition.nodeId);
+    return extentNode is TextNode;
+  }
+}

--- a/super_editor/lib/src/default_editor/document_interaction.dart
+++ b/super_editor/lib/src/default_editor/document_interaction.dart
@@ -139,15 +139,17 @@ class _DocumentInteractorState extends State<DocumentInteractor> with SingleTick
 
   void _onSelectionChange() {
     _log.log('_onSelectionChange', 'EditableDocument: _onSelectionChange()');
-    setState(() {
-      _ensureSelectionExtentIsVisible();
-      // Use a post-frame callback to "ensure selection extent is visible"
-      // so that any pending visual document changes can happen before
-      // attempting to calculate the visual position of the selection extent.
-      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+    if (mounted) {
+      setState(() {
         _ensureSelectionExtentIsVisible();
+        // Use a post-frame callback to "ensure selection extent is visible"
+        // so that any pending visual document changes can happen before
+        // attempting to calculate the visual position of the selection extent.
+        WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+          _ensureSelectionExtentIsVisible();
+        });
       });
-    });
+    }
   }
 
   void _ensureSelectionExtentIsVisible() {

--- a/super_editor/lib/src/default_editor/editor.dart
+++ b/super_editor/lib/src/default_editor/editor.dart
@@ -15,7 +15,6 @@ import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 
-import 'box_component.dart';
 import 'document_interaction.dart';
 import 'document_keyboard_actions.dart';
 import 'layout.dart';
@@ -406,28 +405,21 @@ final defaultComponentBuilders = <ComponentBuilder>[
 /// Keyboard actions for the standard `Editor`.
 final defaultKeyboardActions = <DocumentKeyboardAction>[
   doNothingWhenThereIsNoSelection,
-  indentListItemWhenTabIsPressed,
-  unindentListItemWhenShiftTabIsPressed,
-  unindentListItemWhenBackspaceIsPressed,
-  splitListItemWhenEnterPressed,
-  convertBlockquoteToParagraphWhenBackspaceIsPressed,
-  insertNewlineInBlockquote,
-  splitBlockquoteWhenEnterPressed,
   pasteWhenCmdVIsPressed,
   copyWhenCmdVIsPressed,
   selectAllWhenCmdAIsPressed,
-  applyBoldWhenCmdBIsPressed,
-  applyItalicsWhenCmdIIsPressed,
-  // TODO: see if collapse can be replaced by directional control
-  collapseSelectionWhenDirectionalKeyIsPressed,
-  deleteExpandedSelectionWhenCharacterOrDestructiveKeyPressed,
-  deleteBoxWhenBackspaceOrDeleteIsPressed,
-  insertNewlineInParagraph,
-  splitParagraphWhenEnterPressed,
-  deleteCharacterWhenBackspaceIsPressed,
-  mergeNodeWithPreviousWhenBackspaceIsPressed,
-  deleteCharacterWhenDeleteIsPressed,
   moveUpDownLeftAndRightWithArrowKeys,
-  insertCharacterInParagraph,
-  insertCharacterInTextComposable,
+  tabToIndentListItem,
+  shiftTabToUnIndentListItem,
+  backspaceToUnIndentListItem,
+  backspaceToClearParagraphBlockType,
+  cmdBToToggleBold,
+  cmdIToToggleItalics,
+  shiftEnterToInsertNewlineInBlock,
+  enterToInsertBlockNewline,
+  backspaceToRemoveUpstreamContent,
+  deleteToRemoveDownstreamContent,
+  anyCharacterOrDestructiveKeyToDeleteSelection,
+  anyCharacterToInsertInParagraph,
+  anyCharacterToInsertInTextContent,
 ];

--- a/super_editor/lib/src/default_editor/editor.dart
+++ b/super_editor/lib/src/default_editor/editor.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/blockquote.dart';
+import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/src/default_editor/horizontal_rule.dart';
 import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
@@ -289,6 +290,11 @@ class _EditorState extends State<Editor> {
         editor: widget.editor,
         composer: _composer,
         getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
+        commonOps: CommonEditorOperations(
+          editor: widget.editor,
+          composer: _composer,
+          documentLayoutResolver: () => _docLayoutKey.currentState as DocumentLayout,
+        ),
       ),
       keyboardActions: widget.keyboardActions,
       showDebugPaint: widget.showDebugPaint,
@@ -412,6 +418,7 @@ final defaultKeyboardActions = <DocumentKeyboardAction>[
   selectAllWhenCmdAIsPressed,
   applyBoldWhenCmdBIsPressed,
   applyItalicsWhenCmdIIsPressed,
+  // TODO: see if collapse can be replaced by directional control
   collapseSelectionWhenDirectionalKeyIsPressed,
   deleteExpandedSelectionWhenCharacterOrDestructiveKeyPressed,
   deleteBoxWhenBackspaceOrDeleteIsPressed,
@@ -419,10 +426,7 @@ final defaultKeyboardActions = <DocumentKeyboardAction>[
   splitParagraphWhenEnterPressed,
   deleteCharacterWhenBackspaceIsPressed,
   mergeNodeWithPreviousWhenBackspaceIsPressed,
-  deleteEmptyParagraphWhenBackspaceIsPressed,
-  moveParagraphSelectionUpWhenBackspaceIsPressed,
   deleteCharacterWhenDeleteIsPressed,
-  mergeNodeWithNextWhenDeleteIsPressed,
   moveUpDownLeftAndRightWithArrowKeys,
   insertCharacterInParagraph,
   insertCharacterInTextComposable,

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -35,6 +35,11 @@ class HorizontalRuleNode with ChangeNotifier implements DocumentNode {
 
     return selection.position == BinaryPosition.included() ? '---' : null;
   }
+
+  @override
+  bool hasEquivalentContent(DocumentNode other) {
+    return other is HorizontalRuleNode;
+  }
 }
 
 /// Displays a horizontal rule in a document.

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -55,6 +55,11 @@ class ImageNode with ChangeNotifier implements DocumentNode {
 
     return selection.position == BinaryPosition.included() ? _imageUrl : null;
   }
+
+  @override
+  bool hasEquivalentContent(DocumentNode other) {
+    return other is ImageNode && imageUrl == other.imageUrl && altText == other.altText;
+  }
 }
 
 /// Displays an image in a document.

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -432,7 +432,7 @@ class SplitListItemCommand implements EditorCommand {
   }
 }
 
-ExecutionInstruction indentListItemWhenTabIsPressed({
+ExecutionInstruction tabToIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
@@ -448,7 +448,7 @@ ExecutionInstruction indentListItemWhenTabIsPressed({
   return wasIndented ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
-ExecutionInstruction unindentListItemWhenShiftTabIsPressed({
+ExecutionInstruction shiftTabToUnIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
@@ -464,7 +464,7 @@ ExecutionInstruction unindentListItemWhenShiftTabIsPressed({
   return wasIndented ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
-ExecutionInstruction unindentListItemWhenBackspaceIsPressed({
+ExecutionInstruction backspaceToUnIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -7,10 +7,10 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
+import 'package:super_editor/super_editor.dart';
 
 import '../core/document.dart';
 import '../core/document_editor.dart';
-import '../core/document_selection.dart';
 import 'document_interaction.dart';
 import 'paragraph.dart';
 import 'styles.dart';
@@ -68,6 +68,11 @@ class ListItemNode extends TextNode {
       _indent = newIndent;
       notifyListeners();
     }
+  }
+
+  @override
+  bool hasEquivalentContent(DocumentNode other) {
+    return other is ListItemNode && type == other.type && indent == other.indent && text == other.text;
   }
 }
 
@@ -438,29 +443,9 @@ ExecutionInstruction indentListItemWhenTabIsPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
+  final wasIndented = editContext.commonOps.indentListItem();
 
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ListItemNode) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final textPosition = editContext.composer.selection!.extent.nodePosition;
-  if (textPosition is! TextPosition || textPosition.offset > 0) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  editContext.editor.executeCommand(
-    IndentListItemCommand(nodeId: node.id),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return wasIndented ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction unindentListItemWhenShiftTabIsPressed({
@@ -474,25 +459,9 @@ ExecutionInstruction unindentListItemWhenShiftTabIsPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
+  final wasIndented = editContext.commonOps.unindentListItem();
 
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ListItemNode) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final textPosition = editContext.composer.selection!.extent.nodePosition;
-  if (textPosition is! TextPosition) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  editContext.editor.executeCommand(
-    UnIndentListItemCommand(nodeId: node.id),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return wasIndented ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction unindentListItemWhenBackspaceIsPressed({
@@ -506,26 +475,21 @@ ExecutionInstruction unindentListItemWhenBackspaceIsPressed({
   if (editContext.composer.selection == null) {
     return ExecutionInstruction.continueExecution;
   }
+  if (!editContext.composer.selection!.isCollapsed) {
+    return ExecutionInstruction.continueExecution;
+  }
 
   final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
   if (node is! ListItemNode) {
     return ExecutionInstruction.continueExecution;
   }
-
-  if (!editContext.composer.selection!.isCollapsed) {
+  if ((editContext.composer.selection!.extent.nodePosition as TextPosition).offset > 0) {
     return ExecutionInstruction.continueExecution;
   }
 
-  final textPosition = editContext.composer.selection!.extent.nodePosition;
-  if (textPosition is! TextPosition || textPosition.offset > 0) {
-    return ExecutionInstruction.continueExecution;
-  }
+  final wasIndented = editContext.commonOps.unindentListItem();
 
-  editContext.editor.executeCommand(
-    UnIndentListItemCommand(nodeId: node.id),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return wasIndented ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction splitListItemWhenEnterPressed({
@@ -536,38 +500,13 @@ ExecutionInstruction splitListItemWhenEnterPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-
   final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
   if (node is! ListItemNode) {
     return ExecutionInstruction.continueExecution;
   }
 
-  final newNodeId = DocumentEditor.createNodeId();
-
-  editContext.editor.executeCommand(
-    SplitListItemCommand(
-      nodeId: node.id,
-      splitPosition: editContext.composer.selection!.extent.nodePosition as TextPosition,
-      newNodeId: newNodeId,
-    ),
-  );
-
-  // Place the caret at the beginning of the new paragraph node.
-  editContext.composer.selection = DocumentSelection.collapsed(
-    position: DocumentPosition(
-      nodeId: newNodeId,
-      nodePosition: TextPosition(offset: 0),
-    ),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  final didSplitListItem = editContext.commonOps.insertBlockLevelNewline();
+  return didSplitListItem ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 Widget? unorderedListItemBuilder(ComponentContext componentContext) {

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -1,24 +1,18 @@
-import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:http/http.dart' as http;
-import 'package:linkify/linkify.dart';
 import 'package:super_editor/src/core/document.dart';
-import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_editor.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
-import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
+import 'package:super_editor/src/infrastructure/keyboard.dart';
 
-import 'horizontal_rule.dart';
-import 'image.dart';
-import 'list_items.dart';
 import 'styles.dart';
 
 final _log = Logger(scope: 'paragraph.dart');
@@ -125,6 +119,7 @@ class SplitParagraphCommand implements EditorCommand {
     final newNode = ParagraphNode(
       id: newNodeId,
       text: endText,
+      metadata: node.metadata,
     );
 
     // Insert the new node after the current node.
@@ -146,238 +141,30 @@ ExecutionInstruction insertCharacterInParagraph({
     return ExecutionInstruction.continueExecution;
   }
 
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ParagraphNode) {
+  var character = keyEvent.character;
+  if (character == null || character == '') {
     return ExecutionInstruction.continueExecution;
   }
-  if (keyEvent.character == null || keyEvent.character == '') {
+  // On web, keys like shift and alt are sending their full name
+  // as a character, e.g., "Shift" and "Alt". This check prevents
+  // those keys from inserting their name into content.
+  //
+  // This filter is a blacklist, and therefore it will fail to
+  // catch any key that isn't explicitly listed. The eventual solution
+  // to this is for the web to honor the standard key event contract,
+  // but that's out of our control.
+  if (kIsWeb && webBugBlacklistCharacters.contains(character)) {
     return ExecutionInstruction.continueExecution;
   }
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
+
+  // The web reports a tab as "Tab". Intercept it and translate it to a space.
+  if (character == 'Tab') {
+    character = ' ';
   }
 
-  // Delegate the action to the standard insert-character behavior.
-  insertCharacterInTextComposable(
-    editContext: editContext,
-    keyEvent: keyEvent,
-  );
+  final didInsertCharacter = editContext.commonOps.insertPlainText(character);
 
-  if (keyEvent.character == ' ') {
-    _convertParagraphIfDesired(
-      document: editContext.editor.document,
-      composer: editContext.composer,
-      node: node,
-      editor: editContext.editor,
-    );
-  }
-
-  return ExecutionInstruction.haltExecution;
-}
-
-// TODO: refactor to make prefix matching extensible (#68)
-bool _convertParagraphIfDesired({
-  required Document document,
-  required DocumentComposer composer,
-  required ParagraphNode node,
-  required DocumentEditor editor,
-}) {
-  if (composer.selection == null) {
-    // This method shouldn't be invoked if the given node
-    // doesn't have the caret, but we check just in case.
-    return false;
-  }
-
-  final text = node.text;
-  final textSelection = composer.selection!.extent.nodePosition as TextPosition;
-  final textBeforeCaret = text.text.substring(0, textSelection.offset);
-
-  final unorderedListItemMatch = RegExp(r'^\s*[\*-]\s+$');
-  final hasUnorderedListItemMatch = unorderedListItemMatch.hasMatch(textBeforeCaret);
-
-  final orderedListItemMatch = RegExp(r'^\s*[1].*\s+$');
-  final hasOrderedListItemMatch = orderedListItemMatch.hasMatch(textBeforeCaret);
-
-  _log.log('_convertParagraphIfDesired', ' - text before caret: "$textBeforeCaret"');
-  if (hasUnorderedListItemMatch || hasOrderedListItemMatch) {
-    _log.log('_convertParagraphIfDesired', ' - found unordered list item prefix');
-    int startOfNewText = textBeforeCaret.length;
-    while (startOfNewText < node.text.text.length && node.text.text[startOfNewText] == ' ') {
-      startOfNewText += 1;
-    }
-    // final adjustedText = node.text.text.substring(startOfNewText);
-    final adjustedText = node.text.copyText(startOfNewText);
-    final newNode = hasUnorderedListItemMatch
-        ? ListItemNode.unordered(id: node.id, text: adjustedText)
-        : ListItemNode.ordered(id: node.id, text: adjustedText);
-    final nodeIndex = document.getNodeIndex(node);
-
-    editor.executeCommand(
-      EditorCommandFunction((document, transaction) {
-        transaction
-          ..deleteNodeAt(nodeIndex)
-          ..insertNodeAt(nodeIndex, newNode);
-      }),
-    );
-
-    // We removed some text at the beginning of the list item.
-    // Move the selection back by that same amount.
-    final textPosition = composer.selection!.extent.nodePosition as TextPosition;
-    composer.selection = DocumentSelection.collapsed(
-      position: DocumentPosition(
-        nodeId: node.id,
-        nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
-      ),
-    );
-
-    return true;
-  }
-
-  final hrMatch = RegExp(r'^---*\s$');
-  final hasHrMatch = hrMatch.hasMatch(textBeforeCaret);
-  if (hasHrMatch) {
-    _log.log('_convertParagraphIfDesired', 'Paragraph has an HR match');
-    // Insert an HR before this paragraph and then clear the
-    // paragraph's content.
-    final paragraphNodeIndex = document.getNodeIndex(node);
-
-    editor.executeCommand(
-      EditorCommandFunction((document, transaction) {
-        transaction.insertNodeAt(
-          paragraphNodeIndex,
-          HorizontalRuleNode(
-            id: DocumentEditor.createNodeId(),
-          ),
-        );
-      }),
-    );
-
-    node.text = node.text.removeRegion(startOffset: 0, endOffset: hrMatch.firstMatch(textBeforeCaret)!.end);
-
-    composer.selection = DocumentSelection.collapsed(
-      position: DocumentPosition(
-        nodeId: node.id,
-        nodePosition: TextPosition(offset: 0),
-      ),
-    );
-
-    return true;
-  }
-
-  final blockquoteMatch = RegExp(r'^>\s$');
-  final hasBlockquoteMatch = blockquoteMatch.hasMatch(textBeforeCaret);
-  if (hasBlockquoteMatch) {
-    int startOfNewText = textBeforeCaret.length;
-    while (startOfNewText < node.text.text.length && node.text.text[startOfNewText] == ' ') {
-      startOfNewText += 1;
-    }
-    final adjustedText = node.text.copyText(startOfNewText);
-    final newNode = ParagraphNode(
-      id: node.id,
-      text: adjustedText,
-      metadata: {'blockType': blockquoteAttribution},
-    );
-    final nodeIndex = document.getNodeIndex(node);
-
-    editor.executeCommand(
-      EditorCommandFunction((document, transaction) {
-        transaction
-          ..deleteNodeAt(nodeIndex)
-          ..insertNodeAt(nodeIndex, newNode);
-      }),
-    );
-
-    // We removed some text at the beginning of the list item.
-    // Move the selection back by that same amount.
-    final textPosition = composer.selection!.extent.nodePosition as TextPosition;
-    composer.selection = DocumentSelection.collapsed(
-      position: DocumentPosition(
-        nodeId: node.id,
-        nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
-      ),
-    );
-
-    return true;
-  }
-
-  // URL match, e.g., images, social, etc.
-  _log.log('_convertParagraphIfDesired', 'Looking for URL match...');
-  final extractedLinks = linkify(node.text.text,
-      options: LinkifyOptions(
-        humanize: false,
-      ));
-  final int linkCount = extractedLinks.fold(0, (value, element) => element is UrlElement ? value + 1 : value);
-  final String nonEmptyText =
-      extractedLinks.fold('', (value, element) => element is TextElement ? value + element.text.trim() : value);
-  if (linkCount == 1 && nonEmptyText.isEmpty) {
-    // This node's text is just a URL, try to interpret it
-    // as a known type.
-    final link = extractedLinks.firstWhereOrNull((element) => element is UrlElement)!.text;
-    _processUrlNode(
-      document: document,
-      editor: editor,
-      nodeId: node.id,
-      originalText: node.text.text,
-      url: link,
-    );
-    return true;
-  }
-
-  // No pattern match was found
-  return false;
-}
-
-Future<void> _processUrlNode({
-  required Document document,
-  required DocumentEditor editor,
-  required String nodeId,
-  required String originalText,
-  required String url,
-}) async {
-  final response = await http.get(Uri.parse(url));
-
-  if (response.statusCode < 200 || response.statusCode >= 300) {
-    _log.log('_processUrlNode', 'Failed to load URL: ${response.statusCode} - ${response.reasonPhrase}');
-    return;
-  }
-
-  final contentType = response.headers['content-type'];
-  if (contentType == null) {
-    _log.log('_processUrlNode', 'Failed to determine URL content type.');
-    return;
-  }
-  if (!contentType.startsWith('image/')) {
-    _log.log('_processUrlNode', 'URL is not an image. Ignoring');
-    return;
-  }
-
-  // The URL is an image. Convert the node.
-  _log.log('_processUrlNode', 'The URL is an image. Converting the ParagraphNode to an ImageNode.');
-  final node = document.getNodeById(nodeId);
-  if (node is! ParagraphNode) {
-    _log.log(
-        '_processUrlNode', 'The node has become something other than a ParagraphNode ($node). Can\'t convert ndoe.');
-    return;
-  }
-  final currentText = node.text.text;
-  if (currentText.trim() != originalText.trim()) {
-    _log.log('_processUrlNode', 'The node content changed in a non-trivial way. Aborting node conversion.');
-    return;
-  }
-
-  final imageNode = ImageNode(
-    id: node.id,
-    imageUrl: url,
-  );
-  final nodeIndex = document.getNodeIndex(node);
-
-  editor.executeCommand(
-    EditorCommandFunction((document, transaction) {
-      transaction
-        ..deleteNodeAt(nodeIndex)
-        ..insertNodeAt(nodeIndex, imageNode);
-    }),
-  );
+  return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 class DeleteParagraphsCommand implements EditorCommand {
@@ -418,73 +205,9 @@ ExecutionInstruction splitParagraphWhenEnterPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ParagraphNode) {
-    return ExecutionInstruction.continueExecution;
-  }
+  final didSplitParagraph = editContext.commonOps.insertBlockLevelNewline();
 
-  final newNodeId = DocumentEditor.createNodeId();
-
-  editContext.editor.executeCommand(
-    SplitParagraphCommand(
-      nodeId: node.id,
-      splitPosition: editContext.composer.selection!.extent.nodePosition as TextPosition,
-      newNodeId: newNodeId,
-    ),
-  );
-
-  // Place the caret at the beginning of the new paragraph node.
-  editContext.composer.selection = DocumentSelection.collapsed(
-    position: DocumentPosition(
-      nodeId: newNodeId,
-      nodePosition: TextPosition(offset: 0),
-    ),
-  );
-
-  return ExecutionInstruction.haltExecution;
-}
-
-ExecutionInstruction deleteEmptyParagraphWhenBackspaceIsPressed({
-  required EditContext editContext,
-  required RawKeyEvent keyEvent,
-}) {
-  if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
-  if (node is! ParagraphNode) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (node.text.text.isNotEmpty) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  final nodeAbove = editContext.editor.document.getNodeBefore(node);
-  if (nodeAbove == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-  final newDocumentPosition = DocumentPosition(
-    nodeId: nodeAbove.id,
-    nodePosition: nodeAbove.endPosition,
-  );
-
-  editContext.editor.executeCommand(
-    DeleteParagraphsCommand(nodeId: node.id),
-  );
-
-  editContext.composer.selection = DocumentSelection.collapsed(
-    position: newDocumentPosition,
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return didSplitParagraph ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction moveParagraphSelectionUpWhenBackspaceIsPressed({

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -89,6 +89,9 @@ class TextNode with ChangeNotifier implements DocumentNode {
   bool hasEquivalentContent(DocumentNode other) {
     return other is TextNode && text == other.text && DeepCollectionEquality().equals(metadata, other.metadata);
   }
+
+  @override
+  String toString() => '[TextNode] - text: $text, metadata: $metadata';
 }
 
 /// Displays text in a document.
@@ -749,7 +752,7 @@ class InsertTextCommand implements EditorCommand {
   }
 }
 
-ExecutionInstruction insertCharacterInTextComposable({
+ExecutionInstruction anyCharacterToInsertInTextContent({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
@@ -819,7 +822,7 @@ ExecutionInstruction deleteCharacterWhenBackspaceIsPressed({
   return didDelete ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
-ExecutionInstruction deleteCharacterWhenDeleteIsPressed({
+ExecutionInstruction deleteToRemoveDownstreamContent({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
@@ -832,7 +835,7 @@ ExecutionInstruction deleteCharacterWhenDeleteIsPressed({
   return didDelete ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
-ExecutionInstruction insertNewlineInParagraph({
+ExecutionInstruction shiftEnterToInsertNewlineInBlock({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
@@ -840,15 +843,6 @@ ExecutionInstruction insertNewlineInParagraph({
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isShiftPressed) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!_isTextEntryNode(document: editContext.editor.document, selection: editContext.composer.selection!)) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!editContext.composer.selection!.isCollapsed) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter/rendering.dart';
@@ -18,9 +19,6 @@ import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/selectable_text.dart';
-import 'package:super_editor/src/infrastructure/text_layout.dart';
-
-import 'multi_node_editing.dart';
 
 final _log = Logger(scope: 'text.dart');
 
@@ -85,6 +83,11 @@ class TextNode with ChangeNotifier implements DocumentNode {
     assert(selection is TextSelection);
 
     return (selection as TextSelection).textInside(text.text);
+  }
+
+  @override
+  bool hasEquivalentContent(DocumentNode other) {
+    return other is TextNode && text == other.text && DeepCollectionEquality().equals(metadata, other.metadata);
   }
 }
 
@@ -180,7 +183,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
   }
 
   @override
-  TextPosition? movePositionLeft(dynamic textPosition, [Map<String, dynamic>? movementModifiers]) {
+  TextPosition? movePositionLeft(dynamic textPosition, [Set<MovementModifier>? movementModifiers]) {
     if (textPosition is! TextPosition) {
       // We don't know how to interpret a non-text position.
       return null;
@@ -196,13 +199,11 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
       return null;
     }
 
-    if (movementModifiers?['movement_unit'] == 'line') {
+    if (movementModifiers != null && movementModifiers.contains(MovementModifier.line)) {
       return getPositionAtStartOfLine(
         TextPosition(offset: textPosition.offset),
       );
-    }
-
-    if (movementModifiers?['movement_unit'] == 'word') {
+    } else if (movementModifiers != null && movementModifiers.contains(MovementModifier.word)) {
       final text = getContiguousTextAt(textPosition);
 
       int newOffset = textPosition.offset;
@@ -217,7 +218,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
   }
 
   @override
-  TextPosition? movePositionRight(dynamic textPosition, [Map<String, dynamic>? movementModifiers]) {
+  TextPosition? movePositionRight(dynamic textPosition, [Set<MovementModifier>? movementModifiers]) {
     if (textPosition is! TextPosition) {
       // We don't know how to interpret a non-text position.
       return null;
@@ -228,7 +229,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
       return null;
     }
 
-    if (movementModifiers?['movement_unit'] == 'line') {
+    if (movementModifiers != null && movementModifiers.contains(MovementModifier.line)) {
       final endOfLine = getPositionAtEndOfLine(
         TextPosition(offset: textPosition.offset),
       );
@@ -258,8 +259,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
       // TODO: this logic fails for justified text - find a solution for that (#55)
       return isAutoWrapLine ? TextPosition(offset: endOfLine.offset - 1) : endOfLine;
     }
-
-    if (movementModifiers?['movement_unit'] == 'word') {
+    if (movementModifiers != null && movementModifiers.contains(MovementModifier.word)) {
       final text = getContiguousTextAt(textPosition);
 
       int newOffset = textPosition.offset;
@@ -445,6 +445,184 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
   }
 }
 
+// TODO: the add/remove/toggle commands are almost identical except for what they
+//       do to ranges of text. Pull out the common range calculation behavior.
+/// Applies the given `attributions` to the given `documentSelection`.
+class AddTextAttributionsCommand implements EditorCommand {
+  AddTextAttributionsCommand({
+    required this.documentSelection,
+    required this.attributions,
+  });
+
+  final DocumentSelection documentSelection;
+  final Set<Attribution> attributions;
+
+  @override
+  void execute(Document document, DocumentEditorTransaction transaction) {
+    _log.log('AddTextAttributionsCommand', 'Executing AddTextAttributionsCommand');
+    final nodes = document.getNodesInside(documentSelection.base, documentSelection.extent);
+    if (nodes.isEmpty) {
+      _log.log('AddTextAttributionsCommand',
+          ' - Bad DocumentSelection. Could not get range of nodes. Selection: $documentSelection');
+      return;
+    }
+
+    // Calculate a DocumentRange so we know which DocumentPosition
+    // belongs to the first node, and which belongs to the last node.
+    final nodeRange = document.getRangeBetween(documentSelection.base, documentSelection.extent);
+    _log.log('AddTextAttributionsCommand', ' - node range: $nodeRange');
+
+    final nodesAndSelections = LinkedHashMap<TextNode, TextRange>();
+
+    for (final textNode in nodes) {
+      if (textNode is! TextNode) {
+        continue;
+      }
+
+      int startOffset = -1;
+      int endOffset = -1;
+
+      if (textNode == nodes.first && textNode == nodes.last) {
+        // Handle selection within a single node
+        _log.log('AddTextAttributionsCommand', ' - the selection is within a single node: ${textNode.id}');
+        final baseOffset = (documentSelection.base.nodePosition as TextPosition).offset;
+        final extentOffset = (documentSelection.extent.nodePosition as TextPosition).offset;
+        startOffset = baseOffset < extentOffset ? baseOffset : extentOffset;
+        endOffset = baseOffset < extentOffset ? extentOffset : baseOffset;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset -= 1;
+      } else if (textNode == nodes.first) {
+        // Handle partial node selection in first node.
+        _log.log('AddTextAttributionsCommand', ' - selecting part of the first node: ${textNode.id}');
+        startOffset = (nodeRange.start.nodePosition as TextPosition).offset;
+        endOffset = max(textNode.text.text.length - 1, 0);
+      } else if (textNode == nodes.last) {
+        // Handle partial node selection in last node.
+        _log.log('AddTextAttributionsCommand', ' - adding part of the last node: ${textNode.id}');
+        startOffset = 0;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset = (nodeRange.end.nodePosition as TextPosition).offset - 1;
+      } else {
+        // Handle full node selection.
+        _log.log('AddTextAttributionsCommand', ' - adding full node: ${textNode.id}');
+        startOffset = 0;
+        endOffset = max(textNode.text.text.length - 1, 0);
+      }
+
+      final selectionRange = TextRange(start: startOffset, end: endOffset);
+
+      nodesAndSelections.putIfAbsent(textNode, () => selectionRange);
+    }
+
+    // Add attributions.
+    for (final entry in nodesAndSelections.entries) {
+      for (Attribution attribution in attributions) {
+        final node = entry.key;
+        final range = entry.value;
+        _log.log('AddTextAttributionsCommand', ' - adding attribution: $attribution. Range: $range');
+        node.text.addAttribution(
+          attribution,
+          range,
+        );
+      }
+    }
+
+    _log.log('AddTextAttributionsCommand', ' - done adding attributions');
+  }
+}
+
+/// Removes the given `attributions` from the given `documentSelection`.
+class RemoveTextAttributionsCommand implements EditorCommand {
+  RemoveTextAttributionsCommand({
+    required this.documentSelection,
+    required this.attributions,
+  });
+
+  final DocumentSelection documentSelection;
+  final Set<Attribution> attributions;
+
+  @override
+  void execute(Document document, DocumentEditorTransaction transaction) {
+    _log.log('RemoveTextAttributionsCommand', 'Executing RemoveTextAttributionsCommand');
+    final nodes = document.getNodesInside(documentSelection.base, documentSelection.extent);
+    if (nodes.isEmpty) {
+      _log.log('RemoveTextAttributionsCommand',
+          ' - Bad DocumentSelection. Could not get range of nodes. Selection: $documentSelection');
+      return;
+    }
+
+    // Calculate a DocumentRange so we know which DocumentPosition
+    // belongs to the first node, and which belongs to the last node.
+    final nodeRange = document.getRangeBetween(documentSelection.base, documentSelection.extent);
+    _log.log('RemoveTextAttributionsCommand', ' - node range: $nodeRange');
+
+    final nodesAndSelections = LinkedHashMap<TextNode, TextRange>();
+
+    for (final textNode in nodes) {
+      if (textNode is! TextNode) {
+        continue;
+      }
+
+      int startOffset = -1;
+      int endOffset = -1;
+
+      if (textNode == nodes.first && textNode == nodes.last) {
+        // Handle selection within a single node
+        _log.log('RemoveTextAttributionsCommand', ' - the selection is within a single node: ${textNode.id}');
+        final baseOffset = (documentSelection.base.nodePosition as TextPosition).offset;
+        final extentOffset = (documentSelection.extent.nodePosition as TextPosition).offset;
+        startOffset = baseOffset < extentOffset ? baseOffset : extentOffset;
+        endOffset = baseOffset < extentOffset ? extentOffset : baseOffset;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset -= 1;
+      } else if (textNode == nodes.first) {
+        // Handle partial node selection in first node.
+        _log.log('RemoveTextAttributionsCommand', ' - selecting part of the first node: ${textNode.id}');
+        startOffset = (nodeRange.start.nodePosition as TextPosition).offset;
+        endOffset = max(textNode.text.text.length - 1, 0);
+      } else if (textNode == nodes.last) {
+        // Handle partial node selection in last node.
+        _log.log('RemoveTextAttributionsCommand', ' - adding part of the last node: ${textNode.id}');
+        startOffset = 0;
+
+        // -1 because TextPosition's offset indexes the character after the
+        // selection, not the final character in the selection.
+        endOffset = (nodeRange.end.nodePosition as TextPosition).offset - 1;
+      } else {
+        // Handle full node selection.
+        _log.log('RemoveTextAttributionsCommand', ' - adding full node: ${textNode.id}');
+        startOffset = 0;
+        endOffset = max(textNode.text.text.length - 1, 0);
+      }
+
+      final selectionRange = TextRange(start: startOffset, end: endOffset);
+
+      nodesAndSelections.putIfAbsent(textNode, () => selectionRange);
+    }
+
+    // Add attributions.
+    for (final entry in nodesAndSelections.entries) {
+      for (Attribution attribution in attributions) {
+        final node = entry.key;
+        final range = entry.value;
+        _log.log('RemoveTextAttributionsCommand', ' - removing attribution: $attribution. Range: $range');
+        node.text.removeAttribution(
+          attribution,
+          range,
+        );
+      }
+    }
+
+    _log.log('RemoveTextAttributionsCommand', ' - done adding attributions');
+  }
+}
+
 /// Applies the given `attributions` to the given `documentSelection`,
 /// if none of the content in the selection contains any of the
 /// given `attributions`. Otherwise, all the given `attributions`
@@ -611,27 +789,9 @@ ExecutionInstruction insertCharacterInTextComposable({
     character = ' ';
   }
 
-  final textNode = editContext.editor.document.getNode(editContext.composer.selection!.extent) as TextNode;
-  final initialTextOffset = (editContext.composer.selection!.extent.nodePosition as TextPosition).offset;
+  final didInsertCharacter = editContext.commonOps.insertCharacter(character);
 
-  editContext.editor.executeCommand(
-    InsertTextCommand(
-      documentPosition: editContext.composer.selection!.extent,
-      textToInsert: character,
-      attributions: editContext.composer.preferences.currentStyles,
-    ),
-  );
-
-  editContext.composer.selection = DocumentSelection.collapsed(
-    position: DocumentPosition(
-      nodeId: textNode.id,
-      nodePosition: TextPosition(
-        offset: initialTextOffset + character.length,
-      ),
-    ),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction deleteCharacterWhenBackspaceIsPressed({
@@ -654,37 +814,9 @@ ExecutionInstruction deleteCharacterWhenBackspaceIsPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  final textNode = editContext.editor.document.getNode(editContext.composer.selection!.extent) as TextNode;
-  final currentTextPosition = editContext.composer.selection!.extent.nodePosition as TextPosition;
+  final didDelete = editContext.commonOps.deleteUpstream();
 
-  final previousCharacterOffset = getCharacterStartBounds(textNode.text.text, currentTextPosition.offset);
-
-  final newSelectionPosition = DocumentPosition(
-    nodeId: textNode.id,
-    nodePosition: TextPosition(offset: previousCharacterOffset),
-  );
-
-  // Delete the selected content.
-  editContext.editor.executeCommand(
-    DeleteSelectionCommand(
-      documentSelection: DocumentSelection(
-        base: DocumentPosition(
-          nodeId: textNode.id,
-          nodePosition: currentTextPosition,
-        ),
-        extent: DocumentPosition(
-          nodeId: textNode.id,
-          nodePosition: TextPosition(offset: previousCharacterOffset),
-        ),
-      ),
-    ),
-  );
-
-  _log.log('deleteCharacterWhenBackspaceIsPressed',
-      ' - new document selection position: ${newSelectionPosition.nodePosition}');
-  editContext.composer.selection = DocumentSelection.collapsed(position: newSelectionPosition);
-
-  return ExecutionInstruction.haltExecution;
+  return didDelete ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction deleteCharacterWhenDeleteIsPressed({
@@ -695,85 +827,34 @@ ExecutionInstruction deleteCharacterWhenDeleteIsPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!_isTextEntryNode(document: editContext.editor.document, selection: editContext.composer.selection!)) {
-    return ExecutionInstruction.continueExecution;
-  }
-  if (!editContext.composer.selection!.isCollapsed) {
-    return ExecutionInstruction.continueExecution;
-  }
-  final textNode = editContext.editor.document.getNode(editContext.composer.selection!.extent) as TextNode;
-  final text = textNode.text;
-  final currentTextPosition = (editContext.composer.selection!.extent.nodePosition as TextPosition);
-  if (currentTextPosition.offset >= text.text.length) {
-    return ExecutionInstruction.continueExecution;
-  }
+  final didDelete = editContext.commonOps.deleteDownstream();
 
-  final nextCharacterOffset = getCharacterEndBounds(text.text, currentTextPosition.offset + 1);
-
-  // Delete the selected content.
-  editContext.editor.executeCommand(
-    DeleteSelectionCommand(
-      documentSelection: DocumentSelection(
-        base: DocumentPosition(
-          nodeId: textNode.id,
-          nodePosition: currentTextPosition,
-        ),
-        extent: DocumentPosition(
-          nodeId: textNode.id,
-          nodePosition: TextPosition(offset: nextCharacterOffset),
-        ),
-      ),
-    ),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return didDelete ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction insertNewlineInParagraph({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (editContext.composer.selection == null) {
-    return ExecutionInstruction.continueExecution;
-  }
-
-  if (!_isTextEntryNode(document: editContext.editor.document, selection: editContext.composer.selection!)) {
-    return ExecutionInstruction.continueExecution;
-  }
   if (keyEvent.logicalKey != LogicalKeyboardKey.enter) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isShiftPressed) {
     return ExecutionInstruction.continueExecution;
   }
+  if (editContext.composer.selection == null) {
+    return ExecutionInstruction.continueExecution;
+  }
+  if (!_isTextEntryNode(document: editContext.editor.document, selection: editContext.composer.selection!)) {
+    return ExecutionInstruction.continueExecution;
+  }
   if (!editContext.composer.selection!.isCollapsed) {
     return ExecutionInstruction.continueExecution;
   }
 
-  final textNode = editContext.editor.document.getNode(editContext.composer.selection!.extent) as TextNode;
-  final initialTextOffset = (editContext.composer.selection!.extent.nodePosition as TextPosition).offset;
+  final didInsertNewline = editContext.commonOps.insertPlainText('\n');
 
-  editContext.editor.executeCommand(
-    InsertTextCommand(
-      documentPosition: editContext.composer.selection!.extent,
-      textToInsert: '\n',
-      attributions: editContext.composer.preferences.currentStyles,
-    ),
-  );
-
-  editContext.composer.selection = DocumentSelection.collapsed(
-    position: DocumentPosition(
-      nodeId: textNode.id,
-      nodePosition: TextPosition(
-        offset: initialTextOffset + 1,
-      ),
-    ),
-  );
-
-  return ExecutionInstruction.haltExecution;
+  return didInsertNewline ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 bool _isTextEntryNode({

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -43,6 +43,30 @@ DocumentSelection? getWordSelection({
   );
 }
 
+/// Expands a selection in both directions starting at [textPosition] until
+/// the selection reaches a space, or the end of the available text.
+TextSelection expandPositionToWord({
+  required String text,
+  required TextPosition textPosition,
+}) {
+  if (text.isEmpty) {
+    return TextSelection.collapsed(offset: -1);
+  }
+
+  int start = min(textPosition.offset, text.length - 1);
+  int end = min(textPosition.offset, text.length - 1);
+  while (start > 0 && text[start] != ' ') {
+    start -= 1;
+  }
+  while (end < text.length && text[end] != ' ') {
+    end += 1;
+  }
+  return TextSelection(
+    baseOffset: start,
+    extentOffset: end,
+  );
+}
+
 /// Returns the paragraph of text that contains the given `docPosition`, or `null`
 /// if there is no text at the given `docPosition`.
 ///
@@ -60,7 +84,7 @@ DocumentSelection? getParagraphSelection({
     return null;
   }
 
-  final TextSelection wordSelection = _expandPositionToParagraph(
+  final TextSelection paragraphSelection = expandPositionToParagraph(
     text: (component as TextComposable).getContiguousTextAt(docPosition.nodePosition),
     textPosition: docPosition.nodePosition as TextPosition,
   );
@@ -68,16 +92,18 @@ DocumentSelection? getParagraphSelection({
   return DocumentSelection(
     base: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: wordSelection.base,
+      nodePosition: paragraphSelection.base,
     ),
     extent: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: wordSelection.extent,
+      nodePosition: paragraphSelection.extent,
     ),
   );
 }
 
-TextSelection _expandPositionToParagraph({
+/// Expands a selection in both directions starting at [textPosition] until
+/// the selection reaches a newline, or the end of the available text.
+TextSelection expandPositionToParagraph({
   required String text,
   required TextPosition textPosition,
 }) {

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -891,6 +891,16 @@ class AttributedSpans {
   }
 
   @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AttributedSpans &&
+          runtimeType == other.runtimeType &&
+          DeepCollectionEquality().equals(_attributions, other._attributions);
+
+  @override
+  int get hashCode => _attributions.hashCode;
+
+  @override
   String toString() {
     final buffer = StringBuffer('[AttributedSpans] (${(_attributions.length / 2).round()} spans):');
     for (final marker in _attributions) {

--- a/super_editor/lib/src/infrastructure/attributed_text.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/painting.dart';
 
@@ -266,6 +267,15 @@ class AttributedText with ChangeNotifier {
             style: styleBuilder({}),
           );
   }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is AttributedText && runtimeType == other.runtimeType && text == other.text && spans == other.spans;
+  }
+
+  @override
+  int get hashCode => text.hashCode ^ spans.hashCode;
 
   @override
   String toString() {

--- a/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
+++ b/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
@@ -81,6 +81,18 @@ void main() {
       composer.selection = null;
       await tester.pumpAndSettle();
 
+      // Print statements are for debugging until we have a useful document
+      // comparison matcher to show what doesn't match.
+      // print('Actual document:');
+      // for (final node in documentEditor.document.nodes) {
+      //   print(' - $node');
+      // }
+      // print('------------');
+      // print('Expected document:');
+      // for (final node in expectedDocument.nodes) {
+      //   print(' - $node');
+      // }
+
       expect(documentEditor.document.hasEquivalentContent(expectedDocument), true);
     });
   });

--- a/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
+++ b/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
@@ -1,0 +1,104 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/document_editor.dart';
+import 'package:super_editor/src/core/document_layout.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_editor/src/default_editor/editor.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/infrastructure/attributed_text.dart';
+
+// TODO: Create a fake keyboard that operates at the system channel level
+//       - typeCharacter('m')
+//       - enter()
+//       - backspace()
+//       - delete()
+//       - etc.
+void main() {
+  group('Editor smoke tests', () {
+    testWidgets('document entry', (tester) async {
+      final documentEditor = DocumentEditor(
+        document: MutableDocument(
+          nodes: [
+            ParagraphNode(
+              id: DocumentEditor.createNodeId(),
+              text: AttributedText(text: ''),
+              metadata: {'blockType': header1Attribution},
+            ),
+          ],
+        ),
+      );
+      final composer = DocumentComposer();
+      final layoutKey = GlobalKey();
+      final documentLayoutResolver = () => layoutKey.currentState as DocumentLayout;
+      final commonOps = CommonEditorOperations(
+        editor: documentEditor,
+        composer: composer,
+        documentLayoutResolver: documentLayoutResolver,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Editor.standard(
+              editor: documentEditor,
+              composer: composer,
+              documentLayoutKey: layoutKey,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      composer.selection = DocumentSelection.collapsed(
+          position: DocumentPosition(
+        nodeId: documentEditor.document.nodes.first.id,
+        nodePosition: TextPosition(offset: 0),
+      ));
+
+      final header = 'Smoke Test';
+      for (final character in header.characters) {
+        commonOps.insertCharacter(character);
+      }
+
+      commonOps.insertBlockLevelNewline();
+
+      final p1 =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id.';
+      for (final character in p1.characters) {
+        commonOps.insertCharacter(character);
+      }
+      // TODO: the selection is nulled out to get rid of the blinking caret.
+      //       Add code to the caret painter that prevents animation running in
+      //       debug mode.
+      composer.selection = null;
+      await tester.pumpAndSettle();
+
+      expect(documentEditor.document.hasEquivalentContent(expectedDocument), true);
+    });
+  });
+}
+
+final expectedDocument = MutableDocument(nodes: [
+  ParagraphNode(
+    id: '1',
+    text: AttributedText(text: 'Smoke Test'),
+    metadata: {
+      'blockType': header1Attribution,
+    },
+  ),
+  ParagraphNode(
+    id: '2',
+    text: AttributedText(
+      text:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id.',
+    ),
+  ),
+]);

--- a/super_editor/test/src/_document_test_tools.dart
+++ b/super_editor/test/src/_document_test_tools.dart
@@ -1,4 +1,5 @@
 import 'package:mockito/mockito.dart';
+import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/super_editor.dart';
 
 /// Fake [DocumentLayout], intended for tests that interact with
@@ -11,10 +12,21 @@ EditContext createEditContext({
   DocumentEditor? documentEditor,
   DocumentLayout? documentLayout,
   DocumentComposer? documentComposer,
+  CommonEditorOperations? commonOps,
 }) {
+  final editor = documentEditor ?? DocumentEditor(document: document);
+  final layoutResolver = () => documentLayout ?? FakeDocumentLayout();
+  final composer = documentComposer ?? DocumentComposer();
+
   return EditContext(
-    editor: documentEditor ?? DocumentEditor(document: document),
-    getDocumentLayout: () => documentLayout ?? FakeDocumentLayout(),
-    composer: documentComposer ?? DocumentComposer(),
+    editor: editor,
+    getDocumentLayout: layoutResolver,
+    composer: composer,
+    commonOps: commonOps ??
+        CommonEditorOperations(
+          editor: editor,
+          composer: composer,
+          documentLayoutResolver: layoutResolver,
+        ),
   );
 }

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -8,6 +8,7 @@ import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/box_component.dart';
+import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/default_editor/horizontal_rule.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
@@ -325,5 +326,10 @@ EditContext _createEditContext() {
     editor: documentEditor,
     getDocumentLayout: () => fakeLayout,
     composer: composer,
+    commonOps: CommonEditorOperations(
+      editor: documentEditor,
+      composer: composer,
+      documentLayoutResolver: () => fakeLayout,
+    ),
   );
 }

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -66,7 +66,7 @@ void main() {
         final editContext = _createEditContext();
 
         // Press just the meta key.
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             data: FakeRawKeyEventData(
@@ -82,7 +82,7 @@ void main() {
         expect(result, ExecutionInstruction.continueExecution);
 
         // Press "a" + meta key
-        result = insertCharacterInTextComposable(
+        result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             data: FakeRawKeyEventData(
@@ -102,7 +102,7 @@ void main() {
         final editContext = _createEditContext();
 
         // Try to type a character.
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             data: FakeRawKeyEventData(
@@ -140,7 +140,7 @@ void main() {
         );
 
         // Try to type a character.
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             data: FakeRawKeyEventData(
@@ -171,7 +171,7 @@ void main() {
         );
 
         // Try to type a character.
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             data: FakeRawKeyEventData(
@@ -205,7 +205,7 @@ void main() {
         );
 
         // Press the "alt" key
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             character: null,
@@ -221,7 +221,7 @@ void main() {
         expect(result, ExecutionInstruction.continueExecution);
 
         // Press the "enter" key
-        result = insertCharacterInTextComposable(
+        result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             character: '', // Empirically, pressing enter sends '' as the character instead of null
@@ -256,7 +256,7 @@ void main() {
         );
 
         // Press the "a" key
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             character: 'a',
@@ -295,7 +295,7 @@ void main() {
         );
 
         // Type a non-English character
-        var result = insertCharacterInTextComposable(
+        var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
           keyEvent: FakeRawKeyEvent(
             character: 'ß',


### PR DESCRIPTION
The original implementation of keyboard handlers included the document and selection manipulation that corresponded to those actions. Combining the keyboard handlers and the behaviors makes it more difficult for developers to remap keys or automate document interaction, because developers have to replicate all the behavioral code.

This PR extracts all the document and selection manipulation from the keyboard handlers and puts its in a class called `CommonEditorOperations`. The name isn't very good, but `Editor` and `DocumentInteractor` were already taken. Maybe we can re-evaluate the naming scheme for v0.2.0.

@salihgueler given the volume of code that was moved and *hopefully* simplified, it's probably worth pulling down this branch and trying to break the editor.

PS - I think we should look into how we can create a fake keyboard API that takes over for the system channel and simulates any given raw key event. That way we can setup widget smoke tests that go through full keyboard interaction with a document. We can record a bunch of key events to create a document and then replay them to ensure the same document is created.