### PR TITLE
Improve navigating by word

### DIFF
--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -1,5 +1,7 @@
 import 'package:characters/characters.dart';
 
+final _separatorRegex = RegExp(r'^\p{Z}$', unicode: true);
+
 extension CharacterMovement on String {
   /// Returns the code point index of the character that sits
   /// one word upstream from the given [textOffset] code point index.
@@ -19,34 +21,38 @@ extension CharacterMovement on String {
       return null;
     }
 
-    bool isInSpace = false;
+    bool isInSeparator = false;
 
-    int lastSpaceStartCodePointOffset = 0;
-    int lastSpaceEndCodePointOffset = 0;
+    int lastSeparatorStartCodePointOffset = 0;
+    int lastSeparatorEndCodePointOffset = 0;
 
     int visitedCharacterCount = 0;
     int codePointIndex = 0;
     for (final character in characters) {
       if (visitedCharacterCount >= textOffset - 1) {
         // We're at the given text offset. The upstream word offset is
-        // at lastSpaceEndCodePointOffset.
+        // at lastSeparatorEndCodePointOffset.
         break;
       }
 
-      if (character == " " && !isInSpace) {
-        lastSpaceStartCodePointOffset = codePointIndex;
+      final characterIsSeparator = _separatorRegex.hasMatch(character);
+
+      if (characterIsSeparator && !isInSeparator) {
+        lastSeparatorStartCodePointOffset = codePointIndex;
       }
 
-      isInSpace = character == " ";
+      isInSeparator = characterIsSeparator;
       codePointIndex += character.length;
       visitedCharacterCount += 1;
 
-      if (character == " ") {
-        lastSpaceEndCodePointOffset = codePointIndex;
+      if (characterIsSeparator) {
+        lastSeparatorEndCodePointOffset = codePointIndex;
       }
     }
 
-    return lastSpaceEndCodePointOffset < textOffset ? lastSpaceEndCodePointOffset : lastSpaceStartCodePointOffset;
+    return lastSeparatorEndCodePointOffset < textOffset
+        ? lastSeparatorEndCodePointOffset
+        : lastSeparatorStartCodePointOffset;
   }
 
   /// Returns the code point index of the character that sits
@@ -104,29 +110,31 @@ extension CharacterMovement on String {
       return null;
     }
 
-    bool isInSpace = false;
+    bool isInSeparator = false;
 
-    int lastSpaceStartCodePointOffset = 0;
-    int lastSpaceEndCodePointOffset = 0;
+    int lastSeparatorStartCodePointOffset = 0;
+    int lastSeparatorEndCodePointOffset = 0;
 
     int codePointIndex = 0;
     for (final character in characters) {
-      if (character == " " && !isInSpace) {
-        lastSpaceStartCodePointOffset = codePointIndex;
+      final characterIsSeparator = _separatorRegex.hasMatch(character);
+
+      if (characterIsSeparator && !isInSeparator) {
+        lastSeparatorStartCodePointOffset = codePointIndex;
       }
 
-      isInSpace = character == " ";
+      isInSeparator = characterIsSeparator;
       codePointIndex += character.length;
 
-      if (character == " ") {
-        lastSpaceEndCodePointOffset = codePointIndex;
+      if (characterIsSeparator) {
+        lastSeparatorEndCodePointOffset = codePointIndex;
       }
 
-      if (lastSpaceStartCodePointOffset > textOffset) {
-        return lastSpaceStartCodePointOffset;
+      if (lastSeparatorStartCodePointOffset > textOffset) {
+        return lastSeparatorStartCodePointOffset;
       }
-      if (lastSpaceEndCodePointOffset > textOffset) {
-        return lastSpaceEndCodePointOffset;
+      if (lastSeparatorEndCodePointOffset > textOffset) {
+        return lastSeparatorEndCodePointOffset;
       }
     }
 

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -6,9 +6,8 @@ final _separatorRegex = RegExp(r'^[\p{Z}\p{P}]$', unicode: true);
 
 extension CharacterMovement on String {
   /// Returns the code point index of the character that sits
-  /// one word upstream from the given [textOffset] code
-  /// point index, ignoring separator and punctuation
-  /// characters.
+  /// at the next start of word upstream from the given
+  /// [textOffset] code point index.
   ///
   /// Examples:
   ///   |word up -> `null`
@@ -96,9 +95,8 @@ extension CharacterMovement on String {
   }
 
   /// Returns the code point index of the character that sits
-  /// one word downstream from the given [textOffset] code
-  /// point index, ignoring separator and punctuation
-  /// characters.
+  /// after the next end of word downstream from the given
+  /// [textOffset] code point index.
   ///
   /// Examples:
   ///   |word up -> `4`

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -101,7 +101,7 @@ extension CharacterMovement on String {
   }
 
   /// Returns the code point index of the character that sits
-  /// after the next end of word downstream from the given
+  /// after the end of the next word downstream from the given
   /// [textOffset] code point index.
   ///
   /// Examples:

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -74,7 +74,8 @@ extension CharacterMovement on String {
   ///   a💙c| -> `3` (notice that we moved 2 units due to emoji length)
   int? moveOffsetUpstreamByCharacter(int textOffset, {int characterCount = 1}) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+      throw Exception(
+          "Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == 0) {
@@ -111,31 +112,31 @@ extension CharacterMovement on String {
   ///   word up| -> `null`
   int? moveOffsetDownstreamByWord(int textOffset) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+      throw Exception(
+          "Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == length) {
       return null;
     }
 
-    bool isInSeparator = false;
-
-    int lastSeparatorStartCodePointOffset = 0;
-
+    bool lastCharWasSeparator = true;
     int codePointIndex = 0;
+    int visitedCharacterCount = 0;
     for (final character in characters) {
-      final characterIsSeparator = _separatorRegex.hasMatch(character);
-
-      if (characterIsSeparator && !isInSeparator) {
-        lastSeparatorStartCodePointOffset = codePointIndex;
+      if (visitedCharacterCount >= textOffset) {
+        // No characters before textOffset will impact the results, so don't
+        // bother running the regex on them
+        final isInSeparator = _separatorRegex.hasMatch(character);
+        if (visitedCharacterCount > textOffset &&
+            isInSeparator &&
+            !lastCharWasSeparator) {
+          return codePointIndex;
+        }
+        lastCharWasSeparator = isInSeparator;
       }
-
-      isInSeparator = characterIsSeparator;
+      visitedCharacterCount += 1;
       codePointIndex += character.length;
-
-      if (lastSeparatorStartCodePointOffset > textOffset) {
-        return lastSeparatorStartCodePointOffset;
-      }
     }
 
     // The end of this string is as far as we can go.
@@ -151,9 +152,11 @@ extension CharacterMovement on String {
   ///   a|💙c -> `3` (notice that we moved 2 units due to emoji length)
   ///   a💙|c -> `4`
   ///   a💙c| -> `null`
-  int? moveOffsetDownstreamByCharacter(int textOffset, {int characterCount = 1}) {
+  int? moveOffsetDownstreamByCharacter(int textOffset,
+      {int characterCount = 1}) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception("Index '$textOffset' is out of string range. Length: $length");
+      throw Exception(
+          "Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == length) {

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -21,8 +21,7 @@ extension CharacterMovement on String {
   ///   word up| -> `5`
   int? moveOffsetUpstreamByWord(int textOffset) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception(
-          "Index '$textOffset' is out of string range. Length: $length");
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == 0) {
@@ -79,8 +78,7 @@ extension CharacterMovement on String {
   ///   a💙c| -> `3` (notice that we moved 2 units due to emoji length)
   int? moveOffsetUpstreamByCharacter(int textOffset, {int characterCount = 1}) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception(
-          "Index '$textOffset' is out of string range. Length: $length");
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == 0) {
@@ -117,8 +115,7 @@ extension CharacterMovement on String {
   ///   word up| -> `null`
   int? moveOffsetDownstreamByWord(int textOffset) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception(
-          "Index '$textOffset' is out of string range. Length: $length");
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == length) {
@@ -133,9 +130,7 @@ extension CharacterMovement on String {
         // No characters before textOffset will impact the results, so don't
         // bother running the regex on them
         final isInSeparator = _separatorRegex.hasMatch(character);
-        if (characterIndex > textOffset &&
-            isInSeparator &&
-            !lastCharWasSeparator) {
+        if (characterIndex > textOffset && isInSeparator && !lastCharWasSeparator) {
           return codePointIndex;
         }
         lastCharWasSeparator = isInSeparator;
@@ -157,11 +152,9 @@ extension CharacterMovement on String {
   ///   a|💙c -> `3` (notice that we moved 2 units due to emoji length)
   ///   a💙|c -> `4`
   ///   a💙c| -> `null`
-  int? moveOffsetDownstreamByCharacter(int textOffset,
-      {int characterCount = 1}) {
+  int? moveOffsetDownstreamByCharacter(int textOffset, {int characterCount = 1}) {
     if (textOffset < 0 || textOffset > length) {
-      throw Exception(
-          "Index '$textOffset' is out of string range. Length: $length");
+      throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }
 
     if (textOffset == length) {

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -6,15 +6,17 @@ final _separatorRegex = RegExp(r'^[\p{Z}\p{P}]$', unicode: true);
 
 extension CharacterMovement on String {
   /// Returns the code point index of the character that sits
-  /// one word upstream from the given [textOffset] code point index.
+  /// one word upstream from the given [textOffset] code
+  /// point index, ignoring separator and punctuation
+  /// characters.
   ///
   /// Examples:
   ///   |word up -> `null`
   ///   wo|rd up -> `0`
   ///   word| up -> `0`
-  ///   word |up -> `4`
-  ///   word up| -> `6`
-  int? moveOffsetUpstreamByWord(int textOffset, {int characterCount = 1}) {
+  ///   word |up -> `0`
+  ///   word up| -> `5`
+  int? moveOffsetUpstreamByWord(int textOffset) {
     if (textOffset < 0 || textOffset > length) {
       throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }
@@ -94,16 +96,17 @@ extension CharacterMovement on String {
   }
 
   /// Returns the code point index of the character that sits
-  /// one word downstream from given [textOffset] code point
-  /// index.
+  /// one word downstream from the given [textOffset] code
+  /// point index, ignoring separator and punctuation
+  /// characters.
   ///
   /// Examples:
   ///   |word up -> `4`
   ///   wo|rd up -> `4`
-  ///   word| up -> `5`
+  ///   word| up -> `7`
   ///   word |up -> `7`
   ///   word up| -> `null`
-  int? moveOffsetDownstreamByWord(int textOffset, {int characterCount = 1}) {
+  int? moveOffsetDownstreamByWord(int textOffset) {
     if (textOffset < 0 || textOffset > length) {
       throw Exception("Index '$textOffset' is out of string range. Length: $length");
     }

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -113,7 +113,6 @@ extension CharacterMovement on String {
     bool isInSeparator = false;
 
     int lastSeparatorStartCodePointOffset = 0;
-    int lastSeparatorEndCodePointOffset = 0;
 
     int codePointIndex = 0;
     for (final character in characters) {
@@ -126,15 +125,8 @@ extension CharacterMovement on String {
       isInSeparator = characterIsSeparator;
       codePointIndex += character.length;
 
-      if (characterIsSeparator) {
-        lastSeparatorEndCodePointOffset = codePointIndex;
-      }
-
       if (lastSeparatorStartCodePointOffset > textOffset) {
         return lastSeparatorStartCodePointOffset;
-      }
-      if (lastSeparatorEndCodePointOffset > textOffset) {
-        return lastSeparatorEndCodePointOffset;
       }
     }
 

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -91,7 +91,7 @@ extension CharacterMovement on String {
     final range = characters.iterator;
     // Expand the range so it reaches from the start of the string to the initial text offset. The text offset is passed
     // to us in terms of bytes but the iterator deals in grapheme clusters, so we need to manually count the length of
-    // each cluster as until we reach the desired offset
+    // each cluster until we reach the desired offset
     var remainingOffset = textOffset;
     range.expandWhile((char) {
       remainingOffset -= char.length;
@@ -122,7 +122,7 @@ extension CharacterMovement on String {
     var remainingOffset = textOffset;
     // Expand the range so it reaches from the start of the string to the initial text offset. The text offset is passed
     // to us in terms of bytes but the iterator deals in grapheme clusters, so we need to manually count the length of
-    // each cluster as until we reach the desired offset
+    // each cluster until we reach the desired offset
     range.expandWhile((char) {
       remainingOffset -= char.length;
       return remainingOffset >= 0;

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -2,6 +2,12 @@ import 'dart:collection';
 
 import 'package:characters/characters.dart';
 
+// Match any characters we want skip over while moving by word. This will match
+// Unicode graphemes with a General_Category value in:
+// - Punctuation (P), such as ".", "-", and "。"
+// - Separator (Z), such as " " (space), and "　" (ideographic space)
+// See http://www.unicode.org/reports/tr44/#GC_Values_Table for details on
+// on the Unicode General_Category property.
 final _separatorRegex = RegExp(r'^[\p{Z}\p{P}]$', unicode: true);
 
 extension CharacterMovement on String {

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -90,8 +90,8 @@ extension CharacterMovement on String {
     // characters
     final range = characters.iterator;
     // Expand the range so it reaches from the start of the string to the initial text offset. The text offset is passed
-    // to us in terms of bytes but the iterator deals in grapheme clusters, so we need to manually count the length of
-    // each cluster until we reach the desired offset
+    // to us in terms of code units but the iterator deals in grapheme clusters, so we need to manually count the length
+    // of each cluster until we reach the desired offset
     var remainingOffset = textOffset;
     range.expandWhile((char) {
       remainingOffset -= char.length;
@@ -121,8 +121,8 @@ extension CharacterMovement on String {
     final range = characters.iterator;
     var remainingOffset = textOffset;
     // Expand the range so it reaches from the start of the string to the initial text offset. The text offset is passed
-    // to us in terms of bytes but the iterator deals in grapheme clusters, so we need to manually count the length of
-    // each cluster until we reach the desired offset
+    // to us in terms of code units but the iterator deals in grapheme clusters, so we need to manually count the length
+    // of each cluster until we reach the desired offset
     range.expandWhile((char) {
       remainingOffset -= char.length;
       return remainingOffset >= 0;

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -1,6 +1,6 @@
 import 'package:characters/characters.dart';
 
-final _separatorRegex = RegExp(r'^\p{Z}$', unicode: true);
+final _separatorRegex = RegExp(r'^[\p{Z}\p{P}]$', unicode: true);
 
 extension CharacterMovement on String {
   /// Returns the code point index of the character that sits

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -40,7 +40,7 @@ extension CharacterMovement on String {
         // If the last separator end was before this index, it wasn't really the
         // end. Remove and replace it. Always keep 0 as a special case to make
         // sure we can reach the start of the string.
-        if (separatorEnds.first != 0 && separatorEnds.first == codePointIndex - 1) {
+        if (separatorEnds.first != 0 && separatorEnds.first == codePointIndex - character.length) {
           separatorEnds.removeFirst();
         }
         separatorEnds.addFirst(codePointIndex);

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -23,20 +23,20 @@ void main() {
       });
 
       test("a word", () {
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(18), 15);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(16), 15);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(15), 12);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(14), 12);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(12), 7);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(11), 7);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(10), 7);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(7), 2);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(6), 2);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(2), 0);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(1), 0);
-        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(0), null);
-        expect(() => "  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(-1), throwsException);
-        expect(() => "  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(19), throwsException);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(19), 16);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(17), 16);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(16), 13);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(15), 13);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(13), 7);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(11), 7);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(10), 7);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(7), 2);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(6), 2);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(2), 0);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(1), 0);
+        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(0), null);
+        expect(() => "  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(-1), throwsException);
+        expect(() => "  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(20), throwsException);
       });
     });
 
@@ -60,19 +60,19 @@ void main() {
       });
 
       test("a word", () {
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(0), 4);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(4), 9);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(5), 9);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(6), 9);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(8), 9);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(9), 12);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(10), 12);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(12), 16);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(16), 18);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(17), 18);
-        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(18), null);
-        expect(() => "move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(-1), throwsException);
-        expect(() => "move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(19), throwsException);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(0), 4);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(4), 9);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(5), 9);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(6), 9);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(8), 9);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(9), 13);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(11), 13);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(13), 17);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(17), 19);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(18), 19);
+        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(19), null);
+        expect(() => "move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(-1), throwsException);
+        expect(() => "move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(20), throwsException);
       });
     });
   });

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -23,14 +23,14 @@ void main() {
       });
 
       test("a word", () {
-        expect("move a💙c words".moveOffsetUpstreamByWord(15), 10);
-        expect("move a💙c words".moveOffsetUpstreamByWord(10), 9);
-        expect("move a💙c words".moveOffsetUpstreamByWord(9), 5);
-        expect("move a💙c words".moveOffsetUpstreamByWord(8), 5);
-        expect("move a💙c words".moveOffsetUpstreamByWord(4), 0);
-        expect("move a💙c words".moveOffsetUpstreamByWord(0), null);
-        expect(() => "move a💙c words".moveOffsetUpstreamByWord(-1), throwsException);
-        expect(() => "move a💙c words".moveOffsetUpstreamByWord(16), throwsException);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(15), 10);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(10), 9);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(9), 5);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(8), 5);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(4), 0);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(0), null);
+        expect(() => "move a💙c\u3000words".moveOffsetUpstreamByWord(-1), throwsException);
+        expect(() => "move a💙c\u3000words".moveOffsetUpstreamByWord(16), throwsException);
       });
     });
 
@@ -54,16 +54,16 @@ void main() {
       });
 
       test("a word", () {
-        expect("move a💙c words".moveOffsetDownstreamByWord(0), 4);
-        expect("move a💙c words".moveOffsetDownstreamByWord(4), 5);
-        expect("move a💙c words".moveOffsetDownstreamByWord(5), 9);
-        expect("move a💙c words".moveOffsetDownstreamByWord(6), 9);
-        expect("move a💙c words".moveOffsetDownstreamByWord(8), 9);
-        expect("move a💙c words".moveOffsetDownstreamByWord(9), 10);
-        expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
-        expect("move a💙c words".moveOffsetDownstreamByWord(15), null);
-        expect(() => "move a💙c words".moveOffsetDownstreamByWord(-1), throwsException);
-        expect(() => "move a💙c words".moveOffsetDownstreamByWord(16), throwsException);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(0), 4);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(4), 5);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(5), 9);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(6), 9);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(8), 9);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(9), 10);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(10), 15);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(15), null);
+        expect(() => "move a💙c\u3000words".moveOffsetDownstreamByWord(-1), throwsException);
+        expect(() => "move a💙c\u3000words".moveOffsetDownstreamByWord(16), throwsException);
       });
     });
   });

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -55,11 +55,11 @@ void main() {
 
       test("a word", () {
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(0), 4);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(4), 5);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(4), 9);
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(5), 9);
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(6), 9);
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(8), 9);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(9), 10);
+        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(9), 15);
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(10), 15);
         expect("move a💙c\u3000words".moveOffsetDownstreamByWord(15), null);
         expect(() => "move a💙c\u3000words".moveOffsetDownstreamByWord(-1), throwsException);

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -23,15 +23,20 @@ void main() {
       });
 
       test("a word", () {
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(15), 10);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(10), 5);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(9), 5);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(8), 5);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(5), 0);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(4), 0);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(0), null);
-        expect(() => "move a💙c\u3000words".moveOffsetUpstreamByWord(-1), throwsException);
-        expect(() => "move a💙c\u3000words".moveOffsetUpstreamByWord(16), throwsException);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(18), 15);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(16), 15);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(15), 12);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(14), 12);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(12), 7);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(11), 7);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(10), 7);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(7), 2);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(6), 2);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(2), 0);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(1), 0);
+        expect("  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(0), null);
+        expect(() => "  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(-1), throwsException);
+        expect(() => "  move a💙c\u3000wo.rds".moveOffsetUpstreamByWord(19), throwsException);
       });
     });
 
