### PR TITLE
fix: _isContinuousAttribution now also checks for end span marker 

### DIFF
--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -435,17 +435,26 @@ class AttributedSpans {
     required int end,
   }) {
     _log.fine('attribution: "$attribution", range: $start -> $end');
-    SpanMarker? markerBefore = _getNearestMarkerAtOrBefore(start, attribution: attribution, type: SpanMarkerType.start);
-    _log.fine('marker before: $markerBefore');
+    SpanMarker? startMarkerBefore =
+        _getNearestMarkerAtOrBefore(start, attribution: attribution, type: SpanMarkerType.start);
+    SpanMarker? endMarkerBefore =
+        _getNearestMarkerAtOrBefore(start, attribution: attribution, type: SpanMarkerType.end);
 
-    if (markerBefore == null) {
+    if (startMarkerBefore != null && endMarkerBefore != null && endMarkerBefore.offset >= startMarkerBefore.offset) {
+      return false;
+    }
+    _log.fine('marker before: $startMarkerBefore');
+
+    if (startMarkerBefore == null) {
       return false;
     }
 
-    final indexBefore = _attributions.indexOf(markerBefore);
+    final indexBefore = _attributions.indexOf(startMarkerBefore);
     final nextMarker = _attributions.sublist(indexBefore).firstWhereOrNull((marker) {
-      _log.finest('Comparing start marker $markerBefore to another marker $marker');
-      return marker.attribution == attribution && marker.offset >= markerBefore.offset && marker != markerBefore;
+      _log.finest('Comparing start marker $startMarkerBefore to another marker $marker');
+      return marker.attribution == attribution &&
+          marker.offset >= startMarkerBefore.offset &&
+          marker != startMarkerBefore;
     });
     _log.fine('next marker: $nextMarker');
 


### PR DESCRIPTION
fix: _isContinuousAttribution now also checks for end span marker to avoid crashing due to two spans of the same attribution within the same AttributedText

This commit is to address a problem where two intra-word styles of the same type within the same word will trigger a `Inconsistent attributions state` Exception.

Use the default editor as an example, for the first word `Lorem`, if one turns the 'bold' style on for letter `o` and then turns on the same bold style for letter `e`, this will trigger an Exception.
