### PR TITLE
Fix removeComposingAttributions on AttributedTextEditingController (Resolves #540)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -92,7 +92,7 @@ class AttributedTextEditingController with ChangeNotifier {
 
   /// Removes the given [attributions] from [composingAttributions].
   void removeComposingAttributions(Set<Attribution> attributions) {
-    _composingAttributions.removeWhere((attribution) => _composingAttributions.contains(attribution));
+    _composingAttributions.removeWhere((attribution) => attributions.contains(attribution));
     notifyListeners();
   }
 

--- a/super_editor/test/src/infrastructure/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/attributed_text_editing_controller_test.dart
@@ -699,5 +699,62 @@ void main() {
       expect(text1.hasListeners, false);
       expect(text2.hasListeners, true);
     });
+
+    group('remove composing attributions', () {
+      test('should remove the given attributions', () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(text: 'my text'),
+        );
+        controller.addComposingAttributions(
+          {boldAttribution, italicsAttribution, underlineAttribution},
+        );
+        controller.removeComposingAttributions(
+            {boldAttribution, underlineAttribution});
+        expect(controller.composingAttributions.length, 1);
+        expect(
+            controller.composingAttributions.contains(boldAttribution), false,
+            reason: 'expected to remove boldAttribution');
+        expect(controller.composingAttributions.contains(underlineAttribution),
+            false,
+            reason: 'expected to remove underlineAttribution');
+      });
+
+      test(
+          'should not remove any attributions that are not passed as arguments',
+          () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(text: 'my text'),
+        );
+        controller.addComposingAttributions(
+          {boldAttribution, italicsAttribution, underlineAttribution},
+        );
+        controller.removeComposingAttributions({boldAttribution});
+        expect(controller.composingAttributions.length, 2);
+        expect(
+            controller.composingAttributions.contains(italicsAttribution), true,
+            reason: 'expected to NOT remove italicsAttribution');
+        expect(controller.composingAttributions.contains(underlineAttribution),
+            true,
+            reason: 'expected to NOT remove underlineAttribution');
+      });
+
+      test(
+          'should not modify any attributions if the controller does not contain any of the attributions passed as arguments',
+          () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(text: 'my text'),
+        );
+        controller.addComposingAttributions(
+          {boldAttribution, italicsAttribution},
+        );
+        controller.removeComposingAttributions({underlineAttribution});
+        expect(controller.composingAttributions.length, 2);
+        expect(
+            controller.composingAttributions.contains(italicsAttribution), true,
+            reason: 'expected to NOT remove italicsAttribution');
+        expect(controller.composingAttributions.contains(boldAttribution), true,
+            reason: 'expected to NOT remove boldAttribution');
+      });
+    });
   });
 }

--- a/super_editor/test/src/infrastructure/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/attributed_text_editing_controller_test.dart
@@ -700,60 +700,41 @@ void main() {
       expect(text2.hasListeners, true);
     });
 
-    group('remove composing attributions', () {
-      test('should remove the given attributions', () {
-        final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'my text'),
-        );
-        controller.addComposingAttributions(
-          {boldAttribution, italicsAttribution, underlineAttribution},
-        );
-        controller.removeComposingAttributions(
-            {boldAttribution, underlineAttribution});
-        expect(controller.composingAttributions.length, 1);
-        expect(
-            controller.composingAttributions.contains(boldAttribution), false,
-            reason: 'expected to remove boldAttribution');
-        expect(controller.composingAttributions.contains(underlineAttribution),
-            false,
-            reason: 'expected to remove underlineAttribution');
-      });
+    group('composing attributions', () {
+      group('removal', () {
+        test('should remove the given attributions', () {
+          final controller = AttributedTextEditingController(
+            text: AttributedText(text: 'my text'),
+          );
+          controller.addComposingAttributions(
+            {boldAttribution, italicsAttribution, underlineAttribution},
+          );
+          expect(controller.composingAttributions.length, 3);
 
-      test(
-          'should not remove any attributions that are not passed as arguments',
-          () {
-        final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'my text'),
-        );
-        controller.addComposingAttributions(
-          {boldAttribution, italicsAttribution, underlineAttribution},
-        );
-        controller.removeComposingAttributions({boldAttribution});
-        expect(controller.composingAttributions.length, 2);
-        expect(
-            controller.composingAttributions.contains(italicsAttribution), true,
-            reason: 'expected to NOT remove italicsAttribution');
-        expect(controller.composingAttributions.contains(underlineAttribution),
-            true,
-            reason: 'expected to NOT remove underlineAttribution');
-      });
+          controller.removeComposingAttributions(
+              {boldAttribution, underlineAttribution});
+              
+          expect(controller.composingAttributions.length, 1);
+          expect(controller.composingAttributions.contains(italicsAttribution), true);          
+        });
+       
+        test(
+            "does nothing when it doesn't have the given composing attributions",
+            () {
+          final controller = AttributedTextEditingController(
+            text: AttributedText(text: 'my text'),
+          );
+          controller.addComposingAttributions(
+            {boldAttribution, italicsAttribution},
+          );
+          expect(controller.composingAttributions.length, 2);
 
-      test(
-          'should not modify any attributions if the controller does not contain any of the attributions passed as arguments',
-          () {
-        final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'my text'),
-        );
-        controller.addComposingAttributions(
-          {boldAttribution, italicsAttribution},
-        );
-        controller.removeComposingAttributions({underlineAttribution});
-        expect(controller.composingAttributions.length, 2);
-        expect(
-            controller.composingAttributions.contains(italicsAttribution), true,
-            reason: 'expected to NOT remove italicsAttribution');
-        expect(controller.composingAttributions.contains(boldAttribution), true,
-            reason: 'expected to NOT remove boldAttribution');
+          controller.removeComposingAttributions({underlineAttribution});
+
+          expect(controller.composingAttributions.length, 2);
+          expect(controller.composingAttributions.contains(italicsAttribution), true);
+          expect(controller.composingAttributions.contains(boldAttribution), true);
+        });
       });
     });
   });


### PR DESCRIPTION
`AttributedTextEditingController` was always removing all composing attributions when calling `removeComposingAttributions`, regardless of the `attributions` passed as arguments

(Resolves #540)