@@ -55,16 +60,19 @@ void main() {
       });
 
       test("a word", () {
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(0), 4);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(4), 9);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(5), 9);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(6), 9);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(8), 9);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(9), 15);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(10), 15);
-        expect("move a💙c\u3000words".moveOffsetDownstreamByWord(15), null);
-        expect(() => "move a💙c\u3000words".moveOffsetDownstreamByWord(-1), throwsException);
-        expect(() => "move a💙c\u3000words".moveOffsetDownstreamByWord(16), throwsException);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(0), 4);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(4), 9);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(5), 9);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(6), 9);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(8), 9);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(9), 12);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(10), 12);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(12), 16);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(16), 18);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(17), 18);
+        expect("move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(18), null);
+        expect(() => "move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(-1), throwsException);
+        expect(() => "move a💙c\u3000wo.rds  ".moveOffsetDownstreamByWord(19), throwsException);
       });
     });
   });

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -133,7 +133,7 @@ void main() {
           expect("move a💙c words".moveOffsetDownstreamByWord(4), 9);
           expect("move a💙c words".moveOffsetDownstreamByWord(5), 9);
           expect("move a💙c words".moveOffsetDownstreamByWord(6), 9);
-          expect("move a💙c words".moveOffsetDownstreamByWord(8), 9);
+          expect("move a💙c words".moveOffsetDownstreamByWord(8), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(9), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(15), null);

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -14,17 +14,12 @@ void main() {
       });
 
       test("2 characters", () {
-        expect(
-            "a💙c".moveOffsetUpstreamByCharacter(0, characterCount: 2), null);
-        expect(
-            "a💙c".moveOffsetUpstreamByCharacter(1, characterCount: 2), null);
+        expect("a💙c".moveOffsetUpstreamByCharacter(0, characterCount: 2), null);
+        expect("a💙c".moveOffsetUpstreamByCharacter(1, characterCount: 2), null);
         expect("a💙c".moveOffsetUpstreamByCharacter(3, characterCount: 2), 0);
         expect("a💙c".moveOffsetUpstreamByCharacter(4, characterCount: 2), 1);
-        expect(
-            () => "a💙c".moveOffsetUpstreamByCharacter(-1, characterCount: 2),
-            throwsException);
-        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5, characterCount: 2),
-            throwsException);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(-1, characterCount: 2), throwsException);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5, characterCount: 2), throwsException);
       });
 
       group("a word", () {
@@ -35,10 +30,8 @@ void main() {
           expect("move a💙c words".moveOffsetUpstreamByWord(8), 5);
           expect("move a💙c words".moveOffsetUpstreamByWord(4), 0);
           expect("move a💙c words".moveOffsetUpstreamByWord(0), null);
-          expect(() => "move a💙c words".moveOffsetUpstreamByWord(-1),
-              throwsException);
-          expect(() => "move a💙c words".moveOffsetUpstreamByWord(16),
-              throwsException);
+          expect(() => "move a💙c words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move a💙c words".moveOffsetUpstreamByWord(16), throwsException);
         });
 
         test("separated by multiple spaces", () {
@@ -47,10 +40,8 @@ void main() {
           expect("move   words".moveOffsetUpstreamByWord(6), 0);
           expect("move   words".moveOffsetUpstreamByWord(4), 0);
           expect("move   words".moveOffsetUpstreamByWord(0), null);
-          expect(() => "move   words".moveOffsetUpstreamByWord(-1),
-              throwsException);
-          expect(() => "move   words".moveOffsetUpstreamByWord(13),
-              throwsException);
+          expect(() => "move   words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move   words".moveOffsetUpstreamByWord(13), throwsException);
         });
 
         test("separated by punctuation", () {
@@ -58,10 +49,8 @@ void main() {
           expect("move.words".moveOffsetUpstreamByWord(5), 0);
           expect("move.words".moveOffsetUpstreamByWord(4), 0);
           expect("move.words".moveOffsetUpstreamByWord(0), null);
-          expect(
-              () => "move.words".moveOffsetUpstreamByWord(-1), throwsException);
-          expect(
-              () => "move.words".moveOffsetUpstreamByWord(11), throwsException);
+          expect(() => "move.words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move.words".moveOffsetUpstreamByWord(11), throwsException);
         });
 
         test("separated by punctuation and spaces", () {
@@ -70,10 +59,8 @@ void main() {
           expect("move. words".moveOffsetUpstreamByWord(5), 0);
           expect("move. words".moveOffsetUpstreamByWord(4), 0);
           expect("move. words".moveOffsetUpstreamByWord(0), null);
-          expect(() => "move. words".moveOffsetUpstreamByWord(-1),
-              throwsException);
-          expect(() => "move. words".moveOffsetUpstreamByWord(12),
-              throwsException);
+          expect(() => "move. words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move. words".moveOffsetUpstreamByWord(12), throwsException);
         });
 
         test("separated by multi-byte punctuation", () {
@@ -81,10 +68,8 @@ void main() {
           expect("move\u{10B3F}words".moveOffsetUpstreamByWord(6), 0);
           expect("move\u{10B3F}words".moveOffsetUpstreamByWord(4), 0);
           expect("move\u{10B3F}words".moveOffsetUpstreamByWord(0), null);
-          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1),
-              throwsException);
-          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(12),
-              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(12), throwsException);
         });
 
         test("leading and trailing spaces", () {
@@ -92,10 +77,8 @@ void main() {
           expect("  move words  ".moveOffsetUpstreamByWord(7), 2);
           expect("  move words  ".moveOffsetUpstreamByWord(2), 0);
           expect("  move words  ".moveOffsetUpstreamByWord(0), null);
-          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1),
-              throwsException);
-          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(15),
-              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(15), throwsException);
         });
       });
     });
