### PR TITLE
fix(common_editor_operatons): bug deleting TextPosition's offset = 0 of nodes solved

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -688,7 +688,7 @@ class CommonEditorOperations {
     if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
       return false;
     }
-    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset <= 0) {
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset < 0) {
       return false;
     }
 


### PR DESCRIPTION
I was checking the code for a few days to understand why in web (and I think it happens on desktop too) the first letter(offset = 0) of each node/paragraph could not be forward deleted. I found the error and I made this little fix, but I want to keep helping you. it is a very nice project!