### PR TITLE
Handle empty documents (Resolves #274, Resolves #410)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -301,7 +301,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     editorGesturesLog.info("Tap down on document");
     final docOffset = _getDocOffset(details.localPosition);
     editorGesturesLog.fine(" - document offset: $docOffset");
-    final docPosition = _docLayout.getDocumentPositionAtOffset(docOffset);
+    final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     _focusNode.requestFocus();
@@ -332,7 +332,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     editorGesturesLog.info("Double tap down on document");
     final docOffset = _getDocOffset(details.localPosition);
     editorGesturesLog.fine(" - document offset: $docOffset");
-    final docPosition = _docLayout.getDocumentPositionAtOffset(docOffset);
+    final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null) {
@@ -393,7 +393,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     editorGesturesLog.info("Triple down down on document");
     final docOffset = _getDocOffset(details.localPosition);
     editorGesturesLog.fine(" - document offset: $docOffset");
-    final docPosition = _docLayout.getDocumentPositionAtOffset(docOffset);
+    final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null) {

--- a/super_editor/lib/src/default_editor/layout.dart
+++ b/super_editor/lib/src/default_editor/layout.dart
@@ -1,13 +1,12 @@
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
-
-final _log = Logger(scope: 'DocumentLayout');
 
 /// Displays a `Document` as a single column.
 ///
@@ -101,7 +100,7 @@ class _DefaultDocumentLayoutState extends State<DefaultDocumentLayout> implement
       // to the exact width, that x-value is considered outside the
       // component RenderBox's. However, 1px less than that is
       // considered to be within the component RenderBox's.
-      rawDocumentOffset.dx.clamp(1.0, docBox.size.width - 1),
+      rawDocumentOffset.dx.clamp(1.0, max(docBox.size.width - 1.0, 1.0)),
       rawDocumentOffset.dy,
     );
     editorLayoutLog.info('Getting document position near offset: $documentOffset');

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -384,7 +384,22 @@ class _TextComponentState extends State<TextComponent> with DocumentComponent im
     if (textPosition == null) {
       return null;
     }
-    return TextNodePosition.fromTextPosition(textPosition);
+
+    // Rework the textPosition so that it reports a "downstream" affinity because
+    // the editor doesn't support "upstream" positions, yet.
+    //
+    // Applying the "-1" to switch from upstream to downstream works everywhere, except
+    // when the position is at the very end of the text. In that case, we leave the offset
+    // alone.
+    return TextNodePosition.fromTextPosition(textPosition.affinity == TextAffinity.downstream
+        // The textPosition is already "downstream", leave it alone.
+        ? textPosition
+        // The textPosition if "upstream", adjust it to become "downstream", unless
+        // the position sits at the very end of the text.
+        : TextPosition(
+            offset: textPosition.offset < widget.text.text.length ? textPosition.offset - 1 : textPosition.offset,
+            affinity: TextAffinity.downstream,
+          ));
   }
 
   @override


### PR DESCRIPTION
Handle empty documents (Resolves #274, Resolves #410)

Fixes a bug in empty documents where a `clamp()` method was running with a min > max, which caused an illegal argument error.

Now resolves document taps by finding the "nearest" document position, rather than the "exact" document position. This means that tapping anywhere within `SuperEditor` will place the caret, which is convenient for empty documents.