@@ -106,25 +89,17 @@ void main() {
         expect("a💙c".moveOffsetDownstreamByCharacter(1), 3);
         expect("a💙c".moveOffsetDownstreamByCharacter(3), 4);
         expect("a💙c".moveOffsetDownstreamByCharacter(4), null);
-        expect(
-            () => "a💙c".moveOffsetDownstreamByCharacter(-1), throwsException);
-        expect(
-            () => "a💙c".moveOffsetDownstreamByCharacter(5), throwsException);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1), throwsException);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5), throwsException);
       });
 
       test("2 characters", () {
         expect("a💙c".moveOffsetDownstreamByCharacter(0, characterCount: 2), 3);
         expect("a💙c".moveOffsetDownstreamByCharacter(1, characterCount: 2), 4);
-        expect(
-            "a💙c".moveOffsetDownstreamByCharacter(3, characterCount: 2), null);
-        expect(
-            "a💙c".moveOffsetDownstreamByCharacter(4, characterCount: 2), null);
-        expect(
-            () => "a💙c".moveOffsetDownstreamByCharacter(-1, characterCount: 2),
-            throwsException);
-        expect(
-            () => "a💙c".moveOffsetDownstreamByCharacter(5, characterCount: 2),
-            throwsException);
+        expect("a💙c".moveOffsetDownstreamByCharacter(3, characterCount: 2), null);
+        expect("a💙c".moveOffsetDownstreamByCharacter(4, characterCount: 2), null);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1, characterCount: 2), throwsException);
+        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5, characterCount: 2), throwsException);
       });
 
       group('a word', () {
@@ -137,10 +112,8 @@ void main() {
           expect("move a💙c words".moveOffsetDownstreamByWord(9), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(15), null);
-          expect(() => "move a💙c words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move a💙c words".moveOffsetDownstreamByWord(16),
-              throwsException);
+          expect(() => "move a💙c words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move a💙c words".moveOffsetDownstreamByWord(16), throwsException);
         });
 
         test("separated by multiple spaces", () {
@@ -148,10 +121,8 @@ void main() {
           expect("move   words".moveOffsetDownstreamByWord(4), 12);
           expect("move   words".moveOffsetDownstreamByWord(5), 12);
           expect("move   words".moveOffsetDownstreamByWord(12), null);
-          expect(() => "move   words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move   words".moveOffsetDownstreamByWord(13),
-              throwsException);
+          expect(() => "move   words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move   words".moveOffsetDownstreamByWord(13), throwsException);
         });
 
         test("separated by punctuation", () {
@@ -159,10 +130,8 @@ void main() {
           expect("move.words".moveOffsetDownstreamByWord(4), 10);
           expect("move.words".moveOffsetDownstreamByWord(5), 10);
           expect("move.words".moveOffsetDownstreamByWord(10), null);
-          expect(() => "move.words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move.words".moveOffsetDownstreamByWord(11),
-              throwsException);
+          expect(() => "move.words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move.words".moveOffsetDownstreamByWord(11), throwsException);
         });
 
         test("separated by punctuation and spaces", () {
@@ -171,10 +140,8 @@ void main() {
           expect("move. words".moveOffsetDownstreamByWord(5), 11);
           expect("move. words".moveOffsetDownstreamByWord(6), 11);
           expect("move. words".moveOffsetDownstreamByWord(11), null);
-          expect(() => "move. words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move. words".moveOffsetDownstreamByWord(12),
-              throwsException);
+          expect(() => "move. words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move. words".moveOffsetDownstreamByWord(12), throwsException);
         });
 
         test("separated by multi-byte punctuation", () {
@@ -182,10 +149,8 @@ void main() {
           expect("move\u{10B3F}words".moveOffsetDownstreamByWord(4), 11);
           expect("move\u{10B3F}words".moveOffsetDownstreamByWord(6), 11);
           expect("move\u{10B3F}words".moveOffsetDownstreamByWord(11), null);
-          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(12),
-              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(12), throwsException);
         });
 
         test("leading and trailing spaces", () {
@@ -193,10 +158,8 @@ void main() {
           expect("  move words  ".moveOffsetDownstreamByWord(1), 6);
           expect("  move words  ".moveOffsetDownstreamByWord(6), 12);
           expect("  move words  ".moveOffsetDownstreamByWord(14), null);
-          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1),
-              throwsException);
-          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(15),
-              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1), throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(15), throwsException);
         });
       });
     });

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -24,9 +24,10 @@ void main() {
 
       test("a word", () {
         expect("move a💙c\u3000words".moveOffsetUpstreamByWord(15), 10);
-        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(10), 9);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(10), 5);
         expect("move a💙c\u3000words".moveOffsetUpstreamByWord(9), 5);
         expect("move a💙c\u3000words".moveOffsetUpstreamByWord(8), 5);
+        expect("move a💙c\u3000words".moveOffsetUpstreamByWord(5), 0);
         expect("move a💙c\u3000words".moveOffsetUpstreamByWord(4), 0);
         expect("move a💙c\u3000words".moveOffsetUpstreamByWord(0), null);
         expect(() => "move a💙c\u3000words".moveOffsetUpstreamByWord(-1), throwsException);

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -108,7 +108,7 @@ void main() {
           expect("move a💙c words".moveOffsetDownstreamByWord(4), 9);
           expect("move a💙c words".moveOffsetDownstreamByWord(5), 9);
           expect("move a💙c words".moveOffsetDownstreamByWord(6), 9);
-          expect("move a💙c words".moveOffsetDownstreamByWord(8), 15);
+          expect("move a💙c words".moveOffsetDownstreamByWord(8), 9);
           expect("move a💙c words".moveOffsetDownstreamByWord(9), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
           expect("move a💙c words".moveOffsetDownstreamByWord(15), null);

--- a/super_editor/test/src/infrastructure/strings_test.dart
+++ b/super_editor/test/src/infrastructure/strings_test.dart
@@ -14,29 +14,89 @@ void main() {
       });
 
       test("2 characters", () {
-        expect("a💙c".moveOffsetUpstreamByCharacter(0, characterCount: 2), null);
-        expect("a💙c".moveOffsetUpstreamByCharacter(1, characterCount: 2), null);
+        expect(
+            "a💙c".moveOffsetUpstreamByCharacter(0, characterCount: 2), null);
+        expect(
+            "a💙c".moveOffsetUpstreamByCharacter(1, characterCount: 2), null);
         expect("a💙c".moveOffsetUpstreamByCharacter(3, characterCount: 2), 0);
         expect("a💙c".moveOffsetUpstreamByCharacter(4, characterCount: 2), 1);
-        expect(() => "a💙c".moveOffsetUpstreamByCharacter(-1, characterCount: 2), throwsException);
-        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5, characterCount: 2), throwsException);
+        expect(
+            () => "a💙c".moveOffsetUpstreamByCharacter(-1, characterCount: 2),
+            throwsException);
+        expect(() => "a💙c".moveOffsetUpstreamByCharacter(5, characterCount: 2),
+            throwsException);
       });
 
