### PR TITLE
Fix caret color for horizontal ruler

### DIFF
--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -98,7 +98,7 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
       }
       final showCaret = _shouldDocumentShowCaret && nodeSelection != null ? nodeSelection.isExtent : false;
       final highlightWhenEmpty =
-      nodeSelection == null ? false : nodeSelection.highlightWhenEmpty && _selectionStyles.highlightEmptyTextBlocks;
+          nodeSelection == null ? false : nodeSelection.highlightWhenEmpty && _selectionStyles.highlightEmptyTextBlocks;
 
       editorLayoutLog.finer(' - ${node.id}: $nodeSelection');
       if (showCaret) {
@@ -134,7 +134,7 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
         ..selection = selection
         ..selectionColor = _selectionStyles.selectionColor
         ..caret = _shouldDocumentShowCaret && selection != null && selection.isCollapsed ? selection.extent : null
-        ..caretColor = _selectionStyles.selectionColor;
+        ..caretColor = _selectionStyles.caretColor;
     }
 
     return viewModel;


### PR DESCRIPTION
Use SelectionStyles.caretColor instead of SelectionStyles.selectionColor for the caret color of a horizontal ruler.

Fixes #482 