### PR TITLE
Renamed Editor to SuperEditor and SelectableText to SuperSelectableText

### DIFF
--- a/super_editor/README.md
+++ b/super_editor/README.md
@@ -44,14 +44,14 @@ The example implementation is only a proof of concept. Expect separate packages 
 
 ## Display an editor
 
-Display a default text editor with the `Editor` widget:
+Display a default text editor with the `SuperEditor` widget:
 
 ```dart
 class _MyAppState extends State<MyApp> {
     void build(context) {
         // Display a visual, editable document.
         //
-        // An Editor does not include any app bar controls or popup
+        // A SuperEditor does not include any app bar controls or popup
         // controls. If you want such controls, you need to implement
         // them yourself.
         //
@@ -59,14 +59,14 @@ class _MyAppState extends State<MyApp> {
         // ordered and unordered lists, images, and horizontal rules. 
         // Paragraphs know how to display bold, italics, and strikethrough.
         // Key combinations are provided for bold (cmd+b) and italics (cmd+i).
-        return Editor.standard(
+        return SuperEditor.standard(
             editor: _myDocumentEditor,
         );
     }
 }
 ```
 
-An `Editor` widget requires a `DocumentEditor`, which is a pure-Dart class that's responsible for applying changes to a `Document`. A `DocumentEditor`, in turn, requires a reference to the `Document` that it will alter. Specifically, a `DocumentEditor` requires a `MutableDocument`.
+A `SuperEditor` widget requires a `DocumentEditor`, which is a pure-Dart class that's responsible for applying changes to a `Document`. A `DocumentEditor`, in turn, requires a reference to the `Document` that it will alter. Specifically, a `DocumentEditor` requires a `MutableDocument`.
 
 ```dart
 // A MutableDocument is an in-memory Document. Create the starting
@@ -97,12 +97,12 @@ final docEditor = DocumentEditor(document: myDoc);
 // Next: pass the docEditor to your Editor widget.
 ```
 
-The `Editor` widget can be customized.
+The `SuperEditor` widget can be customized.
 
 ```dart
 class _MyAppState extends State<MyApp> {
     void build(context) {
-        return Editor.custom(
+        return SuperEditor.custom(
             editor: _myDocumentEditor,
             textStyleBuilder: /** INSERT CUSTOMIZATION **/ null,
             selectionStyle: /** INSERT CUSTOMIZATION **/ null,
@@ -113,7 +113,7 @@ class _MyAppState extends State<MyApp> {
 }
 ```
 