-      test("a word", () {
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(19), 16);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(17), 16);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(16), 13);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(15), 13);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(13), 7);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(11), 7);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(10), 7);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(7), 2);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(6), 2);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(2), 0);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(1), 0);
-        expect("  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(0), null);
-        expect(() => "  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(-1), throwsException);
-        expect(() => "  move a💙c\u{10B3F}wo.rds".moveOffsetUpstreamByWord(20), throwsException);
+      group("a word", () {
+        test('separated by space', () {
+          expect("move a💙c words".moveOffsetUpstreamByWord(15), 10);
+          expect("move a💙c words".moveOffsetUpstreamByWord(10), 5);
+          expect("move a💙c words".moveOffsetUpstreamByWord(9), 5);
+          expect("move a💙c words".moveOffsetUpstreamByWord(8), 5);
+          expect("move a💙c words".moveOffsetUpstreamByWord(4), 0);
+          expect("move a💙c words".moveOffsetUpstreamByWord(0), null);
+          expect(() => "move a💙c words".moveOffsetUpstreamByWord(-1),
+              throwsException);
+          expect(() => "move a💙c words".moveOffsetUpstreamByWord(16),
+              throwsException);
+        });
+
+        test("separated by multiple spaces", () {
+          expect("move   words".moveOffsetUpstreamByWord(12), 7);
+          expect("move   words".moveOffsetUpstreamByWord(7), 0);
+          expect("move   words".moveOffsetUpstreamByWord(6), 0);
+          expect("move   words".moveOffsetUpstreamByWord(4), 0);
+          expect("move   words".moveOffsetUpstreamByWord(0), null);
+          expect(() => "move   words".moveOffsetUpstreamByWord(-1),
+              throwsException);
+          expect(() => "move   words".moveOffsetUpstreamByWord(13),
+              throwsException);
+        });
+
+        test("separated by punctuation", () {
+          expect("move.words".moveOffsetUpstreamByWord(10), 5);
+          expect("move.words".moveOffsetUpstreamByWord(5), 0);
+          expect("move.words".moveOffsetUpstreamByWord(4), 0);
+          expect("move.words".moveOffsetUpstreamByWord(0), null);
+          expect(
+              () => "move.words".moveOffsetUpstreamByWord(-1), throwsException);
+          expect(
+              () => "move.words".moveOffsetUpstreamByWord(11), throwsException);
+        });
+
+        test("separated by punctuation and spaces", () {
+          expect("move. words".moveOffsetUpstreamByWord(11), 6);
+          expect("move. words".moveOffsetUpstreamByWord(6), 0);
+          expect("move. words".moveOffsetUpstreamByWord(5), 0);
+          expect("move. words".moveOffsetUpstreamByWord(4), 0);
+          expect("move. words".moveOffsetUpstreamByWord(0), null);
+          expect(() => "move. words".moveOffsetUpstreamByWord(-1),
+              throwsException);
+          expect(() => "move. words".moveOffsetUpstreamByWord(12),
+              throwsException);
+        });
+
+        test("separated by multi-byte punctuation", () {
+          expect("move\u{10B3F}words".moveOffsetUpstreamByWord(11), 6);
+          expect("move\u{10B3F}words".moveOffsetUpstreamByWord(6), 0);
+          expect("move\u{10B3F}words".moveOffsetUpstreamByWord(4), 0);
+          expect("move\u{10B3F}words".moveOffsetUpstreamByWord(0), null);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1),
+              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(12),
+              throwsException);
+        });
+
+        test("leading and trailing spaces", () {
+          expect("  move words  ".moveOffsetUpstreamByWord(14), 7);
+          expect("  move words  ".moveOffsetUpstreamByWord(7), 2);
+          expect("  move words  ".moveOffsetUpstreamByWord(2), 0);
+          expect("  move words  ".moveOffsetUpstreamByWord(0), null);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(-1),
+              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetUpstreamByWord(15),
+              throwsException);
+        });
       });
     });
 
