### PR TITLE
Add Task & Chat demo - investigating scrolling

### DIFF
--- a/super_editor/example/lib/demos/scrolling/demo_task_and_chat.dart
+++ b/super_editor/example/lib/demos/scrolling/demo_task_and_chat.dart
@@ -1,0 +1,427 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// Displays a task + chat UI.
+///
+/// The content area is confined to a vertically oriented layout,
+/// similar to a "task pane" on the right side of a task app. In
+/// that content area is a task definition at the top, followed by
+/// some messages, and then capped off by a message input `TextField`.
+///
+/// The message input field is always docked to the bottom of the display area.
+///
+/// When the content + messages are shorter than the viewport, the messages
+/// are docked to the bottom of the viewport.
+///
+/// When the content + messages are taller than the viewport, the messages are
+/// placed directly below the content, like a `Column`.
+///
+/// This was an exercise to determine if a `SuperEditor` could be combined with
+/// a conditionally docked widget without relying on `Sliver`s.
+class TaskAndChatDemo extends StatefulWidget {
+  @override
+  _TaskAndChatDemoState createState() => _TaskAndChatDemoState();
+}
+
+class _TaskAndChatDemoState extends State<TaskAndChatDemo> {
+  final _scrollViewportKey = GlobalKey();
+
+  late DocumentEditor _editor;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _editor = DocumentEditor(
+      document: MutableDocument(
+        nodes: [
+          ParagraphNode(
+            id: '1234',
+            text: AttributedText(
+                text:
+                    'Notice that when this document is short enough, the messages are pushed to the bottom of the viewport.\n\nTry adding more content to see things scroll.'),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildScaffold(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              key: _scrollViewportKey,
+              child: Builder(builder: (context) {
+                final viewportBox = _scrollViewportKey.currentContext?.findRenderObject();
+                if (viewportBox == null) {
+                  // We don't know the size of the viewport yet. Return an empty box
+                  // and schedule another frame to reflow our layout based on the
+                  // viewport size.
+                  WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+                    if (mounted) {
+                      setState(() {});
+                    }
+                  });
+
+                  return const SizedBox();
+                }
+
+                final viewportSize = (viewportBox as RenderBox).size;
+                print('viewportSize: $viewportSize');
+
+                return ColumnWithBottomPin(
+                  viewportHeight: viewportSize.height,
+                  child: _buildHeaderAndDocument(),
+                  pinnedToBottom: _buildMessages(),
+                );
+              }),
+            ),
+          ),
+          _buildChatInput(),
+        ],
+      ),
+    );
+  }
+
+  // Builds the demo display with the [child] displayed in the center
+  // at proportions that mimic a task area with a chat section beneath it.
+  Widget _buildScaffold({
+    required Widget child,
+  }) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 600),
+        child: Container(
+          width: double.infinity,
+          height: double.infinity,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                offset: const Offset(0, 5),
+                blurRadius: 5,
+                color: Colors.black.withOpacity(0.4),
+              ),
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeaderAndDocument() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 24),
+      child: Column(
+        children: [
+          _buildTaskHeader(),
+          const SizedBox(height: 16),
+          IntrinsicHeight(
+            child: SuperEditor.standard(editor: _editor),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTaskHeader() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'Task and chat scrolling',
+          style: TextStyle(
+            color: Color(0xFF444444),
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: const [
+            Icon(
+              Icons.star,
+              color: Color(0xFFDDDDDD),
+              size: 14,
+            ),
+            SizedBox(width: 8),
+            Icon(
+              Icons.save,
+              color: Color(0xFFDDDDDD),
+              size: 14,
+            ),
+            SizedBox(width: 8),
+            Icon(
+              Icons.group,
+              color: Color(0xFFDDDDDD),
+              size: 14,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+
+  Widget _buildMessages() {
+    return Container(
+      width: double.infinity,
+      color: const Color(0xFFEEEEEE),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Text(
+            'This is the start of your conversation',
+            style: TextStyle(
+              color: Color(0xFF444444),
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const Text(
+            'Yesterday at 23:49',
+            style: TextStyle(
+              color: Color(0xFF888888),
+              fontSize: 10,
+            ),
+          ),
+          const SizedBox(height: 16),
+          _buildMessage('Message input is mounted to bottom.'),
+          const SizedBox(height: 16),
+          _buildMessage('Messages are pushed down when space is available.'),
+          const SizedBox(height: 16),
+          _buildMessage('When the task content is longer, the messages are pushed down.'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessage(String message) {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: const BoxDecoration(
+            color: Colors.lightBlue,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(8),
+              topRight: Radius.circular(8),
+              bottomLeft: Radius.circular(8),
+              bottomRight: Radius.circular(2),
+            )),
+        child: Text(
+          message,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 12,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatInput() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      color: Colors.grey.shade300,
+      child: TextField(
+        style: const TextStyle(
+          fontSize: 14,
+        ),
+        decoration: InputDecoration(
+          filled: true,
+          fillColor: Colors.white,
+          hintText: "what's up?",
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4),
+            borderSide: BorderSide.none,
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4),
+            borderSide: BorderSide.none,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Vertical layout that displays [child] above [pinnedToBottom], similar
+/// to a `Column`.
+///
+/// `ColumnWithBottomPin` expects to be placed within a scrollable
+/// viewport whose height is [viewportHeight].
+///
+/// When [child] + [pinnedToBottom] are shorter than [viewportHeight], the
+/// [pinnedToBottom] widget is positioned so that it's bottom edge is
+/// [viewportHeight] from the top of this layout. This effectively "docks"
+/// the [pinnedToBottom] widget at the bottom of the available space.
+///
+/// When [child] + [pinnedToBottom] are taller than [viewportHeight], the
+/// two widgets are stacked vertically, exactly like a `Column`.
+class ColumnWithBottomPin extends MultiChildRenderObjectWidget {
+  ColumnWithBottomPin({
+    Key? key,
+    required this.viewportHeight,
+    required this.child,
+    this.pinnedToBottom,
+  }) : super(key: key, children: [
+          child,
+          if (pinnedToBottom != null) pinnedToBottom,
+        ]);
+
+  final double viewportHeight;
+  final Widget child;
+  final Widget? pinnedToBottom;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderColumnWithBottomPin(
+      viewportHeight: viewportHeight,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderColumnWithBottomPin renderObject) {
+    renderObject.viewportHeight = viewportHeight;
+  }
+}
+
+/// Renders a vertical layout with two children where the 2nd child is
+/// pinned to the bottom of the available `viewportHeight`, if the two
+/// children don't require the full `viewportHeight`.
+///
+/// See [ColumnWithBottomPin], which is the `Widget` associated with
+/// `RenderColumnWithBottomPin`.
+class RenderColumnWithBottomPin extends RenderBox
+    with
+        ContainerRenderObjectMixin<RenderBox, MultiChildLayoutParentData>,
+        RenderBoxContainerDefaultsMixin<RenderBox, MultiChildLayoutParentData> {
+  RenderColumnWithBottomPin({
+    required double viewportHeight,
+    List<RenderBox>? children,
+  }) : _viewportHeight = viewportHeight {
+    addAll(children);
+  }
+
+  double _viewportHeight;
+  double get viewportHeight => _viewportHeight;
+  set viewportHeight(double newValue) {
+    if (newValue != _viewportHeight) {
+      _viewportHeight = newValue;
+      markNeedsLayout();
+    }
+  }
+
+  @override
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! MultiChildLayoutParentData) child.parentData = MultiChildLayoutParentData();
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    final mainChildWidth = getChildrenAsList().first.computeMinIntrinsicWidth(height);
+    final pinToBottomWidth = getChildrenAsList().last.computeMinIntrinsicWidth(height);
+
+    return mainChildWidth.isFinite || pinToBottomWidth.isFinite ? min(mainChildWidth, pinToBottomWidth) : 0.0;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    final mainChildWidth = getChildrenAsList().first.computeMaxIntrinsicWidth(height);
+    final pinToBottomWidth = getChildrenAsList().last.computeMaxIntrinsicWidth(height);
+
+    if (mainChildWidth.isFinite && pinToBottomWidth.isFinite) {
+      return max(mainChildWidth, pinToBottomWidth);
+    } else if (mainChildWidth.isFinite) {
+      return mainChildWidth;
+    } else if (pinToBottomWidth.isFinite) {
+      return pinToBottomWidth;
+    } else {
+      return 0.0;
+    }
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    final mainChildHeight = getChildrenAsList().first.computeMinIntrinsicHeight(width);
+    final pinToBottomHeight = getChildrenAsList().last.computeMinIntrinsicHeight(width);
+
+    return mainChildHeight + pinToBottomHeight;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    final mainChildHeight = getChildrenAsList().first.computeMaxIntrinsicHeight(width);
+    final pinToBottomHeight = getChildrenAsList().last.computeMaxIntrinsicHeight(width);
+
+    return mainChildHeight + pinToBottomHeight;
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final mainChildSize = getChildrenAsList().first.computeDryLayout(constraints);
+    final pinToBottomSize = getChildrenAsList().last.computeDryLayout(constraints);
+
+    return Size(
+      max(mainChildSize.width, pinToBottomSize.width),
+      mainChildSize.height + pinToBottomSize.height,
+    );
+  }
+
+  @override
+  void performLayout() {
+    final mainChild = getChildrenAsList().first;
+    final pinnedToBottom = getChildrenAsList().last;
+
+    // Measure the bottom widget first so that we can apply a min-height
+    // to the content widget based on the remaining space.
+    pinnedToBottom.layout(constraints, parentUsesSize: true);
+
+    // Determine the minimum height for the content based on the vertical space
+    // that the pinnedToBottom widget DIDN'T take up.
+    final contentMinHeight = max(viewportHeight - pinnedToBottom.size.height, 0.0);
+
+    // Layout the content widget, forcing it to be at least as tall as any vertical
+    // space that the pinnedToBottom widget didn't take up.
+    mainChild.layout(constraints.enforce(BoxConstraints(minHeight: contentMinHeight)), parentUsesSize: true);
+
+    // The content widget is always positioned at the top left corner.
+    (mainChild.parentData as MultiChildLayoutParentData).offset = Offset.zero;
+
+    // The pinnedToBottom widget is either placed at the bottom of the viewport
+    // height, or it's placed immediately below the content.
+    final pinnedToBottomY = pinnedToBottom.size.height + mainChild.size.height <= viewportHeight
+        ? viewportHeight - pinnedToBottom.size.height
+        : mainChild.size.height;
+    (pinnedToBottom.parentData as MultiChildLayoutParentData).offset = Offset(0, pinnedToBottomY);
+
+    // Our height is either the same as the viewportHeight, if the content is
+    // short enough, or it's the height of the content + pinnedToBottom widgets.
+    size = Size(
+      constraints.maxWidth,
+      max(viewportHeight, mainChild.size.height + pinnedToBottom.size.height),
+    );
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    defaultPaint(context, offset);
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return defaultHitTestChildren(result, position: position);
+  }
+}

--- a/super_editor/example/lib/demos/spike_scrolling/compute_text_span_bug.dart
+++ b/super_editor/example/lib/demos/spike_scrolling/compute_text_span_bug.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class ComputeTextSpanBug extends StatefulWidget {
+  @override
+  _ComputeTextSpanBugState createState() => _ComputeTextSpanBugState();
+}
+
+class _ComputeTextSpanBugState extends State<ComputeTextSpanBug> {
+  final TextEditingController _controller = TextEditingController();
+  late Document _doc;
+  late DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createInitialDocument();
+    _docEditor = DocumentEditor(document: _doc as MutableDocument);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor.custom(
+      editor: _docEditor,
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+      textStyleBuilder: _textStyleBuilder,
+    );
+  }
+
+  TextStyle _textStyleBuilder(Set<Attribution> attributions) {
+    var newStyle = defaultStyleBuilder(attributions);
+
+    for (final attribution in attributions) {
+      if (attribution == primaryHeaderAttribution) {
+        newStyle = newStyle.copyWith(
+          color: Colors.blue,
+          fontSize: 48,
+          fontWeight: FontWeight.bold,
+          height: 1.0,
+        );
+      }
+    }
+
+    return newStyle;
+  }
+}
+
+Document _createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: '',
+          spans: AttributedSpans(
+            attributions: [
+              const SpanMarker(
+                attribution: primaryHeaderAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: primaryHeaderAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.end,
+              ),
+            ],
+          ),
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+    ],
+  );
+}
+
+class PrimaryHeaderAttribution extends NamedAttribution {
+  const PrimaryHeaderAttribution() : super('NamedAttribution');
+}
+
+const primaryHeaderAttribution = NamedAttribution('header2');

--- a/super_editor/example/lib/demos/spike_scrolling/header_footer_in_document_use_case.dart
+++ b/super_editor/example/lib/demos/spike_scrolling/header_footer_in_document_use_case.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class HeaderFooterInDocumentUseCase extends StatelessWidget {
+  const HeaderFooterInDocumentUseCase({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor.custom(
+      editor: DocumentEditor(document: _createInitialDocument()),
+      componentBuilders: [
+        _headerBuilder,
+        _footerBuilder,
+        ...defaultComponentBuilders,
+      ],
+    );
+  }
+
+  Widget? _headerBuilder(ComponentContext componentContext) {
+    final node = componentContext.documentNode;
+
+    if (node is! HeaderNode) {
+      return null;
+    }
+
+    return node.child;
+  }
+
+  Widget? _footerBuilder(ComponentContext componentContext) {
+    final node = componentContext.documentNode;
+
+    if (node is! FooterNode) {
+      return null;
+    }
+
+    return node.child;
+  }
+}
+
+MutableDocument _createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      HeaderNode(child: const Header()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Complex Headers & Footers',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Document should take up as much space as it needs. (No scroll within a scroll, which can happen depending on the size of this window). Document should be surrounded by interactive / "complex" headers and footers. Users need to be able to interact with Buttons and Text fields as they normally would.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+            text:
+                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+        ),
+      ),
+      FooterNode(child: const Footer())
+    ],
+  );
+}
+
+class HeaderNode extends HorizontalRuleNode {
+  final Widget child;
+
+  HeaderNode({required this.child}) : super(id: 'header');
+}
+
+class FooterNode extends HorizontalRuleNode {
+  final Widget child;
+
+  FooterNode({required this.child}) : super(id: 'header');
+}
+
+class Header extends StatelessWidget {
+  const Header({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: Stack(
+        children: [
+          Container(
+            height: 150,
+            color: Colors.red,
+          ),
+          Positioned.fill(
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: SizedBox(
+                width: 600,
+                height: 170,
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: IconButton(
+                    icon: const Icon(Icons.send),
+                    onPressed: () {
+                      showDialog(
+                        context: context,
+                        builder: (context) {
+                          return const AlertDialog(
+                            title: Text('Header Button pressed'),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class Footer extends StatefulWidget {
+  const Footer({Key? key}) : super(key: key);
+
+  @override
+  State<Footer> createState() => _FooterState();
+}
+
+class _FooterState extends State<Footer> {
+  final TextEditingController _controller = TextEditingController();
+  final List<String> _messages = [
+    'Dummy',
+    'List',
+    'Of',
+    'Fake',
+    'Messages',
+    'Between',
+    'Users',
+  ];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+            'Headers/Footers may contain Text fields and buttons. Here, we have a "messaging experience"'),
+        for (final message in _messages)
+          ListTile(
+            title: Text(message),
+          ),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: TextField(
+            controller: _controller,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'Enter message...',
+            ),
+          ),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            setState(() {
+              if (_controller.text.isNotEmpty) {
+                _messages.add(_controller.text);
+              }
+            });
+          },
+          child: const Text("Send message"),
+        ),
+      ],
+    );
+  }
+}

--- a/super_editor/example/lib/demos/spike_scrolling/header_footer_use_case.dart
+++ b/super_editor/example/lib/demos/spike_scrolling/header_footer_use_case.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+import 'sliver_stick_to_bottom.dart';
+
+class HeaderFooterUseCase extends StatefulWidget {
+  @override
+  _HeaderFooterUseCaseState createState() => _HeaderFooterUseCaseState();
+}
+
+class _HeaderFooterUseCaseState extends State<HeaderFooterUseCase> {
+  final TextEditingController _controller = TextEditingController();
+  late Document _doc;
+  late DocumentEditor _docEditor;
+  final List<String> _messages = [
+    'Dummy',
+    'List',
+    'Of',
+    'Fake',
+    'Messages',
+    'Between',
+    'Users',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createInitialDocument();
+    _docEditor = DocumentEditor(document: _doc as MutableDocument);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: SizedBox(
+            height: 200,
+            child: Stack(
+              children: [
+                Container(
+                  height: 150,
+                  color: Colors.blue,
+                ),
+                Positioned.fill(
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: SizedBox(
+                      width: 600,
+                      height: 170,
+                      child: Align(
+                        alignment: Alignment.bottomLeft,
+                        child: IconButton(
+                          icon: const Icon(Icons.send),
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (context) {
+                                return const AlertDialog(
+                                  title: Text('Header Button pressed'),
+                                );
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: IntrinsicHeight(
+            child: SuperEditor.standard(
+              editor: _docEditor,
+              padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+            ),
+          ),
+        ),
+        SliverStickToBottom(
+          child: Column(
+            children: [
+              const Text(
+                  'Headers/Footers may contain Text fields and buttons. Here, we have a "messaging experience" that sticks to the bottom of the screen if the document isn\'t large enough, or scrolls with the document if the document is large enough'),
+              for (final message in _messages)
+                ListTile(
+                  title: Text(message),
+                ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Enter message...',
+                  ),
+                ),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    if (_controller.text.isNotEmpty) {
+                      _messages.add(_controller.text);
+                    }
+                  });
+                },
+                child: const Text("Send message"),
+              ),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+Document _createInitialDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Complex Headers & Footers',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Document should take up as much space as it needs. (No scroll within a scroll, which can happen depending on the size of this window). Document should be surrounded by interactive / "complex" headers and footers. Users need to be able to interact with Buttons and Text fields as they normally would.',
+        ),
+      ),
+    ],
+  );
+}

--- a/super_editor/example/lib/demos/spike_scrolling/scrolling_performance_use_case.dart
+++ b/super_editor/example/lib/demos/spike_scrolling/scrolling_performance_use_case.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class ScrollingPerformanceUseCase extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor.standard(
+      // Roughly a 20 page document in a standard word editor
+      editor: DocumentEditor(document: _createInitialDocument(250)),
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+    );
+  }
+}
+
+MutableDocument _createInitialDocument(int size, [int fizz = 3, int buzz = 5]) {
+  return MutableDocument(
+    nodes: List.generate(size, (index) {
+      if (index % fizz == 0 && index % buzz == 0) {
+        return ImageNode(
+          id: DocumentEditor.createNodeId(),
+          imageUrl: 'https://i.imgur.com/fSZwM7G.jpg',
+        );
+      } else if (index % fizz == 0) {
+        return ListItemNode.unordered(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text: 'This is an unordered list item',
+          ),
+        );
+      } else if (index % buzz == 0) {
+        return ListItemNode.ordered(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text: 'First thing to do',
+          ),
+        );
+      }
+
+      return ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              '$index. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      );
+    }),
+  );
+}

--- a/super_editor/example/lib/demos/spike_scrolling/sliver_stick_to_bottom.dart
+++ b/super_editor/example/lib/demos/spike_scrolling/sliver_stick_to_bottom.dart
@@ -1,0 +1,67 @@
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+class SliverStickToBottom extends SingleChildRenderObjectWidget {
+  /// Creates a sliver that positions its child at the bottom of the screen or
+  /// scrolls it off screen if there's not enough space
+  const SliverStickToBottom({
+    required Widget child,
+    Key? key,
+  }) : super(key: key, child: child);
+
+  @override
+  RenderSliverStickToBottom createRenderObject(BuildContext context) =>
+      RenderSliverStickToBottom();
+}
+
+class RenderSliverStickToBottom extends RenderSliverSingleBoxAdapter {
+  /// Creates a [RenderSliver] that wraps a [RenderBox] will be aligned at the
+  /// bottom or scrolled off screen
+  RenderSliverStickToBottom({
+    RenderBox? child,
+  }) : super(child: child);
+
+  @override
+  void performLayout() {
+    if (child == null) {
+      geometry = SliverGeometry.zero;
+      return;
+    }
+    child!.layout(constraints.asBoxConstraints(), parentUsesSize: true);
+    double? childExtent;
+    switch (constraints.axis) {
+      case Axis.horizontal:
+        childExtent = child!.size.width;
+        break;
+      case Axis.vertical:
+        childExtent = child!.size.height;
+        break;
+    }
+    final paintedChildSize = calculatePaintOffset(
+      constraints,
+      from: 0,
+      to: childExtent,
+    );
+    final cacheExtent = calculateCacheOffset(
+      constraints,
+      from: 0,
+      to: childExtent,
+    );
+
+    assert(paintedChildSize.isFinite);
+    assert(paintedChildSize >= 0.0);
+    geometry = SliverGeometry(
+      paintOrigin: math.max(0, constraints.remainingPaintExtent - childExtent),
+      scrollExtent: childExtent,
+      paintExtent: math.min(childExtent, constraints.remainingPaintExtent),
+      cacheExtent: math.min(cacheExtent, constraints.remainingPaintExtent),
+      maxPaintExtent: math.max(childExtent, constraints.remainingPaintExtent),
+      hitTestExtent: paintedChildSize,
+      hasVisualOverflow: childExtent > constraints.remainingPaintExtent ||
+          constraints.scrollOffset > 0.0,
+    );
+    setChildParentData(child!, constraints, geometry!);
+  }
+}

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:example/demos/demo_paragraphs.dart';
 import 'package:example/demos/demo_selectable_text.dart';
 import 'package:example/demos/example_editor/example_editor.dart';
 import 'package:example/demos/flutter_features/textinputclient/basic_text_input_client.dart';
+import 'package:example/demos/scrolling/demo_task_and_chat.dart';
 import 'package:example/demos/supertextfield/ios/demo_superiostextfield.dart';
 import 'package:example/demos/flutter_features/textinputclient/textfield.dart';
 import 'package:example/demos/sliver_example_editor.dart';
@@ -158,6 +159,13 @@ final _menu = <_MenuGroup>[
         title: 'Sliver Editor Demo',
         pageBuilder: (context) {
           return SliverExampleEditor();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.task,
+        title: 'Task and Chat Demo',
+        pageBuilder: (context) {
+          return TaskAndChatDemo();
         },
       ),
       _MenuItem(

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:example/demos/demo_selectable_text.dart';
 import 'package:example/demos/example_editor/example_editor.dart';
 import 'package:example/demos/flutter_features/textinputclient/basic_text_input_client.dart';
 import 'package:example/demos/scrolling/demo_task_and_chat.dart';
+import 'package:example/demos/spike_scrolling/header_footer_use_case.dart';
 import 'package:example/demos/supertextfield/ios/demo_superiostextfield.dart';
 import 'package:example/demos/flutter_features/textinputclient/textfield.dart';
 import 'package:example/demos/sliver_example_editor.dart';
@@ -166,6 +167,13 @@ final _menu = <_MenuGroup>[
         title: 'Task and Chat Demo',
         pageBuilder: (context) {
           return TaskAndChatDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.science,
+        title: 'Exploring: header/footer',
+        pageBuilder: (context) {
+          return HeaderFooterUseCase();
         },
       ),
       _MenuItem(


### PR DESCRIPTION
I'm investigating various scrolling use-cases. Meta ticket is #315 

In this PR I explored a situation where one displays task content, followed by messages, followed by message input.

The message input is always docked to the bottom.

The messages content is conditionally docked to the bottom - they're docked to the bottom when there isn't enough content to scroll, otherwise they're placed directly below the task content.

The purpose of this exercise was to see if such a thing could reasonably be achieved without `Sliver`s. The answer appears to be "yes". This doesn't mean we shouldn't pursue documents within `CustomScrollView`s, but this will hopefully help inform approaches and priorities.


https://user-images.githubusercontent.com/7259036/137232886-043e12e7-bfef-43aa-b32e-45de4b3e8fb7.mov

