### PR TITLE
Clone metadata instead of sharing the same instance when splitting a paragraph

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -118,11 +118,12 @@ class SplitParagraphCommand implements EditorCommand {
     node.text = startText;
 
     // Create a new node that will follow the current node. Set its text
-    // to the text that was removed from the current node.
+    // to the text that was removed from the current node. And create a
+    // new copy of the metadata if `replicateExistingMetdata` is true. 
     final newNode = ParagraphNode(
       id: newNodeId,
       text: endText,
-      metadata: replicateExistingMetdata ? node.metadata : {},
+      metadata: replicateExistingMetdata ? {...node.metadata} : {},
     );
 
     // Insert the new node after the current node.


### PR DESCRIPTION
Fixes #381:

When splitting a paragraph, create a new clone of metadata instead of sharing the same instance with the newly created paragraph nodes to prevent the behavior described in #381.