### PR TITLE
[web] Setting gesture mode to `mouse` on web

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -334,6 +335,8 @@ class _SuperEditorState extends State<SuperEditor> {
   DocumentGestureMode get _gestureMode {
     if (widget.gestureMode != null) {
       return widget.gestureMode!;
+    } else if (kIsWeb) {
+      return DocumentGestureMode.mouse;
     } else if (Platform.isAndroid) {
       return DocumentGestureMode.android;
     } else if (Platform.isIOS) {


### PR DESCRIPTION
The default editor throws an exception on web when it tries to access `Platform.isAndroid`, `Platform.isIOS` etc. in order to determine the gesture mode. This change makes it check for web support first to avoid using the platform getters.

Steps to reproduce:

- Navigate into `super_editor/example`
- Run `flutter run -d chrome`