### PR TITLE
Failing test case for document equality with identical TextNodes

### DIFF
--- a/super_editor/test/src/core/document_editor_test.dart
+++ b/super_editor/test/src/core/document_editor_test.dart
@@ -62,5 +62,27 @@ void main() {
 
       expect(document1 == document2, isFalse);
     });
+
+    test('TextNode equality between two documents', () {
+      final node1 = TextNode(
+        id: '1',
+        text: AttributedText(
+          text: 'a',
+          spans: AttributedSpans(),
+        ),
+      );
+      final node2 = TextNode(
+        id: '1',
+        text: AttributedText(
+          text: 'a',
+          spans: AttributedSpans(),
+        ),
+      );
+
+      final document1 = MutableDocument(nodes: [node1]);
+      final document2 = MutableDocument(nodes: [node2]);
+
+      expect(document1, document2);
+    });
   });
 }


### PR DESCRIPTION
It seems that document equality is broken for documents that contain `TextNode`s. This makes it a bit cumbersome for automated tests where we want to verify that a certain mapping layer produces the correct output.

I tried to investigate this myself, but wasn't able to fix it in a reasonable time, so I decided to submit a failing test case instead.

(feel free to take over and fix it)