### PR TITLE
MutableDocument equality check compares nodes of other document

### DIFF
--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -297,7 +297,7 @@ class MutableDocument with ChangeNotifier implements Document {
       identical(this, other) ||
       other is MutableDocument &&
           runtimeType == other.runtimeType &&
-          const DeepCollectionEquality().equals(_nodes, nodes);
+          const DeepCollectionEquality().equals(_nodes, other.nodes);
 
   @override
   int get hashCode => _nodes.hashCode;

--- a/super_editor/test/src/core/document_editor_test.dart
+++ b/super_editor/test/src/core/document_editor_test.dart
@@ -21,5 +21,23 @@ void main() {
       // newNode exists at index 1
       expect(document.nodes.indexOf(newNode), 1);
     });
+
+    test('it is equal to a similar document with the same content', () {
+      final node = HorizontalRuleNode(id: '0');
+
+      final document1 = MutableDocument(nodes: [node]);
+      final document2 = MutableDocument(nodes: [node]);
+
+      expect(document1 == document2, isTrue);
+    });
+
+    test('it is NOT equal to a similar document with different content', () {
+      final node = HorizontalRuleNode(id: '0');
+
+      final document1 = MutableDocument(nodes: [node]);
+      final document2 = MutableDocument(nodes: [node, node]);
+
+      expect(document1 == document2, isFalse);
+    });
   });
 }

--- a/super_editor/test/src/core/document_editor_test.dart
+++ b/super_editor/test/src/core/document_editor_test.dart
@@ -22,7 +22,16 @@ void main() {
       expect(document.nodes.indexOf(newNode), 1);
     });
 
-    test('it is equal to a similar document with the same content', () {
+    test('it is equal to another document when both documents are empty', () {
+      final document1 = MutableDocument(nodes: []);
+      final document2 = MutableDocument(nodes: []);
+
+      expect(document1 == document2, isTrue);
+    });
+
+    test(
+        'it is equal to another document when each content node is equal to the corresponding node in the other document',
+        () {
       final node = HorizontalRuleNode(id: '0');
 
       final document1 = MutableDocument(nodes: [node]);
@@ -31,11 +40,25 @@ void main() {
       expect(document1 == document2, isTrue);
     });
 
-    test('it is NOT equal to a similar document with different content', () {
-      final node = HorizontalRuleNode(id: '0');
+    test(
+        'it is NOT equal to a document with the same starting nodes but with additional nodes at the end',
+        () {
+      final node1 = HorizontalRuleNode(id: '1');
+      final node2 = HorizontalRuleNode(id: '2');
 
-      final document1 = MutableDocument(nodes: [node]);
-      final document2 = MutableDocument(nodes: [node, node]);
+      final document1 = MutableDocument(nodes: [node1]);
+      final document2 = MutableDocument(nodes: [node1, node2]);
+
+      expect(document1 == document2, isFalse);
+    });
+
+    test('it is NOT equal to a document when corresponding nodes are NOT equal',
+        () {
+      final node1 = HorizontalRuleNode(id: '1');
+      final node2 = HorizontalRuleNode(id: '2');
+
+      final document1 = MutableDocument(nodes: [node1]);
+      final document2 = MutableDocument(nodes: [node2]);
 
       expect(document1 == document2, isFalse);
     });


### PR DESCRIPTION
It was previously comparing `_nodes` with `nodes` but `nodes` is a getter that returns `_nodes` so they're identical and hence `const DeepCollectionEquality().equals(_nodes, nodes)` is always true.

This is my second PR related to misbehaving equality checks so would it be worth adding a few unit tests?