### PR TITLE
Created README_RELEASING.md with instructions for releasing new versions of Super Editor

### DIFF
--- a/super_editor/CHANGELOG.md
+++ b/super_editor/CHANGELOG.md
@@ -1,3 +1,21 @@
-## [0.0.1] - TODO: Add release date.
+## [0.1.0] - June 3, 2021
 
-* TODO: Describe initial release.
+The first release of Super Editor.
+
+ * Document and editor abstractions
+   * See `Document` for a readable document
+   * See `MutableDocument` for a mutable document
+   * See `DocumentEditor` to commit document changes in a transactional manner
+   * See `DocumentSelection` for a logical representation of selected document content
+   * See `DocumentLayout` for the base abstraction for a visual document layout
+ * Out-of-the-box editor: Commonly used types of content, visual layout, and user interactions are supported
+   by artifacts available in the `default_editor` package.
+ * Markdown serialization is available in the `serialization` package.
+ * SuperTextField: An early version of a custom text field called `SuperTextField` is available in
+   the `infrastructure` package.
+ * SuperSelectableText: All text display in Super Editor is based on the `SuperSelectableText` widget,
+   which is available in the `infrastructure` package.
+ * AttributedText: a logical representation of text with attributed spans is available
+   in the `infrastructure` package.
+ * AttributedSpans: a logical representation of attributed spans is available in the
+   `infrastructure` package.

