### PR TITLE
Feature/allow text component to take optional trailing span

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -276,6 +276,7 @@ class TextComponent extends StatefulWidget {
     this.caretColor = Colors.black,
     this.highlightWhenEmpty = false,
     this.showDebugPaint = false,
+    this.trailing,
   }) : super(key: key);
 
   final AttributedText text;
@@ -289,6 +290,7 @@ class TextComponent extends StatefulWidget {
   final Color caretColor;
   final bool highlightWhenEmpty;
   final bool showDebugPaint;
+  final WidgetSpan? trailing;
 
   @override
   _TextComponentState createState() => _TextComponentState();
@@ -612,7 +614,12 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
         TextRange(start: 0, end: widget.text.text.length - 1),
       );
     }
-    final richText = blockText.computeTextSpan(widget.textStyleBuilder);
+    final richText = TextSpan(
+      children: [
+        blockText.computeTextSpan(widget.textStyleBuilder),
+        if (widget.trailing != null) widget.trailing!
+      ],
+    );
 
     return SuperSelectableText(
       key: _selectableTextKey,


### PR DESCRIPTION
One use case is to be able to align, for instance, an icon at the end of a TextComponent, both in single and multiline scenarios.

<img width="912" alt="Bildschirmfoto 2021-11-02 um 08 47 40" src="https://user-images.githubusercontent.com/75316882/139806140-43def49d-d899-4ac4-bc88-47950dd4adf7.png">

This cannot be achieved using Row or Wrap as alignment in a multiline scenario will not be correct.

<img width="912" alt="Bildschirmfoto 2021-11-02 um 08 48 57" src="https://user-images.githubusercontent.com/75316882/139806379-2a93c664-ad2c-4541-991d-baf6843093db.png">
<img width="912" alt="Bildschirmfoto 2021-11-02 um 08 49 22" src="https://user-images.githubusercontent.com/75316882/139806405-00fe16c1-efe5-4831-9b02-9662287f8720.png">

This PR adds an optional `WidgetSpan` trailing to TextComponent, thus achieving the first screenshot as seen above.

For `Text`, a custom `TextEditingController` can be extended with `buildTextSpan` overriden to similarly achieve desired functionality. Thus another potential solution may be to introduce a controller for TextComponent.

Looking forward to your feedback.