### PR TITLE
Add link support to markdown serialization

### DIFF
--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -132,8 +132,19 @@ Document _createInitialDocument() {
       ListItemNode.unordered(
         id: DocumentEditor.createNodeId(),
         text: AttributedText(
-          text: 'This is a 3rd list item',
-        ),
+            text: 'This is a 3rd list item, with a link',
+            spans: AttributedSpans(
+              attributions: [
+                SpanMarker(
+                    attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                    offset: 30,
+                    markerType: SpanMarkerType.start),
+                SpanMarker(
+                    attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                    offset: 35,
+                    markerType: SpanMarkerType.end),
+              ],
+            )),
       ),
       ParagraphNode(
         id: DocumentEditor.createNodeId(),

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -172,7 +172,8 @@ This is some code
         ]);
 
         expect(serializeDocumentToMarkdown(doc).trim(), 'This ***is a** paragraph*.');
-      }, skip: "Markdown serialization does not currently support intersecting styles");
+      }, skip: '''Markdown serialization is currently broken for intersecting styles.
+                  See https://github.com/superlistapp/super_editor/issues/526''');
 
       test('paragraph with overlapping code and bold', () {
         final doc = MutableDocument(nodes: [
@@ -257,22 +258,23 @@ This is some code
                 attributions: [
                   SpanMarker(
                       attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 10,
+                      offset: 0,
                       markerType: SpanMarkerType.start),
                   SpanMarker(
                       attribution: LinkAttribution(url: Uri.https('example.org', '')),
                       offset: 18,
                       markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 18, markerType: SpanMarkerType.end),
+                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [**paragraph**](https://example.org).');
-      }, skip: "Markdown serialization does not currently support intersecting styles");
+        expect(serializeDocumentToMarkdown(doc).trim(), '[This **is a** paragraph](https://example.org).');
+      }, skip: '''Markdown serialization is currently broken for intersecting styles.
+                  See https://github.com/superlistapp/super_editor/issues/526''');
 
       test('image', () {
         final doc = MutableDocument(nodes: [

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -153,6 +153,27 @@ This is some code
         expect(serializeDocumentToMarkdown(doc).trim(), 'This ***is a*** paragraph.');
       });
 
+      test('paragraph with intersecting bold and italics', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
+                  const SpanMarker(attribution: italicsAttribution, offset: 5, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc).trim(), 'This ***is a** paragraph*.');
+      }, skip: "Markdown serialization does not currently support intersecting styles");
+
       test('paragraph with overlapping code and bold', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -173,6 +194,85 @@ This is some code
 
         expect(serializeDocumentToMarkdown(doc).trim(), 'This `**is a**` paragraph.');
       });
+
+      test('paragraph with link', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 10,
+                      markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 18,
+                      markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [paragraph](https://example.org).');
+      });
+
+      test('paragraph with link overlapping style', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 10,
+                      markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 18,
+                      markerType: SpanMarkerType.end),
+                  const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: boldAttribution, offset: 18, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [**paragraph**](https://example.org).');
+      });
+
+      test('paragraph with link intersecting style', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 10,
+                      markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 18,
+                      markerType: SpanMarkerType.end),
+                  const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: boldAttribution, offset: 18, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [**paragraph**](https://example.org).');
+      }, skip: "Markdown serialization does not currently support intersecting styles");
 
       test('image', () {
         final doc = MutableDocument(nodes: [


### PR DESCRIPTION
Resolves #489 

Adds basic link support to markdown serialization. As implemented, links can completely overlap with other attributes, but a partial intersection will break the link into two, such as the following:
`*test [link* text](https://link.com)` would instead be serialized as `*test *[*link*](https://link.com)[ text](https://link.com)` 
I decided to put the PR up anyway with this behaviour since it's consistent(ly broken) with the other markdown styles, which would require a much more significant change to resolve and seemed out of scope of the original issue.