### PR TITLE
Switched super_text dependency on attributed_text from GitHub to Pub.dev

### DIFF
--- a/attributed_text/CHANGELOG.md
+++ b/attributed_text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1] - April 4, 2022
+
+Downgraded `collection` from `1.16.0` to `1.15.0` because `flutter_test` is pinned to `1.15.0`
+
 ## [0.1.0] - April 2, 2022
 
 The first release of attributed_text, which was extracted from super_editor.

--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: attributed_text
 description: Text with metadata spans for easy text editing and styling.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   characters: ^1.2.0
-  collection: ^1.16.0
+  collection: ^1.15.0
   flutter_lints: ^1.0.0
   logging: ^1.0.1
   test: ^1.19.4

--- a/super_text/pubspec.yaml
+++ b/super_text/pubspec.yaml
@@ -11,10 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  attributed_text:
-    git:
-      url: https://github.com/superlistapp/super_editor.git
-      path: attributed_text
+  attributed_text: 0.1.1
   flutter_lints: ^1.0.0
   logging: ^1.0.1
 


### PR DESCRIPTION
Switched `super_text` dependency on attributed_text from GitHub to Pub.dev

Also, this PR includes release 0.1.1 for `attributed_text` because apparently it was using a version of `collection` that's incompatible with Flutter, so I downgraded that dependency within `attributed_text`.