### PR TITLE
[docs] core/document_composer.dart

### DIFF
--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/foundation.dart';
+import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/infrastructure/attributed_spans.dart';
 
 import 'document_selection.dart';
 
-/// Maintains a `DocumentSelection` within a `Document` and
+/// Maintains a [DocumentSelection] within a [Document] and
 /// uses that selection to edit the document.
 class DocumentComposer with ChangeNotifier {
-  /// Constructs a `DocumentComposer` with the given `initialSelection`.
+  /// Constructs a [DocumentComposer] with the given [initialSelection].
   ///
-  /// The `initialSelection` may be omitted if no initial selection is
+  /// The [initialSelection] may be omitted if no initial selection is
   /// desired.
   DocumentComposer({
     DocumentSelection? initialSelection,
@@ -27,10 +28,10 @@ class DocumentComposer with ChangeNotifier {
 
   DocumentSelection? _selection;
 
-  /// Returns the current `DocumentSelection` for a `Document`.
+  /// Returns the current [DocumentSelection] for a [Document].
   DocumentSelection? get selection => _selection;
 
-  /// Sets the current `selection` for a `Document`.
+  /// Sets the current [selection] for a [Document].
   set selection(DocumentSelection? newSelection) {
     if (newSelection != _selection) {
       _selection = newSelection;
@@ -38,7 +39,7 @@ class DocumentComposer with ChangeNotifier {
     }
   }
 
-  /// Clears the current `selection`.
+  /// Clears the current [selection].
   void clearSelection() {
     selection = null;
   }
@@ -57,7 +58,7 @@ class ComposerPreferences with ChangeNotifier {
   final Set<Attribution> _currentAttributions = {};
 
   /// Returns the styles that should be applied to the next
-  /// character that is entered in a `Document`.
+  /// character that is entered in a [Document].
   Set<Attribution> get currentAttributions => _currentAttributions;
 
   /// Adds [attribution] to [currentAttributions].
@@ -108,7 +109,7 @@ class ComposerPreferences with ChangeNotifier {
     notifyListeners();
   }
 
-  /// Removes all styles from `currentStyles`.
+  /// Removes all styles from [currentAttributions].
   void clearStyles() {
     _currentAttributions.clear();
     notifyListeners();


### PR DESCRIPTION
## Summary

As I wanted to learn about and gain a deep understanding of the `super_editor` API in general, I explored the individual parts of the source code.  
In this process, I figured it would be very useful to add public member API docs accordingly and contribute them back to the project.

### Part

In this pull request in particular, I am only adding documentation to the `core/document_composer.dart` file, exclusively. This should hopefully make it easier to review the individual parts of my contribution.

## Guidelines

Because we need to have a common standard for documentation in order to make the developer experience when researching about the API coherent, I **strictly followed** Effective Dart.  
In this case, the relevant articles are:

* [Effective Dart: Documentation](https://dart.dev/guides/language/effective-dart/documentation)
* And [Effective Dart](https://dart.dev/guides/language/effective-dart) for a general overview.

### Assertions

I do consider assertions as part of *docs* in the scope of these pull request. This is because I feel they have a documenting value and can enforce what the docs state using debug-time warnings.

### Imports

Any added imports in the docs changes have been made in order to create references to members from other files to allow the analyzer to recognize them. This is necessary for code navigation e.g.  
This means that if I added an import to `'package:super_editor/src/default_editor/text.dart'`, then this happened because `[TextNodePosition]` was referenced in the docs.

### Meta

I do think enforcing these rules to ensure coherency is important as well, which is why we should consider adding meta documentation for: how to contribute and which guidelines to follow. This might also involve adding the [`public_member_api_docs`](https://dart-lang.github.io/linter/lints/public_member_api_docs.html) lint rule.

## Full contribution

To query the related PRs that make up this effort of contributing docs, you can use [this query](https://github.com/superlistapp/super_editor/pulls?q=is%3Apr+author%3Acreativecreatorormaybenot+%22%5Bdocs%5D%22+).

### Reviews

I hope that these contributions can be merged with the existing efforts. I tried to really understand what the API does and how and why it works the way it does and why it has been designed the way it has been designed.  
Nonetheless, my documentation should of course be thoroughly reviewed. I am not sure who is best-suited for each individual review. cc @matthew-carroll @salihgueler
