### PR TITLE
Add current DocumentSelection to ComponentContext (Resolves #334)

### DIFF
--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -413,6 +413,7 @@ class ComponentContext {
   const ComponentContext({
     required this.context,
     required this.document,
+    this.documentSelection,
     required this.documentNode,
     required this.componentKey,
     required this.showCaret,
@@ -426,6 +427,9 @@ class ComponentContext {
 
   /// The [Document] that contains the [DocumentNode].
   final Document document;
+
+  /// The current user selection in the [document].
+  final DocumentSelection? documentSelection;
 
   /// The [DocumentNode] for which a component is needed.
   final DocumentNode documentNode;

--- a/super_editor/lib/src/default_editor/layout.dart
+++ b/super_editor/lib/src/default_editor/layout.dart
@@ -439,6 +439,7 @@ class _DefaultDocumentLayoutState extends State<DefaultDocumentLayout> implement
       final component = _buildComponent(ComponentContext(
         context: context,
         document: widget.document,
+        documentSelection: widget.documentSelection,
         documentNode: docNode,
         componentKey: componentKey,
         showCaret: widget.showCaret,


### PR DESCRIPTION
The ComponentContext is passed to each component builder so that the builder can make decisions about whether or not to return a component, and how to configure a component that is returned.

The ComponentContext already provides access to the Document, current DocumentNode, and current NodeSelection.

There are situations where the creation of an individual component requires knowledge about the document selection.

Example:
Consider the Medium editor with a title and subtitle at the top of the document. When the user selects any part of the title, both the title and subtitle show side-bar labels that read "Title" and "Subtitle". Therefore, the title component makes a decision based on selection in the subtitle and vis-a-versa.