### PR TITLE
fixes shift+tab exception for non ListItemNode

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1910,7 +1910,7 @@ class CommonEditorOperations {
 
     final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId);
     final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
-    if (baseNode!.id != extentNode!.id) {
+    if (baseNode!.id != extentNode!.id || baseNode is! ListItemNode) {
       return false;
     }
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1910,7 +1910,11 @@ class CommonEditorOperations {
 
     final baseNode = editor.document.getNodeById(composer.selection!.base.nodeId);
     final extentNode = editor.document.getNodeById(composer.selection!.extent.nodeId);
-    if (baseNode!.id != extentNode!.id || baseNode is! ListItemNode) {
+    if (baseNode!.id != extentNode!.id) {
+      return false;
+    }
+
+    if (baseNode is! ListItemNode) {
       return false;
     }
 


### PR DESCRIPTION
fixes #364 

I added a condition for `unindentListItem` to skip `shift + tab` if the node isn't a `ListItemNode`