### PR TITLE
Introduced NodeSelection and NodePosition marker interfaces to avoid dynamic references. (#209)

### DIFF
--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -3,63 +3,63 @@ import 'package:flutter/widgets.dart';
 
 /// A read-only document with styled text and multimedia elements.
 ///
-/// A `Document` is comprised of a list of `DocumentNode`s,
+/// A [Document] is comprised of a list of [DocumentNode]s,
 /// which describe the type and substance of a piece of content
-/// within the document. For example, a `ParagraphNode` holds a
+/// within the document. For example, a [ParagraphNode] holds a
 /// single paragraph of text within the document.
 ///
-/// New types of content can be added by subclassing `DocumentNode`.
+/// New types of content can be added by subclassing [DocumentNode].
 ///
-/// To represent a specific location within a `Document`,
-/// see `DocumentPosition`.
+/// To represent a specific location within a [Document],
+/// see [DocumentPosition].
 ///
-/// A `Document` has no opinion on the visual presentation of its
+/// A [Document] has no opinion on the visual presentation of its
 /// content.
 ///
-/// To edit the content of a document, see `DocumentEditor`.
+/// To edit the content of a document, see [DocumentEditor].
 abstract class Document with ChangeNotifier {
   /// Returns all of the content within the document as a list
-  /// of `DocumentNode`s.
+  /// of [DocumentNode]s.
   List<DocumentNode> get nodes;
 
-  /// Returns the `DocumentNode` with the given `nodeId`, or `null`
+  /// Returns the [DocumentNode] with the given [nodeId], or [null]
   /// if no such node exists.
   DocumentNode? getNodeById(String nodeId);
 
-  /// Returns the `DocumentNode` at the given `index`, or `null`
+  /// Returns the [DocumentNode] at the given [index], or [null]
   /// if no such node exists.
   DocumentNode? getNodeAt(int index);
 
-  /// Returns the index of the given `node`, or `-1` if the `node`
-  /// does not exist within this `Document`.
+  /// Returns the index of the given [node], or [-1] if the [node]
+  /// does not exist within this [Document].
   int getNodeIndex(DocumentNode node);
 
-  /// Returns the `DocumentNode` that appears immediately before the
-  /// given `node` in this `Document`, or null if the given `node`
-  /// is the first node, or the given `node` does not exist in this
-  /// `Document`.
+  /// Returns the [DocumentNode] that appears immediately before the
+  /// given [node] in this [Document], or null if the given [node]
+  /// is the first node, or the given [node] does not exist in this
+  /// [Document].
   DocumentNode? getNodeBefore(DocumentNode node);
 
-  /// Returns the `DocumentNode` that appears immediately after the
-  /// given `node` in this `Document`, or null if the given `node`
-  /// is the last node, or the given `node` does not exist in this
-  /// `Document`.
+  /// Returns the [DocumentNode] that appears immediately after the
+  /// given [node] in this [Document], or null if the given [node]
+  /// is the last node, or the given [node] does not exist in this
+  /// [Document].
   DocumentNode? getNodeAfter(DocumentNode node);
 
-  /// Returns the `DocumentNode` at the given `position`, or `null` if
-  /// no such node exists in this `Document`.
+  /// Returns the [DocumentNode] at the given [position], or [null] if
+  /// no such node exists in this [Document].
   DocumentNode? getNode(DocumentPosition position);
 
-  /// Returns a `DocumentRange` that ranges from `position1` to
-  /// `position2`, including `position1` and `position2`.
+  /// Returns a [DocumentRange] that ranges from [position1] to
+  /// [position2], including [position1] and [position2].
   // TODO: this method is misleading (#48) because if `position1` and
   //       `position2` are in the same node, they may be returned
   //       in the wrong order because the document doesn't know
   //       how to interpret positions within a node.
   DocumentRange getRangeBetween(DocumentPosition position1, DocumentPosition position2);
 
-  /// Returns all `DocumentNode`s from `position1` to `position2`, including
-  /// the nodes at `position1` and `position2`.
+  /// Returns all [DocumentNode]s from [position1] to [position2], including
+  /// the nodes at [position1] and [position2].
   List<DocumentNode> getNodesInside(DocumentPosition position1, DocumentPosition position2);
 
   /// Returns [true] if the content in the [other] document is equivalent to
@@ -70,10 +70,10 @@ abstract class Document with ChangeNotifier {
   bool hasEquivalentContent(Document other);
 }
 
-/// A span within a `Document` that begins at `start` and
-/// ends at `end`.
+/// A span within a [Document] that begins at [start] and
+/// ends at [end].
 ///
-/// The `start` position must come before the `end` position in
+/// The [start] position must come before the [end] position in
 /// the document.
 class DocumentRange {
   DocumentRange({
@@ -81,8 +81,8 @@ class DocumentRange {
     required this.end,
   });
 
-  final DocumentPosition<dynamic> start;
-  final DocumentPosition<dynamic> end;
+  final DocumentPosition start;
+  final DocumentPosition end;
 
   @override
   bool operator ==(Object other) =>
@@ -98,28 +98,28 @@ class DocumentRange {
   }
 }
 
-/// A specific position within a `Document`.
+/// A logical position within a [Document].
 ///
-/// A `DocumentPosition` points to a specific node by way of a `nodeId`,
+/// A [DocumentPosition] points to a specific node by way of a [nodeId],
 /// and points to a specific position within the node by way of a
-/// `nodePosition`.
+/// [nodePosition].
 ///
-/// The type of the `nodePosition` depends upon the type of `DocumentNode`
-/// that this position points to. For example, a `ParagraphNode`
-/// uses a `TextPosition` to represent a `nodePosition`.
-class DocumentPosition<PositionType> {
+/// The type of the [nodePosition] depends upon the type of [DocumentNode]
+/// that this position points to. For example, a [ParagraphNode]
+/// uses a [TextPosition] to represent a [nodePosition].
+class DocumentPosition {
   const DocumentPosition({
     required this.nodeId,
     required this.nodePosition,
   });
 
-  /// ID of a `DocumentNode` within a `Document`.
+  /// ID of a [DocumentNode] within a [Document].
   final String nodeId;
 
   /// Node-specific representation of a position.
   ///
-  /// For example: a paragraph node might use a `TextPosition`.
-  final PositionType nodePosition;
+  /// For example: a paragraph node might use a [TextNodePosition].
+  final NodePosition nodePosition;
 
   @override
   bool operator ==(Object other) =>
@@ -135,41 +135,55 @@ class DocumentPosition<PositionType> {
   }
 }
 
-/// A single content node within a `Document`.
+/// A single content node within a [Document].
 abstract class DocumentNode implements ChangeNotifier {
-  /// ID that is unique within a `Document`.
+  /// ID that is unique within a [Document].
   String get id;
 
-  /// Returns the node position that corresponds to the beginning
+  /// Returns the [NodePosition] that corresponds to the beginning
   /// of content in this node.
   ///
-  /// For example, a `ParagraphNode` would return `TextPosition(offset: 0)`.
-  dynamic get beginningPosition;
+  /// For example, a [ParagraphNode] would return [TextNodePosition(offset: 0)].
+  NodePosition get beginningPosition;
 
-  /// Returns the node position that corresponds to the end of the
+  /// Returns the [NodePosition] that corresponds to the end of the
   /// content in this node.
   ///
-  /// For example, a `ParagraphNode` would return
-  /// `TextPosition(offset: text.length)`.
-  dynamic get endPosition;
+  /// For example, a [ParagraphNode] would return
+  /// [TextNodePosition(offset: text.length)].
+  NodePosition get endPosition;
 
   /// Returns a node-specific representation of a selection from
-  /// `base` to `extent`.
+  /// [base] to [extent].
   ///
-  /// For example, a `ParagraphNode` would return a `TextSelection`.
-  dynamic computeSelection({
-    @required dynamic base,
-    @required dynamic extent,
+  /// For example, a [ParagraphNode] would return a [TextNodeSelection].
+  NodeSelection computeSelection({
+    required NodePosition base,
+    required NodePosition extent,
   });
 
   /// Returns a plain-text version of the content in this node
-  /// within `selection`, or null if the given selection does
+  /// within [selection], or null if the given selection does
   /// not make sense as plain-text.
-  String? copyContent(dynamic selection);
+  String? copyContent(NodeSelection selection);
 
   /// Returns true of the [other] node is the same type as this
   /// node, and contains the same content.
   ///
   /// Content equivalency ignores the node ID.
   bool hasEquivalentContent(DocumentNode other);
+}
+
+/// Marker interface for a selection within a [DocumentNode].
+abstract class NodeSelection {
+  // marker interface
+}
+
+/// Marker interface for all node positions.
+///
+/// A node position is a logical position within a [DocumentNode],
+/// e.g., a [TextNodePosition] within a [ParagraphNode], or a [BinaryNodePosition]
+/// within an [ImageNode].
+abstract class NodePosition {
+  // marker interface
 }

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -15,30 +15,30 @@ typedef DocumentLayoutResolver = DocumentLayout Function();
 
 /// Abstract representation of a document layout.
 ///
-/// Regardless of how a document is displayed, a `DocumentLayout` needs
+/// Regardless of how a document is displayed, a [DocumentLayout] needs
 /// to answer various questions about where content sits within the layout.
-/// A `DocumentLayout` is the source of truth for the mapping between logical
-/// `DocumentPosition`s and visual (x,y) positions. For example, this mapping
-/// allows the app to determine which portion of a `String` should be selected
+/// A [DocumentLayout] is the source of truth for the mapping between logical
+/// [DocumentPosition]s and visual (x,y) positions. For example, this mapping
+/// allows the app to determine which portion of a [String] should be selected
 /// when the user drags from one (x,y) position to another (x,y) position on
 /// the screen.
 abstract class DocumentLayout {
-  /// Returns the `DocumentPosition` that corresponds to the given
-  /// `layoutOffset`, or `null` if the `layoutOffset` does not exist
+  /// Returns the [DocumentPosition] that corresponds to the given
+  /// [layoutOffset], or [null] if the [layoutOffset] does not exist
   /// within a piece of document content.
   DocumentPosition? getDocumentPositionAtOffset(Offset layoutOffset);
 
-  /// Returns the `DocumentPosition` at the y-value of the given `layoutOffset`
-  /// that sits closest to the x-value of the given `layoutOffset`, or `null`
+  /// Returns the [DocumentPosition] at the y-value of the given [layoutOffset]
+  /// that sits closest to the x-value of the given [layoutOffset], or [null]
   /// if there is no document content at the given y-value.
   ///
   /// For example, a y-position within the first line of a paragraph, and an
   /// x-position that sits to the left of the paragraph would return the
-  /// `DocumentPosition` for the first character within the paragraph.
+  /// [DocumentPosition] for the first character within the paragraph.
   DocumentPosition? getDocumentPositionNearestToOffset(Offset layoutOffset);
 
   /// Returns the bounding box of the component that renders the given
-  /// `position`, or `null` if no corresponding component can be found, or
+  /// [position], or [null] if no corresponding component can be found, or
   /// the corresponding component has not yet been laid out.
   Rect? getRectForPosition(DocumentPosition position);
 
@@ -46,18 +46,18 @@ abstract class DocumentLayout {
   /// [basePosition] and [extentPosition].
   Rect? getRectForSelection(DocumentPosition basePosition, DocumentPosition extentPosition);
 
-  /// Returns a `DocumentSelection` that begins near `baseOffset` and extends
-  /// to `extentOffset`, or `null` if no document content sits between the
+  /// Returns a [DocumentSelection] that begins near [baseOffset] and extends
+  /// to [extentOffset], or [null] if no document content sits between the
   /// provided points.
   DocumentSelection? getDocumentSelectionInRegion(Offset baseOffset, Offset extentOffset);
 
-  /// Returns the `MouseCursor` that's desired by the component at `documentOffset`, or
-  /// `null` if the document has no preference for the `MouseCursor` at the given
-  /// `documentOffset`.
+  /// Returns the [MouseCursor] that's desired by the component at [documentOffset], or
+  /// [null] if the document has no preference for the [MouseCursor] at the given
+  /// [documentOffset].
   MouseCursor? getDesiredCursorAtOffset(Offset documentOffset);
 
-  /// Returns the `DocumentComponent` that renders the `DocumentNode` with
-  /// the given `nodeId`, or `null` if no such component exists.
+  /// Returns the [DocumentComponent] that renders the [DocumentNode] with
+  /// the given [nodeId], or [null] if no such component exists.
   DocumentComponent? getComponentByNodeId(String nodeId);
 
   /// Converts [ancestorOffset] from the [ancestor]'s coordinate space to the
@@ -70,40 +70,40 @@ abstract class DocumentLayout {
 }
 
 /// Contract for all widgets that operate as document components
-/// within a `DocumentLayout`.
+/// within a [DocumentLayout].
 mixin DocumentComponent<T extends StatefulWidget> on State<T> {
   /// Returns the node position within this component at the given
-  /// `localOffset`, or `null` if the `localOffset` does not sit
+  /// [localOffset], or [null] if the [localOffset] does not sit
   /// within any content.
   ///
-  /// See `Document` for more information about `DocumentNode`s and
+  /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  dynamic? getPositionAtOffset(Offset localOffset);
+  NodePosition? getPositionAtOffset(Offset localOffset);
 
-  /// Returns the (x,y) `Offset` for the given `nodePosition`, or throws
-  /// an exception if the given `nodePosition` is not compatible
+  /// Returns the (x,y) [Offset] for the given [nodePosition], or throws
+  /// an exception if the given [nodePosition] is not compatible
   /// with this component's node type.
   ///
-  /// If the given `nodePosition` corresponds to a component where
-  /// a position is ambiguous with regard to an (x,y) `Offset`, like
+  /// If the given [nodePosition] corresponds to a component where
+  /// a position is ambiguous with regard to an (x,y) [Offset], like
   /// an image or horizontal rule, it's up to that component to
-  /// choose a reasonable `Offset`, such as the center of the image.
+  /// choose a reasonable [Offset], such as the center of the image.
   ///
-  /// See `Document` for more information about `DocumentNode`s and
+  /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  Offset getOffsetForPosition(dynamic nodePosition);
+  Offset getOffsetForPosition(NodePosition nodePosition);
 
-  /// Returns a `Rect` for the given `nodePosition`, or throws
-  /// an exception if the given `nodePosition` is not compatible
+  /// Returns a [Rect] for the given [nodePosition], or throws
+  /// an exception if the given [nodePosition] is not compatible
   /// with this component's node type.
   ///
-  /// If the given `nodePosition` corresponds to a single (x,y)
-  /// offset rather than a `Rect`, a `Rect` with zero width and
+  /// If the given [nodePosition] corresponds to a single (x,y)
+  /// offset rather than a [Rect], a [Rect] with zero width and
   /// height may be returned.
   ///
-  /// See `Document` for more information about `DocumentNode`s and
+  /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  Rect getRectForPosition(dynamic nodePosition);
+  Rect getRectForPosition(NodePosition nodePosition);
 
   /// Returns a [Rect] that bounds the content selected between
   /// [baseNodePosition] and [extentNodePosition].
@@ -113,125 +113,126 @@ mixin DocumentComponent<T extends StatefulWidget> on State<T> {
   ///
   /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  Rect getRectForSelection(dynamic baseNodePosition, dynamic extentNodePosition);
+  Rect getRectForSelection(NodePosition baseNodePosition, NodePosition extentNodePosition);
 
   /// Returns the node position that represents the "beginning" of
   /// the content within this component, such as the first character
   /// of a paragraph.
   ///
-  /// See `Document` for more information about `DocumentNode`s and
+  /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  dynamic getBeginningPosition();
+  NodePosition getBeginningPosition();
 
   /// Returns the earliest position within this component's
-  /// `DocumentNode` that appears at or near the given `x` position.
+  /// [DocumentNode] that appears at or near the given [x] position.
   ///
   /// This is useful, for example, when moving selection into the
   /// beginning of some text while maintaining the existing horizontal
   /// position of the selection.
-  dynamic getBeginningPositionNearX(double x);
+  NodePosition getBeginningPositionNearX(double x);
 
   /// Returns a new position within this component's node that
-  /// corresponds to the `currentPosition` moved left one unit,
+  /// corresponds to the [currentPosition] moved left one unit,
   /// as interpreted by this component/node, in conjunction with
-  /// any relevant `movementModifier`.
+  /// any relevant [movementModifier].
   ///
-  /// The structure and options for `movementModifier`s is
+  /// The structure and options for [movementModifier]s is
   /// determined by each component/node combination.
   ///
-  /// Returns `null` if the concept of horizontal movement does not
+  /// Returns [null] if the concept of horizontal movement does not
   /// make sense for this component.
   ///
-  /// Returns `null` if there is nowhere to move left within this
-  /// component, such as when the `currentPosition` is the first
+  /// Returns [null] if there is nowhere to move left within this
+  /// component, such as when the [currentPosition] is the first
   /// character within a paragraph.
-  dynamic? movePositionLeft(dynamic currentPosition, [Set<MovementModifier> movementModifiers]);
+  NodePosition? movePositionLeft(NodePosition currentPosition, [Set<MovementModifier> movementModifiers]);
 
   /// Returns a new position within this component's node that
-  /// corresponds to the `currentPosition` moved right one unit,
+  /// corresponds to the [currentPosition] moved right one unit,
   /// as interpreted by this component/node, in conjunction with
-  /// any relevant `movementModifier`.
+  /// any relevant [movementModifier].
   ///
-  /// The structure and options for `movementModifier`s is
+  /// The structure and options for [movementModifier]s is
   /// determined by each component/node combination.
   ///
   /// Returns null if the concept of horizontal movement does not
   /// make sense for this component.
   ///
   /// Returns null if there is nowhere to move right within this
-  /// component, such as when the `currentPosition` refers to the
+  /// component, such as when the [currentPosition] refers to the
   /// last character in a paragraph.
-  dynamic? movePositionRight(dynamic currentPosition, [Set<MovementModifier> movementModifiers]);
+  NodePosition? movePositionRight(NodePosition currentPosition, [Set<MovementModifier> movementModifiers]);
 
   /// Returns a new position within this component's node that
-  /// corresponds to the `currentPosition` moved up one unit,
+  /// corresponds to the [currentPosition] moved up one unit,
   /// as interpreted by this component/node.
   ///
   /// Returns null if the concept of vertical movement does not
   /// make sense for this component.
   ///
   /// Returns null if there is nowhere to move up within this
-  /// component, such as when the `currentPosition` refers to
+  /// component, such as when the [currentPosition] refers to
   /// the first line of a paragraph.
-  dynamic? movePositionUp(dynamic currentPosition);
+  NodePosition? movePositionUp(NodePosition currentPosition);
 
   /// Returns a new position within this component's node that
-  /// corresponds to the `currentPosition` moved down one unit,
+  /// corresponds to the [currentPosition] moved down one unit,
   /// as interpreted by this component/node.
   ///
   /// Returns null if the concept of vertical movement does not
   /// make sense for this component.
   ///
   /// Returns null if there is nowhere to move down within this
-  /// component, such as when the `currentPosition` refers to
+  /// component, such as when the [currentPosition] refers to
   /// the last line of a paragraph.
-  dynamic? movePositionDown(dynamic currentPosition);
+  NodePosition? movePositionDown(NodePosition currentPosition);
 
-  /// Returns the node position that represents the "end" of
+  /// Returns the [NodePosition that represents the "end" of
   /// the content within this component, such as the last character
   /// of a paragraph.
   ///
-  /// See `Document` for more information about `DocumentNode`s and
+  /// See [Document] for more information about [DocumentNode]s and
   /// node positions.
-  dynamic getEndPosition();
+  NodePosition getEndPosition();
 
   /// Returns the latest position within this component's
-  /// `DocumentNode` that appears at or near the given `x` position.
+  /// [DocumentNode] that appears at or near the given [x] position.
   ///
   /// This is useful, for example, when moving selection into the
   /// end of some text while maintaining the existing horizontal
   /// position of the selection.
-  dynamic getEndPositionNearX(double x);
+  NodePosition getEndPositionNearX(double x);
 
-  /// Returns a selection of content that appears between the `localBaseOffset`
-  /// and the `localExtentOffset`, or `null` if the given region does not
+  /// Returns a selection of content that appears between the [localBaseOffset]
+  /// and the [localExtentOffset], or [null] if the given region does not
   /// include any of the content within this component.
   ///
-  /// The selection type depends on the type of `DocumentNode` that this
+  /// The selection type depends on the type of [DocumentNode] that this
   /// component displays.
-  dynamic? getSelectionInRange(Offset localBaseOffset, Offset localExtentOffset);
+  NodeSelection? getSelectionInRange(Offset localBaseOffset, Offset localExtentOffset);
 
-  /// Returns a node selection within this component's `DocumentNode` that
-  /// is collapsed at the given `nodePosition`, or throws an exception if
-  /// the given `nodePosition` is not compatible with this component's
-  /// node type.
-  dynamic getCollapsedSelectionAt(dynamic nodePosition);
-
-  /// Returns a node selection within this component's `DocumentNode` that
-  /// spans from `basePosition` to `extentPosition`.
+  /// Returns a [NodeSelection] within this component's [DocumentNode] that
+  /// is collapsed at the given [nodePosition]
   ///
-  /// Throws an exception if `basePosition` or `extentPosition` are
+  /// Throws an exception if the given [nodePosition] is not compatible with
+  /// this component's node type.
+  NodeSelection getCollapsedSelectionAt(NodePosition nodePosition);
+
+  /// Returns a [NodeSelection] within this component's [DocumentNode] that
+  /// spans from [basePosition] to [extentPosition].
+  ///
+  /// Throws an exception if [basePosition] or [extentPosition] are
   /// incompatible with this component's node type.
-  dynamic getSelectionBetween({
-    required dynamic basePosition,
-    required dynamic extentPosition,
+  NodeSelection getSelectionBetween({
+    required NodePosition basePosition,
+    required NodePosition extentPosition,
   });
 
-  /// Returns a node selection that includes all content within the node.
-  dynamic getSelectionOfEverything();
+  /// Returns a [NodeSelection that includes all content within the node.
+  NodeSelection getSelectionOfEverything();
 
-  /// Returns the desired `MouseCursor` at the given (x,y) `localOffset`, or
-  /// `null` if this component has no preference for the cursor style.
+  /// Returns the desired [MouseCursor] at the given (x,y) [localOffset], or
+  /// [null] if this component has no preference for the cursor style.
   MouseCursor? getDesiredCursorAtOffset(Offset localOffset);
 }
 
@@ -262,23 +263,23 @@ class MovementModifier {
 }
 
 /// Builds a widget that renders the desired UI for one or
-/// more `DocumentNode`s.
+/// more [DocumentNode]s.
 ///
-/// Every widget returned from a `ComponentBuilder` should be
-/// a `StatefulWidget` that mixes in `DocumentComponent`.
+/// Every widget returned from a [ComponentBuilder] should be
+/// a [StatefulWidget] that mixes in [DocumentComponent].
 ///
-/// A `ComponentBuilder` might be invoked with a type of
-/// `DocumentNode` that it doesn't know how to work with. When
-/// this happens, the `ComponentBuilder` should return `null`,
+/// A [ComponentBuilder] might be invoked with a type of
+/// [DocumentNode] that it doesn't know how to work with. When
+/// this happens, the [ComponentBuilder] should return [null],
 /// indicating that it doesn't know how to build a component
-/// for the given `DocumentNode`.
+/// for the given [DocumentNode].
 ///
-/// See `ComponentContext` for expectations about how to use
+/// See [ComponentContext] for expectations about how to use
 /// the context to build a component widget.
 typedef ComponentBuilder = Widget? Function(ComponentContext);
 
-/// Information that is provided to a `ComponentBuilder` to
-/// construct an appropriate `DocumentComponent` widget.
+/// Information that is provided to a [ComponentBuilder] to
+/// construct an appropriate [DocumentComponent] widget.
 class ComponentContext {
   const ComponentContext({
     required this.context,
@@ -290,20 +291,20 @@ class ComponentContext {
     this.extensions = const {},
   });
 
-  /// The `BuildContext` for the parent of the `DocumentComponent`
+  /// The [BuildContext] for the parent of the [DocumentComponent]
   /// that needs to be built.
   final BuildContext context;
 
-  /// The `Document` that contains the `DocumentNode`.
+  /// The [Document] that contains the [DocumentNode].
   final Document document;
 
-  /// The `DocumentNode` for which a component is needed.
+  /// The [DocumentNode] for which a component is needed.
   final DocumentNode documentNode;
 
-  /// A `GlobalKey` that must be assigned to the `DocumentComponent`
-  /// widget returned by a `ComponentBuilder`.
+  /// A [GlobalKey] that must be assigned to the [DocumentComponent]
+  /// widget returned by a [ComponentBuilder].
   ///
-  /// The `componentKey` is used by the `DocumentLayout` to query for
+  /// The [componentKey] is used by the [DocumentLayout] to query for
   /// node-specific information, like node positions and selections.
   final GlobalKey componentKey;
 
@@ -315,12 +316,12 @@ class ComponentContext {
   /// a paragraph, should respect this property.
   final bool showCaret;
 
-  /// The current selected region within the `documentNode`.
+  /// The current selected region within the [documentNode].
   ///
   /// The component should paint this selection.
   final DocumentNodeSelection? nodeSelection;
 
   /// May contain additional information needed to build the
-  /// component, based on the specific type of the `documentNode`.
+  /// component, based on the specific type of the [documentNode].
   final Map<String, dynamic> extensions;
 }

--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -1,4 +1,3 @@
-
 import 'document.dart';
 
 /// A selection within a `Document`.
@@ -27,8 +26,8 @@ class DocumentSelection {
     required this.extent,
   });
 
-  final DocumentPosition<dynamic> base;
-  final DocumentPosition<dynamic> extent;
+  final DocumentPosition base;
+  final DocumentPosition extent;
 
   bool get isCollapsed => base == extent;
 

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -26,43 +26,43 @@ class BoxComponent extends StatefulWidget {
 
 class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
   @override
-  BinaryPosition getBeginningPosition() {
-    return BinaryPosition.included();
+  BinaryNodePosition getBeginningPosition() {
+    return BinaryNodePosition.included();
   }
 
   @override
-  BinaryPosition getBeginningPositionNearX(double x) {
-    return BinaryPosition.included();
+  BinaryNodePosition getBeginningPositionNearX(double x) {
+    return BinaryNodePosition.included();
   }
 
   @override
-  BinaryPosition? movePositionLeft(dynamic currentPosition, [Set<MovementModifier>? movementModifiers]) {
+  BinaryNodePosition? movePositionLeft(dynamic currentPosition, [Set<MovementModifier>? movementModifiers]) {
     // BoxComponents don't support internal movement.
     return null;
   }
 
   @override
-  BinaryPosition? movePositionRight(dynamic currentPosition, [Set<MovementModifier>? movementModifiers]) {
+  BinaryNodePosition? movePositionRight(dynamic currentPosition, [Set<MovementModifier>? movementModifiers]) {
     // BoxComponents don't support internal movement.
     return null;
   }
 
   @override
-  BinaryPosition? movePositionUp(dynamic currentPosition) {
+  BinaryNodePosition? movePositionUp(dynamic currentPosition) {
     // BoxComponents don't support internal movement.
     return null;
   }
 
   @override
-  BinaryPosition? movePositionDown(dynamic currentPosition) {
+  BinaryNodePosition? movePositionDown(dynamic currentPosition) {
     // BoxComponents don't support internal movement.
     return null;
   }
 
   @override
-  BinarySelection? getCollapsedSelectionAt(nodePosition) {
-    if (nodePosition is! BinaryPosition) {
-      return null;
+  BinarySelection getCollapsedSelectionAt(nodePosition) {
+    if (nodePosition is! BinaryNodePosition) {
+      throw Exception('The given nodePosition ($nodePosition) is not compatible with BoxComponent');
     }
 
     return BinarySelection.all();
@@ -74,18 +74,18 @@ class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
   }
 
   @override
-  BinaryPosition getEndPosition() {
-    return BinaryPosition.included();
+  BinaryNodePosition getEndPosition() {
+    return BinaryNodePosition.included();
   }
 
   @override
-  BinaryPosition getEndPositionNearX(double x) {
-    return BinaryPosition.included();
+  BinaryNodePosition getEndPositionNearX(double x) {
+    return BinaryNodePosition.included();
   }
 
   @override
   Offset getOffsetForPosition(nodePosition) {
-    if (nodePosition is! BinaryPosition) {
+    if (nodePosition is! BinaryNodePosition) {
       throw Exception('Expected nodePosition of type BinaryPosition but received: $nodePosition');
     }
 
@@ -95,7 +95,7 @@ class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
 
   @override
   Rect getRectForPosition(dynamic nodePosition) {
-    if (nodePosition is! BinaryPosition) {
+    if (nodePosition is! BinaryNodePosition) {
       throw Exception('Expected nodePosition of type BinaryPosition but received: $nodePosition');
     }
 
@@ -105,10 +105,10 @@ class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
 
   @override
   Rect getRectForSelection(dynamic basePosition, dynamic extentPosition) {
-    if (basePosition is! BinaryPosition) {
+    if (basePosition is! BinaryNodePosition) {
       throw Exception('Expected nodePosition of type BinaryPosition but received: $basePosition');
     }
-    if (extentPosition is! BinaryPosition) {
+    if (extentPosition is! BinaryNodePosition) {
       throw Exception('Expected nodePosition of type BinaryPosition but received: $extentPosition');
     }
 
@@ -117,14 +117,17 @@ class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
   }
 
   @override
-  BinaryPosition getPositionAtOffset(Offset localOffset) {
-    return BinaryPosition.included();
+  BinaryNodePosition getPositionAtOffset(Offset localOffset) {
+    return BinaryNodePosition.included();
   }
 
   @override
-  BinarySelection? getSelectionBetween({basePosition, extentPosition}) {
-    if (basePosition is! BinaryPosition || extentPosition is! BinaryPosition) {
-      return null;
+  BinarySelection getSelectionBetween({required basePosition, required extentPosition}) {
+    if (basePosition is! BinaryNodePosition) {
+      throw Exception('The given basePosition ($basePosition) is not compatible with BoxComponent');
+    }
+    if (extentPosition is! BinaryNodePosition) {
+      throw Exception('The given extentPosition ($extentPosition) is not compatible with BoxComponent');
     }
 
     return BinarySelection.all();
@@ -148,16 +151,16 @@ class _BoxComponentState extends State<BoxComponent> with DocumentComponent {
 
 /// Document position for a [DocumentNode] that is either fully selected
 /// or unselected, like an image or a horizontal rule.
-class BinaryPosition {
-  const BinaryPosition.included() : isIncluded = true;
-  const BinaryPosition.notIncluded() : isIncluded = false;
+class BinaryNodePosition implements NodePosition {
+  const BinaryNodePosition.included() : isIncluded = true;
+  const BinaryNodePosition.notIncluded() : isIncluded = false;
 
   final bool isIncluded;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is BinaryPosition && runtimeType == other.runtimeType && isIncluded == other.isIncluded;
+      other is BinaryNodePosition && runtimeType == other.runtimeType && isIncluded == other.isIncluded;
 
   @override
   int get hashCode => isIncluded.hashCode;
@@ -166,16 +169,16 @@ class BinaryPosition {
 /// Document selection for a [DocumentNode] that is either fully selected
 /// or unselected, like an image or a horizontal rule.
 ///
-/// Technically, a [BinarySelection] represents the same thing as a [BinaryPosition],
+/// Technically, a [BinarySelection] represents the same thing as a [BinaryNodePosition],
 /// because a binary selectable node is either completely selected or unselected.
 /// However, participation within a generic editor requires that binary selectable
 /// nodes behave like all other nodes, i.e., offering a "position" type and a
 /// "selection" type.
-class BinarySelection {
-  const BinarySelection.all() : position = const BinaryPosition.included();
-  const BinarySelection.none() : position = const BinaryPosition.notIncluded();
+class BinarySelection implements NodeSelection {
+  const BinarySelection.all() : position = const BinaryNodePosition.included();
+  const BinarySelection.none() : position = const BinaryNodePosition.notIncluded();
 
-  final BinaryPosition position;
+  final BinaryNodePosition position;
 
   /// A [BinarySelection] is always collapsed because there is no distinction
   /// between the "beginning" or "end" of a [BinarySelection], therefore, there

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -156,19 +156,20 @@ class CommonEditorOperations {
       return false;
     }
 
-    final wordSelection = expandPositionToWord(
+    final wordTextSelection = expandPositionToWord(
       text: selectedNode.text.text,
       textPosition: TextPosition(offset: (docSelection.extent.nodePosition as TextPosition).offset),
     );
+    final wordNodeSelection = TextNodeSelection.fromTextSelection(wordTextSelection);
 
     composer.selection = DocumentSelection(
       base: DocumentPosition(
         nodeId: selectedNode.id,
-        nodePosition: wordSelection.base,
+        nodePosition: wordNodeSelection.base,
       ),
       extent: DocumentPosition(
         nodeId: selectedNode.id,
-        nodePosition: wordSelection.extent,
+        nodePosition: wordNodeSelection.extent,
       ),
     );
 
@@ -208,19 +209,20 @@ class CommonEditorOperations {
       return false;
     }
 
-    final paragraphSelection = expandPositionToParagraph(
+    final paragraphTextSelection = expandPositionToParagraph(
       text: selectedNode.text.text,
       textPosition: TextPosition(offset: (docSelection.extent.nodePosition as TextPosition).offset),
     );
+    final paragraphNodeSelection = TextNodeSelection.fromTextSelection(paragraphTextSelection);
 
     composer.selection = DocumentSelection(
       base: DocumentPosition(
         nodeId: selectedNode.id,
-        nodePosition: paragraphSelection.base,
+        nodePosition: paragraphNodeSelection.base,
       ),
       extent: DocumentPosition(
         nodeId: selectedNode.id,
-        nodePosition: paragraphSelection.extent,
+        nodePosition: paragraphNodeSelection.extent,
       ),
     );
 
@@ -580,7 +582,7 @@ class CommonEditorOperations {
       return false;
     }
 
-    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryPosition) {
+    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryNodePosition) {
       // A span of content is selected. Delete the selection.
       return deleteSelection();
     } else if (composer.selection!.extent.nodePosition is TextPosition) {
@@ -664,7 +666,7 @@ class CommonEditorOperations {
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(
         nodeId: node.id,
-        nodePosition: TextPosition(offset: firstNodeTextLength),
+        nodePosition: TextNodePosition(offset: firstNodeTextLength),
       ),
     );
 
@@ -684,7 +686,7 @@ class CommonEditorOperations {
 
     final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
     final text = textNode.text;
-    final currentTextPosition = (composer.selection!.extent.nodePosition as TextPosition);
+    final currentTextPosition = (composer.selection!.extent.nodePosition as TextNodePosition);
     if (currentTextPosition.offset >= text.text.length) {
       return false;
     }
@@ -701,7 +703,7 @@ class CommonEditorOperations {
           ),
           extent: DocumentPosition(
             nodeId: textNode.id,
-            nodePosition: TextPosition(offset: nextCharacterOffset),
+            nodePosition: TextNodePosition(offset: nextCharacterOffset),
           ),
         ),
       ),
@@ -724,7 +726,7 @@ class CommonEditorOperations {
       return false;
     }
 
-    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryPosition) {
+    if (!composer.selection!.isCollapsed || composer.selection!.extent.nodePosition is BinaryNodePosition) {
       // A span of content is selected. Delete the selection.
       return deleteSelection();
     }
@@ -813,7 +815,7 @@ class CommonEditorOperations {
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(
         nodeId: nodeAbove.id,
-        nodePosition: TextPosition(offset: aboveParagraphLength),
+        nodePosition: TextNodePosition(offset: aboveParagraphLength),
       ),
     );
 
@@ -832,13 +834,13 @@ class CommonEditorOperations {
     }
 
     final textNode = editor.document.getNode(composer.selection!.extent) as TextNode;
-    final currentTextPosition = composer.selection!.extent.nodePosition as TextPosition;
+    final currentTextPosition = composer.selection!.extent.nodePosition as TextNodePosition;
 
     final previousCharacterOffset = getCharacterStartBounds(textNode.text.text, currentTextPosition.offset);
 
     final newSelectionPosition = DocumentPosition(
       nodeId: textNode.id,
-      nodePosition: TextPosition(offset: previousCharacterOffset),
+      nodePosition: TextNodePosition(offset: previousCharacterOffset),
     );
 
     // Delete the selected content.
@@ -851,7 +853,7 @@ class CommonEditorOperations {
           ),
           extent: DocumentPosition(
             nodeId: textNode.id,
-            nodePosition: TextPosition(offset: previousCharacterOffset),
+            nodePosition: TextNodePosition(offset: previousCharacterOffset),
           ),
         ),
       ),
@@ -872,10 +874,10 @@ class CommonEditorOperations {
     }
 
     if (composer.selection!.isCollapsed) {
-      if (composer.selection!.extent.nodePosition is! BinaryPosition) {
+      if (composer.selection!.extent.nodePosition is! BinaryNodePosition) {
         return false;
       }
-      if (!(composer.selection!.extent.nodePosition as BinaryPosition).isIncluded) {
+      if (!(composer.selection!.extent.nodePosition as BinaryNodePosition).isIncluded) {
         return false;
       }
 
@@ -1005,11 +1007,11 @@ class CommonEditorOperations {
 
       // If it's a binary selection node then that node will
       // be replaced by a ParagraphNode with the same ID.
-      if (newSelectionPosition.nodePosition is BinaryPosition) {
+      if (newSelectionPosition.nodePosition is BinaryNodePosition) {
         // Assume that the node was replaced with an empty paragraph.
         newSelectionPosition = DocumentPosition(
           nodeId: newSelectionPosition.nodeId,
-          nodePosition: TextPosition(offset: 0),
+          nodePosition: TextNodePosition(offset: 0),
         );
       }
     } else {
@@ -1018,11 +1020,11 @@ class CommonEditorOperations {
       // a ParagraphNode with the same ID. Otherwise, it must
       // be a TextNode, in which case we need to figure out
       // which DocumentPosition contains the earlier TextPosition.
-      if (basePosition.nodePosition is BinaryPosition) {
+      if (basePosition.nodePosition is BinaryNodePosition) {
         // Assume that the node was replace with an empty paragraph.
         newSelectionPosition = DocumentPosition(
           nodeId: baseNode.id,
-          nodePosition: TextPosition(offset: 0),
+          nodePosition: TextNodePosition(offset: 0),
         );
       } else if (basePosition.nodePosition is TextPosition) {
         final baseOffset = (basePosition.nodePosition as TextPosition).offset;
@@ -1030,7 +1032,7 @@ class CommonEditorOperations {
 
         newSelectionPosition = DocumentPosition(
           nodeId: baseNode.id,
-          nodePosition: TextPosition(offset: min(baseOffset, extentOffset)),
+          nodePosition: TextNodePosition(offset: min(baseOffset, extentOffset)),
         );
       } else {
         throw Exception(
@@ -1193,7 +1195,7 @@ class CommonEditorOperations {
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(
         nodeId: textNode.id,
-        nodePosition: TextPosition(
+        nodePosition: TextNodePosition(
           offset: initialTextOffset + 1,
         ),
       ),
@@ -1286,7 +1288,7 @@ class CommonEditorOperations {
       composer.selection = DocumentSelection.collapsed(
         position: DocumentPosition(
           nodeId: node.id,
-          nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
+          nodePosition: TextNodePosition(offset: textPosition.offset - startOfNewText),
         ),
       );
 
@@ -1317,7 +1319,7 @@ class CommonEditorOperations {
       composer.selection = DocumentSelection.collapsed(
         position: DocumentPosition(
           nodeId: node.id,
-          nodePosition: TextPosition(offset: 0),
+          nodePosition: TextNodePosition(offset: 0),
         ),
       );
 
@@ -1353,7 +1355,7 @@ class CommonEditorOperations {
       composer.selection = DocumentSelection.collapsed(
         position: DocumentPosition(
           nodeId: node.id,
-          nodePosition: TextPosition(offset: textPosition.offset - startOfNewText),
+          nodePosition: TextNodePosition(offset: textPosition.offset - startOfNewText),
         ),
       );
 
@@ -1475,7 +1477,7 @@ class CommonEditorOperations {
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(
         nodeId: textNode.id,
-        nodePosition: TextPosition(
+        nodePosition: TextNodePosition(
           offset: initialTextOffset + character.length,
         ),
       ),
@@ -1567,7 +1569,7 @@ class CommonEditorOperations {
     composer.selection = DocumentSelection.collapsed(
       position: DocumentPosition(
         nodeId: newNodeId,
-        nodePosition: TextPosition(offset: 0),
+        nodePosition: TextNodePosition(offset: 0),
       ),
     );
 

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -160,7 +160,7 @@ class _PasteEditorCommand implements EditorCommand {
       // position is at the end of the text that was just pasted.
       newSelectionPosition = DocumentPosition(
         nodeId: currentNodeWithSelection.id,
-        nodePosition: TextPosition(
+        nodePosition: TextNodePosition(
           offset: pasteTextOffset + splitContent.first.length,
         ),
       );
@@ -397,11 +397,11 @@ DocumentPosition _getDocumentPositionAfterDeletion({
 
     // If it's a binary selection node then that node will
     // be replaced by a ParagraphNode with the same ID.
-    if (newSelectionPosition.nodePosition is BinaryPosition) {
+    if (newSelectionPosition.nodePosition is BinaryNodePosition) {
       // Assume that the node was replaced with an empty paragraph.
       newSelectionPosition = DocumentPosition(
         nodeId: newSelectionPosition.nodeId,
-        nodePosition: TextPosition(offset: 0),
+        nodePosition: TextNodePosition(offset: 0),
       );
     }
   } else {
@@ -410,11 +410,11 @@ DocumentPosition _getDocumentPositionAfterDeletion({
     // a ParagraphNode with the same ID. Otherwise, it must
     // be a TextNode, in which case we need to figure out
     // which DocumentPosition contains the earlier TextPosition.
-    if (basePosition.nodePosition is BinaryPosition) {
+    if (basePosition.nodePosition is BinaryNodePosition) {
       // Assume that the node was replace with an empty paragraph.
       newSelectionPosition = DocumentPosition(
         nodeId: baseNode.id,
-        nodePosition: TextPosition(offset: 0),
+        nodePosition: TextNodePosition(offset: 0),
       );
     } else if (basePosition.nodePosition is TextPosition) {
       final baseOffset = (basePosition.nodePosition as TextPosition).offset;
@@ -422,7 +422,7 @@ DocumentPosition _getDocumentPositionAfterDeletion({
 
       newSelectionPosition = DocumentPosition(
         nodeId: baseNode.id,
-        nodePosition: TextPosition(offset: min(baseOffset, extentOffset)),
+        nodePosition: TextNodePosition(offset: min(baseOffset, extentOffset)),
       );
     } else {
       throw Exception(
@@ -489,7 +489,7 @@ ExecutionInstruction mergeNodeWithNextWhenDeleteIsPressed({
   editContext.composer.selection = DocumentSelection.collapsed(
     position: DocumentPosition(
       nodeId: node.id,
-      nodePosition: TextPosition(offset: currentParagraphLength),
+      nodePosition: TextNodePosition(offset: currentParagraphLength),
     ),
   );
 

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -18,10 +18,10 @@ class HorizontalRuleNode with ChangeNotifier implements DocumentNode {
   final String id;
 
   @override
-  BinaryPosition get beginningPosition => BinaryPosition.included();
+  BinaryNodePosition get beginningPosition => BinaryNodePosition.included();
 
   @override
-  BinaryPosition get endPosition => BinaryPosition.included();
+  BinaryNodePosition get endPosition => BinaryNodePosition.included();
 
   @override
   BinarySelection computeSelection({
@@ -37,7 +37,7 @@ class HorizontalRuleNode with ChangeNotifier implements DocumentNode {
       throw Exception('HorizontalRuleNode can only copy content from a BinarySelection.');
     }
 
-    return selection.position == BinaryPosition.included() ? '---' : null;
+    return selection.position == BinaryNodePosition.included() ? '---' : null;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -38,10 +38,10 @@ class ImageNode with ChangeNotifier implements DocumentNode {
   }
 
   @override
-  BinaryPosition get beginningPosition => BinaryPosition.included();
+  BinaryNodePosition get beginningPosition => BinaryNodePosition.included();
 
   @override
-  BinaryPosition get endPosition => BinaryPosition.included();
+  BinaryNodePosition get endPosition => BinaryNodePosition.included();
 
   @override
   BinarySelection computeSelection({
@@ -57,7 +57,7 @@ class ImageNode with ChangeNotifier implements DocumentNode {
       throw Exception('ImageNode can only copy content from a BinarySelection.');
     }
 
-    return selection.position == BinaryPosition.included() ? _imageUrl : null;
+    return selection.position == BinaryNodePosition.included() ? _imageUrl : null;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/layout.dart
+++ b/super_editor/lib/src/default_editor/layout.dart
@@ -89,6 +89,10 @@ class _DefaultDocumentLayoutState extends State<DefaultDocumentLayout> implement
     final componentOffset = _componentOffset(componentBox, documentOffset);
     final componentPosition = component.getPositionAtOffset(componentOffset);
 
+    if (componentPosition == null) {
+      return null;
+    }
+
     final selectionAtOffset = DocumentPosition(
       nodeId: _nodeIdsToComponentKeys.entries.firstWhere((element) => element.value == componentKey).key,
       nodePosition: componentPosition,

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -100,7 +100,7 @@ class DeleteSelectionCommand implements EditorCommand {
     final basePosition = documentSelection.base.nodePosition;
     final extentPosition = documentSelection.extent.nodePosition;
 
-    if (basePosition is BinaryPosition) {
+    if (basePosition is BinaryNodePosition) {
       // Binary positions are all-or-nothing. Therefore, partial
       // selection means delete the whole node.
       transaction.deleteNode(node);
@@ -147,7 +147,7 @@ class DeleteSelectionCommand implements EditorCommand {
     required dynamic nodePosition,
     required DocumentEditorTransaction transaction,
   }) {
-    if (nodePosition is BinaryPosition) {
+    if (nodePosition is BinaryNodePosition) {
       _deleteBinaryNode(
         document: document,
         node: node,
@@ -169,7 +169,7 @@ class DeleteSelectionCommand implements EditorCommand {
     required dynamic nodePosition,
     required DocumentEditorTransaction transaction,
   }) {
-    if (nodePosition is BinaryPosition) {
+    if (nodePosition is BinaryNodePosition) {
       _deleteBinaryNode(
         document: document,
         node: node,

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -224,7 +224,7 @@ ExecutionInstruction backspaceToClearParagraphBlockType({
   }
 
   final textPosition = editContext.composer.selection!.extent.nodePosition;
-  if (textPosition is! TextPosition || textPosition.offset > 0) {
+  if (textPosition is! TextNodePosition || textPosition.offset > 0) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
 
@@ -28,17 +29,23 @@ DocumentSelection? getWordSelection({
     return null;
   }
 
-  final TextSelection wordSelection = (component as TextComposable).getWordSelectionAt(docPosition.nodePosition);
+  final nodePosition = docPosition.nodePosition;
+  if (nodePosition is! TextNodePosition) {
+    return null;
+  }
 
-  _log.log('getWordSelection', ' - word selection: $wordSelection');
+  final TextSelection wordTextSelection = (component as TextComposable).getWordSelectionAt(nodePosition);
+  final wordNodeSelection = TextNodeSelection.fromTextSelection(wordTextSelection);
+
+  _log.log('getWordSelection', ' - word selection: $wordNodeSelection');
   return DocumentSelection(
     base: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: wordSelection.base,
+      nodePosition: wordNodeSelection.base,
     ),
     extent: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: wordSelection.extent,
+      nodePosition: wordNodeSelection.extent,
     ),
   );
 }
@@ -84,19 +91,25 @@ DocumentSelection? getParagraphSelection({
     return null;
   }
 
-  final TextSelection paragraphSelection = expandPositionToParagraph(
-    text: (component as TextComposable).getContiguousTextAt(docPosition.nodePosition),
+  final nodePosition = docPosition.nodePosition;
+  if (nodePosition is! TextNodePosition) {
+    return null;
+  }
+
+  final TextSelection paragraphTextSelection = expandPositionToParagraph(
+    text: (component as TextComposable).getContiguousTextAt(nodePosition),
     textPosition: docPosition.nodePosition as TextPosition,
   );
+  final paragraphNodeSelection = TextNodeSelection.fromTextSelection(paragraphTextSelection);
 
   return DocumentSelection(
     base: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: paragraphSelection.base,
+      nodePosition: paragraphNodeSelection.base,
     ),
     extent: DocumentPosition(
       nodeId: docPosition.nodeId,
-      nodePosition: paragraphSelection.extent,
+      nodePosition: paragraphNodeSelection.extent,
     ),
   );
 }

--- a/super_editor/lib/src/infrastructure/composable_text.dart
+++ b/super_editor/lib/src/infrastructure/composable_text.dart
@@ -1,55 +1,32 @@
-import 'package:flutter/rendering.dart';
+import 'package:super_editor/src/default_editor/text.dart';
 
 /// Contract for widgets that include editable text.
 ///
 /// Examples: paragraphs, list items, images with captions.
-///
-/// The text positions accepted by a [TextComposable] are [dynamic]
-/// rather than [TextPosition]s because a use-case might include
-/// complex text composition, like tables, which might choose to
-/// index positions based on cell IDs, or row and column indices.
 abstract class TextComposable {
-  /// Returns a [TextSelection] that encompasses the entire word
-  /// found at the given [textPosition].
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  TextSelection getWordSelectionAt(dynamic textPosition);
+  /// Returns a [TextNodeSelection] that encompasses the entire word
+  /// found at the given [textNodePosition].
+  TextNodeSelection getWordSelectionAt(TextNodePosition textNodePosition);
 
   /// Returns all text surrounding [textPosition] that is not
   /// broken by white space.
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  String getContiguousTextAt(dynamic textPosition);
+  String getContiguousTextAt(TextNodePosition textPosition);
 
-  /// Returns the text position that corresponds to a text location
-  /// that is one line above the given [textPosition], or [null] if
+  /// Returns the [TextNodePosition] that corresponds to a text location
+  /// that is one line above the given [textNodePosition], or [null] if
   /// there is no position one line up.
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  dynamic getPositionOneLineUp(dynamic textPosition);
+  TextNodePosition? getPositionOneLineUp(TextNodePosition textNodePosition);
 
-  /// Returns the node position that corresponds to a text location
-  /// that is one line below the given [textPosition], or [null] if
+  /// Returns the [TextNodePosition] that corresponds to a text location
+  /// that is one line below the given [textNodePosition], or [null] if
   /// there is no position one line down.
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  dynamic getPositionOneLineDown(dynamic textPosition);
+  TextNodePosition? getPositionOneLineDown(TextNodePosition textNodePosition);
 
   /// Returns the node position that corresponds to the first character
-  /// in the line of text that contains the given [textPosition].
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  dynamic getPositionAtStartOfLine(dynamic textPosition);
+  /// in the line of text that contains the given [textNodePosition].
+  TextNodePosition getPositionAtStartOfLine(TextNodePosition textNodePosition);
 
-  /// Returns the node position that corresponds to the last character
-  /// in the line of text that contains the given [textPosition].
-  ///
-  /// Throws an exception if [textPosition] is not the right type
-  /// for this [TextComposable].
-  dynamic getPositionAtEndOfLine(dynamic textPosition);
+  /// Returns the [TextNodePosition] that corresponds to the last character
+  /// in the line of text that contains the given [textNodePosition].
+  TextNodePosition getPositionAtEndOfLine(TextNodePosition textNodePosition);
 }

--- a/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
+++ b/super_editor/test/editor_smoke_tests/editor_entry_smoke_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -12,6 +11,7 @@ import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
+import 'package:super_editor/super_editor.dart';
 
 // TODO: Create a fake keyboard that operates at the system channel level
 //       - typeCharacter('m')
@@ -58,7 +58,7 @@ void main() {
       composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
         nodeId: documentEditor.document.nodes.first.id,
-        nodePosition: TextPosition(offset: 0),
+        nodePosition: TextNodePosition(offset: 0),
       ));
 
       final header = 'Smoke Test';

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/default_editor/document_interaction.dart';
 import 'package:super_editor/src/default_editor/document_keyboard_actions.dart';
 import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 
@@ -131,14 +132,14 @@ void main() {
                 _editContext.composer.selection!.base,
                 DocumentPosition(
                   nodeId: 'paragraph',
-                  nodePosition: TextPosition(offset: 0),
+                  nodePosition: TextNodePosition(offset: 0),
                 ),
               );
               expect(
                 _editContext.composer.selection!.extent,
                 DocumentPosition(
                   nodeId: 'paragraph',
-                  nodePosition: TextPosition(offset: 'This is some text'.length),
+                  nodePosition: TextNodePosition(offset: 'This is some text'.length),
                 ),
               );
 
@@ -182,14 +183,14 @@ void main() {
                 _editContext.composer.selection!.base,
                 DocumentPosition(
                   nodeId: 'paragraph_1',
-                  nodePosition: TextPosition(offset: 0),
+                  nodePosition: TextNodePosition(offset: 0),
                 ),
               );
               expect(
                 _editContext.composer.selection!.extent,
                 DocumentPosition(
                   nodeId: 'paragraph_2',
-                  nodePosition: TextPosition(offset: 'This is some text'.length),
+                  nodePosition: TextNodePosition(offset: 'This is some text'.length),
                 ),
               );
 
@@ -237,14 +238,14 @@ void main() {
                 _editContext.composer.selection!.base,
                 DocumentPosition(
                   nodeId: 'image_1',
-                  nodePosition: BinaryPosition.included(),
+                  nodePosition: BinaryNodePosition.included(),
                 ),
               );
               expect(
                 _editContext.composer.selection!.extent,
                 DocumentPosition(
                   nodeId: 'image_2',
-                  nodePosition: BinaryPosition.included(),
+                  nodePosition: BinaryNodePosition.included(),
                 ),
               );
 

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -36,7 +35,7 @@ void main() {
           documentSelection: DocumentSelection(
             base: DocumentPosition(
               nodeId: 'paragraph',
-              nodePosition: TextPosition(offset: 1),
+              nodePosition: TextNodePosition(offset: 1),
             ),
             extent: DocumentPosition(
               nodeId: 'paragraph',
@@ -45,7 +44,7 @@ void main() {
               // TextPosition references the character after the selection, not
               // the last character in the selection. See the TextPosition class
               // definition for more information.
-              nodePosition: TextPosition(offset: 13),
+              nodePosition: TextNodePosition(offset: 13),
             ),
           ),
           attributions: {boldAttribution},
@@ -131,11 +130,11 @@ void main() {
         editContext.composer.selection = DocumentSelection(
           base: DocumentPosition(
             nodeId: 'paragraph',
-            nodePosition: TextPosition(offset: 0),
+            nodePosition: TextNodePosition(offset: 0),
           ),
           extent: DocumentPosition(
             nodeId: 'paragraph',
-            nodePosition: TextPosition(offset: 1),
+            nodePosition: TextNodePosition(offset: 1),
           ),
         );
 
@@ -166,7 +165,7 @@ void main() {
         editContext.composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'horizontal_rule',
-            nodePosition: BinaryPosition.notIncluded(),
+            nodePosition: BinaryNodePosition.notIncluded(),
           ),
         );
 
@@ -200,7 +199,7 @@ void main() {
         editContext.composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'paragraph',
-            nodePosition: TextPosition(offset: 0),
+            nodePosition: TextNodePosition(offset: 0),
           ),
         );
 
@@ -251,7 +250,7 @@ void main() {
         editContext.composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'paragraph',
-            nodePosition: TextPosition(offset: 0),
+            nodePosition: TextNodePosition(offset: 0),
           ),
         );
 
@@ -290,7 +289,7 @@ void main() {
         editContext.composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'paragraph',
-            nodePosition: TextPosition(offset: 0),
+            nodePosition: TextNodePosition(offset: 0),
           ),
         );
 


### PR DESCRIPTION
Based on user feedback, I've replaced various `dynamic` references with `NodeSelection` and `NodePosition` marker interfaces.

For text-related behaviors `TextPosition` has been replaced by `TextNodePosition` and `TextSelection` has been replaced by `TextNodeSelection`. `TextNodePosition` extends `TextPosition` and `TextNodeSelection` extends `TextSelection` to minimize rework.