### PR TITLE
Optimizing AttributedSpans.collapseSpans() to run in linear time

### DIFF
--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -864,7 +864,7 @@ class AttributedSpans {
       // Because we handle committing completed spans before this, we know that by this point the current marker should
       // indicate changes to the current span.
       if (marker.isStart) {
-        // Merge the new attribution into the current span.
+        // Add the new attribution to the current span.
         currentSpan.attributions.add(marker.attribution);
         _log.fine('merging ${marker.attribution}, current span is now $currentSpan.');
       } else if (marker.isEnd) {

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -831,11 +831,8 @@ class AttributedSpans {
     var currentSpan = MultiAttributionSpan(attributions: {}, start: 0, end: contentLength);
 
     var i = 0;
+    var marker = _attributions[i];
     while (i < _attributions.length) {
-      var marker = _attributions[i];
-      final currentOffset = marker.offset;
-      final currentType = marker.markerType;
-
       do {
         // Consume markers as long as they are in a contiguous block with the same offset and type.
         if (marker.offset >= contentLength) {
@@ -875,8 +872,8 @@ class AttributedSpans {
         }
         marker = _attributions[i];
 
-        // If we have reached the end of this block of markers, exit the loop to commit the current span.
-      } while (marker.offset == currentOffset && marker.markerType == currentType);
+        // Keep consuming markers as long as they modify the current span.
+      } while (marker.offset <= currentSpan.start);
 
       final int currentEnd;
       if (i == _attributions.length) {

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -880,8 +880,9 @@ class AttributedSpans {
     }
 
     if (collapsedSpans.last.end < contentLength - 1) {
-      // The spans committed during the loop didn't cover the entire range.  The value in currentSpan should already
-      // span from the end of the last token to the end of the requested content, so just add it to the result.
+      // The last span committed during the loop does not reach the end of the requested content range. We either ran
+      // out of markers or the remaining markers are outside the content range. In both cases the value in currentSpan
+      // should already have the correct start, end, and attributions values to cover the remaining content.
       collapsedSpans.add(currentSpan);
       _log.fine('committing last span to cover requested content length of $contentLength: ${collapsedSpans.last}');
     }

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -821,6 +821,11 @@ class AttributedSpans {
       return [];
     }
 
+    if (_attributions.isEmpty || _attributions.first.offset > contentLength - 1) {
+      // There is content but no attributions that apply to it.
+      return [MultiAttributionSpan(attributions: {}, start: 0, end: contentLength - 1)];
+    }
+
     final collapsedSpans = <MultiAttributionSpan>[];
     var currentSpan = MultiAttributionSpan(attributions: {}, start: 0, end: contentLength - 1);
 
@@ -874,7 +879,7 @@ class AttributedSpans {
       }
     }
 
-    if (collapsedSpans.isEmpty || collapsedSpans.last.end < contentLength - 1) {
+    if (collapsedSpans.last.end < contentLength - 1) {
       // The spans committed during the loop didn't cover the entire range.  The value in currentSpan should already
       // span from the end of the last token to the end of the requested content, so just add it to the result.
       collapsedSpans.add(currentSpan);

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -840,14 +840,20 @@ class AttributedSpans {
         _log.fine(
             'encountered a span boundary with ${marker.isStart ? "a start" : "an end"} marker at offset ${marker.offset}.');
 
-        // If we encountered a start token, end the current span 1 index earlier to simulate the missing end marker.
-        final currentEnd = marker.isStart ? marker.offset - 1 : marker.offset;
+        // Calculate the end of the current span.
+        //
+        // If the current marker is an end marker, then the current span at that marker. Otherwise, if the
+        // marker is an start marker, the current span ends 1 unit before the marker.
+        final currentEnd = marker.isEnd ? marker.offset : marker.offset - 1;
 
         // Commit the completed span.
         collapsedSpans.add(currentSpan.copyWith(end: currentEnd));
         _log.fine('committed span ${collapsedSpans.last}');
 
-        // If we encountered an end token, start the next span 1 index later to simulate the missing start marker.
+        // Calculate the start of the next span.
+        //
+        // If the current marker is a start marker, then the next span begins at that marker. Otherwise, if the
+        // marker is an end marker, the next span begins 1 unit after the marker.
         final nextStart = marker.isStart ? marker.offset : marker.offset + 1;
 
         // Create the next span and continue consumeing markers

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -54,7 +54,7 @@ class AttributedSpans {
   final List<SpanMarker> _attributions;
 
   void _sortAttributions() {
-    _attributions.sort((m1, m2) => m1.compareTo(m2));
+    _attributions.sort();
   }
 
   /// Returns true if this [AttributedSpans] contains at least one

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -505,10 +505,13 @@ class AttributedSpans {
   /// Precondition: There must not already exist a marker with
   /// the same attribution at the same offset.
   void _insertMarker(SpanMarker newMarker) {
-    int markerAfterIndex = _attributions.indexWhere((existingMarker) => existingMarker.compareTo(newMarker) > 0);
+    int indexOfFirstMarkerAfterInsertionPoint =
+        _attributions.indexWhere((existingMarker) => existingMarker.compareTo(newMarker) > 0);
+    // [indexWhere] returns -1 if no matching element is found.
+    final foundMarkerToInsertBefore = indexOfFirstMarkerAfterInsertionPoint >= 0;
 
-    if (markerAfterIndex >= 0) {
-      _attributions.insert(markerAfterIndex, newMarker);
+    if (foundMarkerToInsertBefore) {
+      _attributions.insert(indexOfFirstMarkerAfterInsertionPoint, newMarker);
     } else {
       // Insert the new marker at the end.
       _attributions.add(newMarker);

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -866,8 +866,8 @@ class AttributedSpans {
         _log.fine('new current span is $currentSpan');
       }
 
-      // Because we handle committing completed spans before this, we know that by this point the current marker should
-      // indicate changes to the current span.
+      // By the time we get here, we are guaranteed that the current marker should modify the current span. Apply
+      // changes based on the type of the marker.
       if (marker.isStart) {
         // Add the new attribution to the current span.
         currentSpan.attributions.add(marker.attribution);

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
 final _log = attributionsLog;
@@ -53,9 +52,6 @@ class AttributedSpans {
   // _attributions must always be in order from lowest
   // marker offset to highest marker offset.
   final List<SpanMarker> _attributions;
-
-  @visibleForTesting
-  List<SpanMarker> get attributions => [..._attributions];
 
   void _sortAttributions() {
     _attributions.sort((m1, m2) => m1.compareTo(m2));
@@ -977,15 +973,7 @@ class SpanMarker implements Comparable<SpanMarker> {
 
   @override
   int compareTo(SpanMarker other) {
-    final offsetDiff = offset - other.offset;
-    if (offsetDiff != 0) {
-      return offsetDiff;
-    }
-    if (isStart == other.isStart) {
-      return 0;
-    }
-
-    return isStart ? -1 : 1;
+    return offset - other.offset;
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -820,6 +820,11 @@ class AttributedSpans {
       return [];
     }
 
+    if (_attributions.isEmpty) {
+      // There is content but no attributions, return a single collapsed span with no attributions.
+      return [MultiAttributionSpan(attributions: {}, start: 0, end: contentLength - 1)];
+    }
+
     final collapsedSpans = <MultiAttributionSpan>[];
     var currentSpan = MultiAttributionSpan(attributions: {}, start: 0, end: contentLength);
 

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
 final _log = attributionsLog;
@@ -52,6 +53,9 @@ class AttributedSpans {
   // _attributions must always be in order from lowest
   // marker offset to highest marker offset.
   final List<SpanMarker> _attributions;
+
+  @visibleForTesting
+  List<SpanMarker> get attributions => [..._attributions];
 
   void _sortAttributions() {
     _attributions.sort((m1, m2) => m1.compareTo(m2));
@@ -505,11 +509,9 @@ class AttributedSpans {
   /// Precondition: There must not already exist a marker with
   /// the same attribution at the same offset.
   void _insertMarker(SpanMarker newMarker) {
-    SpanMarker? markerAfter =
-        _attributions.firstWhereOrNull((existingMarker) => existingMarker.offset >= newMarker.offset);
+    int markerAfterIndex = _attributions.indexWhere((existingMarker) => existingMarker.compareTo(newMarker) > 0);
 
-    if (markerAfter != null) {
-      final markerAfterIndex = _attributions.indexOf(markerAfter);
+    if (markerAfterIndex >= 0) {
       _attributions.insert(markerAfterIndex, newMarker);
     } else {
       // Insert the new marker at the end.

--- a/super_editor/lib/src/infrastructure/attributed_spans.dart
+++ b/super_editor/lib/src/infrastructure/attributed_spans.dart
@@ -837,21 +837,13 @@ class AttributedSpans {
         final currentEnd = marker.isStart ? marker.offset - 1 : marker.offset;
 
         // Commit the completed span.
-        collapsedSpans.add(MultiAttributionSpan(
-          attributions: currentSpan.attributions,
-          start: currentSpan.start,
-          end: currentEnd,
-        ));
+        collapsedSpans.add(currentSpan.copyWith(end: currentEnd));
 
         // If we encountered an end token, start the next span 1 index later to simulate the missing start marker.
         final nextStart = marker.isStart ? marker.offset : marker.offset + 1;
 
         // Create the next span and continue consumeing markers
-        currentSpan = MultiAttributionSpan(
-          attributions: {...currentSpan.attributions},
-          start: nextStart,
-          end: contentLength - 1,
-        );
+        currentSpan = currentSpan.copyWith(start: nextStart);
       }
 
       // Because we handle committing completed spans before this, we know that by this point the current marker should
@@ -1037,6 +1029,17 @@ class MultiAttributionSpan {
   final Set<Attribution> attributions;
   final int start;
   final int end;
+
+  MultiAttributionSpan copyWith({
+    Set<Attribution>? attributions,
+    int? start,
+    int? end,
+  }) =>
+      MultiAttributionSpan(
+        attributions: attributions ?? {...this.attributions},
+        start: start ?? this.start,
+        end: end ?? this.end,
+      );
 }
 
 typedef AttributionFilter = bool Function(Attribution candidate);

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -367,6 +367,13 @@ void main() {
 
         expect(spans.hasAttributionsWithin(attributions: {boldAttribution}, start: 0, end: 16), false);
       });
+
+      test('single character attribution markers are inserted in order', () {
+        final spans = AttributedSpans()..addAttribution(newAttribution: boldAttribution, start: 1, end: 1);
+        final initalAttributions = spans.attributions;
+        final sortedAttributions = spans.attributions..sort();
+        expect(initalAttributions, equals(sortedAttributions));
+      });
     });
 
     group('multiple attributions', () {

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -9,6 +9,31 @@ import '../../test_tools.dart';
 import '_attributed_text_test_tools.dart';
 
 void main() {
+  group('SpanMarker', () {
+    group('compareTo', () {
+      test('fully equal', () {
+        const m1 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
+        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
+
+        expect(m1.compareTo(m2), equals(0));
+      });
+
+      test('lower offset', () {
+        const m1 = SpanMarker(offset: 1, markerType: SpanMarkerType.end, attribution: boldAttribution);
+        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
+
+        expect(m1.compareTo(m2), lessThan(0));
+      });
+
+      test('equal offset, different markerType', () {
+        const m1 = SpanMarker(offset: 3, markerType: SpanMarkerType.end, attribution: boldAttribution);
+        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
+
+        expect(m1.compareTo(m2), greaterThan(0));
+      });
+    });
+  });
+
   groupWithLogging('Spans', Level.OFF, {attributionsLog}, () {
     group('attribution queries', () {
       test('it expands a span from a given offset', () {

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -9,31 +9,6 @@ import '../../test_tools.dart';
 import '_attributed_text_test_tools.dart';
 
 void main() {
-  group('SpanMarker', () {
-    group('compareTo', () {
-      test('fully equal', () {
-        const m1 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
-        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
-
-        expect(m1.compareTo(m2), equals(0));
-      });
-
-      test('lower offset', () {
-        const m1 = SpanMarker(offset: 1, markerType: SpanMarkerType.end, attribution: boldAttribution);
-        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
-
-        expect(m1.compareTo(m2), lessThan(0));
-      });
-
-      test('equal offset, different markerType', () {
-        const m1 = SpanMarker(offset: 3, markerType: SpanMarkerType.end, attribution: boldAttribution);
-        const m2 = SpanMarker(offset: 3, markerType: SpanMarkerType.start, attribution: boldAttribution);
-
-        expect(m1.compareTo(m2), greaterThan(0));
-      });
-    });
-  });
-
   groupWithLogging('Spans', Level.OFF, {attributionsLog}, () {
     group('attribution queries', () {
       test('it expands a span from a given offset', () {
@@ -391,13 +366,6 @@ void main() {
         )..toggleAttribution(attribution: boldAttribution, start: 0, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {boldAttribution}, start: 0, end: 16), false);
-      });
-
-      test('single character attribution markers are inserted in order', () {
-        final spans = AttributedSpans()..addAttribution(newAttribution: boldAttribution, start: 1, end: 1);
-        final initalAttributions = spans.attributions;
-        final sortedAttributions = spans.attributions..sort();
-        expect(initalAttributions, equals(sortedAttributions));
       });
     });
 

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -537,6 +537,23 @@ void main() {
         expect(collapsedSpans[3].attributions.length, 0);
       });
 
+      test('adjacent non-overlapping attributions', () {
+        final collapsedSpans = AttributedSpans(
+          attributions: [
+            const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 4, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: italicsAttribution, offset: 5, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: italicsAttribution, offset: 9, markerType: SpanMarkerType.end),
+          ],
+        ).collapseSpans(contentLength: 10);
+
+        expect(collapsedSpans, hasLength(2));
+        expect(collapsedSpans.first.start, 0);
+        expect(collapsedSpans.first.end, 4);
+        expect(collapsedSpans.last.start, 5);
+        expect(collapsedSpans.last.end, 9);
+      });
+
       test('multiple non-overlapping attributions', () {
         final collapsedSpans = AttributedSpans(
           attributions: [

--- a/super_editor/test/src/infrastructure/attributed_spans_test.dart
+++ b/super_editor/test/src/infrastructure/attributed_spans_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/super_editor.dart';
 import 'package:logging/logging.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_spans.dart';
+import 'package:super_editor/super_editor.dart';
 
 import '../../test_tools.dart';
 import '_attributed_text_test_tools.dart';
@@ -478,6 +478,14 @@ void main() {
         // Make sure no exceptions are thrown when collapsing
         // spans on an empty AttributedSpans.
         AttributedSpans().collapseSpans(contentLength: 0);
+      });
+
+      test('non-empty span with no attributions', () {
+        final collapsedSpans = AttributedSpans().collapseSpans(contentLength: 10);
+        expect(collapsedSpans, hasLength(1));
+        expect(collapsedSpans.first.start, 0);
+        expect(collapsedSpans.first.end, 9);
+        expect(collapsedSpans.first.attributions, isEmpty);
       });
 
       test('single continuous attribution', () {


### PR DESCRIPTION
The current implementation of `collapseSpans` operates by pre-generating the list of start and end points for the collapsed spans, then walking that list and repeatedly checking the list of `SpanMarker`s to determine which `Attribution`s should apply to each span. In cases with many spans this causes a large amount of duplicate work, especially in cases with overlapping spans. In my testing it takes the method almost 2 seconds to return with 1000 spans. For a less contrived example, it only needs about 50 overlapping spans to take over 16ms (time for a frame when running at 60fps).

This PR:

- Changes `collapseSpans` to run with a single linear pass of the `SpanMarker` list. It also eliminates the preprocessing step of generating the start and end locations for the collapsed spans, which wasn't significantly contributing to the runtime but fewer LoC is always a nice bonus.
- Updates the sorting logic for `SpanMarker` to always have `start` markers precede `end` markers. Without this the inner loop of `collapseSpans` needs some ugly conditionals to handle an edge case where an end marker precedes a start marker with the same offset.
- Adds a couple tests to the AttributedSpans test suite for behavior that that wasn't already covered but broke tests from other parts of the library while I was working on this.
- Adds some minor additions to `MultiAttributionSpan`: `copyWith` for convenient copying, `toString` override for better log messages.

After these changes it the method takes 3ms to return with 50 spans and 30ms with 1000. I ran the tests locally via `flutter test` and everything passed.