### PR TITLE
fix toolbar location when there are multiple editors in one screen

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -151,8 +151,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
           .getRectForSelection(_composer.selection!.base, _composer.selection!.extent)!;
       final docBox = _docLayoutKey.currentContext!.findRenderObject() as RenderBox;
       final overlayBoundingBox = Rect.fromPoints(
-        docBox.localToGlobal(docBoundingBox.topLeft, ancestor: context.findRenderObject()),
-        docBox.localToGlobal(docBoundingBox.bottomRight, ancestor: context.findRenderObject()),
+        docBox.localToGlobal(docBoundingBox.topLeft),
+        docBox.localToGlobal(docBoundingBox.bottomRight),
       );
 
       _textSelectionAnchor.value = overlayBoundingBox.topCenter;
@@ -252,8 +252,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
           .getRectForSelection(_composer.selection!.base, _composer.selection!.extent)!;
       final docBox = _docLayoutKey.currentContext!.findRenderObject() as RenderBox;
       final overlayBoundingBox = Rect.fromPoints(
-        docBox.localToGlobal(docBoundingBox.topLeft, ancestor: context.findRenderObject()),
-        docBox.localToGlobal(docBoundingBox.bottomRight, ancestor: context.findRenderObject()),
+        docBox.localToGlobal(docBoundingBox.topLeft),
+        docBox.localToGlobal(docBoundingBox.bottomRight),
       );
 
       _imageSelectionAnchor.value = overlayBoundingBox.center;


### PR DESCRIPTION
Fix default toolbar location when there are multiple editors on one screen (Resolves #486 )

When there are multiple editors on one screen, the toolbar in `example_editor.dart` is not displayed correctly, as other editors except the first editor shows the toolbar based on the position of the first editor. This PR fixes the above issue, as displayed below.

This PR does not affect the `super_editor` components, but rather gives the user a better default implementation in the example file.

The PR is created thanks to hillelcoren. 

MacOS:
![image](https://user-images.githubusercontent.com/102536904/161941012-304a0ebe-a071-4d8f-8f61-117a8eaa2613.png)
