### PR TITLE
Added local dependency overrides to all packages in the repo to allow for local dev

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -49,6 +49,15 @@ dependencies:
       url: https://github.com/superlistapp/super_editor.git
       path: super_editor_markdown
 
+dependency_overrides:
+  # Override to local mono-repo path so devs can test this repo
+  # against changes that they're making to other mono-repo packages
+  super_editor:
+    path: ../../super_editor
+  super_editor_markdown:
+    path: ../../super_editor_markdown
+
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -25,6 +25,12 @@ dependencies:
       path: super_text
   uuid: ^3.0.3
 
+dependency_overrides:
+  # Override to local mono-repo path so devs can test this repo
+  # against changes that they're making to other mono-repo packages
+  super_text:
+    path: ../super_text
+
 dev_dependencies:
   golden_toolkit: ^0.11.0
   mockito: ^5.0.4

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -19,6 +19,12 @@ dependencies:
   logging: ^1.0.1
   markdown: ^4.0.0
 
+dependency_overrides:
+  # Override to local mono-repo path so devs can test this repo
+  # against changes that they're making to other mono-repo packages
+  super_editor:
+    path: ../super_editor
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/super_text/pubspec.yaml
+++ b/super_text/pubspec.yaml
@@ -18,6 +18,12 @@ dependencies:
   flutter_lints: ^1.0.0
   logging: ^1.0.1
 
+dependency_overrides:
+  # Override to local mono-repo path so devs can test this repo
+  # against changes that they're making to other mono-repo packages
+  attributed_text:
+    path: ../attributed_text
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Added local dependency overrides to all packages in the repo to allow for local dev.

The problem we're solving is this:

1. We split super_editor into multiple packages in a mono-repo: attributed_text, super_text, super_text_markdown.
2. Pub.dev won't let us specify local path dependencies. Instead, for example, super_editor must depend upon a public version of super_text.
3. We need to develop against multiple packages at the same time. For example, we make a change to super_text and then we need to demo that change in super_editor. But super_editor is using the published version of super_text, not the local one.

By adding dependency overrides with local paths, developers can run each package against the other local packages during development, while we continue to satisfy pub.dev's requirement that we use public release dependencies for all other situations.

In the longer term, we should investigate the Melos package, which might provide a number of mono-repo benefits. This change is intended as a quick solution to a problem that's breaking tests and requiring local developer changes to run the example app.