### PR TITLE
Pass ignoreComposerAttributions to insertCharacter

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1353,7 +1353,10 @@ class CommonEditorOperations {
     }
 
     // Delegate the action to the standard insert-character behavior.
-    final inserted = _insertCharacterInTextComposable(character);
+    final inserted = _insertCharacterInTextComposable(
+      character,
+      ignoreComposerAttributions: ignoreComposerAttributions,
+    );
     if (!inserted) {
       return false;
     }


### PR DESCRIPTION
`_insertCharacterInTextComposable` takes as input `ignoreComposerAttributions`, but the caller (`insertCharacter`) never passes it.

This PR updates `insertCharacter` to pass the this value. 