### PR TITLE
Convert paragraph to list item for "1." and "1)" but not "1 " (Resolves #339)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1276,7 +1276,7 @@ class CommonEditorOperations {
     final hasUnorderedListItemMatch = unorderedListItemMatch.hasMatch(textBeforeCaret);
 
     // We want to match "1 ", " 1 ", " 1. ".
-    final orderedListItemMatch = RegExp(r'^\s*[1]\.?\s+$');
+    final orderedListItemMatch = RegExp(r'^\s*[1]\.\s+$');
     final hasOrderedListItemMatch = orderedListItemMatch.hasMatch(textBeforeCaret);
 
     _log.log('_convertParagraphIfDesired', ' - text before caret: "$textBeforeCaret"');

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1275,7 +1275,7 @@ class CommonEditorOperations {
     final unorderedListItemMatch = RegExp(r'^\s*[\*-]\s+$');
     final hasUnorderedListItemMatch = unorderedListItemMatch.hasMatch(textBeforeCaret);
 
-    // We want to match "1 ", " 1 ", " 1. ".
+    // We want to match "1. ", " 1. ".
     final orderedListItemMatch = RegExp(r'^\s*[1]\.\s+$');
     final hasOrderedListItemMatch = orderedListItemMatch.hasMatch(textBeforeCaret);
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1275,8 +1275,8 @@ class CommonEditorOperations {
     final unorderedListItemMatch = RegExp(r'^\s*[\*-]\s+$');
     final hasUnorderedListItemMatch = unorderedListItemMatch.hasMatch(textBeforeCaret);
 
-    // We want to match "1. ", " 1. ".
-    final orderedListItemMatch = RegExp(r'^\s*[1]\.\s+$');
+    // We want to match "1. ", " 1. ", "1) ", " 1) ".
+    final orderedListItemMatch = RegExp(r'^\s*1[.)]\s+$');
     final hasOrderedListItemMatch = orderedListItemMatch.hasMatch(textBeforeCaret);
 
     _log.log('_convertParagraphIfDesired', ' - text before caret: "$textBeforeCaret"');

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -1,87 +1,267 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/core/document.dart';
-import 'package:super_editor/src/core/document_composer.dart';
-import 'package:super_editor/src/core/document_editor.dart';
-import 'package:super_editor/src/core/document_selection.dart';
-import 'package:super_editor/src/default_editor/list_items.dart';
-import 'package:super_editor/src/default_editor/paragraph.dart';
-import 'package:super_editor/src/default_editor/text.dart';
-import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
+import 'package:super_editor/super_editor.dart';
 
 import '../_document_test_tools.dart';
 import '../_text_entry_test_tools.dart';
 import '../infrastructure/_platform_test_tools.dart';
 
 void main() {
-  group('list_items.dart', () {
-    group('Text entry', () {
-      test(
-        'it converts paragraph node to list node when "1. " is pressed',
-        () {
-          Platform.setTestInstance(MacPlatform());
+  group('List items', () {
+    group('node conversion', () {
+      test('converts paragraph with "1. " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
 
-          final _editContext = createEditContext(
-            document: MutableDocument(
-              nodes: [
-                ParagraphNode(
-                  id: 'paragraph',
-                  text: AttributedText(text: ''),
-                ),
-              ],
-            ),
-            documentComposer: DocumentComposer(
-              initialSelection: const DocumentSelection.collapsed(
-                position: DocumentPosition(
-                  nodeId: 'paragraph',
-                  nodePosition: TextNodePosition(offset: 0),
-                ),
-              ),
-            ),
-          );
+        final _editContext = _createEditContextWithParagraph();
 
-          const keyOrder = [
-            FakeRawKeyEvent(
-              data: FakeRawKeyEventData(
-                logicalKey: LogicalKeyboardKey.numpad1,
-                physicalKey: PhysicalKeyboardKey.numpad1,
-                isMetaPressed: false,
-                isModifierKeyPressed: false,
-              ),
-              character: '1',
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
             ),
-            FakeRawKeyEvent(
-              data: FakeRawKeyEventData(
-                logicalKey: LogicalKeyboardKey.period,
-                physicalKey: PhysicalKeyboardKey.period,
-                isMetaPressed: false,
-                isModifierKeyPressed: false,
-              ),
-              character: '.',
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.period,
+              physicalKey: PhysicalKeyboardKey.period,
             ),
-            FakeRawKeyEvent(
-              data: FakeRawKeyEventData(
-                logicalKey: LogicalKeyboardKey.space,
-                physicalKey: PhysicalKeyboardKey.space,
-                isMetaPressed: false,
-                isModifierKeyPressed: false,
-              ),
-              character: ' ',
+            character: '.',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
             ),
-          ];
+            character: ' ',
+          ),
+        ]);
 
-          for (final key in keyOrder) {
-            anyCharacterToInsertInParagraph(
-              editContext: _editContext,
-              keyEvent: key,
-            );
-          }
+        final listItemNode = _editContext.editor.document.nodes.first;
+        expect(listItemNode, isA<ListItemNode>());
+        expect((listItemNode as ListItemNode).text.text.isEmpty, isTrue);
 
-          expect(_editContext.editor.document.nodes.first, isA<ListItemNode>());
-          Platform.setTestInstance(null);
-        },
-      );
+        Platform.setTestInstance(null);
+      });
+
+      test('converts paragraph with " 1. " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
+
+        final _editContext = _createEditContextWithParagraph();
+
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
+            ),
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.period,
+              physicalKey: PhysicalKeyboardKey.period,
+            ),
+            character: '.',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+        ]);
+
+        final listItemNode = _editContext.editor.document.nodes.first;
+        expect(listItemNode, isA<ListItemNode>());
+        expect((listItemNode as ListItemNode).text.text.isEmpty, isTrue);
+
+        Platform.setTestInstance(null);
+      });
+
+      test('converts paragraph with "1) " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
+
+        final _editContext = _createEditContextWithParagraph();
+
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
+            ),
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.parenthesisRight,
+              physicalKey: PhysicalKeyboardKey.digit0,
+            ),
+            character: ')',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+        ]);
+
+        final listItemNode = _editContext.editor.document.nodes.first;
+        expect(listItemNode, isA<ListItemNode>());
+        expect((listItemNode as ListItemNode).text.text.isEmpty, isTrue);
+
+        Platform.setTestInstance(null);
+      });
+
+      test('converts paragraph with " 1) " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
+
+        final _editContext = _createEditContextWithParagraph();
+
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
+            ),
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.parenthesisRight,
+              physicalKey: PhysicalKeyboardKey.digit0,
+            ),
+            character: ')',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+        ]);
+
+        final listItemNode = _editContext.editor.document.nodes.first;
+        expect(listItemNode, isA<ListItemNode>());
+        expect((listItemNode as ListItemNode).text.text.isEmpty, isTrue);
+
+        Platform.setTestInstance(null);
+      });
+
+      test('does not convert paragraph with "1 " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
+
+        final _editContext = _createEditContextWithParagraph();
+
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
+            ),
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+        ]);
+
+        final paragraphNode = _editContext.editor.document.nodes.first;
+        expect(paragraphNode, isA<ParagraphNode>());
+        expect((paragraphNode as ParagraphNode).text.text, "1 ");
+
+        Platform.setTestInstance(null);
+      });
+
+      test('does not convert paragraph with " 1 " to ordered list item', () {
+        Platform.setTestInstance(MacPlatform());
+
+        final _editContext = _createEditContextWithParagraph();
+
+        _typeKeys(_editContext, [
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.numpad1,
+              physicalKey: PhysicalKeyboardKey.numpad1,
+            ),
+            character: '1',
+          ),
+          const FakeRawKeyEvent(
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+            character: ' ',
+          ),
+        ]);
+
+        final paragraphNode = _editContext.editor.document.nodes.first;
+        expect(paragraphNode, isA<ParagraphNode>());
+        expect((paragraphNode as ParagraphNode).text.text, " 1 ");
+
+        Platform.setTestInstance(null);
+      });
     });
   });
