### PR TITLE
Updated super text field test APIs for platform adaptive version (Resolves #448)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/_test_tools.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/_test_tools.dart
@@ -1,28 +1,27 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/infrastructure/super_textfield/android/android_textfield.dart';
-import 'package:super_editor/src/infrastructure/super_textfield/ios/ios_textfield.dart';
 
 import 'super_textfield.dart';
 
 extension SuperTextFieldTesting on WidgetTester {
   Future<void> tapAtSuperTextPosition(Finder finder, int offset) async {
-    final match = _findSuperTextField(finder);
+    final fieldFinder = _findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().first.widget;
 
-    if (match.widget is SuperDesktopTextField) {
-      final didTap = await _tapAtTextPositionOnDesktop(state<SuperDesktopTextFieldState>(finder), offset);
+    if (match is SuperDesktopTextField) {
+      final didTap = await _tapAtTextPositionOnDesktop(state<SuperDesktopTextFieldState>(fieldFinder), offset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       return;
     }
 
-    if (match.widget is SuperAndroidTextField) {
+    if (match is SuperAndroidTextField) {
       throw Exception("Entering text on an Android SuperTextField is not yet supported");
     }
 
-    if (match.widget is SuperIOSTextField) {
+    if (match is SuperIOSTextField) {
       throw Exception("Entering text on an iOS SuperTextField is not yet supported");
     }
 
@@ -43,22 +42,61 @@ extension SuperTextFieldTesting on WidgetTester {
   }
 
   Future<void> enterSuperTextPlain(Finder finder, String plainText) async {
-    final match = _findSuperTextField(finder);
+    final fieldFinder = _findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().first.widget;
 
-    if (match.widget is SuperDesktopTextField) {
+    if (match is SuperDesktopTextField) {
       await _enterTextOnDesktop(plainText);
       return;
     }
 
-    if (match.widget is SuperAndroidTextField) {
+    if (match is SuperAndroidTextField) {
       throw Exception("Entering text on an Android SuperTextField is not yet supported");
     }
 
-    if (match.widget is SuperIOSTextField) {
+    if (match is SuperIOSTextField) {
       throw Exception("Entering text on an iOS SuperTextField is not yet supported");
     }
 
     throw Exception("Couldn't find a SuperTextField with the given Finder: $finder");
+  }
+
+  Finder _findInnerPlatformTextField(Finder rootFieldFinder) {
+    final rootMatches = rootFieldFinder.evaluate();
+    if (rootMatches.isEmpty) {
+      throw Exception("Couldn't find a super text field variant with the given finder: $rootFieldFinder");
+    }
+    if (rootMatches.length > 1) {
+      throw Exception("Found more than 1 super text field match with finder: $rootFieldFinder");
+    }
+
+    final rootMatch = rootMatches.first.widget;
+    if (rootMatch is! SuperTextField) {
+      // The match isn't a generic SuperTextField. Assume that it's a platform
+      // specific super text field, which is what we're looking for. Return it.
+      return rootFieldFinder;
+    }
+
+    final desktopFieldCandidates =
+        find.descendant(of: rootFieldFinder, matching: find.byType(SuperDesktopTextField)).evaluate();
+    if (desktopFieldCandidates.isNotEmpty) {
+      return find.descendant(of: rootFieldFinder, matching: find.byType(SuperDesktopTextField));
+    }
+
+    final androidFieldCandidates =
+        find.descendant(of: rootFieldFinder, matching: find.byType(SuperAndroidTextField)).evaluate();
+    if (androidFieldCandidates.isNotEmpty) {
+      return find.descendant(of: rootFieldFinder, matching: find.byType(SuperAndroidTextField));
+    }
+
+    final iosFieldCandidates =
+        find.descendant(of: rootFieldFinder, matching: find.byType(SuperIOSTextField)).evaluate();
+    if (iosFieldCandidates.isNotEmpty) {
+      return find.descendant(of: rootFieldFinder, matching: find.byType(SuperIOSTextField));
+    }
+
+    throw Exception(
+        "Couldn't find the platform-specific super text field within the root SuperTextField. Root finder: $rootFieldFinder");
   }
 
   Future<void> _enterTextOnDesktop(String plainText) async {
@@ -83,18 +121,6 @@ extension SuperTextFieldTesting on WidgetTester {
 
       await pump();
     }
-  }
-
-  Element _findSuperTextField(Finder finder) {
-    final matches = finder.evaluate().toList();
-    if (matches.isEmpty) {
-      throw Exception("Couldn't find a SuperTextField with the given Finder: $finder");
-    }
-    if (matches.length > 1) {
-      throw Exception("Found multiple SuperTextField candidates with the given Finder: $finder");
-    }
-
-    return matches.first;
   }
 
   _KeyboardCombo _keyCodeFromCharacter(String character) {

--- a/super_editor/test/src/infrastructure/super_textfield/type_into_super_textfield_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/type_into_super_textfield_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
@@ -8,11 +9,11 @@ void main() {
       testWidgets("in empty field", (tester) async {
         await _pumpDesktopScaffold(tester);
 
-        await tester.tap(find.byType(SuperDesktopTextField));
+        await tester.tap(find.byType(SuperTextField));
         await tester.pumpAndSettle();
 
         await tester.enterSuperTextPlain(
-          find.byType(SuperDesktopTextField),
+          find.byType(SuperTextField),
           // TODO: we can only send lowercase text until Flutter bug #96021 is resolved
           "hello world",
         );
@@ -23,11 +24,11 @@ void main() {
       testWidgets("shift characters", (tester) async {
         await _pumpDesktopScaffold(tester);
 
-        await tester.tap(find.byType(SuperDesktopTextField));
+        await tester.tap(find.byType(SuperTextField));
         await tester.pumpAndSettle();
 
         await tester.enterSuperTextPlain(
-          find.byType(SuperDesktopTextField),
+          find.byType(SuperTextField),
           "@",
         );
 
@@ -38,12 +39,12 @@ void main() {
       testWidgets("doesn't support Android", (tester) async {
         await _pumpAndroidScaffold(tester);
 
-        await tester.tap(find.byType(SuperAndroidTextField));
+        await tester.tap(find.byType(SuperTextField));
         await tester.pumpAndSettle();
 
         await expectLater(() async {
           await tester.enterSuperTextPlain(
-            find.byType(SuperAndroidTextField),
+            find.byType(SuperTextField),
             "a",
           );
         }, throwsException);
@@ -52,12 +53,12 @@ void main() {
       testWidgets("doesn't support iOS", (tester) async {
         await _pumpIOSScaffold(tester);
 
-        await tester.tap(find.byType(SuperIOSTextField));
+        await tester.tap(find.byType(SuperTextField));
         await tester.pumpAndSettle();
 
         await expectLater(() async {
           await tester.enterSuperTextPlain(
-            find.byType(SuperIOSTextField),
+            find.byType(SuperTextField),
             "a",
           );
         }, throwsException);
@@ -71,7 +72,7 @@ void main() {
           ),
         );
 
-        final textFieldFinder = find.byType(SuperDesktopTextField);
+        final textFieldFinder = find.byType(SuperTextField);
 
         await tester.tapAtSuperTextPosition(textFieldFinder, 6);
         await tester.pumpAndSettle();
@@ -88,38 +89,50 @@ void main() {
 }
 
 Future<void> _pumpDesktopScaffold(WidgetTester tester, [AttributedTextEditingController? controller]) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
   await _pumpScaffold(
     tester,
-    SuperDesktopTextField(
+    SuperTextField(
       textController: controller,
+      controlsColor: Colors.blue,
+      selectionColor: Colors.lightBlueAccent,
     ),
   );
+
+  debugDefaultTargetPlatformOverride = null;
 }
 
 Future<void> _pumpAndroidScaffold(WidgetTester tester, [ImeAttributedTextEditingController? controller]) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
   await _pumpScaffold(
     tester,
-    SuperAndroidTextField(
+    SuperTextField(
       textController: controller,
-      caretColor: Colors.blue,
-      handlesColor: Colors.blue,
+      controlsColor: Colors.blue,
       selectionColor: Colors.lightBlueAccent,
       lineHeight: 24,
     ),
   );
+
+  debugDefaultTargetPlatformOverride = null;
 }
 
 Future<void> _pumpIOSScaffold(WidgetTester tester, [ImeAttributedTextEditingController? controller]) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
   await _pumpScaffold(
     tester,
-    SuperIOSTextField(
+    SuperTextField(
       textController: controller,
-      caretColor: Colors.blue,
-      handlesColor: Colors.blue,
       selectionColor: Colors.lightBlueAccent,
+      controlsColor: Colors.blue,
       lineHeight: 24,
     ),
   );
+
+  debugDefaultTargetPlatformOverride = null;
 }
 
 Future<void> _pumpScaffold(WidgetTester tester, Widget textField) async {


### PR DESCRIPTION
Updated super text field test APIs for platform adaptive version (Resolves #448)

@miguelcmedeiros I wasn't sure what you were asking for in #448. I wasn't seeing any error with the existing tests. But I assumed that what you were looking for was for tests to use a platform adaptive `SuperTextField`, so I updated the tests and test APIs to support that.