@@ -46,33 +106,98 @@ void main() {
         expect("a💙c".moveOffsetDownstreamByCharacter(1), 3);
         expect("a💙c".moveOffsetDownstreamByCharacter(3), 4);
         expect("a💙c".moveOffsetDownstreamByCharacter(4), null);
-        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1), throwsException);
-        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5), throwsException);
+        expect(
+            () => "a💙c".moveOffsetDownstreamByCharacter(-1), throwsException);
+        expect(
+            () => "a💙c".moveOffsetDownstreamByCharacter(5), throwsException);
       });
 
       test("2 characters", () {
         expect("a💙c".moveOffsetDownstreamByCharacter(0, characterCount: 2), 3);
         expect("a💙c".moveOffsetDownstreamByCharacter(1, characterCount: 2), 4);
-        expect("a💙c".moveOffsetDownstreamByCharacter(3, characterCount: 2), null);
-        expect("a💙c".moveOffsetDownstreamByCharacter(4, characterCount: 2), null);
-        expect(() => "a💙c".moveOffsetDownstreamByCharacter(-1, characterCount: 2), throwsException);
-        expect(() => "a💙c".moveOffsetDownstreamByCharacter(5, characterCount: 2), throwsException);
+        expect(
+            "a💙c".moveOffsetDownstreamByCharacter(3, characterCount: 2), null);
+        expect(
+            "a💙c".moveOffsetDownstreamByCharacter(4, characterCount: 2), null);
+        expect(
+            () => "a💙c".moveOffsetDownstreamByCharacter(-1, characterCount: 2),
+            throwsException);
+        expect(
+            () => "a💙c".moveOffsetDownstreamByCharacter(5, characterCount: 2),
+            throwsException);
       });
 
