### PR TITLE
Bugfix: caret no longer gets stuck in middle of emojis when moving left/right (Resolves #391)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -13,7 +13,7 @@ jobs:
       # Setup Flutter environment
       - uses: subosito/flutter-action@v1
         with:
-          channel: "dev"
+          channel: "stable"
       # Download all the packages that the app uses
       - run: flutter pub get
       # TODO: run static analysis here when we get to zero analysis warnings
@@ -32,7 +32,7 @@ jobs:
       # Setup Flutter environment
       - uses: subosito/flutter-action@v1
         with:
-          channel: "dev"
+          channel: "stable"
       # Download all the packages that the app uses
       - run: flutter pub get
       # TODO: run static analysis here when we get to zero analysis warnings
@@ -51,7 +51,7 @@ jobs:
       # Setup Flutter environment
       - uses: subosito/flutter-action@v1
         with:
-          channel: "dev"
+          channel: "stable"
       # Download all the packages that the app uses
       - run: flutter pub get
       # TODO: run static analysis here when we get to zero analysis warnings

--- a/super_editor/example/analysis_options.yaml
+++ b/super_editor/example/analysis_options.yaml
@@ -1,8 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  exclude: [lib/spikes]
-
 linter:
   rules:
     avoid_print: false

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -16,6 +16,7 @@ import 'package:super_editor/src/infrastructure/attributed_text.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/raw_key_event_extensions.dart';
+import 'package:super_editor/src/infrastructure/strings.dart';
 import 'package:super_editor/src/infrastructure/super_selectable_text.dart';
 
 import 'document_input_keyboard.dart';
@@ -465,15 +466,17 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
     } else if (movementModifiers != null && movementModifiers.contains(MovementModifier.word)) {
       final text = getContiguousTextAt(textPosition);
 
-      int newOffset = textPosition.offset;
-      newOffset -= 1; // we always want to jump at least 1 character.
-      while (newOffset > 0 && text[newOffset - 1] != ' ') {
-        newOffset -= 1;
+      final newOffset = text.moveOffsetUpstreamByWord(textPosition.offset);
+      if (newOffset == null) {
+        return textPosition;
       }
+
       return TextNodePosition(offset: newOffset);
     }
 
-    return TextNodePosition(offset: textPosition.offset - 1);
+    final text = getContiguousTextAt(textPosition);
+    final newOffset = text.moveOffsetUpstreamByCharacter(textPosition.offset);
+    return newOffset != null ? TextNodePosition(offset: newOffset) : textPosition;
   }
 
   @override
