### PR TITLE
 Updates for Superlist tokenization work

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -646,9 +646,8 @@ class AttributedTextEditingController with ChangeNotifier {
     _composingAttributions.clear();
     _composingRegion = TextRange.empty;
   }
-}
 
-extension DefaultSuperTextFieldActions on AttributedTextEditingController {
+  //------ START: Methods moved here from extension methods ---------
   void copySelectedTextToClipboard() {
     if (selection.extentOffset == -1) {
       // Nothing selected to copy.
@@ -877,4 +876,5 @@ extension DefaultSuperTextFieldActions on AttributedTextEditingController {
     );
     selection = TextSelection.collapsed(offset: currentSelectionExtent.offset + 1);
   }
+  //------ END: Methods moved here from extension methods -------
 }

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -1,5 +1,4 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
@@ -27,9 +26,7 @@ final _log = imeTextFieldLog;
 /// By default, an [ImeAttributedTextEditingController] is not connected to the platform
 /// IME. To connect to the IME, call `attachToIme`. To detach from the IME, call
 /// `detachFromIme`.
-class ImeAttributedTextEditingController
-    with ChangeNotifier
-    implements AttributedTextEditingController, DeltaTextInputClient {
+class ImeAttributedTextEditingController extends AttributedTextEditingController implements DeltaTextInputClient {
   ImeAttributedTextEditingController({
     AttributedTextEditingController? controller,
     bool disposeClientController = true,
@@ -50,6 +47,9 @@ class ImeAttributedTextEditingController
   }
 
   final AttributedTextEditingController _realController;
+
+  @Deprecated("this property is exposed temporarily as super_editor evaluates what to do with controllers")
+  AttributedTextEditingController get innerController => _realController;
 
   final bool _disposeClientController;
 


### PR DESCRIPTION
Moved all AttributedTextEditingController extension methods into the class, also exposed the 'innerController' from ImeTextEditingController because Superlist token behavior needs access to the inner controller.