-      test("a word", () {
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(0), 4);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(4), 9);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(5), 9);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(6), 9);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(8), 9);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(9), 13);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(11), 13);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(13), 17);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(17), 19);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(18), 19);
-        expect("move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(19), null);
-        expect(() => "move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(-1), throwsException);
-        expect(() => "move a💙c\u{10B3F}wo.rds  ".moveOffsetDownstreamByWord(20), throwsException);
+      group('a word', () {
+        test("separated by space", () {
+          expect("move a💙c words".moveOffsetDownstreamByWord(0), 4);
+          expect("move a💙c words".moveOffsetDownstreamByWord(4), 9);
+          expect("move a💙c words".moveOffsetDownstreamByWord(5), 9);
+          expect("move a💙c words".moveOffsetDownstreamByWord(6), 9);
+          expect("move a💙c words".moveOffsetDownstreamByWord(8), 9);
+          expect("move a💙c words".moveOffsetDownstreamByWord(9), 15);
+          expect("move a💙c words".moveOffsetDownstreamByWord(10), 15);
+          expect("move a💙c words".moveOffsetDownstreamByWord(15), null);
+          expect(() => "move a💙c words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move a💙c words".moveOffsetDownstreamByWord(16),
+              throwsException);
+        });
+
+        test("separated by multiple spaces", () {
+          expect("move   words".moveOffsetDownstreamByWord(0), 4);
+          expect("move   words".moveOffsetDownstreamByWord(4), 12);
+          expect("move   words".moveOffsetDownstreamByWord(5), 12);
+          expect("move   words".moveOffsetDownstreamByWord(12), null);
+          expect(() => "move   words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move   words".moveOffsetDownstreamByWord(13),
+              throwsException);
+        });
+
+        test("separated by punctuation", () {
+          expect("move.words".moveOffsetDownstreamByWord(0), 4);
+          expect("move.words".moveOffsetDownstreamByWord(4), 10);
+          expect("move.words".moveOffsetDownstreamByWord(5), 10);
+          expect("move.words".moveOffsetDownstreamByWord(10), null);
+          expect(() => "move.words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move.words".moveOffsetDownstreamByWord(11),
+              throwsException);
+        });
+
+        test("separated by punctuation and spaces", () {
+          expect("move. words".moveOffsetDownstreamByWord(0), 4);
+          expect("move. words".moveOffsetDownstreamByWord(4), 11);
+          expect("move. words".moveOffsetDownstreamByWord(5), 11);
+          expect("move. words".moveOffsetDownstreamByWord(6), 11);
+          expect("move. words".moveOffsetDownstreamByWord(11), null);
+          expect(() => "move. words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move. words".moveOffsetDownstreamByWord(12),
+              throwsException);
+        });
+
+        test("separated by multi-byte punctuation", () {
+          expect("move\u{10B3F}words".moveOffsetDownstreamByWord(0), 4);
+          expect("move\u{10B3F}words".moveOffsetDownstreamByWord(4), 11);
+          expect("move\u{10B3F}words".moveOffsetDownstreamByWord(6), 11);
+          expect("move\u{10B3F}words".moveOffsetDownstreamByWord(11), null);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(12),
+              throwsException);
+        });
+
+        test("leading and trailing spaces", () {
+          expect("  move words  ".moveOffsetDownstreamByWord(0), 6);
+          expect("  move words  ".moveOffsetDownstreamByWord(1), 6);
+          expect("  move words  ".moveOffsetDownstreamByWord(6), 12);
+          expect("  move words  ".moveOffsetDownstreamByWord(14), null);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(-1),
+              throwsException);
+          expect(() => "move\u{10B3F}words".moveOffsetDownstreamByWord(15),
+              throwsException);
+        });
       });
     });
   });


