### PR TITLE
[Bugfix] Use caret color from selections styles extensions (if defined)

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -338,6 +338,9 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
       (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle?)?.selectionColor ??
           const Color(0x00000000);
 
+  final caretColor = (componentContext.extensions[selectionStylesExtensionKey] as SelectionStyle?)?.textCaretColor ??
+      const Color(0x00000000);
+
   return TextComponent(
     key: componentContext.componentKey,
     text: (componentContext.documentNode as TextNode).text,
@@ -348,7 +351,7 @@ Widget? paragraphBuilder(ComponentContext componentContext) {
     textSelection: textSelection,
     selectionColor: selectionColor,
     showCaret: showCaret,
-    caretColor: selectionColor,
+    caretColor: caretColor,
     highlightWhenEmpty: highlightWhenEmpty,
   );
 }


### PR DESCRIPTION
### Problem ###
It is possible to define a color for the caret using the selections styles extension, but in practice (for paragraphs only), this value is ignored. Instead, the text selection color (defined in the same extension) is used as the caret color.

### Solution ###
As done for other node types (e.g. list items or block quote), use the value coming from the extension (if defined).