### PR TITLE
Trying to fix mono repo path issues

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -41,9 +41,13 @@ dependencies:
   uuid: ^3.0.3
 
   super_editor:
-    path: ../
+    git:
+      url: https://github.com/superlistapp/super_editor.git
+      path: super_editor
   super_editor_markdown:
-    path: ../../super_editor_markdown
+    git:
+      url: https://github.com/superlistapp/super_editor.git
+      path: super_editor_markdown
 
 dev_dependencies:
   flutter_test:

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '../core/document_layout.dart';
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -14,7 +14,7 @@ import 'package:super_editor/src/infrastructure/platforms/android/magnifier.dart
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import 'document_gestures.dart';
 import 'document_gestures_touch.dart';

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -15,7 +15,7 @@ import 'package:super_editor/src/infrastructure/platforms/ios/magnifier.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import 'document_gestures.dart';
 import 'document_gestures_touch.dart';

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -17,7 +17,7 @@ import 'package:super_editor/src/infrastructure/composable_text.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/raw_key_event_extensions.dart';
 import 'package:super_editor/src/infrastructure/strings.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import 'document_input_keyboard.dart';
 import 'layout_single_column/layout_single_column.dart';

--- a/super_editor/lib/src/infrastructure/platforms/ios/selection_handles.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/selection_handles.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 /// An iOS-style text selection handle.
 ///

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_caret.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_caret.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 /// Factory that creates an Android-style caret to be displayed in
 /// a [SuperSelectableText] widget.

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
@@ -10,7 +10,7 @@ import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/a
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 final _log = androidTextFieldLog;
 

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '_editing_controls.dart';
 

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/android/_editing_controls.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/android/_user_interaction.dart';
 import 'package:super_editor/super_editor.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 export '_caret.dart';
 export '../../platforms/android/selection_handles.dart';

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -12,7 +12,7 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/hint_text.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '../../keyboard.dart';
 import '../../multi_tap_gesture.dart';

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 class AttributedTextEditingController with ChangeNotifier {
   AttributedTextEditingController({

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 final _log = scrollingTextFieldLog;
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_caret.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_caret.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 /// [TextCaretFactory] that creates an [IOSTextFieldCaret], which
 /// paints a blinking iOS-style caret on top of a [SuperSelectableText].

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_editing_controls.dart
@@ -6,7 +6,7 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/magnifier.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 final _log = iosTextFieldLog;
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 /// An iOS floating cursor.
 ///

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '_editing_controls.dart';
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -10,7 +10,7 @@ import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/h
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/ios/_editing_controls.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '../../platforms/ios/toolbar.dart';
 import '_caret.dart';

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -8,7 +8,7 @@ import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/a
 import 'package:super_editor/src/infrastructure/super_textfield/infrastructure/hint_text.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/ios/ios_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '../../default_editor/attributions.dart';
 

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -1,7 +1,7 @@
 library super_editor;
 
 export 'package:attributed_text/attributed_text.dart';
-export 'package:super_selectable_text/super_selectable_text.dart';
+export 'package:super_text/super_selectable_text.dart';
 export 'src/infrastructure/attributed_text_styles.dart';
 export 'src/infrastructure/super_textfield/super_textfield.dart';
 export 'src/infrastructure/_listenable_builder.dart';

--- a/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
-import 'package:super_selectable_text/super_selectable_text.dart';
+import 'package:super_text/super_selectable_text.dart';
 
 import '../../../_text_entry_test_tools.dart';
 import '../../_platform_test_tools.dart';


### PR DESCRIPTION
Trying to fix mono repo path issues. My previous rename of `super_selectable_text` to `super_text` seemed to work locally before the PR, but now it's broken on my machine. Hopefully this fixes it.