### PR TITLE
[attributed_text] - added LICENSE and CHANGELOG

### DIFF
--- a/attributed_text/CHANGELOG.md
+++ b/attributed_text/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [0.1.0] - April 2, 2022
+
+The first release of attributed_text, which was extracted from super_editor.

--- a/attributed_text/LICENSE
+++ b/attributed_text/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2021 Superlist, SuperDeclarative! and the contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   characters: ^1.2.0
+  collection: ^1.16.0
   flutter_lints: ^1.0.0
   logging: ^1.0.1
   test: ^1.19.4


### PR DESCRIPTION
Preparing `attributed_text` for release by adding LICENSE and CHANGELOG