### PR TITLE
Use LogicalKeyboardKey to detect shortcuts

### DIFF
--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -21,9 +21,6 @@ import 'text.dart';
 
 final _log = Logger(scope: 'document_keyboard_actions.dart');
 
-bool _isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
-    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
-
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
@@ -40,7 +37,7 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyV) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -81,7 +78,7 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyA) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -226,7 +223,7 @@ ExecutionInstruction copyWhenCmdCIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyC) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -252,7 +249,7 @@ ExecutionInstruction cutWhenCmdXIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyX) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -339,7 +336,7 @@ ExecutionInstruction cmdBToToggleBold({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyB) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -356,7 +353,7 @@ ExecutionInstruction cmdIToToggleItalics({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyI) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -21,6 +21,9 @@ import 'text.dart';
 
 final _log = Logger(scope: 'document_keyboard_actions.dart');
 
+bool _isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
+    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
+
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
@@ -37,7 +40,7 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'v') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -78,7 +81,7 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'a') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -223,7 +226,7 @@ ExecutionInstruction copyWhenCmdCIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'c') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -249,7 +252,7 @@ ExecutionInstruction cutWhenCmdXIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'x') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -336,7 +339,7 @@ ExecutionInstruction cmdBToToggleBold({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'b') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -353,7 +356,7 @@ ExecutionInstruction cmdIToToggleItalics({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.character?.toLowerCase() != 'i') {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -21,9 +21,6 @@ import 'text.dart';
 
 final _log = Logger(scope: 'document_keyboard_actions.dart');
 
-bool _isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
-    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
-
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
@@ -40,7 +37,7 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -81,7 +78,7 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -226,7 +223,7 @@ ExecutionInstruction copyWhenCmdCIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -252,7 +249,7 @@ ExecutionInstruction cutWhenCmdXIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -339,7 +336,7 @@ ExecutionInstruction cmdBToToggleBold({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -356,7 +353,7 @@ ExecutionInstruction cmdIToToggleItalics({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
+  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -21,6 +21,9 @@ import 'text.dart';
 
 final _log = Logger(scope: 'document_keyboard_actions.dart');
 
+bool _isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
+    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
+
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
@@ -37,7 +40,7 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyV)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -78,7 +81,7 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyA)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -223,7 +226,7 @@ ExecutionInstruction copyWhenCmdCIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyC)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -249,7 +252,7 @@ ExecutionInstruction cutWhenCmdXIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyX)) {
     return ExecutionInstruction.continueExecution;
   }
   if (editContext.composer.selection == null) {
@@ -336,7 +339,7 @@ ExecutionInstruction cmdBToToggleBold({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyB)) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -353,7 +356,7 @@ ExecutionInstruction cmdIToToggleItalics({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  if (!isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
+  if (!_isShortcutPressed(keyEvent, LogicalKeyboardKey.keyI)) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -7,9 +7,6 @@ extension PrimaryShortcutKey on RawKeyEvent {
       (Platform.instance.isMac && isMetaPressed) || (!Platform.instance.isMac && isControlPressed);
 }
 
-bool isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
-    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
-
 /// On web, Flutter reports control character labels as
 /// the [RawKeyEvent.character], which we don't want.
 /// Until Flutter fixes the problem, this blacklist

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -7,6 +7,9 @@ extension PrimaryShortcutKey on RawKeyEvent {
       (Platform.instance.isMac && isMetaPressed) || (!Platform.instance.isMac && isControlPressed);
 }
 
+bool isShortcutPressed(RawKeyEvent keyEvent, LogicalKeyboardKey key) =>
+    keyEvent.isPrimaryShortcutKeyPressed && keyEvent.logicalKey == key;
+
 /// On web, Flutter reports control character labels as
 /// the [RawKeyEvent.character], which we don't want.
 /// Until Flutter fixes the problem, this blacklist

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -24,7 +24,7 @@ void main() {
                 editContext: _editContext,
                 keyEvent: const FakeRawKeyEvent(
                   data: FakeRawKeyEventData(
-                    logicalKey: LogicalKeyboardKey.meta,
+                    logicalKey: LogicalKeyboardKey.keyC,
                     physicalKey: PhysicalKeyboardKey.keyC,
                     isMetaPressed: true,
                     isModifierKeyPressed: false,
@@ -76,7 +76,7 @@ void main() {
                 editContext: _editContext,
                 keyEvent: const FakeRawKeyEvent(
                     data: FakeRawKeyEventData(
-                      logicalKey: LogicalKeyboardKey.meta,
+                      logicalKey: LogicalKeyboardKey.keyA,
                       physicalKey: PhysicalKeyboardKey.keyA,
                       isMetaPressed: true,
                       isModifierKeyPressed: false,
@@ -110,7 +110,7 @@ void main() {
                 editContext: _editContext,
                 keyEvent: const FakeRawKeyEvent(
                   data: FakeRawKeyEventData(
-                    logicalKey: LogicalKeyboardKey.meta,
+                    logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
                     isMetaPressed: true,
                     isModifierKeyPressed: false,
@@ -161,7 +161,7 @@ void main() {
                 editContext: _editContext,
                 keyEvent: const FakeRawKeyEvent(
                   data: FakeRawKeyEventData(
-                    logicalKey: LogicalKeyboardKey.meta,
+                    logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
                     isMetaPressed: true,
                     isModifierKeyPressed: false,
@@ -216,7 +216,7 @@ void main() {
                 editContext: _editContext,
                 keyEvent: const FakeRawKeyEvent(
                   data: FakeRawKeyEventData(
-                    logicalKey: LogicalKeyboardKey.meta,
+                    logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
                     isMetaPressed: true,
                     isModifierKeyPressed: false,


### PR DESCRIPTION
On Windows the keyboard shortcuts don't work because `keyEvent.character` is null. This PR changes the code to match against `keyEvent.logcialKey`, which in my testing works on both Windows and MacOS. I also moved this matching logic into a public helper function to cut down on code duplication and make it easier to add custom keybindings.