### PR TITLE
Fix #286, Breaking upstream changes in flutter SDK

### DIFF
--- a/super_editor/lib/src/infrastructure/text_layout.dart
+++ b/super_editor/lib/src/infrastructure/text_layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/rendering.dart';
+import 'package:super_editor/src/infrastructure/utilities.dart';
 
 /// Contract to interrogate the layout of a blob of text.
 abstract class TextLayout {
@@ -112,13 +113,7 @@ TextSelection paragraphExpansionFilter(String text, TextPosition startingPositio
 int getCharacterEndBounds(String text, int startingCodePointIndex) {
   assert(startingCodePointIndex >= 0 && startingCodePointIndex <= text.length);
 
-  // TODO: copy the implementation of nextCharacter to this package because
-  //       it's marked as visible for testing
-  // ignore: invalid_use_of_visible_for_testing_member
-  final startOffset =
-      // ignore: invalid_use_of_visible_for_testing_member
-      RenderEditable.nextCharacter(startingCodePointIndex, text);
-  return startOffset;
+  return Utilities.nextCharacter(startingCodePointIndex, text);
 }
 
 /// Returns the code point index for the code point that begins the visual
@@ -138,12 +133,5 @@ int getCharacterEndBounds(String text, int startingCodePointIndex) {
 /// the given character is returned.
 int getCharacterStartBounds(String text, int endingCodePointIndex) {
   assert(endingCodePointIndex >= 0 && endingCodePointIndex <= text.length);
-
-  // TODO: copy the implementation of previousCharacter to this package because
-  //       it's marked as visible for testing
-  // ignore: invalid_use_of_visible_for_testing_member
-  final startOffset =
-      // ignore: invalid_use_of_visible_for_testing_member
-      RenderEditable.previousCharacter(endingCodePointIndex, text);
-  return startOffset;
+  return Utilities.previousCharacter(endingCodePointIndex, text);
 }

--- a/super_editor/lib/src/infrastructure/text_layout.dart
+++ b/super_editor/lib/src/infrastructure/text_layout.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/rendering.dart';
-import 'package:super_editor/src/infrastructure/utilities.dart';
+import './utilities.dart';
 
 /// Contract to interrogate the layout of a blob of text.
 abstract class TextLayout {

--- a/super_editor/lib/src/infrastructure/utilities.dart
+++ b/super_editor/lib/src/infrastructure/utilities.dart
@@ -1,0 +1,55 @@
+import 'package:characters/characters.dart';
+
+/// Used to store random utilities that don't fit anywhere else.
+class Utilities {
+  Utilities._();
+
+  /// Returns the index into the string of the next character boundary after the
+  /// given index.
+  ///
+  /// The character boundary is determined by the characters package, so
+  /// surrogate pairs and extended grapheme clusters are considered.
+  ///
+  /// The index must be between 0 and string.length, inclusive. If given
+  /// string.length, string.length is returned.
+  static int nextCharacter(int index, String string) {
+    assert(index >= 0 && index <= string.length);
+    if (index == string.length) {
+      return string.length;
+    }
+
+    int count = 0;
+    final Characters remaining = string.characters.skipWhile((String currentString) {
+      if (count <= index) {
+        count += currentString.length;
+        return true;
+      }
+      return false;
+    });
+    return string.length - remaining.toString().length;
+  }
+
+  /// Returns the index into the string of the previous character boundary
+  /// before the given index.
+  ///
+  /// The character boundary is determined by the characters package, so
+  /// surrogate pairs and extended grapheme clusters are considered.
+  ///
+  /// The index must be between 0 and string.length, inclusive. If index is 0,
+  /// 0 will be returned.
+  static int previousCharacter(int index, String string) {
+    assert(index >= 0 && index <= string.length);
+    if (index == 0) {
+      return 0;
+    }
+
+    int count = 0;
+    for (final String currentString in string.characters) {
+      if (count + currentString.length >= index) {
+        return count;
+      }
+      count += currentString.length;
+    }
+    return 0;
+  }
+}

--- a/super_editor/pubspec.lock
+++ b/super_editor/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.0.0"
+    version: "25.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "2.2.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,23 +42,23 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.4"
+    version: "8.1.2"
   characters:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: characters
       url: "https://pub.dartlang.org"
@@ -77,7 +77,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.3"
   clock:
     dependency: transitive
     description:
@@ -105,21 +105,21 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -152,7 +152,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -171,7 +171,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "0.13.3"
   http_parser:
     dependency: transitive
     description:
@@ -185,7 +185,7 @@ packages:
       name: linkify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   lints:
     dependency: transitive
     description:
@@ -213,7 +213,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -248,7 +248,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   pub_semver:
     dependency: transitive
     description:
@@ -267,7 +267,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   source_span:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -323,7 +323,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
 
   collection: ^1.15.0
+  characters: ^1.1.0
   http: ^0.13.1
   linkify: ^4.0.0
   # TODO: move markdown serialization to a separate package and


### PR DESCRIPTION
As noted in #286, changes to the `RenderEditable` class removed `previousCharacter` and `nextCharacter` methods. This PR moves them into a `src/infrastructure/utilities.dart` file. I'm not too familiar with the structure of the library, but I'm fairly certain there isn't another home for these functions other than the `text_layout.dart` file itself, if that's more desirable.

Resolves #286.