### PR TITLE
[DO NOT MERGE] Using `customStylePhases`

### DIFF
--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -194,6 +194,8 @@ class HeaderWithHintComponentBuilder implements ComponentBuilder {
       textSelection: componentViewModel.selection,
       selectionColor: componentViewModel.selectionColor,
       showCaret: componentViewModel.caret != null,
+      caretColor: componentViewModel.caretColor,
+      highlightWhenEmpty: componentViewModel.highlightWhenEmpty,
     );
   }
 }
@@ -326,7 +328,8 @@ class ParagraphWithHintStyler extends SingleColumnLayoutStylePhase {
       }
 
       final documentSelection = composer.selection;
-      final shouldShowHintText = documentSelection?.isCollapsed == true;
+      final shouldShowHintText =
+          documentSelection != null && documentSelection.isCollapsed && documentSelection.extent.nodeId == node.id;
 
       return ParagraphWithHintComponentViewModel(
         nodeId: viewModel.nodeId,

--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -167,11 +167,6 @@ class HeaderWithHintComponentBuilder implements ComponentBuilder {
       return null;
     }
 
-    final blockAttribution = componentViewModel.blockType;
-    if (!(const [header1Attribution, header2Attribution, header3Attribution]).contains(blockAttribution)) {
-      return null;
-    }
-
     return TextWithHintComponent(
       key: componentContext.componentKey,
       text: componentViewModel.text,
@@ -325,6 +320,11 @@ class ParagraphWithHintStyler extends SingleColumnLayoutStylePhase {
     final node = document.getNodeById(viewModel.nodeId)!;
 
     if (node is TextNode && viewModel is ParagraphComponentViewModel) {
+      final blockAttribution = viewModel.blockType;
+      if (!(const [header1Attribution, header2Attribution, header3Attribution]).contains(blockAttribution)) {
+        return viewModel;
+      }
+
       final documentSelection = composer.selection;
       final shouldShowHintText = documentSelection?.isCollapsed == true;
 


### PR DESCRIPTION
@matthew-carroll 
This PR intends to implement what we discussed during our call.

It currently applies the behaviour that we intended (hide the hint text whenever the document selection is not collapsed, even when it overlaps with the empty text nodes).

There is one thing that I got wrong somehow which is, the `highlightWhenEmpty` property seems to always false for the header nodes. 

Is this what you had in mind?