### PR TITLE
Add link support to markdown deserialization

### DIFF
--- a/super_editor_markdown/lib/src/markdown.dart
+++ b/super_editor_markdown/lib/src/markdown.dart
@@ -405,6 +405,14 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
           end: styledText.text.length - 1,
         ),
       );
+    } else if (element.tag == 'a') {
+      styledText.addAttribution(
+        LinkAttribution(url: Uri.parse(element.attributes['href']!)),
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
     }
 
     if (_textStack.isNotEmpty) {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -631,6 +631,22 @@ This is some code
         expect(styledText.getAllAttributionsAt(12).single, LinkAttribution(url: Uri.https('example.org', '')));
       });
 
+      test('empty link', () {
+        // This isn't necessarily the behavior that you would expect, but it has been tested against multiple Markdown
+        // renderers (such as VS Code) and it matches their behaviour.
+        const markdown = 'This is [a link]() test';
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 1);
+        expect(document.nodes.first, isA<ParagraphNode>());
+
+        final paragraph = document.nodes.first as ParagraphNode;
+        final styledText = paragraph.text;
+        expect(styledText.text, 'This is a link test');
+
+        expect(styledText.getAllAttributionsAt(12).single, LinkAttribution(url: Uri.parse('')));
+      });
+
       test('unordered list', () {
         const markdown = '''
  * list item 1


### PR DESCRIPTION
Updates the markdown deserialization visitor with a new case to handle links.