### PR TITLE
Bugfix/Fix marketing asset path

### DIFF
--- a/super_editor/README.md
+++ b/super_editor/README.md
@@ -1,4 +1,4 @@
-<img src="doc/marketing/readme-header.png" width="100%" alt="Super Editor">
+<img src="https://raw.githubusercontent.com/superlistapp/super_editor/main/super_editor/doc/marketing/readme-header.png" width="100%" alt="Super Editor">
 
 # Super Editor
 


### PR DESCRIPTION
Presently the marketing asset path in README uses a relative path which works well on GitHub (or in IDE), however on [pub.dev](https://pub.dev/packages/super_editor) it results in an asset not found error:

![Bildschirmfoto 2022-03-16 um 10 00 27](https://user-images.githubusercontent.com/13286425/158553965-22e05505-5e17-408e-9f34-4d800eb995b5.png)

By using the full raw asset path, this will work across GitHub and pub.dev.