--- a/super_editor/README_RELEASING.md
+++ b/super_editor/README_RELEASING.md
@@ -1,0 +1,9 @@
+# Releasing Super Editor
+
+Follow these steps to release new versions of Super Editor:
+
+1. Checkout the tip of the `main` branch
+2. Update the `CHANGELOG.md` to describe the important changes in this release
+3. Merge the `CHANGELOG.md` update into `main` and ensure you're at the new tip of `main`
+4. Follow official instructions to publish a new version to pub.dev: https://dart.dev/tools/pub/publishing#publishing-your-package
+5. Tag the commit that was published with the version, e.g., "v0.1.0", and push that tag to `origin`

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -35,32 +35,24 @@ class _AttributedTextDemoState extends State<AttributedTextDemo> {
     }
 
     setState(() {
-      _richText = _text.computeTextSpan((Set<dynamic> attributions) {
+      _richText = _text.computeTextSpan((Set<Attribution> attributions) {
         TextStyle newStyle = const TextStyle(
           color: Colors.black,
           fontSize: 30,
         );
         for (final attribution in attributions) {
-          if (attribution is! String) {
-            continue;
-          }
-
-          switch (attribution) {
-            case 'bold':
-              newStyle = newStyle.copyWith(
-                fontWeight: FontWeight.bold,
-              );
-              break;
-            case 'italics':
-              newStyle = newStyle.copyWith(
-                fontStyle: FontStyle.italic,
-              );
-              break;
-            case 'strikethrough':
-              newStyle = newStyle.copyWith(
-                decoration: TextDecoration.lineThrough,
-              );
-              break;
+          if (attribution == boldAttribution) {
+            newStyle = newStyle.copyWith(
+              fontWeight: FontWeight.bold,
+            );
+          } else if (attribution == italicsAttribution) {
+            newStyle = newStyle.copyWith(
+              fontStyle: FontStyle.italic,
+            );
+          } else if (attribution == strikethroughAttribution) {
+            newStyle = newStyle.copyWith(
+              decoration: TextDecoration.lineThrough,
+            );
           }
         }
         return newStyle;

--- a/super_editor/example/lib/demos/demo_selectable_text.dart
+++ b/super_editor/example/lib/demos/demo_selectable_text.dart
@@ -42,7 +42,7 @@ class _SelectableTextDemoState extends State<SelectableTextDemo> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _buildTitle('Selectable Text Widget'),
+                _buildTitle('SuperSelectableText Widget'),
                 SizedBox(height: 24),
                 _buildDemo(
                   title: 'EMPTY TEXT WITH CARET',

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -33,11 +33,11 @@ class _ExampleEditorState extends State<ExampleEditor> {
   @override
   void initState() {
     super.initState();
-    _doc = createInitialDocument()..addListener(_updateToolbarDisplay);
+    _doc = createInitialDocument()..addListener(_hideOrShowToolbar);
     _docEditor = DocumentEditor(document: _doc as MutableDocument);
-    _composer = DocumentComposer()..addListener(_updateToolbarDisplay);
+    _composer = DocumentComposer()..addListener(_hideOrShowToolbar);
     _editorFocusNode = FocusNode();
-    _scrollController = ScrollController()..addListener(_updateToolbarDisplay);
+    _scrollController = ScrollController()..addListener(_hideOrShowToolbar);
   }
 
   @override
@@ -52,7 +52,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
     super.dispose();
   }
 
-  void _updateToolbarDisplay() {
+  void _hideOrShowToolbar() {
     final selection = _composer!.selection;
     if (selection == null) {
       // Nothing is selected. We don't want to show a toolbar
@@ -106,22 +106,26 @@ class _ExampleEditorState extends State<ExampleEditor> {
       // Display the toolbar in the application overlay.
       final overlay = Overlay.of(context)!;
       overlay.insert(_formatBarOverlayEntry!);
-
-      // Schedule a callback after this frame to locate the selection
-      // bounds on the screen and display the toolbar near the selected
-      // text.
-      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
-        final docBoundingBox = (_docLayoutKey.currentState as DocumentLayout)
-            .getRectForSelection(_composer!.selection!.base, _composer!.selection!.extent)!;
-        final docBox = _docLayoutKey.currentContext!.findRenderObject() as RenderBox;
-        final overlayBoundingBox = Rect.fromPoints(
-          docBox.localToGlobal(docBoundingBox.topLeft, ancestor: context.findRenderObject()),
-          docBox.localToGlobal(docBoundingBox.bottomRight, ancestor: context.findRenderObject()),
-        );
-
-        _selectionAnchor.value = overlayBoundingBox.topCenter;
-      });
     }
+
+    // Schedule a callback after this frame to locate the selection
+    // bounds on the screen and display the toolbar near the selected
+    // text.
+    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+      if (_formatBarOverlayEntry == null) {
+        return;
+      }
+
+      final docBoundingBox = (_docLayoutKey.currentState as DocumentLayout)
+          .getRectForSelection(_composer!.selection!.base, _composer!.selection!.extent)!;
+      final docBox = _docLayoutKey.currentContext!.findRenderObject() as RenderBox;
+      final overlayBoundingBox = Rect.fromPoints(
+        docBox.localToGlobal(docBoundingBox.topLeft, ancestor: context.findRenderObject()),
+        docBox.localToGlobal(docBoundingBox.bottomRight, ancestor: context.findRenderObject()),
+      );
+
+      _selectionAnchor.value = overlayBoundingBox.topCenter;
+    });
   }
 
   void _hideEditorToolbar() {

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -201,7 +201,7 @@ final _menu = <_MenuGroup>[
       ),
       _MenuItem(
         icon: Icons.text_fields,
-        title: 'Selectable Text',
+        title: 'SuperSelectableText',
         pageBuilder: (context) {
           return SelectableTextDemo();
         },

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -129,6 +129,16 @@ class DocumentPosition {
   @override
   int get hashCode => nodeId.hashCode ^ nodePosition.hashCode;
 
+  DocumentPosition copyWith({
+    String? nodeId,
+    NodePosition? nodePosition,
+  }) {
+    return DocumentPosition(
+      nodeId: nodeId ?? this.nodeId,
+      nodePosition: nodePosition ?? this.nodePosition,
+    );
+  }
+
   @override
   String toString() {
     return '[DocumentPosition] - node: "$nodeId", position: ($nodePosition)';
@@ -152,6 +162,26 @@ abstract class DocumentNode implements ChangeNotifier {
   /// For example, a [ParagraphNode] would return
   /// [TextNodePosition(offset: text.length)].
   NodePosition get endPosition;
+
+  /// Inspects [position1] and [position2] and returns the one that's
+  /// positioned further upstream in this [DocumentNode].
+  ///
+  /// For example, in a [TextNode], this returns the [TextPosition]
+  /// for the character that appears earlier in the block of text.
+  NodePosition selectUpstreamPosition(
+    NodePosition position1,
+    NodePosition position2,
+  );
+
+  /// Inspects [position1] and [position2] and returns the one that's
+  /// positioned further downstream in this [DocumentNode].
+  ///
+  /// For example, in a [TextNode], this returns the [TextPosition]
+  /// for the character that appears later in the block of text.
+  NodePosition selectDownstreamPosition(
+    NodePosition position1,
+    NodePosition position2,
+  );
 
   /// Returns a node-specific representation of a selection from
   /// [base] to [extent].

--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -1,19 +1,19 @@
 import 'document.dart';
 
-/// A selection within a `Document`.
+/// A selection within a [Document].
 ///
-/// A `DocumentSelection` spans from a `base` position to an
-/// `extent` position, and includes all content in between.
+/// A [DocumentSelection] spans from a [base] position to an
+/// [extent] position, and includes all content in between.
 ///
-/// `base` and `extent` are instances of `DocumentPosition`,
-/// which represents a single position within a `Document`.
+/// [base] and [extent] are instances of [DocumentPosition],
+/// which represents a single position within a [Document].
 ///
-/// A `DocumentSelection` does not hold a reference to a
-/// `Document`, it only represents a directional selection
-/// within a `Document`. The `base` and `extent` positions must
-/// be interpreted within the context of a specific `Document`
-/// to locate nodes between `base` and `extent`, and to identify
-/// partial content that is selected within the `base` and `extent`
+/// A [DocumentSelection] does not hold a reference to a
+/// [Document], it only represents a directional selection
+/// within a [Document]. The [base] and [extent] positions must
+/// be interpreted within the context of a specific [Document]
+/// to locate nodes between [base] and [extent], and to identify
+/// partial content that is selected within the [base] and [extent]
 /// nodes within the document.
 class DocumentSelection {
   const DocumentSelection.collapsed({
@@ -45,6 +45,68 @@ class DocumentSelection {
         extent: extent,
       );
     }
+  }
+
+  /// Returns a version of this [DocumentSelection] that is collapsed
+  /// in the upstream (start) direction.
+  ///
+  /// The source [Document] is required so that the upstream [DocumentPosition]
+  /// can be selected from [base] and [extent].
+  DocumentSelection collapseUpstream(Document document) {
+    if (isCollapsed) {
+      // The selection is already collapsed. Therefore, the collapsed
+      // version of this selection is the same as this selection.
+      return this;
+    }
+
+    final baseNode = document.getNodeById(base.nodeId)!;
+    final extentNode = document.getNodeById(extent.nodeId)!;
+
+    if (baseNode == extentNode) {
+      // The selection is expanded, but it sits within a single node.
+      final upstreamNodePosition = extentNode.selectUpstreamPosition(
+        base.nodePosition,
+        extent.nodePosition,
+      );
+      return DocumentSelection.collapsed(
+        position: extent.copyWith(nodePosition: upstreamNodePosition),
+      );
+    }
+
+    return document.getNodeIndex(baseNode) < document.getNodeIndex(extentNode)
+        ? DocumentSelection.collapsed(position: base)
+        : DocumentSelection.collapsed(position: extent);
+  }
+
+  /// Returns a version of this [DocumentSelection] that is collapsed
+  /// in the downstream (end) direction.
+  ///
+  /// The source [Document] is required so that the downstream [DocumentPosition]
+  /// can be selected from [base] and [extent].
+  DocumentSelection collapseDownstream(Document document) {
+    if (isCollapsed) {
+      // The selection is already collapsed. Therefore, the collapsed
+      // version of this selection is the same as this selection.
+      return this;
+    }
+
+    final baseNode = document.getNodeById(base.nodeId)!;
+    final extentNode = document.getNodeById(extent.nodeId)!;
+
+    if (baseNode == extentNode) {
+      // The selection is expanded, but it sits within a single node.
+      final downstreamNodePosition = extentNode.selectDownstreamPosition(
+        base.nodePosition,
+        extent.nodePosition,
+      );
+      return DocumentSelection.collapsed(
+        position: extent.copyWith(nodePosition: downstreamNodePosition),
+      );
+    }
+
+    return document.getNodeIndex(baseNode) > document.getNodeIndex(extentNode)
+        ? DocumentSelection.collapsed(position: base)
+        : DocumentSelection.collapsed(position: extent);
   }
 
   @override

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -24,6 +24,34 @@ class HorizontalRuleNode with ChangeNotifier implements DocumentNode {
   BinaryNodePosition get endPosition => BinaryNodePosition.included();
 
   @override
+  NodePosition selectUpstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    // BinaryNodePosition's don't disambiguate between upstream and downstream so
+    // it doesn't matter which one we return.
+    return position1;
+  }
+
+  @override
+  NodePosition selectDownstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    // BinaryNodePosition's don't disambiguate between upstream and downstream so
+    // it doesn't matter which one we return.
+    return position1;
+  }
+
+  @override
   BinarySelection computeSelection({
     @required dynamic base,
     @required dynamic extent,

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -44,6 +44,34 @@ class ImageNode with ChangeNotifier implements DocumentNode {
   BinaryNodePosition get endPosition => BinaryNodePosition.included();
 
   @override
+  NodePosition selectUpstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    // BinaryNodePosition's don't disambiguate between upstream and downstream so
+    // it doesn't matter which one we return.
+    return position1;
+  }
+
+  @override
+  NodePosition selectDownstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! BinaryNodePosition) {
+      throw Exception('Expected a BinaryNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    // BinaryNodePosition's don't disambiguate between upstream and downstream so
+    // it doesn't matter which one we return.
+    return position1;
+  }
+
+  @override
   BinarySelection computeSelection({
     @required dynamic base,
     @required dynamic extent,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -65,6 +65,30 @@ class TextNode with ChangeNotifier implements DocumentNode {
   TextNodePosition get endPosition => TextNodePosition(offset: text.text.length);
 
   @override
+  NodePosition selectUpstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! TextNodePosition) {
+      throw Exception('Expected a TextNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! TextNodePosition) {
+      throw Exception('Expected a TextNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    return position1.offset < position2.offset ? position1 : position2;
+  }
+
+  @override
+  NodePosition selectDownstreamPosition(NodePosition position1, NodePosition position2) {
+    if (position1 is! TextNodePosition) {
+      throw Exception('Expected a TextNodePosition for position1 but received a ${position1.runtimeType}');
+    }
+    if (position2 is! TextNodePosition) {
+      throw Exception('Expected a TextNodePosition for position2 but received a ${position2.runtimeType}');
+    }
+
+    return position1.offset > position2.offset ? position1 : position2;
+  }
+
+  @override
   TextNodeSelection computeSelection({
     required NodePosition base,
     required NodePosition extent,

--- a/super_editor/lib/src/infrastructure/super_selectable_text.dart
+++ b/super_editor/lib/src/infrastructure/super_selectable_text.dart
@@ -794,7 +794,7 @@ class DebugSelectableTextDecorator extends StatefulWidget {
 
 class _DebugSelectableTextDecoratorState extends State<DebugSelectableTextDecorator> {
   SuperSelectableTextState? get _selectableTextState =>
-      widget.selectableTextKey.currentState as SuperSelectableTextState;
+      widget.selectableTextKey.currentState as SuperSelectableTextState?;
 
   RenderParagraph? get _renderParagraph => _selectableTextState?._renderParagraph;
 

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -11,17 +11,13 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pedantic: ^1.11.0
-
-  uuid: ^3.0.3
-
   http: ^0.13.1
-
   linkify: ^4.0.0
-
   # TODO: move markdown serialization to a separate package and
   #       then remove this dependency.
   markdown: ^4.0.0
+  pedantic: ^1.11.0
+  uuid: ^3.0.3
 
 dev_dependencies:
   flutter_test:
@@ -29,39 +25,5 @@ dev_dependencies:
 
   mockito: ^5.0.4
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+  # no Flutter configuration


### PR DESCRIPTION
 - Updated CHANGELOG.md with release notes for v0.1.0
 - Fixed a bug where pressing delete in an empty paragraph below an image/HR would move the selection up but not delete the paragraph
 - Fixed a bug where pressing left/right with an expanded selection would move the caret after collapsing, but the caret shouldn't move
 - Fixed a bug where the format bar in the example app wasn't changing position with a changing selection
 - Updated the demo of AttributedText to use the new Attribution definitions instead of Strings