### PR TITLE
Bugfix: mobile handles mis-aligned on desktop (Resolves #446)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -73,9 +73,9 @@ class ScrollableDocument extends StatelessWidget {
   }
 
   Widget _buildDocument() {
-    return CompositedTransformTarget(
-      link: documentLayerLink,
-      child: Center(
+    return Center(
+      child: CompositedTransformTarget(
+        link: documentLayerLink,
         child: child,
       ),
     );


### PR DESCRIPTION
Bugfix: mobile handles mis-aligned on desktop (Resolves #446)

The problem was that the document layer link was applied on the outside of a `Center` widget, which caused the layer link to wrap all available space, instead of just the document. I switched the order of the two widgets so that the layer link applies to the exact bounds of the document.