### PR DESCRIPTION
This PR updates the `CharacterMovement` extension on `String` to fix some bugs and more closely match the behavior of other text editors.

Bugs:

- Currently only space is considered when checking for word breaks, causing the cursor to skip over whitespace created with other Unicode characters. This is fixed by using a regex to match on any characters in the Unicode "Separator" category [^1].
- Currently moving upstream by word does not handle multiple spaces well: it will step through one space at a time until it hits a space immediately after a non-space character, then jump to the beginning of the previous word. This is fixed by changing how previous spaces are counted and when the loop is broken in `moveOffsetUpstreamByWord`.

Behavior changes:

- Most other editors jump to the end of each word when moving downstream and the start when moving upstream. The current behavior kind of does this, with upstream movement jumping by start of word but downstream movement jumping to both the start and end of words, whichever it encounters first on each move. This behavior is updated so downstream movement only considers the end of words.
- Most other editors do not consume punctuation when moving upstream and downstream. This behavior is added by updating the previously mentioned regex to also match characters in the Unicode "Punctuation" category.

Here is a recording of the current behavior:

https://user-images.githubusercontent.com/1316184/156390693-17b78612-a290-4199-9f29-d50ca5481d4d.mov

Here is the behavior with the changes from this PR:

https://user-images.githubusercontent.com/1316184/156390855-61b96a80-92c1-41b8-b9a4-51dbb0b022cc.mov

And here's a recording of the same text/moves in the macOS notes app for reference:

https://user-images.githubusercontent.com/1316184/156391037-a626a874-9a1f-408a-ab3a-6df29ad0ea5c.mov

It's worth noting that this doesn't implement perfect parity with other text editors. I observed inconsistent behavior between different editors regarding repeated punctuation and emoji, which I did not try to replicate here.


[^1]: [Unicode General_Category Values Table](http://www.unicode.org/reports/tr44/#GC_Values_Table)