### PR TITLE
Bugfix: header2 wasn't being applied on mobile

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -1165,7 +1165,7 @@ class KeyboardEditingToolbar extends StatelessWidget {
                               IconButton(
                                 onPressed: isSingleNodeSelected &&
                                         (selectedNode is TextNode &&
-                                            selectedNode.getMetadataValue('blockType') == header2Attribution)
+                                            selectedNode.getMetadataValue('blockType') != header2Attribution)
                                     ? _convertToHeader2
                                     : null,
                                 icon: const Icon(Icons.title),


### PR DESCRIPTION
H2's were not being applied properly due to an incorrect boolean check in the document IME toolbar.