-If your app requires deeper customization than `Editor` provides, you can construct your own version of the `Editor` widget by using lower level tools within the `super_editor` package.
+If your app requires deeper customization than `SuperEditor` provides, you can construct your own version of the `SuperEditor` widget by using lower level tools within the `super_editor` package.
 
 See the wiki for more information about how to customize an editor experience.
 

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -142,7 +142,7 @@ Try it yourself by adding and removing attributions to characters in a string...
               TableRow(
                 children: [
                   _buildRowTitle('Attributed Text'),
-                  SelectableText(
+                  SuperSelectableText(
                     key: GlobalKey(),
                     textSpan: _richText ?? TextSpan(text: 'error'),
                   ),

--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -2,8 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
-/// Demo of an [Editor] widget that can lose focus to a nearby
-/// [TextField] to ensure that the [Editor] correctly removes
+/// Demo of an [SuperEditor] widget that can lose focus to a nearby
+/// [TextField] to ensure that the [SuperEditor] correctly removes
 /// its caret.
 // TODO: Add widget tests for focus interaction verifications
 class LoseFocusDemo extends StatefulWidget {
@@ -34,7 +34,7 @@ class _LoseFocusDemoState extends State<LoseFocusDemo> {
         children: [
           _buildDocSelector(),
           Expanded(
-            child: Editor.standard(
+            child: SuperEditor.standard(
               editor: _docEditor,
               maxWidth: 600,
               padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),

--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -61,7 +61,7 @@ class _MarkdownSerializationDemoState extends State<MarkdownSerializationDemo> {
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: Editor.standard(
+            child: SuperEditor.standard(
               key: _docKey,
               editor: _docEditor,
               maxWidth: 600,

--- a/super_editor/example/lib/demos/demo_paragraphs.dart
+++ b/super_editor/example/lib/demos/demo_paragraphs.dart
@@ -26,7 +26,7 @@ class _ParagraphsDemoState extends State<ParagraphsDemo> {
 
   @override
   Widget build(BuildContext context) {
-    return Editor.standard(
+    return SuperEditor.standard(
       editor: _docEditor,
       maxWidth: 600,
       padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),

--- a/super_editor/example/lib/demos/demo_selectable_text.dart
+++ b/super_editor/example/lib/demos/demo_selectable_text.dart
@@ -46,7 +46,7 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'EMPTY TEXT WITH CARET',
-                  demo: SelectableText.plain(
+                  demo: SuperSelectableText.plain(
                     text: '',
                     textSelection: TextSelection.collapsed(offset: 0),
                     showCaret: true,
@@ -60,14 +60,14 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'TEXT WITHOUT SELECTION OR CARET',
-                  demo: SelectableText(
+                  demo: SuperSelectableText(
                     textSpan: _demoText1,
                   ),
                 ),
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'TEXT WITH CARET + COLLAPSED SELECTION',
-                  demo: SelectableText(
+                  demo: SuperSelectableText(
                     textSpan: _demoText1,
                     textSelection: TextSelection.collapsed(offset: _demoText1.toPlainText().length),
                     showCaret: true,
@@ -76,7 +76,7 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'TEXT WITH LEFT-TO-RIGHT SELECTION + CARET',
-                  demo: SelectableText(
+                  demo: SuperSelectableText(
                     textSpan: _demoText1,
                     textSelection: const TextSelection(baseOffset: 0, extentOffset: 12),
                     showCaret: true,
@@ -85,7 +85,7 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'TEXT WITH RIGHT-TO-LEFT SELECTION + CARET',
-                  demo: SelectableText(
+                  demo: SuperSelectableText(
                     textSpan: _demoText1,
                     textSelection: TextSelection(
                         baseOffset: _demoText1.toPlainText().length,
@@ -100,7 +100,7 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
                     selectableTextKey: _debugTextKey,
                     textLength: _demoText1.toPlainText().length,
                     showDebugPaint: true,
-                    child: SelectableText(
+                    child: SuperSelectableText(
                       key: _debugTextKey,
                       textSpan: _demoText1,
                       textSelection: TextSelection(baseOffset: 0, extentOffset: _demoText1.toPlainText().length),

--- a/super_editor/example/lib/demos/demo_switch_document_content.dart
+++ b/super_editor/example/lib/demos/demo_switch_document_content.dart
@@ -2,9 +2,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
-/// Demo of an [Editor] widget where the [DocumentEditor] changes.
+/// Demo of an [SuperEditor] widget where the [DocumentEditor] changes.
 ///
-/// This demo ensures that [Editor] state resets where appropriate
+/// This demo ensures that [SuperEditor] state resets where appropriate
 /// when its content is replaced.
 class SwitchDocumentDemo extends StatefulWidget {
   @override
@@ -44,7 +44,7 @@ class _SwitchDocumentDemoState extends State<SwitchDocumentDemo> {
         children: [
           _buildDocSelector(),
           Expanded(
-            child: Editor.standard(
+            child: SuperEditor.standard(
               editor: _activeDocumentEditor,
               maxWidth: 600,
               padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -149,7 +149,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
 
   @override
   Widget build(BuildContext context) {
-    return Editor.standard(
+    return SuperEditor.standard(
       editor: _docEditor,
       composer: _composer,
       focusNode: _editorFocusNode,

--- a/super_editor/example/lib/demos/sliver_example_editor.dart
+++ b/super_editor/example/lib/demos/sliver_example_editor.dart
@@ -5,7 +5,7 @@ import 'package:super_editor/super_editor.dart';
 ///
 /// As the editor has an internal scrolling mechanism, for using it with Slivers
 /// you need to give them a finite height or space to fill itself. That is why
-/// the [Editor] has a [SizedBox] wrapped around it to give a height.
+/// the [SuperEditor] has a [SizedBox] wrapped around it to give a height.
 class SliverExampleEditor extends StatefulWidget {
   @override
   _SliverExampleEditorState createState() => _SliverExampleEditorState();
@@ -56,7 +56,7 @@ class _SliverExampleEditorState extends State<SliverExampleEditor> {
         ),
         SliverToBoxAdapter(
           child: IntrinsicHeight(
-            child: Editor.standard(
+            child: SuperEditor.standard(
               editor: _docEditor,
               padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
             ),

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -194,7 +194,7 @@ class _MarketingVideoState extends State<MarketingVideo> {
         width: double.infinity,
         height: double.infinity,
         padding: const EdgeInsets.symmetric(horizontal: 96, vertical: 48),
-        child: Editor.custom(
+        child: SuperEditor.custom(
           documentLayoutKey: _docLayoutKey,
           editor: _editor,
           composer: _composer,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -25,7 +25,7 @@ import 'unknown_component.dart';
 
 /// A text editor for styled text and multi-media elements.
 ///
-/// An `Editor` brings together the key pieces needed
+/// An [SuperEditor] brings together the key pieces needed
 /// to display a user-editable document:
 ///  * document model
 ///  * document editor
@@ -33,19 +33,19 @@ import 'unknown_component.dart';
 ///  * document interaction (tapping, dragging, typing, scrolling)
 ///  * document composer
 ///
-/// An `Editor` determines the visual styling by way of:
-///  * `componentBuilders`, which produce individual components
+/// An [SuperEditor] determines the visual styling by way of:
+///  * [componentBuilders], which produce individual components
 ///     within the document layout
-///  * `textStyleBuilder`, which vends `TextStyle`s for every
+///  * [textStyleBuilder], which vends [TextStyle]s for every
 ///     combination of text attributions
-///  * `selectionStyle`, which dictates the color of the caret
+///  * [selectionStyle], which dictates the color of the caret
 ///     and the color of selected text and components
 ///
-/// An `Editor` determines how the keyboard interacts with the
-/// document by way of `keyboardActions`.
+/// An [SuperEditor] determines how the keyboard interacts with the
+/// document by way of [keyboardActions].
 ///
-/// All styling artifacts and `keyboardActions` are configurable
-/// via the `Editor.custom` constructor.
+/// All styling artifacts and [keyboardActions] are configurable
+/// via the [SuperEditor.custom] constructor.
 ///
 /// ## Deeper explanation of core artifacts:
 ///
@@ -65,8 +65,8 @@ import 'unknown_component.dart';
 ///
 /// Document composer is responsible for owning document
 /// selection and the current text entry mode.
-class Editor extends StatefulWidget {
-  factory Editor.standard({
+class SuperEditor extends StatefulWidget {
+  factory SuperEditor.standard({
     Key? key,
     required DocumentEditor editor,
     DocumentComposer? composer,
@@ -78,7 +78,7 @@ class Editor extends StatefulWidget {
     GlobalKey? documentLayoutKey,
     bool showDebugPaint = false,
   }) {
-    return Editor._(
+    return SuperEditor._(
       key: key,
       editor: editor,
       composer: composer,
@@ -96,7 +96,7 @@ class Editor extends StatefulWidget {
     );
   }
 
-  factory Editor.custom({
+  factory SuperEditor.custom({
     Key? key,
     required DocumentEditor editor,
     DocumentComposer? composer,
@@ -112,7 +112,7 @@ class Editor extends StatefulWidget {
     GlobalKey? documentLayoutKey,
     bool showDebugPaint = false,
   }) {
-    return Editor._(
+    return SuperEditor._(
       key: key,
       editor: editor,
       composer: composer,
@@ -130,7 +130,7 @@ class Editor extends StatefulWidget {
     );
   }
 
-  const Editor._({
+  const SuperEditor._({
     Key? key,
     required this.editor,
     this.composer,
@@ -147,7 +147,7 @@ class Editor extends StatefulWidget {
     this.showDebugPaint = false,
   }) : super(key: key);
 
-  /// Contains a `Document` and alters that document as desired.
+  /// Contains a [Document] and alters that document as desired.
   final DocumentEditor editor;
 
   final DocumentComposer? composer;
@@ -158,9 +158,9 @@ class Editor extends StatefulWidget {
   /// horizontal rule component, etc.
   final List<ComponentBuilder> componentBuilders;
 
-  /// Factory that creates `TextStyle`s based on given
+  /// Factory that creates [TextStyle]s based on given
   /// attributions. An attribution can be anything. It is up
-  /// to the `textStyleBuilder` to interpret attributions
+  /// to the [textStyleBuilder] to interpret attributions
   /// as desired to produce corresponding styles.
   final AttributionStyleBuilder textStyleBuilder;
 
@@ -189,11 +189,11 @@ class Editor extends StatefulWidget {
   final showDebugPaint;
 
   @override
-  _EditorState createState() => _EditorState();
+  _SuperEditorState createState() => _SuperEditorState();
 }
 
-class _EditorState extends State<Editor> {
-  // GlobalKey used to access the `DocumentLayoutState` to figure
+class _SuperEditorState extends State<SuperEditor> {
+  // GlobalKey used to access the [DocumentLayoutState] to figure
   // out where in the document the user taps or drags.
   late GlobalKey _docLayoutKey;
 
@@ -215,10 +215,9 @@ class _EditorState extends State<Editor> {
   }
 
   @override
-  void didUpdateWidget(Editor oldWidget) {
+  void didUpdateWidget(SuperEditor oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.composer != oldWidget.composer) {
-      print('Composer changed!');
       _composer.removeListener(_updateComposerPreferencesAtSelection);
 
       _composer = widget.composer ?? DocumentComposer();
@@ -344,7 +343,7 @@ final defaultSelectionStyle = const SelectionStyle(
   selectionColor: Color(0xFFACCEF7),
 );
 
-/// Creates `TextStyles` for the standard `Editor`.
+/// Creates [TextStyles] for the standard [SuperEditor].
 TextStyle defaultStyleBuilder(Set<Attribution> attributions) {
   TextStyle newStyle = TextStyle(
     color: Colors.black,
@@ -395,7 +394,7 @@ TextStyle defaultStyleBuilder(Set<Attribution> attributions) {
   return newStyle;
 }
 
-/// Creates visual components for the standard `Editor`.
+/// Creates visual components for the standard [SuperEditor].
 ///
 /// These builders are in priority order. The first builder
 /// to return a non-null component is used. The final
@@ -410,7 +409,7 @@ final defaultComponentBuilders = <ComponentBuilder>[
   unknownComponentBuilder,
 ];
 
-/// Keyboard actions for the standard `Editor`.
+/// Keyboard actions for the standard [SuperEditor].
 final defaultKeyboardActions = <DocumentKeyboardAction>[
   doNothingWhenThereIsNoSelection,
   pasteWhenCmdVIsPressed,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -19,7 +19,7 @@ import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
-import 'package:super_editor/src/infrastructure/selectable_text.dart';
+import 'package:super_editor/src/infrastructure/super_selectable_text.dart';
 
 final _log = Logger(scope: 'text.dart');
 
@@ -129,7 +129,7 @@ class TextComponent extends StatefulWidget {
 }
 
 class _TextComponentState extends State<TextComponent> with DocumentComponent implements TextComposable {
-  final _selectableTextKey = GlobalKey<SelectableTextState>();
+  final _selectableTextKey = GlobalKey<SuperSelectableTextState>();
 
   @override
   TextPosition? getPositionAtOffset(Offset localOffset) {
@@ -436,7 +436,7 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
     }
     final richText = blockText.computeTextSpan(widget.textStyleBuilder);
 
-    return SelectableText(
+    return SuperSelectableText(
       key: _selectableTextKey,
       textSpan: richText,
       textAlign: widget.textAlign ?? TextAlign.left,

--- a/super_editor/lib/src/infrastructure/super_selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/super_selectable_text.dart
@@ -8,30 +8,30 @@ import 'text_layout.dart';
 
 /// Displays text with a selection highlight and a caret.
 ///
-/// `SelectableText` does not recognize any user interaction. It's the
+/// [SuperSelectableText] does not recognize any user interaction. It's the
 /// responsibility of ancestor widgets to recognize interactions that
 /// should alter this widget's text selection and/or caret position.
 ///
-/// `textSelection` determines the span of text to be painted
+/// [textSelection] determines the span of text to be painted
 /// with a selection highlight.
 ///
-/// `showCaret` and `textSelection` together determine whether or not the
-/// caret is painted in this `SelectableText`. If `textSelection` is collapsed
-/// with an offset less than 0 then no caret is displayed. If `showCaret` is
-/// false then no caret is displayed. If `textSelection` has a `baseOffset`
-/// or `extentOffset` that is >= zero and `showCaret` is true then a caret is
-/// displayed. An explicit `showCaret` control is offered because multiple
-/// `SelectableText` widgets might be displayed together with a selection
-/// spanning multiple `SelectableText` widgets, but only one of the
-/// `SelectableText` widgets displays a caret.
+/// [showCaret] and [textSelection] together determine whether or not the
+/// caret is painted in this [SuperSelectableText]. If [textSelection] is collapsed
+/// with an offset less than 0 then no caret is displayed. If [showCaret] is
+/// false then no caret is displayed. If [textSelection] has a [baseOffset]
+/// or [extentOffset] that is >= zero and [showCaret] is true then a caret is
+/// displayed. An explicit [showCaret] control is offered because multiple
+/// [SuperSelectableText] widgets might be displayed together with a selection
+/// spanning multiple [SuperSelectableText] widgets, but only one of the
+/// [SuperSelectableTex]` widgets displays a caret.
 ///
-/// If `text` is empty, and a `textSelection` with an extent >= 0 is provided, and
-/// `highlightWhenEmpty` is `true`, then `SelectableText` will paint a small
+/// If [text] is empty, and a [textSelection] with an extent >= 0 is provided, and
+/// [highlightWhenEmpty] is [true], then [SuperSelectableText] will paint a small
 /// highlight, despite having no content. This is useful when showing that
 /// one or more empty text areas are selected.
-class SelectableText extends StatefulWidget {
-  /// `SelectableText` that displays plain text (only one text style).
-  SelectableText.plain({
+class SuperSelectableText extends StatefulWidget {
+  /// [SuperSelectableText] that displays plain text (only one text style).
+  SuperSelectableText.plain({
     Key? key,
     required String text,
     required TextStyle style,
@@ -50,8 +50,8 @@ class SelectableText extends StatefulWidget {
   })  : richText = TextSpan(text: text, style: style),
         super(key: key);
 
-  /// `SelectableText` that displays styled text.
-  SelectableText({
+  /// [SuperSelectableText] that displays styled text.
+  SuperSelectableText({
     Key? key,
     required TextSpan textSpan,
     this.textAlign = TextAlign.left,
@@ -69,44 +69,44 @@ class SelectableText extends StatefulWidget {
   })  : richText = textSpan,
         super(key: key);
 
-  /// The text to display in this `SelectableText` widget.
+  /// The text to display in this [SuperSelectableText] widget.
   final TextSpan richText;
 
-  /// The alignment to use for `richText` display.
+  /// The alignment to use for [richText] display.
   final TextAlign textAlign;
 
-  /// The portion of `richText` to display with the
-  /// `textSelectionDecoration`.
+  /// The portion of [richText] to display with the
+  /// [textSelectionDecoration].
   final TextSelection textSelection;
 
-  /// The visual decoration to apply to the `textSelection`.
+  /// The visual decoration to apply to the [textSelection].
   final TextSelectionDecoration textSelectionDecoration;
 
   /// Builds the visual representation of the caret in this
-  /// `SelectableText` widget.
+  /// [SuperSelectableText] widget.
   final TextCaretFactory textCaretFactory;
 
-  /// True to show a thin selection highlight when `richText`
+  /// True to show a thin selection highlight when [richText]
   /// is empty, or false to avoid showing a selection highlight
-  /// when `richText` is empty.
+  /// when [richText] is empty.
   ///
-  /// This is useful when multiple `SelectableText` widgets
-  /// are selected and some of the selected `SelectableText`
+  /// This is useful when multiple [SuperSelectableText] widgets
+  /// are selected and some of the selected [SuperSelectableText]
   /// widgets are empty.
   final bool highlightWhenEmpty;
 
-  /// True to display a caret in this `SelectableText` at
-  /// the `extent` of `textSelection`, or false to avoid
+  /// True to display a caret in this [SuperSelectableText] at
+  /// the [extent] of [textSelection], or false to avoid
   /// displaying a caret.
   final bool showCaret;
 
   @override
-  SelectableTextState createState() => SelectableTextState();
+  SuperSelectableTextState createState() => SuperSelectableTextState();
 }
 
-class SelectableTextState extends State<SelectableText> implements TextLayout {
-  // `GlobalKey` that provides access to the `RenderParagraph` associated
-  // with the text that this `SelectableText` widget displays.
+class SuperSelectableTextState extends State<SuperSelectableText> implements TextLayout {
+  // [GlobalKey] that provides access to the [RenderParagraph] associated
+  // with the text that this [SuperSelectableText] widget displays.
   final GlobalKey _textKey = GlobalKey();
 
   @override
@@ -117,7 +117,7 @@ class SelectableTextState extends State<SelectableText> implements TextLayout {
   }
 
   @override
-  void didUpdateWidget(SelectableText oldWidget) {
+  void didUpdateWidget(SuperSelectableText oldWidget) {
     super.didUpdateWidget(oldWidget);
 
     if (widget.richText != oldWidget.richText) {
@@ -772,7 +772,7 @@ class _CaretBlinkController with ChangeNotifier {
   }
 }
 
-/// Wraps a given `SelectableText` and paints extra decoration
+/// Wraps a given [SuperSelectableText] and paints extra decoration
 /// to visualize text boundaries.
 class DebugSelectableTextDecorator extends StatefulWidget {
   const DebugSelectableTextDecorator({
@@ -785,7 +785,7 @@ class DebugSelectableTextDecorator extends StatefulWidget {
 
   final GlobalKey selectableTextKey;
   final int textLength;
-  final SelectableText child;
+  final SuperSelectableText child;
   final bool showDebugPaint;
 
   @override
@@ -793,7 +793,8 @@ class DebugSelectableTextDecorator extends StatefulWidget {
 }
 
 class _DebugSelectableTextDecoratorState extends State<DebugSelectableTextDecorator> {
-  SelectableTextState? get _selectableTextState => widget.selectableTextKey.currentState as SelectableTextState;
+  SuperSelectableTextState? get _selectableTextState =>
+      widget.selectableTextKey.currentState as SuperSelectableTextState;
 
   RenderParagraph? get _renderParagraph => _selectableTextState?._renderParagraph;
 

--- a/super_editor/lib/src/infrastructure/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield.dart
@@ -7,10 +7,10 @@ import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:super_editor/src/default_editor/editor.dart';
+import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
-import 'package:super_editor/src/infrastructure/selectable_text.dart';
+import 'package:super_editor/src/infrastructure/super_selectable_text.dart';
 import 'package:super_editor/src/infrastructure/text_layout.dart';
 
 import 'attributed_text.dart';
@@ -92,7 +92,7 @@ class SuperTextField extends StatefulWidget {
 }
 
 class SuperTextFieldState extends State<SuperTextField> {
-  final _selectableTextKey = GlobalKey<SelectableTextState>();
+  final _selectableTextKey = GlobalKey<SuperSelectableTextState>();
   final _textScrollKey = GlobalKey<SuperTextFieldScrollviewState>();
   late FocusNode _focusNode;
   bool _hasFocus = false; // cache whether we have focus so we know when it changes
@@ -302,7 +302,7 @@ class SuperTextFieldState extends State<SuperTextField> {
   }
 
   Widget _buildSelectableText() {
-    return SelectableText(
+    return SuperSelectableText(
       key: _selectableTextKey,
       textSpan: _controller.text.computeTextSpan(widget.textStyleBuilder),
       textAlign: widget.textAlign,
@@ -336,11 +336,11 @@ enum HintBehavior {
 /// is defined on its own so that it can be replaced with a widget that handles
 /// gestures differently.
 ///
-/// The gestures are applied to a [SelectableText] widget that is
+/// The gestures are applied to a [SuperSelectableText] widget that is
 /// tied to [textKey].
 ///
 /// A [SuperTextFieldScrollview] must sit between this [SuperTextFieldGestureInteractor]
-/// and the underlying [SelectableText]. That [SuperTextFieldScrollview] must
+/// and the underlying [SuperSelectableText]. That [SuperTextFieldScrollview] must
 /// be tied to [textScrollKey].
 class SuperTextFieldGestureInteractor extends StatefulWidget {
   const SuperTextFieldGestureInteractor({
@@ -361,8 +361,8 @@ class SuperTextFieldGestureInteractor extends StatefulWidget {
   final AttributedTextEditingController textController;
 
   /// [GlobalKey] that links this [SuperTextFieldGestureInteractor] to
-  /// the [SelectableText] widget that paints the text for this text field.
-  final GlobalKey<SelectableTextState> textKey;
+  /// the [SuperSelectableText] widget that paints the text for this text field.
+  final GlobalKey<SuperSelectableTextState> textKey;
 
   /// [GlobalKey] that links this [SuperTextFieldGestureInteractor] to
   /// the [SuperTextFieldScrollview] that's responsible for scrolling
@@ -395,7 +395,7 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
   final _dragGutterExtent = 24;
   final _maxDragSpeed = 20;
 
-  SelectableTextState get _text => widget.textKey.currentState!;
+  SuperSelectableTextState get _text => widget.textKey.currentState!;
 
   SuperTextFieldScrollviewState get _textScroll => widget.textScrollKey.currentState!;
 
@@ -763,7 +763,7 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
 /// is defined on its own so that it can be replaced with a widget that handles
 /// key events differently.
 ///
-/// The key events are applied to a [SelectableText] widget that is tied to [textKey].
+/// The key events are applied to a [SuperSelectableText] widget that is tied to [textKey].
 class SuperTextFieldKeyboardInteractor extends StatefulWidget {
   const SuperTextFieldKeyboardInteractor({
     Key? key,
@@ -781,8 +781,8 @@ class SuperTextFieldKeyboardInteractor extends StatefulWidget {
   final AttributedTextEditingController textController;
 
   /// [GlobalKey] that links this [SuperTextFieldGestureInteractor] to
-  /// the [SelectableText] widget that paints the text for this text field.
-  final GlobalKey<SelectableTextState> textKey;
+  /// the [SuperSelectableText] widget that paints the text for this text field.
+  final GlobalKey<SuperSelectableTextState> textKey;
 
   /// Ordered list of actions that correspond to various key events.
   ///
@@ -853,7 +853,7 @@ class _SuperTextFieldKeyboardInteractorState extends State<SuperTextFieldKeyboar
 /// scrolling differently.
 ///
 /// [SuperTextFieldScrollview] determines when and where to scroll by working
-/// with a corresponding [SelectableText] widget that is tied to [textKey].
+/// with a corresponding [SuperSelectableText] widget that is tied to [textKey].
 class SuperTextFieldScrollview extends StatefulWidget {
   const SuperTextFieldScrollview({
     Key? key,
@@ -871,8 +871,8 @@ class SuperTextFieldScrollview extends StatefulWidget {
   final AttributedTextEditingController textController;
 
   /// [GlobalKey] that links this [SuperTextFieldScrollview] to
-  /// the [SelectableText] widget that paints the text for this text field.
-  final GlobalKey<SelectableTextState> textKey;
+  /// the [SuperSelectableText] widget that paints the text for this text field.
+  final GlobalKey<SuperSelectableTextState> textKey;
 
   /// [ScrollController] that controls the scroll offset of this [SuperTextFieldScrollview].
   final ScrollController scrollController;
@@ -940,7 +940,7 @@ class SuperTextFieldScrollviewState extends State<SuperTextFieldScrollview> with
     super.dispose();
   }
 
-  SelectableTextState get _text => widget.textKey.currentState!;
+  SuperSelectableTextState get _text => widget.textKey.currentState!;
 
   void _onSelectionOrContentChange() {
     // Use a post-frame callback to "ensure selection extent is visible"
@@ -1181,7 +1181,7 @@ enum TextFieldKeyboardHandlerResult {
 
 typedef TextFieldKeyboardHandler = TextFieldKeyboardHandlerResult Function({
   required AttributedTextEditingController controller,
-  required SelectableTextState selectableTextState,
+  required SuperSelectableTextState selectableTextState,
   required RawKeyEvent keyEvent,
 });
 
@@ -1214,7 +1214,7 @@ const defaultTextFieldKeyboardHandlers = <TextFieldKeyboardHandler>[
 class DefaultSuperTextFieldKeyboardHandlers {
   static TextFieldKeyboardHandlerResult copyTextWhenCmdCIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (!keyEvent.isPrimaryShortcutKeyPressed) {
@@ -1231,7 +1231,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult pasteTextWhenCmdVIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (!keyEvent.isPrimaryShortcutKeyPressed) {
@@ -1252,7 +1252,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult selectAllTextFieldWhenCmdAIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (!keyEvent.isPrimaryShortcutKeyPressed) {
@@ -1269,7 +1269,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult moveUpDownLeftAndRightWithArrowKeys({
     required AttributedTextEditingController controller,
-    required SelectableTextState selectableTextState,
+    required SuperSelectableTextState selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     const arrowKeys = [
@@ -1345,7 +1345,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult insertCharacterWhenKeyIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (keyEvent.isMetaPressed || keyEvent.isControlPressed) {
@@ -1378,7 +1378,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed({
     required AttributedTextEditingController controller,
-    required SelectableTextState selectableTextState,
+    required SuperSelectableTextState selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -1402,7 +1402,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult deleteTextWhenBackspaceOrDeleteIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     final isBackspace = keyEvent.logicalKey == LogicalKeyboardKey.backspace;
@@ -1425,7 +1425,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
   static TextFieldKeyboardHandlerResult insertNewlineWhenEnterIsPressed({
     required AttributedTextEditingController controller,
-    SelectableTextState? selectableTextState,
+    SuperSelectableTextState? selectableTextState,
     required RawKeyEvent keyEvent,
   }) {
     if (keyEvent.logicalKey != LogicalKeyboardKey.enter) {
@@ -1538,7 +1538,7 @@ extension DefaultSuperTextFieldActions on AttributedTextEditingController {
   }
 
   void moveCaretHorizontally({
-    required SelectableTextState selectableTextState,
+    required SuperSelectableTextState selectableTextState,
     required bool expandSelection,
     required bool moveLeft,
     Map<String, dynamic> movementModifiers = const {},
@@ -1623,7 +1623,7 @@ extension DefaultSuperTextFieldActions on AttributedTextEditingController {
   }
 
   void moveCaretVertically({
-    required SelectableTextState selectableTextState,
+    required SuperSelectableTextState selectableTextState,
     required bool expandSelection,
     required bool moveUp,
   }) {
@@ -1692,7 +1692,7 @@ extension DefaultSuperTextFieldActions on AttributedTextEditingController {
   }
 
   void deleteTextOnLineBeforeCaret({
-    required SelectableTextState selectableTextState,
+    required SuperSelectableTextState selectableTextState,
   }) {
     assert(selection.isCollapsed);
 

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -1,6 +1,6 @@
 library super_editor;
 
-export 'src/infrastructure/selectable_text.dart';
+export 'src/infrastructure/super_selectable_text.dart';
 export 'src/infrastructure/attributed_text.dart';
 export 'src/infrastructure/attributed_spans.dart';
 export 'src/infrastructure/multi_tap_gesture.dart';
@@ -18,7 +18,7 @@ export 'src/default_editor/box_component.dart';
 export 'src/default_editor/common_editor_operations.dart';
 export 'src/default_editor/document_interaction.dart';
 export 'src/default_editor/document_keyboard_actions.dart';
-export 'src/default_editor/editor.dart';
+export 'src/default_editor/super_editor.dart';
 export 'src/default_editor/horizontal_rule.dart';
 export 'src/default_editor/image.dart';
 export 'src/default_editor/layout.dart';

--- a/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
+++ b/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
@@ -11,7 +11,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
-import 'package:super_editor/src/default_editor/editor.dart';
+import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 
@@ -47,7 +47,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Editor.standard(
+            body: SuperEditor.standard(
               editor: documentEditor,
               composer: composer,
               documentLayoutKey: layoutKey,

--- a/super_editor/test/src/infrastructure/super_textfield_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
-import 'package:super_editor/src/infrastructure/selectable_text.dart';
+import 'package:super_editor/src/infrastructure/super_selectable_text.dart';
 import 'package:super_editor/src/infrastructure/super_textfield.dart';
 
 import '../_text_entry_test_tools.dart';
@@ -2472,7 +2472,7 @@ final _multilineLayoutText = 'this text is long enough to be multiline in the av
 // (18)enough to be (31 - upstream)
 // (31)multiline in the (48 - upstream)
 // (48)available space(63)
-Future<SelectableTextState> _pumpMultilineLayout(
+Future<SuperSelectableTextState> _pumpMultilineLayout(
   WidgetTester tester,
 ) async {
   final selectableText = await _pumpAndReturnSelectableText(
@@ -2496,14 +2496,14 @@ Future<SelectableTextState> _pumpMultilineLayout(
   return selectableText;
 }
 
-Future<SelectableTextState> _pumpAndReturnSelectableText(
+Future<SuperSelectableTextState> _pumpAndReturnSelectableText(
   WidgetTester tester,
   String text, [
   Widget Function(Widget child)? decorator,
 ]) async {
-  final textKey = GlobalKey<SelectableTextState>();
+  final textKey = GlobalKey<SuperSelectableTextState>();
 
-  final selectableText = SelectableText.plain(
+  final selectableText = SuperSelectableText.plain(
     key: textKey,
     text: text,
     style: TextStyle(),


### PR DESCRIPTION
Renamed Editor to SuperEditor and SelectableText to SuperSelectableText to disambiguate with other widgets and classes.