### PR TITLE
Fix Auto-scroll in CustomScrollView, and Android Editor in CustomScrollView (resolve #521)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -220,9 +220,9 @@ class DragHandleAutoScroller {
   final RenderBox Function() _getViewportBox;
 
   /// Jumps to a scroll offset so that the given [offsetInViewport] is
-  /// visible within the viewport.
+  /// visible within the viewport boundary.
   ///
-  /// Does nothing, if the given [offsetInViewport] is already visible within the boundary.
+  /// Does nothing, if the given [offsetInViewport] is already visible within the viewport boundary.
   void ensureOffsetIsVisible(Offset offsetInViewport) {
     editorGesturesLog.fine("Ensuring content offset is visible in scrollable: $offsetInViewport");
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -226,7 +226,7 @@ class DragHandleAutoScroller {
   /// which is used to calculate the scrolling distance
   ///
   /// Does nothing, if the given [documentOffset] is already visible.
-  void ensureOffsetIsVisible(Offset documentOffset, Offset docGlobalOffset) {
+  void ensureOffsetIsVisible(Offset documentOffset, Offset editorOffset) {
     editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $documentOffset");
 
     final scrollPosition = _getScrollPosition();
@@ -236,13 +236,13 @@ class DragHandleAutoScroller {
     if (documentOffset.dy < currentScrollOffset) {
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
       scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading);
-    } else if (documentOffset.dy > _getViewportBox().size.height - docGlobalOffset.dy) {
+    } else if (documentOffset.dy > _getViewportBox().size.height - editorOffset.dy) {
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(
         documentOffset.dy +
             _dragAutoScrollBoundary.trailing -
             _getViewportBox().size.height +
-            (docGlobalOffset.dy + currentScrollOffset),
+            (editorOffset.dy + currentScrollOffset),
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -222,8 +222,11 @@ class DragHandleAutoScroller {
   /// Jumps to a scroll offset so that the given [documentOffset] is visible within the
   /// scrollable.
   ///
+  /// The [editorOffset] is used to determine offset of from editor from its `Scrollable` e.g [CustomScrollView]
+  /// which is used to calculate the scrolling distance
+  ///
   /// Does nothing, if the given [documentOffset] is already visible.
-  void ensureOffsetIsVisible(Offset documentOffset) {
+  void ensureOffsetIsVisible(Offset documentOffset, Offset docGlobalOffset) {
     editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $documentOffset");
 
     final scrollPosition = _getScrollPosition();
@@ -233,9 +236,14 @@ class DragHandleAutoScroller {
     if (documentOffset.dy < currentScrollOffset) {
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
       scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading);
-    } else if (documentOffset.dy > _getViewportBox().size.height + currentScrollOffset) {
+    } else if (documentOffset.dy > _getViewportBox().size.height - docGlobalOffset.dy) {
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
-      scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.trailing - _getViewportBox().size.height);
+      scrollPosition.jumpTo(
+        documentOffset.dy +
+            _dragAutoScrollBoundary.trailing -
+            _getViewportBox().size.height +
+            (docGlobalOffset.dy + currentScrollOffset),
+      );
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -219,32 +219,32 @@ class DragHandleAutoScroller {
   /// that this auto-scroller controls.
   final RenderBox Function() _getViewportBox;
 
-  /// Jumps to a scroll offset so that the given [documentOffset] is visible within the
-  /// scrollable.
+  /// Jumps to a scroll offset so that the given [contentOffset] is visible
+  /// within the viewport.
   ///
-  /// The [editorToViewportOffset] determines the offset from editor to its [Scrollable]
-  /// which is used to calculate the scrolling distance
+  /// Let's consider the triggering condition as an inequality. The position to
+  /// jump to is the difference between the first expression and the second one,
+  /// added with the current scroll offset
   ///
-  /// Does nothing, if the given [documentOffset] is already visible.
-  void ensureOffsetIsVisible(Offset documentOffset, Offset editorToViewportOffset) {
-    editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $documentOffset");
+  /// Does nothing, if the given [contentOffset] is already visible.
+  void ensureOffsetIsVisible(Offset contentOffset) {
+    editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $contentOffset");
 
     final scrollPosition = _getScrollPosition();
     final currentScrollOffset = scrollPosition.pixels;
     editorGesturesLog.fine("Current scroll offset: $currentScrollOffset");
 
-    final viewportOffset = _getViewportBox().localToGlobal(Offset.zero);
-
-    if (documentOffset.dy < currentScrollOffset - viewportOffset.dy) {
+    if (contentOffset.dy < _dragAutoScrollBoundary.leading) {
+      // Ensure the handle is below the viewport with the leading boundary
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
-      scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading + viewportOffset.dy);
-    } else if (documentOffset.dy > _getViewportBox().size.height + editorToViewportOffset.dy) {
+      scrollPosition.jumpTo(
+        contentOffset.dy - _dragAutoScrollBoundary.leading + currentScrollOffset,
+      );
+    } else if (contentOffset.dy > _getViewportBox().size.height - _dragAutoScrollBoundary.trailing) {
+      // Ensure the handle is above the viewport with the trailing boundary
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(
-        documentOffset.dy +
-            _dragAutoScrollBoundary.trailing -
-            _getViewportBox().size.height +
-            (currentScrollOffset - editorToViewportOffset.dy),
+        contentOffset.dy - (_getViewportBox().size.height - _dragAutoScrollBoundary.trailing) + currentScrollOffset,
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -219,34 +219,31 @@ class DragHandleAutoScroller {
   /// that this auto-scroller controls.
   final RenderBox Function() _getViewportBox;
 
-  /// Jumps to a scroll offset so that the given [contentToViewportOffset] is
+  /// Jumps to a scroll offset so that the given [offsetInViewport] is
   /// visible within the viewport.
   ///
-  /// Let's consider the triggering condition as an inequality. The position to
-  /// jump to is the difference between the first expression and the second one,
-  /// added with the current scroll offset
-  ///
-  /// Does nothing, if the given [contentToViewportOffset] is already visible.
-  void ensureOffsetIsVisible(Offset contentToViewportOffset) {
-    editorGesturesLog.fine("Ensuring content offset is visible in scrollable: $contentToViewportOffset");
+  /// Does nothing, if the given [offsetInViewport] is already visible within the boundary.
+  void ensureOffsetIsVisible(Offset offsetInViewport) {
+    editorGesturesLog.fine("Ensuring content offset is visible in scrollable: $offsetInViewport");
 
     final scrollPosition = _getScrollPosition();
     final currentScrollOffset = scrollPosition.pixels;
     editorGesturesLog.fine("Current scroll offset: $currentScrollOffset");
 
-    if (contentToViewportOffset.dy < _dragAutoScrollBoundary.leading) {
-      // Ensure the handle is below the viewport with the leading boundary
+    if (offsetInViewport.dy < _dragAutoScrollBoundary.leading) {
+      // The offset is above the leading boundary. We need to scroll up
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
+      // Jump to the position where the offset sits at the leading boundary
       scrollPosition.jumpTo(
-        contentToViewportOffset.dy - _dragAutoScrollBoundary.leading + currentScrollOffset,
+        currentScrollOffset + (offsetInViewport.dy - _dragAutoScrollBoundary.leading),
       );
-    } else if (contentToViewportOffset.dy > _getViewportBox().size.height - _dragAutoScrollBoundary.trailing) {
-      // Ensure the handle is above the viewport with the trailing boundary
+    } else if (offsetInViewport.dy > _getViewportBox().size.height - _dragAutoScrollBoundary.trailing) {
+      // The offset is below the trailing boundary. We need to scroll down
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
+      // Jump to the position where the offset sits at the trailing boundary
       scrollPosition.jumpTo(
-        contentToViewportOffset.dy -
-            (_getViewportBox().size.height - _dragAutoScrollBoundary.trailing) +
-            currentScrollOffset,
+        currentScrollOffset +
+            (offsetInViewport.dy - (_getViewportBox().size.height - _dragAutoScrollBoundary.trailing)),
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -222,27 +222,29 @@ class DragHandleAutoScroller {
   /// Jumps to a scroll offset so that the given [documentOffset] is visible within the
   /// scrollable.
   ///
-  /// The [editorOffset] is used to determine offset of from editor from its `Scrollable` e.g [CustomScrollView]
+  /// The [editorToViewportOffset] determines the offset from editor to its [Scrollable]
   /// which is used to calculate the scrolling distance
   ///
   /// Does nothing, if the given [documentOffset] is already visible.
-  void ensureOffsetIsVisible(Offset documentOffset, Offset editorOffset) {
+  void ensureOffsetIsVisible(Offset documentOffset, Offset editorToViewportOffset) {
     editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $documentOffset");
 
     final scrollPosition = _getScrollPosition();
     final currentScrollOffset = scrollPosition.pixels;
     editorGesturesLog.fine("Current scroll offset: $currentScrollOffset");
 
-    if (documentOffset.dy < currentScrollOffset) {
+    final viewportOffset = _getViewportBox().localToGlobal(Offset.zero);
+
+    if (documentOffset.dy < currentScrollOffset - viewportOffset.dy) {
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
       scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading);
-    } else if (documentOffset.dy > _getViewportBox().size.height + editorOffset.dy) {
+    } else if (documentOffset.dy > _getViewportBox().size.height + editorToViewportOffset.dy) {
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(
         documentOffset.dy +
             _dragAutoScrollBoundary.trailing -
             _getViewportBox().size.height +
-            (currentScrollOffset - editorOffset.dy),
+            (currentScrollOffset - editorToViewportOffset.dy),
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -237,7 +237,7 @@ class DragHandleAutoScroller {
 
     if (documentOffset.dy < currentScrollOffset - viewportOffset.dy) {
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
-      scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading);
+      scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading + viewportOffset.dy);
     } else if (documentOffset.dy > _getViewportBox().size.height + editorToViewportOffset.dy) {
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -219,32 +219,34 @@ class DragHandleAutoScroller {
   /// that this auto-scroller controls.
   final RenderBox Function() _getViewportBox;
 
-  /// Jumps to a scroll offset so that the given [contentOffset] is visible
-  /// within the viewport.
+  /// Jumps to a scroll offset so that the given [contentToViewportOffset] is
+  /// visible within the viewport.
   ///
   /// Let's consider the triggering condition as an inequality. The position to
   /// jump to is the difference between the first expression and the second one,
   /// added with the current scroll offset
   ///
-  /// Does nothing, if the given [contentOffset] is already visible.
-  void ensureOffsetIsVisible(Offset contentOffset) {
-    editorGesturesLog.fine("Ensuring document offset is visible in scrollable: $contentOffset");
+  /// Does nothing, if the given [contentToViewportOffset] is already visible.
+  void ensureOffsetIsVisible(Offset contentToViewportOffset) {
+    editorGesturesLog.fine("Ensuring content offset is visible in scrollable: $contentToViewportOffset");
 
     final scrollPosition = _getScrollPosition();
     final currentScrollOffset = scrollPosition.pixels;
     editorGesturesLog.fine("Current scroll offset: $currentScrollOffset");
 
-    if (contentOffset.dy < _dragAutoScrollBoundary.leading) {
+    if (contentToViewportOffset.dy < _dragAutoScrollBoundary.leading) {
       // Ensure the handle is below the viewport with the leading boundary
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
       scrollPosition.jumpTo(
-        contentOffset.dy - _dragAutoScrollBoundary.leading + currentScrollOffset,
+        contentToViewportOffset.dy - _dragAutoScrollBoundary.leading + currentScrollOffset,
       );
-    } else if (contentOffset.dy > _getViewportBox().size.height - _dragAutoScrollBoundary.trailing) {
+    } else if (contentToViewportOffset.dy > _getViewportBox().size.height - _dragAutoScrollBoundary.trailing) {
       // Ensure the handle is above the viewport with the trailing boundary
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(
-        contentOffset.dy - (_getViewportBox().size.height - _dragAutoScrollBoundary.trailing) + currentScrollOffset,
+        contentToViewportOffset.dy -
+            (_getViewportBox().size.height - _dragAutoScrollBoundary.trailing) +
+            currentScrollOffset,
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -236,13 +236,13 @@ class DragHandleAutoScroller {
     if (documentOffset.dy < currentScrollOffset) {
       editorGesturesLog.fine("The scrollable needs to scroll up to make offset visible.");
       scrollPosition.jumpTo(documentOffset.dy + _dragAutoScrollBoundary.leading);
-    } else if (documentOffset.dy > _getViewportBox().size.height - editorOffset.dy) {
+    } else if (documentOffset.dy > _getViewportBox().size.height + editorOffset.dy) {
       editorGesturesLog.fine('The scrollable needs to scroll down to make offset visible.');
       scrollPosition.jumpTo(
         documentOffset.dy +
             _dragAutoScrollBoundary.trailing -
             _getViewportBox().size.height +
-            (editorOffset.dy + currentScrollOffset),
+            (currentScrollOffset - editorOffset.dy),
       );
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -249,6 +249,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   }
 
   void _ensureSelectionExtentIsVisible() {
+    editorGesturesLog.fine("Ensuring selection extent is visible");
     final collapsedHandleOffset = _editingController.collapsedHandleOffset;
     final extentHandleOffset = _editingController.downstreamHandleOffset;
     if (collapsedHandleOffset == null && extentHandleOffset == null) {
@@ -256,22 +257,21 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    // Determines the offset from the editor to the viewport
+    // Determines the offset of the editor in the viewport coordinate
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-    final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
+    final editorInViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
-    // Determines the offset from the bottom of the handle to the viewport
-    late Offset handleToViewportOffset;
+    // Determines the offset of the bottom of the handle in the viewport coordinate
+    late Offset handleInViewportOffset;
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      handleToViewportOffset = collapsedHandleOffset - editorToViewportOffset;
-      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
+      handleInViewportOffset = collapsedHandleOffset - editorInViewportOffset;
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      handleToViewportOffset = extentHandleOffset! - editorToViewportOffset;
-      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
+      handleInViewportOffset = extentHandleOffset! - editorInViewportOffset;
     }
+    _handleAutoScrolling.ensureOffsetIsVisible(handleInViewportOffset);
   }
 
   void _onFocusChange() {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -261,7 +261,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
     final editorInViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
-    // Determines the offset of the bottom of the handle in the viewport coordinate
+    // Determines the offset of the handle in the viewport coordinate
     late Offset handleInViewportOffset;
 
     if (collapsedHandleOffset != null) {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -258,7 +258,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     // Determine offset from the editor to the current viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-    final editorToViewportOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
+    final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -256,16 +256,16 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
+    // Determine offset from the editor to the current viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-
-    final editorOffset = editorBox.globalToLocal(Offset.zero) - viewportBox.globalToLocal(Offset.zero);
+    final editorToViewportOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorToViewportOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorToViewportOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -258,7 +258,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
 
-    final editorOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
+    final editorOffset = editorBox.globalToLocal(Offset.zero) - viewportBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -256,8 +256,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    final editorOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
-        .localToGlobal(viewportBox.globalToLocal(Offset.zero));
+    final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
+
+    final editorOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
@@ -684,6 +685,8 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     // Calculate the new (x,y) offset for the collapsed handle.
     final extentRect = _docLayout.getRectForPosition(selection.extent);
     late Offset handleOffset = extentRect!.bottomLeft;
+
+    editorGesturesLog.fine('handleOffset: $handleOffset');
 
     _editingController
       ..collapsedHandleOffset = handleOffset

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -148,6 +148,8 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void didChangeDependencies() {
     super.didChangeDependencies();
 
+    _ancestorScrollPosition = Scrollable.of(context)?.position;
+
     // On the next frame, check if our active scroll position changed to a
     // different instance. If it did, move our listener to the new one.
     //

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -686,8 +686,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     final extentRect = _docLayout.getRectForPosition(selection.extent);
     late Offset handleOffset = extentRect!.bottomLeft;
 
-    editorGesturesLog.fine('handleOffset: $handleOffset');
-
     _editingController
       ..collapsedHandleOffset = handleOffset
       ..unHideCollapsedHandle()

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -254,13 +254,13 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    final docGlobalOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
+    final editorOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
         .localToGlobal(viewportBox.globalToLocal(Offset.zero));
 
     if (collapsedHandleOffset != null) {
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, docGlobalOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
     } else {
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, docGlobalOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -261,8 +261,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     final editorOffset = editorBox.globalToLocal(Offset.zero) - viewportBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
+      editorGesturesLog.fine("The selection is collapsed");
       _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
     } else {
+      editorGesturesLog.fine("The selection is expanded");
       _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorOffset);
     }
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -256,16 +256,21 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    // Determine offset from the editor to the current viewport
+    // Determines the offset from the editor to the viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
     final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
+    // Determines the offset from the bottom of the handle to the viewport
+    late Offset handleToViewportOffset;
+
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorToViewportOffset);
+      handleToViewportOffset = collapsedHandleOffset - editorToViewportOffset;
+      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorToViewportOffset);
+      handleToViewportOffset = extentHandleOffset! - editorToViewportOffset;
+      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -254,10 +254,13 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
+    final docGlobalOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
+        .localToGlobal(viewportBox.globalToLocal(Offset.zero));
+
     if (collapsedHandleOffset != null) {
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, docGlobalOffset);
     } else {
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, docGlobalOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -272,7 +272,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
 
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
 
-    final editorOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
+    final editorOffset = editorBox.globalToLocal(Offset.zero) - viewportBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,15 +270,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
-    final docGlobalOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
+    final editorOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
         .localToGlobal(viewportBox.globalToLocal(Offset.zero));
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, docGlobalOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, docGlobalOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,6 +270,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
+    // Determine offset from the editor to the current viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
     final editorToViewportOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -272,7 +272,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
 
     // Determine offset from the editor to the current viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-    final editorToViewportOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
+    final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,22 +270,21 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
-    // Determines the offset from the editor to the viewport
+    // Determines the offset of the editor in the viewport coordinate
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-    final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
+    final editorInViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
-    // Determines the offset from the bottom of the handle to the viewport
-    late Offset handleToViewportOffset;
+    // Determines the offset of the bottom of the handle in the viewport coordinate
+    late Offset handleInViewportOffset;
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      handleToViewportOffset = collapsedHandleOffset - editorToViewportOffset;
-      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
+      handleInViewportOffset = collapsedHandleOffset - editorInViewportOffset;
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      handleToViewportOffset = extentHandleOffset! - editorToViewportOffset;
-      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
+      handleInViewportOffset = extentHandleOffset! - editorInViewportOffset;
     }
+    _handleAutoScrolling.ensureOffsetIsVisible(handleInViewportOffset);
   }
 
   void _onFocusChange() {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -271,15 +271,14 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     }
 
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
-
-    final editorOffset = editorBox.globalToLocal(Offset.zero) - viewportBox.globalToLocal(Offset.zero);
+    final editorToViewportOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorToViewportOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorToViewportOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,8 +270,9 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
-    final editorOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
-        .localToGlobal(viewportBox.globalToLocal(Offset.zero));
+    final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
+
+    final editorOffset = viewportBox.globalToLocal(Offset.zero) - editorBox.globalToLocal(Offset.zero);
 
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,12 +270,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
+    final docGlobalOffset = (widget.documentKey.currentContext!.findRenderObject() as RenderBox)
+        .localToGlobal(viewportBox.globalToLocal(Offset.zero));
+
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset);
+      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, docGlobalOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!);
+      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, docGlobalOffset);
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -270,16 +270,21 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       return;
     }
 
-    // Determine offset from the editor to the current viewport
+    // Determines the offset from the editor to the viewport
     final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
     final editorToViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
+    // Determines the offset from the bottom of the handle to the viewport
+    late Offset handleToViewportOffset;
+
     if (collapsedHandleOffset != null) {
       editorGesturesLog.fine("The selection is collapsed");
-      _handleAutoScrolling.ensureOffsetIsVisible(collapsedHandleOffset, editorToViewportOffset);
+      handleToViewportOffset = collapsedHandleOffset - editorToViewportOffset;
+      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
     } else {
       editorGesturesLog.fine("The selection is expanded");
-      _handleAutoScrolling.ensureOffsetIsVisible(extentHandleOffset!, editorToViewportOffset);
+      handleToViewportOffset = extentHandleOffset! - editorToViewportOffset;
+      _handleAutoScrolling.ensureOffsetIsVisible(handleToViewportOffset);
     }
   }
 

--- a/super_editor/test/src/_document_test_tools.dart
+++ b/super_editor/test/src/_document_test_tools.dart
@@ -1,5 +1,4 @@
 import 'package:mockito/mockito.dart';
-import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/super_editor.dart';
 
 /// Fake [DocumentLayout], intended for tests that interact with
@@ -28,5 +27,49 @@ EditContext createEditContext({
           composer: composer,
           documentLayoutResolver: layoutResolver,
         ),
+  );
+}
+
+Document createExampleDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text: 'Example Document',
+        ),
+        metadata: {
+          'blockType': header1Attribution,
+        },
+      ),
+      HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+            text:
+                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: DocumentEditor.createNodeId(),
+        text: AttributedText(
+          text:
+              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+        ),
+      ),
+    ],
   );
 }

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -17,8 +17,11 @@ void main() {
           var screenHeight = 844.0;
           const screenWidth = 390.0;
 
-          const frameCount = 60;
-          const shrinkPerFrame = 5.0;
+          // TODO: Figure out why changing the [shrinkPerFrame] and/or [frameCount]
+          // could result in the final actual scroll offset is smaller than the expected scroll offset
+          // by a fraction of [shrinkPerFrame]
+          const frameCount = 5;
+          const shrinkPerFrame = 60.0;
 
           // The position should be in the middle bottom of the screen, so that
           // if the document is layed out properly, tapping this position should place a caret to the document.
@@ -50,7 +53,28 @@ void main() {
             screenHeight,
           );
 
-          expect(scrollController.offset, greaterThanOrEqualTo(tapPosition.dy - screenHeight));
+          final handleFinder = find.byType(BlinkingCaret);
+          final handleBox = handleFinder.evaluate().last.findRenderObject() as RenderBox;
+
+          final editorFinder = find.byType(SuperEditor);
+          final editorBox = editorFinder.evaluate().first.findRenderObject() as RenderBox;
+
+          final documentOffset = handleBox.localToGlobal(editorBox.globalToLocal(Offset.zero));
+
+          // Determine the caret's height. Related to the position of the tapped caret and the document
+          const lineHeight = 18;
+
+          // Dy from the SuperEditor to its Scrollable parent
+          const editorOffsetDy = 212.0;
+
+          // DragAutoScrollBoundary.trailing of default_editor in [AndroidDocumentTouchInteractor]
+          const dragAutoScrollBoundary = 54.0;
+
+          // The math was taken from [ensureOffsetIsVisible] in [document_gestures_touch.dart]
+          expect(
+            scrollController.offset,
+            equals((documentOffset.dy + lineHeight) + dragAutoScrollBoundary - screenHeight + editorOffsetDy),
+          );
         });
       });
       group('iOS', () {
@@ -63,8 +87,11 @@ void main() {
           var screenHeight = 844.0;
           const screenWidth = 390.0;
 
-          const frameCount = 60;
-          const shrinkPerFrame = 5.0;
+          // TODO: Figure out why changing the [shrinkPerFrame] and/or [frameCount]
+          // could result in the final actual scroll offset is smaller than the expected scroll offset
+          // by a fraction of [shrinkPerFrame]
+          const frameCount = 5;
+          const shrinkPerFrame = 60.0;
 
           // The position should be in the middle bottom of the screen, so that
           // if the document is layed out properly, tapping this position should place a caret to the document.
@@ -96,7 +123,28 @@ void main() {
             screenHeight,
           );
 
-          expect(scrollController.offset, greaterThanOrEqualTo(tapPosition.dy - screenHeight));
+          final handleFinder = find.byType(BlinkingCaret);
+          final handleBox = handleFinder.evaluate().last.findRenderObject() as RenderBox;
+
+          final editorFinder = find.byType(SuperEditor);
+          final editorBox = editorFinder.evaluate().first.findRenderObject() as RenderBox;
+
+          final documentOffset = handleBox.localToGlobal(editorBox.globalToLocal(Offset.zero));
+
+          // Determine the caret's height. Related to the position of the tapped caret
+          const lineHeight = 18;
+
+          // Dy from the SuperEditor to its Scrollable parent
+          const editorOffsetDy = 212.0;
+
+          // dragAutoScrollBoundary.trailing of default_editor in [IOSDocumentTouchInteractor]
+          const dragAutoScrollBoundary = 54.0;
+
+          // The math was taken from [ensureOffsetIsVisible] in [document_gestures_touch.dart]
+          expect(
+            scrollController.offset,
+            equals((documentOffset.dy + lineHeight) + dragAutoScrollBoundary - screenHeight + editorOffsetDy),
+          );
         });
       });
     });
@@ -121,7 +169,7 @@ Future<double> _shrinkViewportAndEnsureVisibleCaret(
     await tester.pumpAndSettle();
 
     // Ensure visible caret
-    final handleBox = handleFinder.evaluate().last.renderObject as RenderBox;
+    final handleBox = handleFinder.evaluate().last.findRenderObject() as RenderBox;
     final handleOffset = handleBox.localToGlobal(Offset.zero);
 
     expect(handleOffset.dy, lessThanOrEqualTo(height));

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -55,7 +55,7 @@ void main() {
 
           final handleToEditorOffset = handleOffset - editorOffset;
 
-          // Determine the caret's height. Related to the position of the tapped caret
+          // Determine the caret's height. Related to the tapped text position
           const lineHeight = 18;
 
           // Dy from the SuperEditor to its Scrollable parent
@@ -119,13 +119,13 @@ void main() {
 
           final handleToEditorOffset = handleOffset - editorOffset;
 
-          // Determine the caret's height. Related to the position of the tapped caret
+          // Determine the caret's height. Related to the tapped text position
           const lineHeight = 18;
 
           // Dy from the SuperEditor to its Scrollable parent
           const editorOffsetDy = 212.0;
 
-          // DragAutoScrollBoundary.trailing of default_editor in [AndroidDocumentTouchInteractor]
+          // DragAutoScrollBoundary.trailing of default_editor in [iOSDocumentTouchInteractor]
           const dragAutoScrollBoundary = 54.0;
 
           // The math was taken from [ensureOffsetIsVisible] in [document_gestures_touch.dart]

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('SuperEditor', () {
     group('auto-scroll', () {
       const screenSizeWithoutKeyboard = Size(390.0, 844.0);
-      const screenSizeWithKeyboard = Size(390.0, 444.0);
+      const screenSizeWithKeyboard = Size(390.0, 544.0);
       const keyboardExpansionFrameCount = 60;
       final shrinkPerFrame =
           (screenSizeWithoutKeyboard.height - screenSizeWithKeyboard.height) / keyboardExpansionFrameCount;
@@ -37,19 +37,24 @@ void main() {
           frameCount: keyboardExpansionFrameCount,
         );
 
-        // Ensure that the editor auto-scrolled to keep the caret visible.
-        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
-        final handleFinder = find.byType(BlinkingCaret);
-        final handleOffset = tester.getTopLeft(handleFinder.last);
-
         // Hard-code a reasonable line-height because carets do not currently
         // report their height.
         // TODO: look up the actual line height of the text at the selection extent
         // TODO: update caret implementation so that it reports its own height.
         const lineHeight = 18;
 
-        final bottomOfCaret = handleOffset.dy + lineHeight;
-        expect(bottomOfCaret, lessThanOrEqualTo(screenSizeWithKeyboard.height));
+        // Ensure that the editor auto-scrolled to keep the caret visible.
+        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
+        final caretFinder = find.byType(BlinkingCaret);
+        final caretOffset = tester.getTopLeft(caretFinder.last);
+        final bottomOfCaret = caretOffset.dy + lineHeight;
+
+        // The default trailing boundary of the default `SuperEditor`
+        const trailingBoundary = 54.0;
+
+        // The caret should be at the trailing boundary, within a small margin of error
+        expect(bottomOfCaret, lessThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary + .001));
+        expect(bottomOfCaret, greaterThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary - .001));
       });
 
       testWidgets('on iOS, keeps caret visible when keyboard appears', (WidgetTester tester) async {
@@ -76,19 +81,24 @@ void main() {
           frameCount: keyboardExpansionFrameCount,
         );
 
-        // Ensure that the editor auto-scrolled to keep the caret visible.
-        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
-        final handleFinder = find.byType(BlinkingCaret);
-        final handleOffset = tester.getTopLeft(handleFinder.last);
-
         // Hard-code a reasonable line-height because carets do not currently
         // report their height.
         // TODO: look up the actual line height of the text at the selection extent
         // TODO: update caret implementation so that it reports its own height.
         const lineHeight = 18;
 
-        final bottomOfCaret = handleOffset.dy + lineHeight;
-        expect(bottomOfCaret, lessThanOrEqualTo(screenSizeWithKeyboard.height));
+        // Ensure that the editor auto-scrolled to keep the caret visible.
+        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
+        final caretFinder = find.byType(BlinkingCaret);
+        final caretOffset = tester.getTopLeft(caretFinder.last);
+        final bottomOfCaret = caretOffset.dy + lineHeight;
+
+        // The default trailing boundary of the default `SuperEditor`
+        const trailingBoundary = 54.0;
+
+        // The caret should be at the trailing boundary, within a small margin of error
+        expect(bottomOfCaret, lessThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary + .001));
+        expect(bottomOfCaret, greaterThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary - .001));
       });
     });
   });

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -223,11 +223,10 @@ class _SliverTestEditorState extends State<_SliverTestEditor> {
   }
 }
 
-/// Slowly reduces window size in order to mimic keyboard
-/// showing behaviour while ensuring the caret is being displayed
+/// Slowly reduces window size while ensuring the caret is being displayed
 ///
-/// The window size will shrink for a number of [frameCount], each time
-/// it reduces an amount of [shrinkPerFrame]
+/// To mimic the keyboard showing behaviour, the window size will be shrinking
+/// for a number of [frameCount], each time it reduces an amount of [shrinkPerFrame]
 ///
 /// Returns the new height, which equals to [height] - [frameCount] * [shrinkPerFrame]
 Future<double> _shrinkViewportAndEnsureVisibleCaret({

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -38,6 +38,7 @@ void main() {
         );
 
         // Ensure that the editor auto-scrolled to keep the caret visible.
+        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
         final handleFinder = find.byType(BlinkingCaret);
         final handleOffset = tester.getTopLeft(handleFinder.last);
 
@@ -76,6 +77,7 @@ void main() {
         );
 
         // Ensure that the editor auto-scrolled to keep the caret visible.
+        // TODO: there are 2 `BlinkingCaret` at the same time. There should be only 1 caret
         final handleFinder = find.byType(BlinkingCaret);
         final handleOffset = tester.getTopLeft(handleFinder.last);
 

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -12,7 +12,7 @@ void main() {
           final scrollController = ScrollController();
 
           // Setting initial fake screen size. The height would shrink later on.
-          // The size should be set properly so that when the _SliverTestEditor is layed out,
+          // The size should be set properly so that when the _SliverTestEditor is laid out,
           // the document is within bottom of the viewport.
           var screenHeight = 844.0;
           const screenWidth = 390.0;
@@ -24,7 +24,7 @@ void main() {
           const shrinkPerFrame = 60.0;
 
           // The position should be in the middle bottom of the screen, so that
-          // if the document is layed out properly, tapping this position should place a caret to the document.
+          // if the document is laid out properly, tapping this position should place a caret to the document.
           // dy should be less than height to prevent tapping outside the screen
           final tapPosition = Offset(screenWidth / 2, screenHeight - 1);
 
@@ -82,7 +82,7 @@ void main() {
           final scrollController = ScrollController();
 
           // Setting initial fake screen size. The height would shrink later on.
-          // The size should be set properly so that when the _SliverTestEditor is layed out,
+          // The size should be set properly so that when the _SliverTestEditor is laid out,
           // the document is within bottom of the viewport.
           var screenHeight = 844.0;
           const screenWidth = 390.0;
@@ -94,7 +94,7 @@ void main() {
           const shrinkPerFrame = 60.0;
 
           // The position should be in the middle bottom of the screen, so that
-          // if the document is layed out properly, tapping this position should place a caret to the document.
+          // if the document is laid out properly, tapping this position should place a caret to the document.
           // dy should be less than height to prevent tapping outside the screen
           final tapPosition = Offset(screenWidth / 2, screenHeight - 1);
 

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -151,33 +151,6 @@ void main() {
   });
 }
 
-/// Slowly reduce screen size and pump
-/// To mimic keyboard showing behaviour
-/// Return the reduced height
-Future<double> _shrinkViewportAndEnsureVisibleCaret(
-  WidgetTester tester,
-  int frameCount,
-  double shrinkPerFrame,
-  double width,
-  double height,
-) async {
-  final handleFinder = find.byType(BlinkingCaret);
-
-  for (var i = 0; i < frameCount; i++) {
-    height -= shrinkPerFrame;
-    tester.binding.window.physicalSizeTestValue = Size(width, height);
-    await tester.pumpAndSettle();
-
-    // Ensure visible caret
-    final handleBox = handleFinder.evaluate().last.findRenderObject() as RenderBox;
-    final handleOffset = handleBox.localToGlobal(Offset.zero);
-
-    expect(handleOffset.dy, lessThanOrEqualTo(height));
-  }
-
-  return height;
-}
-
 class _SliverTestEditor extends StatefulWidget {
   const _SliverTestEditor({
     Key? key,
@@ -260,4 +233,31 @@ class _SliverTestEditorState extends State<_SliverTestEditor> {
       debugShowCheckedModeBanner: false,
     );
   }
+}
+
+/// Slowly reduce screen size and pump
+/// To mimic keyboard showing behaviour
+/// Return the reduced height
+Future<double> _shrinkViewportAndEnsureVisibleCaret(
+  WidgetTester tester,
+  int frameCount,
+  double shrinkPerFrame,
+  double width,
+  double height,
+) async {
+  final handleFinder = find.byType(BlinkingCaret);
+
+  for (var i = 0; i < frameCount; i++) {
+    height -= shrinkPerFrame;
+    tester.binding.window.physicalSizeTestValue = Size(width, height);
+    await tester.pumpAndSettle();
+
+    // Ensure visible caret
+    final handleBox = handleFinder.evaluate().last.findRenderObject() as RenderBox;
+    final handleOffset = handleBox.localToGlobal(Offset.zero);
+
+    expect(handleOffset.dy, lessThanOrEqualTo(height));
+  }
+
+  return height;
 }

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -15,8 +15,8 @@ void main() {
           var screenHeight = 844.0;
           const screenWidth = 390.0;
 
-          const frameCount = 5;
-          const shrinkPerFrame = 60.0;
+          const frameCount = 60;
+          const shrinkPerFrame = 5.0;
 
           // Tap offset to select an arbitrary text position in the document.
           final tapPosition = Offset(screenWidth / 2, screenHeight - 1);
@@ -71,8 +71,9 @@ void main() {
             scrollController.offset,
             equals((handleToEditorOffset.dy + lineHeight) +
                 dragAutoScrollBoundary -
-                (screenHeight - unscrolledOffset) +
-                editorOffsetDy),
+                screenHeight +
+                editorOffsetDy -
+                unscrolledOffset),
           );
         });
       });
@@ -140,8 +141,9 @@ void main() {
             scrollController.offset,
             equals((handleToEditorOffset.dy + lineHeight) +
                 dragAutoScrollBoundary -
-                (screenHeight - unscrolledOffset) +
-                editorOffsetDy),
+                screenHeight +
+                editorOffsetDy -
+                unscrolledOffset),
           );
         });
       });

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+void main() {
+  group('SuperEditor', () {
+    group('auto-scroll', () {
+      group('Android', () {
+        testAutoScroll(
+          'maintain visible caret when the viewport is being minimized',
+          DocumentGestureMode.android,
+        );
+      });
+      group('iOS', () {
+        testAutoScroll(
+          'maintain visible caret when the viewport is being minimized',
+          DocumentGestureMode.iOS,
+        );
+      });
+    });
+  });
+}
+
+void testAutoScroll(
+  String description,
+  DocumentGestureMode gestureMode,
+) {
+  testWidgets(description, (WidgetTester tester) async {
+    final scrollController = ScrollController();
+
+    var height = 844.0;
+    const width = 390.0;
+    const tapDy = 800.0;
+
+    tester.binding.window
+      ..physicalSizeTestValue = Size(width, height)
+      ..textScaleFactorTestValue = 1.0
+      ..devicePixelRatioTestValue = 1.0;
+
+    final testEditor = SliverTestEditor(
+      scrollController: scrollController,
+      gestureMode: gestureMode,
+    );
+
+    await tester.pumpWidget(testEditor);
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, 0.0);
+
+    // Tap at the middle bottom of the screen
+    await tester.tapAt(const Offset(width / 2, tapDy));
+    await tester.pumpAndSettle();
+
+    // Slowly reduce screen size and pump
+    // To mimic keyboard showing behaviour
+    for (var i = 0; i < 30; i++) {
+      height -= 10;
+      tester.binding.window.physicalSizeTestValue = Size(width, height);
+      await tester.pumpAndSettle();
+
+      // Maintain visible caret
+      final handleFinder = find.byType(
+        gestureMode == DocumentGestureMode.iOS ? IOSCollapsedHandle : AndroidSelectionHandle,
+      );
+      expect(handleFinder.evaluate(), isNotEmpty);
+    }
+
+    expect(scrollController.offset, greaterThanOrEqualTo(tapDy - height));
+  });
+}
+
+class SliverTestEditor extends StatefulWidget {
+  const SliverTestEditor({
+    Key? key,
+    this.scrollController,
+    required this.gestureMode,
+  }) : super(key: key);
+
+  final ScrollController? scrollController;
+  final DocumentGestureMode gestureMode;
+
+  @override
+  State<SliverTestEditor> createState() => SliverTestEditorState();
+}
+
+class SliverTestEditorState extends State<SliverTestEditor> {
+  late Document _doc;
+  late DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _doc = _createInitialDocument();
+    _docEditor = DocumentEditor(document: _doc as MutableDocument);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: CustomScrollView(
+          controller: widget.scrollController,
+          slivers: [
+            SliverAppBar(
+              title: const Text(
+                'Rich Text Editor Sliver Example',
+              ),
+              expandedHeight: 200.0,
+              leading: const SizedBox(),
+              flexibleSpace: FlexibleSpaceBar(
+                background: Container(color: Colors.blue),
+              ),
+            ),
+            const SliverToBoxAdapter(
+              child: Text(
+                'Lorem Ipsum Dolor',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: SuperEditor(
+                editor: _docEditor,
+                stylesheet: defaultStylesheet.copyWith(
+                  documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+                ),
+                gestureMode: widget.gestureMode,
+                inputSource: DocumentInputSource.ime,
+              ),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) {
+                  return ListTile(
+                    title: Text('$index'),
+                    onTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            'SliverList element tapped with index $index.',
+                          ),
+                          duration: const Duration(milliseconds: 500),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+
+  Document _createInitialDocument() {
+    return MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text: 'Example Document',
+          ),
+          metadata: {
+            'blockType': header1Attribution,
+          },
+        ),
+        HorizontalRuleNode(id: DocumentEditor.createNodeId()),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          ),
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+              text:
+                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text:
+                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+          ),
+        ),
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text:
+                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/super_editor/test/src/default_editor/auto_scroll_test.dart
+++ b/super_editor/test/src/default_editor/auto_scroll_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('SuperEditor', () {
     group('auto-scroll', () {
       const screenSizeWithoutKeyboard = Size(390.0, 844.0);
-      const screenSizeWithKeyboard = Size(390.0, 544.0);
+      const screenSizeWithKeyboard = Size(390.0, 444.0);
       const keyboardExpansionFrameCount = 60;
       final shrinkPerFrame =
           (screenSizeWithoutKeyboard.height - screenSizeWithKeyboard.height) / keyboardExpansionFrameCount;
@@ -39,7 +39,7 @@ void main() {
 
         // Ensure that the editor auto-scrolled to keep the caret visible.
         final handleFinder = find.byType(BlinkingCaret);
-        final handleOffset = tester.getTopLeft(handleFinder.first);
+        final handleOffset = tester.getTopLeft(handleFinder.last);
 
         // Hard-code a reasonable line-height because carets do not currently
         // report their height.
@@ -92,13 +92,12 @@ void main() {
   });
 }
 
-/// Displays a `SuperEditor` within a parent `Scrollable`, including additional content
-/// above the `SuperEditor`, so that `SuperEditor` doesn't have the same origin as the
-/// parent `Scrollable`.
+/// Displays a [SuperEditor] within a parent [Scrollable], including additional
+/// content above the [SuperEditor] and additional content on top of [Scrollable].
 ///
-/// The difference in origin is important because some calculations might assume that
-/// they're the same, and this test suite helps to make sure that scrolling calculations
-/// fully account for the editor's origin.
+/// By including content above the [SuperEditor], it doesn't have the same origin as the parent [Scrollable].
+///
+/// By including content on top of [Scrollable], it doesn't have the origin at [Offset.zero].
 class _SliverTestEditor extends StatefulWidget {
   const _SliverTestEditor({
     Key? key,
@@ -127,46 +126,49 @@ class _SliverTestEditorState extends State<_SliverTestEditor> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              title: const Text(
-                'Rich Text Editor Sliver Example',
-              ),
-              expandedHeight: 200.0,
-              leading: const SizedBox(),
-              flexibleSpace: FlexibleSpaceBar(
-                background: Container(color: Colors.blue),
-              ),
-            ),
-            const SliverToBoxAdapter(
-              child: Text(
-                'Lorem Ipsum Dolor',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 12,
+        body: Padding(
+          padding: const EdgeInsets.only(top: 300),
+          child: CustomScrollView(
+            slivers: [
+              SliverAppBar(
+                title: const Text(
+                  'Rich Text Editor Sliver Example',
                 ),
-                textAlign: TextAlign.center,
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: SuperEditor(
-                editor: _docEditor,
-                stylesheet: defaultStylesheet.copyWith(
-                  documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+                expandedHeight: 200.0,
+                leading: const SizedBox(),
+                flexibleSpace: FlexibleSpaceBar(
+                  background: Container(color: Colors.blue),
                 ),
-                gestureMode: widget.gestureMode,
-                inputSource: DocumentInputSource.ime,
               ),
-            ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) {
-                  return ListTile(title: Text('$index'));
-                },
+              const SliverToBoxAdapter(
+                child: Text(
+                  'Lorem Ipsum Dolor',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 12,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
-            ),
-          ],
+              SliverToBoxAdapter(
+                child: SuperEditor(
+                  editor: _docEditor,
+                  stylesheet: defaultStylesheet.copyWith(
+                    documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+                  ),
+                  gestureMode: widget.gestureMode,
+                  inputSource: DocumentInputSource.ime,
+                ),
+              ),
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) {
+                    return ListTile(title: Text('$index'));
+                  },
+                ),
+              ),
+            ],
+          ),
         ),
       ),
       debugShowCheckedModeBanner: false,


### PR DESCRIPTION
Fix auto-scroll when Editor is in a CustomScrollView (Resolves #521 ), and fix scrolling when using Editor in a CustomScrollView with `gestureMode: DocumentGestureMode.android`

I reimplemented the scrolling trigger, which checks for content (which is a handle in this case) that is not visible within the viewport and its boundary. The scrolling could trigger either when the content is above or below the desired viewport, and it jumps to the position based on its trigger position, added with the current scroll offset.

Along the way, I found that the `_ancestorScrollPosition` is not set in `document_gesture_touch_android.dart`, compared to `document_gesture_touch_ios.dart`, which leads to errors when using in CustomScrollView. So I made the change accordingly.

iOS:
<img src=https://user-images.githubusercontent.com/39979207/162781238-9073bfa1-55d5-4a9b-be7d-3e29a3fa6c3b.gif width="250"/>

Android:
<img src=https://user-images.githubusercontent.com/39979207/162781189-f7eb3bc0-5049-4a36-8f4c-80ec579a5683.gif width="250"/>


