### PR TITLE
Temporary hack fix to avoid caret mis-placement in SuperTextField (Resolves #369)

### DIFF
--- a/super_editor/lib/src/infrastructure/caret.dart
+++ b/super_editor/lib/src/infrastructure/caret.dart
@@ -29,6 +29,8 @@ class BlinkingTextCaret extends StatefulWidget {
 }
 
 class _BlinkingTextCaretState extends State<BlinkingTextCaret> {
+  Offset? _caretOffset;
+
   @override
   Widget build(BuildContext context) {
     if (widget.textPosition.offset < 0) {
@@ -64,6 +66,30 @@ class _BlinkingTextCaretState extends State<BlinkingTextCaret> {
         }
       });
 
+      return const SizedBox();
+    }
+
+    // This is a hack to solve super_editor bug #369.
+    //
+    // In profile/release mode, we don't get assertion errors when we try to
+    // measure against a dirty text layout. In fact, there's no signal at all
+    // that we measured against a dirty text layout. In practice, measuring
+    // while dirty results in the caret position thinking that the final word
+    // in a single-line of text is wrapped to a 2nd line, causing the caret to
+    // sit below the line of text.
+    //
+    // To deal with this (temporarily), we force the caret offset to be the same
+    // for 2 frames before we draw anything. This causes flickering, but that
+    // flickering is tolerable because carets blink, normally.
+    if (_caretOffset != caretOffset) {
+      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+        if (mounted) {
+          // Trigger another build after the current layout pass.
+          setState(() {
+            _caretOffset = caretOffset;
+          });
+        }
+      });
       return const SizedBox();
     }
 

--- a/super_editor/lib/src/infrastructure/caret.dart
+++ b/super_editor/lib/src/infrastructure/caret.dart
@@ -81,6 +81,8 @@ class _BlinkingTextCaretState extends State<BlinkingTextCaret> {
     // To deal with this (temporarily), we force the caret offset to be the same
     // for 2 frames before we draw anything. This causes flickering, but that
     // flickering is tolerable because carets blink, normally.
+    //
+    // See #370 for the ticket that aims to fix all similar timing issues.
     if (_caretOffset != caretOffset) {
       WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
         if (mounted) {


### PR DESCRIPTION
Temporary hack fix to avoid caret mis-placement in SuperTextField (Resolves #369)

See #369 for my investigation into the problem and how I arrived at this solution.

See #370 for a ticket to fix these issues in general.