### PR TITLE
fix(common_editor_operations): exception when deleting without existence of nodes has been solved

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -688,7 +688,7 @@ class CommonEditorOperations {
     if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
       return false;
     }
-    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset <= 0) {
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset < 0) {
       return false;
     }
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -758,11 +758,12 @@ class CommonEditorOperations {
         } else if ((node as TextNode).text.text.isEmpty) {
           // The caret is at the beginning of an empty TextNode and the preceding
           // node is not a TextNode. Delete the current TextNode and move the
-          // selection up to the preceding node.
-          _moveSelectionToEndOfPrecedingNode();
-          editor.executeCommand(EditorCommandFunction((doc, transaction) {
-            transaction.deleteNode(node);
-          }));
+          // selection up to the preceding node if exist.
+          if (_moveSelectionToEndOfPrecedingNode()) {
+            editor.executeCommand(EditorCommandFunction((doc, transaction) {
+              transaction.deleteNode(node);
+            }));
+          }
           return true;
         } else {
           // The caret is at the beginning of a non-empty TextNode, and the

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -688,7 +688,7 @@ class CommonEditorOperations {
     if (!_isTextEntryNode(document: editor.document, selection: composer.selection!)) {
       return false;
     }
-    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset < 0) {
+    if (composer.selection!.isCollapsed && (composer.selection!.extent.nodePosition as TextNodePosition).offset <= 0) {
       return false;
     }
 


### PR DESCRIPTION
An exception was getting if the user keeps trying to delete (with backspace key) when all nodes are already deleted