### PR TITLE
Add `replaceNode` to `DocumentEditorTransaction`

### DIFF
--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -91,6 +91,14 @@ class DocumentEditorTransaction {
     _document.deleteNodeAt(index);
   }
 
+  /// Replaces the given [oldNode] with the given [newNode]
+  void replaceNode({
+    required DocumentNode oldNode,
+    required DocumentNode newNode,
+  }) {
+    _document.replaceNode(oldNode: oldNode, newNode: newNode);
+  }
+
   /// Deletes the given [node] from the [Document].
   bool deleteNode(DocumentNode node) {
     return _document.deleteNode(node);
@@ -237,6 +245,26 @@ class MutableDocument with ChangeNotifier implements Document {
     notifyListeners();
 
     return isRemoved;
+  }
+
+  /// Replaces the given [oldNode] with the given [newNode]
+  void replaceNode({
+    required DocumentNode oldNode,
+    required DocumentNode newNode,
+  }) {
+    final index = _nodes.indexOf(oldNode);
+
+    if (index != -1) {
+      oldNode.removeListener(_forwardNodeChange);
+      _nodes.removeAt(index);
+
+      newNode.addListener(_forwardNodeChange);
+      _nodes.insert(index, newNode);
+
+      notifyListeners();
+    } else {
+      throw Exception('Could not find oldNode: ${oldNode.id}');
+    }
   }
 
   void _forwardNodeChange() {

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -79,10 +79,7 @@ class ConvertBlockquoteToParagraphCommand implements EditorCommand {
       id: blockquote.id,
       text: blockquote.text,
     );
-    final blockquoteNodeIndex = document.getNodeIndex(blockquote);
-    transaction
-      ..deleteNodeAt(blockquoteNodeIndex)
-      ..insertNodeAt(blockquoteNodeIndex, newParagraphNode);
+    transaction.replaceNode(oldNode: blockquote, newNode: newParagraphNode);
   }
 }
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1288,13 +1288,10 @@ class CommonEditorOperations {
       final newNode = hasUnorderedListItemMatch
           ? ListItemNode.unordered(id: node.id, text: adjustedText)
           : ListItemNode.ordered(id: node.id, text: adjustedText);
-      final nodeIndex = editor.document.getNodeIndex(node);
 
       editor.executeCommand(
         EditorCommandFunction((document, transaction) {
-          transaction
-            ..deleteNodeAt(nodeIndex)
-            ..insertNodeAt(nodeIndex, newNode);
+          transaction.replaceNode(oldNode: node, newNode: newNode);
         }),
       );
 
@@ -1355,13 +1352,10 @@ class CommonEditorOperations {
         text: adjustedText,
         metadata: {'blockType': blockquoteAttribution},
       );
-      final nodeIndex = editor.document.getNodeIndex(node);
 
       editor.executeCommand(
         EditorCommandFunction((document, transaction) {
-          transaction
-            ..deleteNodeAt(nodeIndex)
-            ..insertNodeAt(nodeIndex, newNode);
+          transaction.replaceNode(oldNode: node, newNode: newNode);
         }),
       );
 
@@ -1447,13 +1441,10 @@ class CommonEditorOperations {
       id: node.id,
       imageUrl: url,
     );
-    final nodeIndex = document.getNodeIndex(node);
 
     editor.executeCommand(
       EditorCommandFunction((document, transaction) {
-        transaction
-          ..deleteNodeAt(nodeIndex)
-          ..insertNodeAt(nodeIndex, imageNode);
+        transaction.replaceNode(oldNode: node, newNode: imageNode);
       }),
     );
 
@@ -1629,16 +1620,12 @@ class CommonEditorOperations {
         final paragraphPosition = composer.selection!.extent.nodePosition as TextNodePosition;
         final endOfParagraph = node.endPosition;
 
-        final nodeIndex = editor.document.getNodeIndex(node);
-
         DocumentSelection newSelection;
         if (node.text.text.isEmpty) {
           // Convert empty paragraph to HR.
           final imageNode = ImageNode(id: nodeId, imageUrl: url);
 
-          transaction
-            ..deleteNodeAt(nodeIndex)
-            ..insertNodeAt(nodeIndex, imageNode);
+          transaction.replaceNode(oldNode: node, newNode: imageNode);
 
           newSelection = DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -1719,8 +1706,6 @@ class CommonEditorOperations {
       return false;
     }
 
-    final nodeIndex = editor.document.getNodeIndex(node);
-
     editor.executeCommand(
       EditorCommandFunction((document, transaction) {
         final paragraphPosition = composer.selection!.extent.nodePosition as TextNodePosition;
@@ -1731,9 +1716,7 @@ class CommonEditorOperations {
           // Convert empty paragraph to HR.
           final hrNode = HorizontalRuleNode(id: nodeId);
 
-          transaction
-            ..deleteNodeAt(nodeIndex)
-            ..insertNodeAt(nodeIndex, hrNode);
+          transaction.replaceNode(oldNode: node, newNode: hrNode);
 
           newSelection = DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -1854,14 +1837,11 @@ class CommonEditorOperations {
       return false;
     }
 
-    final nodeIndex = editor.document.getNodeIndex(node);
     final newNode = ListItemNode(id: nodeId, itemType: type, text: text);
 
     editor.executeCommand(
       EditorCommandFunction((document, transaction) {
-        transaction
-          ..deleteNodeAt(nodeIndex)
-          ..insertNodeAt(nodeIndex, newNode);
+        transaction.replaceNode(oldNode: node, newNode: newNode);
 
         composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
@@ -1896,14 +1876,11 @@ class CommonEditorOperations {
       return false;
     }
 
-    final nodeIndex = editor.document.getNodeIndex(node);
     final newNode = ParagraphNode(id: nodeId, metadata: {'blockType': blockquoteAttribution}, text: text);
 
     editor.executeCommand(
       EditorCommandFunction((document, transaction) {
-        transaction
-          ..deleteNodeAt(nodeIndex)
-          ..insertNodeAt(nodeIndex, newNode);
+        transaction.replaceNode(oldNode: node, newNode: newNode);
 
         composer.selection = DocumentSelection.collapsed(
           position: DocumentPosition(
@@ -1953,11 +1930,8 @@ class CommonEditorOperations {
             id: extentNode.id,
             text: extentNode.text,
           );
-          final extentNodeIndex = document.getNodeIndex(extentNode);
 
-          transaction
-            ..deleteNodeAt(extentNodeIndex)
-            ..insertNodeAt(extentNodeIndex, newParagraphNode);
+          transaction.replaceNode(oldNode: extentNode, newNode: newParagraphNode);
         }
       }),
     );

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -321,10 +321,7 @@ class ConvertListItemToParagraphCommand implements EditorCommand {
       text: listItem.text,
       metadata: paragraphMetadata ?? {},
     );
-    final listItemIndex = document.getNodeIndex(listItem);
-    transaction
-      ..deleteNodeAt(listItemIndex)
-      ..insertNodeAt(listItemIndex, newParagraphNode);
+    transaction.replaceNode(oldNode: listItem, newNode: newParagraphNode);
   }
 }
 
@@ -347,10 +344,7 @@ class ConvertParagraphToListItemCommand implements EditorCommand {
       itemType: type,
       text: paragraphNode.text,
     );
-    final paragraphIndex = document.getNodeIndex(paragraphNode);
-    transaction
-      ..deleteNodeAt(paragraphIndex)
-      ..insertNodeAt(paragraphIndex, newListItemNode);
+    transaction.replaceNode(oldNode: paragraphNode, newNode: newListItemNode);
   }
 }
 
@@ -372,10 +366,7 @@ class ChangeListItemTypeCommand implements EditorCommand {
       itemType: newType,
       text: existingListItem.text,
     );
-    final nodeIndex = document.getNodeIndex(existingListItem);
-    transaction
-      ..deleteNodeAt(nodeIndex)
-      ..insertNodeAt(nodeIndex, newListItemNode);
+    transaction.replaceNode(oldNode: existingListItem, newNode: newListItemNode);
   }
 }
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -201,14 +201,8 @@ class DeleteSelectionCommand implements EditorCommand {
     //       the deletion. This is a fragile relationship between the
     //       composer and the editor and needs to be addressed.
     _log.log('_deleteBinaryNode', ' - replacing BinaryNode with a ParagraphNode: ${node.id}');
-    final nodeIndex = document.getNodeIndex(node);
-    transaction.insertNodeAt(
-      nodeIndex,
-      ParagraphNode(
-        id: node.id,
-        text: AttributedText(),
-      ),
-    );
-    transaction.deleteNode(node);
+
+    final newNode = ParagraphNode(id: node.id, text: AttributedText());
+    transaction.replaceNode(oldNode: node, newNode: newNode);
   }
 }

--- a/super_editor/test/src/core/document_editor.dart
+++ b/super_editor/test/src/core/document_editor.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+void main() {
+  group('MutableDocument', () {
+    test('it replaces one node by another ', () {
+      final oldNode = ParagraphNode(id: 'old', text: AttributedText());
+      final document = MutableDocument(
+        nodes: [
+          HorizontalRuleNode(id: '0'),
+          oldNode,
+          HorizontalRuleNode(id: '2'),
+        ],
+      );
+
+      final newNode = ParagraphNode(id: 'new', text: AttributedText());
+      document.replaceNode(oldNode: oldNode, newNode: newNode);
+
+      // oldNode does not exist
+      expect(document.nodes.contains(oldNode), false);
+      // newNode exists at index 1
+      expect(document.nodes.indexOf(newNode), 1);
+    });
+  });
+}


### PR DESCRIPTION
closes: #251 

I wasn't sure how to properly handle the case when the `oldNode` doesn't exist. I noticed some APIs do nothing, print to console or throw an exception. So I went with the latter. 