### PR TITLE
Caret size doesn't match hint text

### DIFF
--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// Example of various [TextWithHintComponent] visual configurations.
+class TextWithHintDemo extends StatefulWidget {
+  @override
+  _TextWithHintDemoState createState() => _TextWithHintDemoState();
+}
+
+class _TextWithHintDemoState extends State<TextWithHintDemo> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        child: SizedBox(
+          width: 500,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextWithHintComponent(
+                text: AttributedText(text: ''),
+                hintText: AttributedText(text: 'hint text...'),
+                textAlign: TextAlign.left,
+                textStyleBuilder: (attributions) {
+                  return const TextStyle(
+                    color: Color(0xFF444444),
+                    fontSize: 30,
+                  );
+                },
+                showCaret: true,
+                textSelection: const TextSelection.collapsed(offset: 0),
+              ),
+              const SizedBox(height: 24),
+              TextWithHintComponent(
+                text: AttributedText(text: ''),
+                hintText: AttributedText(text: 'hint text...'),
+                textAlign: TextAlign.left,
+                textStyleBuilder: (attributions) {
+                  return const TextStyle(
+                    color: Color(0xFF444444),
+                    fontSize: 24,
+                  );
+                },
+                showCaret: true,
+                textSelection: const TextSelection.collapsed(offset: 0),
+              ),
+              const SizedBox(height: 24),
+              TextWithHintComponent(
+                text: AttributedText(text: ''),
+                hintText: AttributedText(text: 'hint text...'),
+                textAlign: TextAlign.left,
+                textStyleBuilder: (attributions) {
+                  return const TextStyle(
+                    color: Color(0xFF444444),
+                    fontSize: 14,
+                  );
+                },
+                showCaret: true,
+                textSelection: const TextSelection.collapsed(offset: 0),
+              ),
+              const SizedBox(height: 24),
+              TextWithHintComponent(
+                text: AttributedText(text: 'Regular text display without a hint'),
+                textAlign: TextAlign.left,
+                textStyleBuilder: (attributions) {
+                  return const TextStyle(
+                    color: Color(0xFF444444),
+                    fontSize: 18,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -3,90 +3,210 @@ import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
 /// Example of various [TextWithHintComponent] visual configurations.
+///
+/// To replicate behavior like this in your own code, ensure that you
+/// do the following:
+///
+///  * Customize text styling as desired for various headers.
+///  * Add a custom [ComponentBuilder] that builds a widget capable
+///    of rendering hint text and add it to the builders passed to
+///    [SuperEditor].
+///    * In your custom [ComponentBuilder], wrap the style builder
+///      function and explicitly add your desired block-level
+///      attribution to the attributions that are passed to the
+///      standard style builder
+///
+/// Each of the above steps are demonstrated in this example.
 class TextWithHintDemo extends StatefulWidget {
   @override
   _TextWithHintDemoState createState() => _TextWithHintDemoState();
 }
 
 class _TextWithHintDemoState extends State<TextWithHintDemo> {
+  late MutableDocument _doc;
+  late DocumentEditor _docEditor;
+
   @override
   void initState() {
     super.initState();
+    _doc = _createDocument();
+    _docEditor = DocumentEditor(document: _doc);
   }
 
   @override
   void dispose() {
+    _doc.dispose();
     super.dispose();
+  }
+
+  /// Creates a document with multiple levels of headers with hint text, and a
+  /// regular paragraph for comparison.
+  MutableDocument _createDocument() {
+    return MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(text: ''),
+          metadata: {'blockType': header1Attribution},
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(text: ''),
+          metadata: {'blockType': header2Attribution},
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(text: ''),
+          metadata: {'blockType': header3Attribution},
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text:
+                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+          ),
+        ),
+      ],
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: SingleChildScrollView(
-        child: SizedBox(
-          width: 500,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              TextWithHintComponent(
-                text: AttributedText(text: ''),
-                hintText: AttributedText(text: 'hint text...'),
-                textAlign: TextAlign.left,
-                textStyleBuilder: (attributions) {
-                  return const TextStyle(
-                    color: Color(0xFF444444),
-                    fontSize: 30,
-                  );
-                },
-                showCaret: true,
-                textSelection: const TextSelection.collapsed(offset: 0),
-              ),
-              const SizedBox(height: 24),
-              TextWithHintComponent(
-                text: AttributedText(text: ''),
-                hintText: AttributedText(text: 'hint text...'),
-                textAlign: TextAlign.left,
-                textStyleBuilder: (attributions) {
-                  return const TextStyle(
-                    color: Color(0xFF444444),
-                    fontSize: 24,
-                  );
-                },
-                showCaret: true,
-                textSelection: const TextSelection.collapsed(offset: 0),
-              ),
-              const SizedBox(height: 24),
-              TextWithHintComponent(
-                text: AttributedText(text: ''),
-                hintText: AttributedText(text: 'hint text...'),
-                textAlign: TextAlign.left,
-                textStyleBuilder: (attributions) {
-                  return const TextStyle(
-                    color: Color(0xFF444444),
-                    fontSize: 14,
-                  );
-                },
-                showCaret: true,
-                textSelection: const TextSelection.collapsed(offset: 0),
-              ),
-              const SizedBox(height: 24),
-              TextWithHintComponent(
-                text: AttributedText(
-                    text:
-                        'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.'),
-                textAlign: TextAlign.left,
-                textStyleBuilder: (attributions) {
-                  return const TextStyle(
-                    color: Color(0xFF444444),
-                    fontSize: 18,
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-      ),
+    return SuperEditor.custom(
+      editor: _docEditor,
+      padding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+
+      /// Adjust the default styles to style 3 levels of headers
+      /// with large font sizes.
+      textStyleBuilder: _textStyleBuilder,
+
+      /// Add a new component builder to the front of the list
+      /// that knows how to render header widgets with hint text.
+      componentBuilders: [
+        _headerWithHintBuilder,
+        ...defaultComponentBuilders,
+      ],
     );
   }
+}
+
+/// Our selection of styles to apply to all the text in the editor.
+TextStyle _textStyleBuilder(Set<Attribution> attributions) {
+  // We only care about altering a few styles. Start by getting
+  // the standard styles for these attributions.
+  var newStyle = defaultStyleBuilder(attributions);
+
+  // Style headers
+  for (final attribution in attributions) {
+    if (attribution == header1Attribution) {
+      newStyle = newStyle.copyWith(
+        color: const Color(0xFF444444),
+        fontSize: 48,
+        fontWeight: FontWeight.bold,
+      );
+    } else if (attribution == header2Attribution) {
+      newStyle = newStyle.copyWith(
+        color: const Color(0xFF444444),
+        fontSize: 38,
+        fontWeight: FontWeight.bold,
+      );
+    } else if (attribution == header3Attribution) {
+      newStyle = newStyle.copyWith(
+        color: const Color(0xFF444444),
+        fontSize: 28,
+        fontWeight: FontWeight.bold,
+      );
+    }
+  }
+
+  return newStyle;
+}
+
+/// SuperEditor [ComponentBuilder] that builds a component for Header 1, Header 2,
+/// and Header 3 `ParagraphNode`s, displays "hint text..." when the content
+/// text is empty.
+///
+/// [ComponentBuilder]s operate at the document level, which means that they can
+/// make decisions based on global document structure. Therefore, if you'd like
+/// to limit hint text to the very first header in a document, or the first header
+/// and paragraph, you can make that decision at the beginning of your
+/// [ComponentBuilder]:
+///
+/// ```
+/// final nodeIndex = componentContext.document.getNodeIndex(
+///   componentContext.documentNode,
+/// );
+///
+/// if (nodeIndex > 0) {
+///   // This isn't the first node, we don't ever want to show hint text.
+///   return null;
+/// }
+/// ```
+Widget? _headerWithHintBuilder(ComponentContext componentContext) {
+  if (componentContext.documentNode is! ParagraphNode) {
+    return null;
+  }
+
+  final blockAttribution = (componentContext.documentNode as TextNode).metadata['blockType'];
+  if (!(const [header1Attribution, header2Attribution, header3Attribution]).contains(blockAttribution)) {
+    return null;
+  }
+
+  final textSelection =
+      componentContext.nodeSelection == null || componentContext.nodeSelection!.nodeSelection is! TextSelection
+          ? null
+          : componentContext.nodeSelection!.nodeSelection as TextSelection;
+
+  final showCaret = componentContext.showCaret && componentContext.nodeSelection != null
+      ? componentContext.nodeSelection!.isExtent
+      : false;
+  final highlightWhenEmpty =
+      componentContext.nodeSelection == null ? false : componentContext.nodeSelection!.highlightWhenEmpty;
+
+  final textDirection = getParagraphDirection((componentContext.documentNode as TextNode).text.text);
+
+  TextAlign textAlign = (textDirection == TextDirection.ltr) ? TextAlign.left : TextAlign.right;
+  final textAlignName = (componentContext.documentNode as TextNode).metadata['textAlign'];
+  switch (textAlignName) {
+    case 'left':
+      textAlign = TextAlign.left;
+      break;
+    case 'center':
+      textAlign = TextAlign.center;
+      break;
+    case 'right':
+      textAlign = TextAlign.right;
+      break;
+    case 'justify':
+      textAlign = TextAlign.justify;
+      break;
+  }
+
+  final defaultStyleBuilder = (componentContext.extensions[textStylesExtensionKey] as AttributionStyleBuilder);
+
+  // We want this node's block attribution to impact the text styling. Therefore,
+  // when the style builder is called, we explicitly add the block attribution
+  // to any span attributions for the given text.
+  //
+  // ignore: prefer_function_declarations_over_variables
+  final headerStyleBuilder = (Set<Attribution> attributions) {
+    final adjustedAttributions = Set<Attribution>.from(attributions)..add(blockAttribution);
+
+    return defaultStyleBuilder(adjustedAttributions);
+  };
+
+  return TextWithHintComponent(
+    key: componentContext.componentKey,
+    text: (componentContext.documentNode as TextNode).text,
+    textStyleBuilder: headerStyleBuilder,
+    metadata: (componentContext.documentNode as TextNode).metadata,
+    hintText: AttributedText(text: 'hint text...'),
+    textAlign: textAlign,
+    textDirection: textDirection,
+    textSelection: textSelection,
+    selectionColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).selectionColor,
+    showCaret: showCaret,
+    caretColor: (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle).textCaretColor,
+    highlightWhenEmpty: highlightWhenEmpty,
+  );
 }

--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -72,7 +72,9 @@ class _TextWithHintDemoState extends State<TextWithHintDemo> {
               ),
               const SizedBox(height: 24),
               TextWithHintComponent(
-                text: AttributedText(text: 'Regular text display without a hint'),
+                text: AttributedText(
+                    text:
+                        'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.'),
                 textAlign: TextAlign.left,
                 textStyleBuilder: (attributions) {
                   return const TextStyle(

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/components/demo_text_with_hint.dart';
 import 'package:example/demos/demo_rtl.dart';
 import 'package:example/demos/demo_markdown_serialization.dart';
 import 'package:example/demos/demo_paragraphs.dart';
@@ -211,6 +212,18 @@ final _menu = <_MenuGroup>[
         title: 'Paragraphs',
         pageBuilder: (context) {
           return ParagraphsDemo();
+        },
+      ),
+    ],
+  ),
+  _MenuGroup(
+    title: 'DOC COMPONENTS',
+    items: [
+      _MenuItem(
+        icon: Icons.short_text,
+        title: 'Text with hint',
+        pageBuilder: (context) {
+          return TextWithHintDemo();
         },
       ),
     ],

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -227,8 +227,8 @@ class _TextWithHintComponentState extends State<TextWithHintComponent>
       attributionsWithBlock.add(blockType);
     }
 
-    final contentStyle = widget.textStyleBuilder(attributions);
-    final hintStyle = contentStyle.merge(widget.hintStyleBuilder?.call(attributions) ?? const TextStyle());
+    final contentStyle = widget.textStyleBuilder(attributionsWithBlock);
+    final hintStyle = contentStyle.merge(widget.hintStyleBuilder?.call(attributionsWithBlock) ?? const TextStyle());
     return hintStyle;
   }
 
@@ -602,21 +602,9 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
   Widget build(BuildContext context) {
     _log.log('build', 'Building a TextComponent with key: ${widget.key}');
 
-    Attribution? blockType = widget.metadata['blockType'];
-
-    // Surround the text with block level attributions.
-    final blockText = widget.text.copyText(0);
-    if (blockType != null) {
-      blockText.addAttribution(
-        blockType,
-        TextRange(start: 0, end: widget.text.text.length - 1),
-      );
-    }
-    final richText = blockText.computeTextSpan(widget.textStyleBuilder);
-
     return SuperSelectableText(
       key: _selectableTextKey,
-      textSpan: richText,
+      textSpan: widget.text.computeTextSpan(_textStyleWithBlockType),
       textAlign: widget.textAlign ?? TextAlign.left,
       textDirection: widget.textDirection ?? TextDirection.ltr,
       textSelection: widget.textSelection ?? const TextSelection.collapsed(offset: -1),
@@ -625,6 +613,18 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
       textCaretFactory: TextCaretFactory(color: widget.caretColor),
       highlightWhenEmpty: widget.highlightWhenEmpty,
     );
+  }
+
+  /// Creates a `TextStyle` based on the given [attributions], plus any
+  /// "block type" that's specified in [widget.metadata].
+  TextStyle _textStyleWithBlockType(Set<Attribution> attributions) {
+    final attributionsWithBlockType = Set<Attribution>.from(attributions);
+    Attribution? blockType = widget.metadata['blockType'];
+    if (blockType != null) {
+      attributionsWithBlockType.add(blockType);
+    }
+
+    return widget.textStyleBuilder(attributionsWithBlockType);
   }
 }
 


### PR DESCRIPTION
I investigated the issue where the caret doesn't match the height of the hint text. I found a few areas in the code that might contribute to the problem. To test the issue directly, I created a new component called `TextWithHintComponent` and then I painted a demo screen with multiple text hints at different sizes.

You can see in the attached video that the carets all match the hint text. Therefore, I'll need some further information to understand why this is a problem in Superlist.


https://user-images.githubusercontent.com/7259036/138003325-6ed2a6b3-2d42-47a1-a8c2-825a17a2e7aa.mov



Changes:
 - Created a demo screen for text components with hint text
 - Created ProxyDocumentComponent to easily wrap an existing DocumentComponent with decoration
 - Created ProxyTextComposable to easily wrap an existing TextComposable with decoration
 (Resolves #314)