### PR TITLE
Fixing typo: s/Metdata/Metadata/g

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1725,7 +1725,7 @@ class CommonEditorOperations {
           nodeId: extentNode.id,
           splitPosition: currentExtentPosition,
           newNodeId: newNodeId,
-          replicateExistingMetdata: currentExtentPosition.offset != endOfParagraph.offset,
+          replicateExistingMetadata: currentExtentPosition.offset != endOfParagraph.offset,
         ),
       );
     } else if (composer.selection!.extent.nodePosition is UpstreamDownstreamNodePosition) {

--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -148,7 +148,7 @@ class _PasteEditorCommand implements EditorCommand {
             nodeId: currentNodeWithSelection.id,
             splitPosition: TextPosition(offset: pasteTextOffset),
             newNodeId: DocumentEditor.createNodeId(),
-            replicateExistingMetdata: false,
+            replicateExistingMetadata: false,
           ).execute(document, transaction);
         } else {
           throw Exception('Can\'t handle pasting text within node of type: $currentNodeWithSelection');

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -86,13 +86,13 @@ class SplitParagraphCommand implements EditorCommand {
     required this.nodeId,
     required this.splitPosition,
     required this.newNodeId,
-    required this.replicateExistingMetdata,
+    required this.replicateExistingMetadata,
   });
 
   final String nodeId;
   final TextPosition splitPosition;
   final String newNodeId;
-  final bool replicateExistingMetdata;
+  final bool replicateExistingMetadata;
 
   @override
   void execute(Document document, DocumentEditorTransaction transaction) {
@@ -117,11 +117,11 @@ class SplitParagraphCommand implements EditorCommand {
 
     // Create a new node that will follow the current node. Set its text
     // to the text that was removed from the current node. And create a
-    // new copy of the metadata if `replicateExistingMetdata` is true.
+    // new copy of the metadata if `replicateExistingMetadata` is true.
     final newNode = ParagraphNode(
       id: newNodeId,
       text: endText,
-      metadata: replicateExistingMetdata ? {...node.metadata} : {},
+      metadata: replicateExistingMetadata ? {...node.metadata} : {},
     );
 
     // Insert the new node after the current node.


### PR DESCRIPTION
Title pretty much says it all: there's a typo in a named parameter. This PR fixes it.