### PR TITLE
fix(common_editor_operatons): bug in web deleting first letter of node solved

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -688,7 +688,7 @@ class CommonEditorOperations {
     if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
       return false;
     }
-    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset <= 0) {
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset < 0) {
       return false;
     }
 

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -1,6 +1,6 @@
 name: website
 description: The marketing website for SuperEditor.
-publish_to: "none" # Remove this line if you wish to publish to pub.dev
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 environment:
   sdk: ">=2.7.0 <3.0.0"
 

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -1,6 +1,6 @@
 name: website
 description: The marketing website for SuperEditor.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 environment:
   sdk: ">=2.7.0 <3.0.0"
 


### PR DESCRIPTION
I was checking the code for a few days to understand why in web the first letter(offset = 0) of each node/paragraph would not able to deleted. I found the error and I made this little fix, but I want to keep helping you. it is a very nice project!