### PR TITLE
Moves caret to end of document on focus

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -605,6 +605,47 @@ class CommonEditorOperations {
     return true;
   }
 
+  void _moveCaretToEndOfComponent(String nodeId, DocumentComponent component) {
+    final endOfComponent = component.getEndPosition();
+    final newPosition = DocumentPosition(
+      nodeId: nodeId,
+      nodePosition: endOfComponent,
+    );
+
+    composer.selection = DocumentSelection.collapsed(position: newPosition);
+  }
+
+  bool _selectNodeIfPossible(DocumentNode node) {
+    final component = documentLayoutResolver().getComponentByNodeId(node.id);
+
+    if (component != null && component.isVisualSelectionSupported() == true) {
+      _moveCaretToEndOfComponent(node.id, component);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// Moves the caret to the last position of the last selectable [DocumentNode]
+  bool moveCaretToEnd() {
+    final lastNode = editor.document.nodes.last;
+    final isSelected = _selectNodeIfPossible(lastNode);
+
+    if (isSelected) {
+      return true;
+    } else {
+      final selectableNodeBefore = _getUpstreamSelectableNodeBefore(lastNode);
+      // There are no selectable nodes in the document if this is true
+      if (selectableNodeBefore == null) {
+        return false;
+      }
+
+      final previousIsSelected = _selectNodeIfPossible(selectableNodeBefore);
+
+      return previousIsSelected;
+    }
+  }
+
   /// Returns the first [DocumentNode] before [startingNode] whose
   /// [DocumentComponent] is visually selectable.
   DocumentNode? _getUpstreamSelectableNodeBefore(DocumentNode startingNode) {

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -292,7 +292,9 @@ class _SuperEditorState extends State<SuperEditor> {
     // selection to the end of the document.
 
     if (_focusNode.hasFocus && !_hasFocus) {
-      _editContext.commonOps.moveCaretToEnd();
+      if (_editContext.composer.selection == null) {
+        _editContext.commonOps.moveCaretToEnd();
+      }
     }
     _hasFocus = _focusNode.hasFocus;
   }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -224,11 +224,14 @@ class _SuperEditorState extends State<SuperEditor> {
   late GlobalKey _docLayoutKey;
 
   late FocusNode _focusNode;
+
   late DocumentComposer _composer;
 
   DocumentPosition? _previousSelectionExtent;
 
   late EditContext _editContext;
+
+  bool _hasFocus = false;
 
   @override
   void initState() {
@@ -237,7 +240,7 @@ class _SuperEditorState extends State<SuperEditor> {
     _composer = widget.composer ?? DocumentComposer();
     _composer.addListener(_updateComposerPreferencesAtSelection);
 
-    _focusNode = widget.focusNode ?? FocusNode();
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
 
     _docLayoutKey = widget.documentLayoutKey ?? GlobalKey();
 
@@ -277,10 +280,21 @@ class _SuperEditorState extends State<SuperEditor> {
 
     if (widget.focusNode == null) {
       // We are using our own private FocusNode. Dispose it.
+      _focusNode.removeListener(_onFocusChange);
       _focusNode.dispose();
     }
 
     super.dispose();
+  }
+
+  void _onFocusChange() {
+    // If our FocusNode just received focus, automatically set our
+    // selection to the end of the document.
+
+    if (_focusNode.hasFocus && !_hasFocus) {
+      _editContext.commonOps.moveCaretToEnd();
+    }
+    _hasFocus = _focusNode.hasFocus;
   }
 
   void _createEditContext() {


### PR DESCRIPTION
**Note: This is my first PR to this project, so bear with me.**

This PR solves an issue where `requestFocus` does not show a caret as detailed in #376. The `SuperTextField` solves this issue by moving the caret to the end of the text content. I used a similar solution to move the caret to the last selectable node and within the node to the last possible `NodePosition`.

If the editor composer already has a selection, this solution will maintain the current selection on focus.