### PR TITLE
Fix typo `composable` in `pubspec.yaml`

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -1,5 +1,5 @@
 name: super_editor
-description: Configurable, composeable, extensible text editor and document renderer for Flutter.
+description: Configurable, composable, extensible text editor and document renderer for Flutter.
 version: 0.2.0
 homepage: https://github.com/superlistapp/super_editor
 


### PR DESCRIPTION
I think `composable` should be the correct word.