+}
+
+EditContext _createEditContextWithParagraph() {
+  return createEditContext(
+    document: MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: 'paragraph',
+          text: AttributedText(text: ''),
+        ),
+      ],
+    ),
+    documentComposer: DocumentComposer(
+      initialSelection: const DocumentSelection.collapsed(
+        position: DocumentPosition(
+          nodeId: 'paragraph',
+          nodePosition: TextNodePosition(offset: 0),
+        ),
+      ),
+    ),
+  );
+}
+
+void _typeKeys(EditContext editContext, List<FakeRawKeyEvent> keys) {
+  for (final key in keys) {
+    anyCharacterToInsertInParagraph(
+      editContext: editContext,
+      keyEvent: key,
+    );
+  }
 }

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/document_editor.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/list_items.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/attributed_text.dart';
+import 'package:super_editor/src/infrastructure/platform_detector.dart';
+
+import '../_document_test_tools.dart';
+import '../_text_entry_test_tools.dart';
+import '../infrastructure/_platform_test_tools.dart';
+
+void main() {
+  group('list_items.dart', () {
+    group('Text entry', () {
+      test(
+        'it converts paragraph node to list node when "1. " is pressed',
+        () {
+          Platform.setTestInstance(MacPlatform());
+
+          final _editContext = createEditContext(
+            document: MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: 'paragraph',
+                  text: AttributedText(text: ''),
+                ),
+              ],
+            ),
+            documentComposer: DocumentComposer(
+              initialSelection: const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: 'paragraph',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+
+          const keyOrder = [
+            FakeRawKeyEvent(
+              data: FakeRawKeyEventData(
+                logicalKey: LogicalKeyboardKey.numpad1,
+                physicalKey: PhysicalKeyboardKey.numpad1,
+                isMetaPressed: false,
+                isModifierKeyPressed: false,
+              ),
+              character: '1',
+            ),
+            FakeRawKeyEvent(
+              data: FakeRawKeyEventData(
+                logicalKey: LogicalKeyboardKey.period,
+                physicalKey: PhysicalKeyboardKey.period,
+                isMetaPressed: false,
+                isModifierKeyPressed: false,
+              ),
+              character: '.',
+            ),
+            FakeRawKeyEvent(
+              data: FakeRawKeyEventData(
+                logicalKey: LogicalKeyboardKey.space,
+                physicalKey: PhysicalKeyboardKey.space,
+                isMetaPressed: false,
+                isModifierKeyPressed: false,
+              ),
+              character: ' ',
+            ),
+          ];
+
+          for (final key in keyOrder) {
+            anyCharacterToInsertInParagraph(
+              editContext: _editContext,
+              keyEvent: key,
+            );
+          }
+
+          expect(_editContext.editor.document.nodes.first, isA<ListItemNode>());
+          Platform.setTestInstance(null);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
Convert paragraph to list item for "1." and "1)" but not "1 " (Resolves #339)

This is an adjustment and resubmission to a PR from @wilsonowilson.

CC @britannio 