@@ -518,15 +521,17 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
     if (movementModifiers != null && movementModifiers.contains(MovementModifier.word)) {
       final text = getContiguousTextAt(textPosition);
 
-      int newOffset = textPosition.offset;
-      newOffset += 1; // we always want to jump at least 1 character.
-      while (newOffset < text.length && text[newOffset] != ' ') {
-        newOffset += 1;
+      final newOffset = text.moveOffsetDownstreamByWord(textPosition.offset);
+      if (newOffset == null) {
+        return textPosition;
       }
+
       return TextNodePosition(offset: newOffset);
     }
 
-    return TextNodePosition(offset: textPosition.offset + 1);
+    final text = getContiguousTextAt(textPosition);
+    final newOffset = text.moveOffsetDownstreamByCharacter(textPosition.offset);
+    return newOffset != null ? TextNodePosition(offset: newOffset) : textPosition;
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -1,0 +1,174 @@
+import 'package:characters/characters.dart';
+
+extension CharacterMovement on String {
+  /// Returns the code point index of the character that sits
+  /// one word upstream from the given [textOffset] code point index.
+  ///
+  /// Examples:
+  ///   |word up -> `null`
+  ///   wo|rd up -> `0`
+  ///   word| up -> `0`
+  ///   word |up -> `4`
+  ///   word up| -> `6`
+  int? moveOffsetUpstreamByWord(int textOffset, {int characterCount = 1}) {
+    if (textOffset < 0 || textOffset > length) {
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+    }
+
+    if (textOffset == 0) {
+      return null;
+    }
+
+    bool isInSpace = false;
+
+    int lastSpaceStartCodePointOffset = 0;
+    int lastSpaceEndCodePointOffset = 0;
+
+    int visitedCharacterCount = 0;
+    int codePointIndex = 0;
+    for (final character in characters) {
+      if (visitedCharacterCount >= textOffset - 1) {
+        // We're at the given text offset. The upstream word offset is
+        // at lastSpaceEndCodePointOffset.
+        break;
+      }
+
+      if (character == " " && !isInSpace) {
+        lastSpaceStartCodePointOffset = codePointIndex;
+      }
+
+      isInSpace = character == " ";
+      codePointIndex += character.length;
+      visitedCharacterCount += 1;
+
+      if (character == " ") {
+        lastSpaceEndCodePointOffset = codePointIndex;
+      }
+    }
+
+    return lastSpaceEndCodePointOffset < textOffset ? lastSpaceEndCodePointOffset : lastSpaceStartCodePointOffset;
+  }
+
+  /// Returns the code point index of the character that sits
+  /// [characterCount] upstream from the given [textOffset] code
+  /// point index.
+  ///
+  /// Examples:
+  ///   |a💙c -> `null`
+  ///   a|💙c -> `0`
+  ///   a💙|c -> `1`
+  ///   a💙c| -> `3` (notice that we moved 2 units due to emoji length)
+  int? moveOffsetUpstreamByCharacter(int textOffset, {int characterCount = 1}) {
+    if (textOffset < 0 || textOffset > length) {
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+    }
+
+    if (textOffset == 0) {
+      return null;
+    }
+
+    int codePointIndex = 0;
+    final characterIndices = <int>[];
+    for (final character in characters) {
+      if (codePointIndex == textOffset) {
+        break;
+      }
+
+      characterIndices.add(codePointIndex);
+      codePointIndex += character.length;
+    }
+
+    if (characterIndices.length < characterCount) {
+      return null;
+    }
+
+    return characterIndices[characterIndices.length - characterCount];
+  }
+
+  /// Returns the code point index of the character that sits
+  /// one word downstream from given [textOffset] code point
+  /// index.
+  ///
+  /// Examples:
+  ///   |word up -> `4`
+  ///   wo|rd up -> `4`
+  ///   word| up -> `5`
+  ///   word |up -> `7`
+  ///   word up| -> `null`
+  int? moveOffsetDownstreamByWord(int textOffset, {int characterCount = 1}) {
+    if (textOffset < 0 || textOffset > length) {
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+    }
+
+    if (textOffset == length) {
+      return null;
+    }
+
+    bool isInSpace = false;
+
+    int lastSpaceStartCodePointOffset = 0;
+    int lastSpaceEndCodePointOffset = 0;
+
+    int codePointIndex = 0;
+    for (final character in characters) {
+      if (character == " " && !isInSpace) {
+        lastSpaceStartCodePointOffset = codePointIndex;
+      }
+
+      isInSpace = character == " ";
+      codePointIndex += character.length;
+
+      if (character == " ") {
+        lastSpaceEndCodePointOffset = codePointIndex;
+      }
+
+      if (lastSpaceStartCodePointOffset > textOffset) {
+        return lastSpaceStartCodePointOffset;
+      }
+      if (lastSpaceEndCodePointOffset > textOffset) {
+        return lastSpaceEndCodePointOffset;
+      }
+    }
+
+    // The end of this string is as far as we can go.
+    return length;
+  }
+
+  /// Returns the code point index of the character that sits
+  /// [characterCount] downstream from given [textOffset] code
+  /// point index.
+  ///
+  /// Examples:
+  ///   |a💙c -> `1`
+  ///   a|💙c -> `3` (notice that we moved 2 units due to emoji length)
+  ///   a💙|c -> `4`
+  ///   a💙c| -> `null`
+  int? moveOffsetDownstreamByCharacter(int textOffset, {int characterCount = 1}) {
+    if (textOffset < 0 || textOffset > length) {
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+    }
+
+    if (textOffset == length) {
+      return null;
+    }
+
+    int visitedCharacterCodePointLength = 0;
+    int characterCountBeyondTextOffset = 0;
+    for (final character in characters) {
+      visitedCharacterCodePointLength += character.length;
+      if (visitedCharacterCodePointLength > textOffset) {
+        characterCountBeyondTextOffset += 1;
+      }
+
+      if (characterCountBeyondTextOffset == characterCount) {
+        break;
+      }
+    }
+
+    if (characterCountBeyondTextOffset < characterCount) {
+      return null;
+    }
+
+    return visitedCharacterCodePointLength;
+  }
+}

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/strings.dart';
+
+void main() {
+  group("Strings", () {
+    group("find upstream", () {
+      test("1 character", () {
+        expect("a💙c".moveOffsetUpstreamByCharacter(0), null);
+        expect("a💙c".moveOffsetUpstreamByCharacter(1), 0);
+        expect("a💙c".moveOffsetUpstreamByCharacter(3), 1);
+        expect("a💙c".moveOffsetUpstreamByCharacter(4), 3);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(-1), throwsException);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5), throwsException);
+      });
+
+      test("2 characters", () {
+        expect("a💙c".moveOffsetUpstreamByCharacter(0, characterCount: 2), null);
+        expect("a💙c".moveOffsetUpstreamByCharacter(1, characterCount: 2), null);
+        expect("a💙c".moveOffsetUpstreamByCharacter(3, characterCount: 2), 0);
+        expect("a💙c".moveOffsetUpstreamByCharacter(4, characterCount: 2), 1);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(-1, characterCount: 2), throwsException);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5, characterCount: 2), throwsException);
+      });
+
+      test("a word", () {
+        expect("move a💙c words".moveOffsetUpstreamByWord(15), 10);
+        expect("move a💙c words".moveOffsetUpstreamByWord(10), 9);
+        expect("move a💙c words".moveOffsetUpstreamByWord(9), 5);
+        expect("move a💙c words".moveOffsetUpstreamByWord(8), 5);
+        expect("move a💙c words".moveOffsetUpstreamByWord(4), 0);
+        expect("move a💙c words".moveOffsetUpstreamByWord(0), null);
+        expect(() => "move a💙c words".moveOffsetUpstreamByWord(-1), throwsException);
+        expect(() => "move a💙c words".moveOffsetUpstreamByWord(16), throwsException);
+      });
+    });
+
+    group("find downstream", () {
+      test("1 character", () {
+        expect("a💙c".moveOffsetDownstreamByCharacter(0), 1);
+        expect("a💙c".moveOffsetDownstreamByCharacter(1), 3);
+        expect("a💙c".moveOffsetDownstreamByCharacter(3), 4);
+        expect("a💙c".moveOffsetDownstreamByCharacter(4), null);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1), throwsException);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5), throwsException);
+      });
+
+      test("2 characters", () {
+        expect("a💙c".moveOffsetDownstreamByCharacter(0, characterCount: 2), 3);
+        expect("a💙c".moveOffsetDownstreamByCharacter(1, characterCount: 2), 4);
+        expect("a💙c".moveOffsetDownstreamByCharacter(3, characterCount: 2), null);
+        expect("a💙c".moveOffsetDownstreamByCharacter(4, characterCount: 2), null);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1, characterCount: 2), throwsException);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5, characterCount: 2), throwsException);
+      });
+
+      test("a word", () {
+        expect("move a💙c words".moveOffsetDownstreamByWord(0), 4);
+        expect("move a💙c words".moveOffsetDownstreamByWord(4), 5);
+        expect("move a💙c words".moveOffsetDownstreamByWord(5), 9);
+        expect("move a💙c words".moveOffsetDownstreamByWord(6), 9);
+        expect("move a💙c words".moveOffsetDownstreamByWord(8), 9);
+        expect("move a💙c words".moveOffsetDownstreamByWord(9), 10);
+        expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
+        expect("move a💙c words".moveOffsetDownstreamByWord(15), null);
+        expect(() => "move a💙c words".moveOffsetDownstreamByWord(-1), throwsException);
+        expect(() => "move a💙c words".moveOffsetDownstreamByWord(16), throwsException);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Bugfix: caret no longer gets stuck in middle of emojis when moving left/right (Resolves #391)

#391 said errors were being thrown. I wasn't able to reproduce any errors by selecting emojis on desktop in the example app. However, the caret was getting stuck in the middle of emojis because we were moving by code point rather than by character. This PR adds machinery to all `String`s to move by character, and updates the keyboard handler to use the new behavior.

@miguelcmedeiros please let me know if you're still seeing any errors or related problems with emojis.