### PR TITLE
Fixed regression where caret line-jumping and word-jumping broke (Resolves #551)

### DIFF
--- a/super_editor/lib/src/default_editor/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_keyboard_actions.dart
@@ -5,7 +5,6 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
-import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 
@@ -13,14 +12,11 @@ import 'document_input_keyboard.dart';
 import 'paragraph.dart';
 import 'text.dart';
 
-final _log = Logger(scope: 'document_keyboard_actions.dart');
-
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
   if (editContext.composer.selection == null) {
-    _log.log('doNothingWhenThereIsNoSelection', ' - no selection. Returning.');
     return ExecutionInstruction.haltExecution;
   } else {
     return ExecutionInstruction.continueExecution;
@@ -38,7 +34,6 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
     return ExecutionInstruction.continueExecution;
   }
 
-  _log.log('pasteWhenCmdVIsPressed', 'Pasting clipboard content...');
   editContext.commonOps.paste();
 
   return ExecutionInstruction.haltExecution;
@@ -134,7 +129,6 @@ ExecutionInstruction anyCharacterOrDestructiveKeyToDeleteSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
-  _log.log('deleteExpandedSelectionWhenCharacterOrDestructiveKeyPressed', 'Running...');
   if (editContext.composer.selection == null || editContext.composer.selection!.isCollapsed) {
     return ExecutionInstruction.continueExecution;
   }
@@ -218,21 +212,17 @@ ExecutionInstruction mergeNodeWithNextWhenDeleteIsPressed({
 
   final node = editContext.editor.document.getNodeById(editContext.composer.selection!.extent.nodeId);
   if (node is! TextNode) {
-    _log.log('mergeNodeWithNextWhenDeleteIsPressed', 'WARNING: Cannot combine node of type: $node');
     return ExecutionInstruction.continueExecution;
   }
 
   final nextNode = editContext.editor.document.getNodeAfter(node);
   if (nextNode == null) {
-    _log.log('mergeNodeWithNextWhenDeleteIsPressed', 'At bottom of document. Cannot merge with node above.');
     return ExecutionInstruction.continueExecution;
   }
   if (nextNode is! TextNode) {
-    _log.log('mergeNodeWithNextWhenDeleteIsPressed', 'Cannot merge ParagraphNode into node of type: $nextNode');
     return ExecutionInstruction.continueExecution;
   }
 
-  _log.log('mergeNodeWithNextWhenDeleteIsPressed', 'Combining node with next.');
   final currentParagraphLength = node.text.text.length;
 
   // Send edit command.
@@ -270,13 +260,11 @@ ExecutionInstruction moveUpDownLeftAndRightWithArrowKeys({
 
   bool didMove = false;
   if (keyEvent.logicalKey == LogicalKeyboardKey.arrowLeft || keyEvent.logicalKey == LogicalKeyboardKey.arrowRight) {
-    _log.log('moveUpDownLeftAndRightWithArrowKeys', ' - handling left arrow key');
-
     MovementModifier? movementModifier;
     if (keyEvent.isPrimaryShortcutKeyPressed) {
-      movementModifier == MovementModifier.line;
+      movementModifier = MovementModifier.line;
     } else if (keyEvent.isAltPressed) {
-      movementModifier == MovementModifier.word;
+      movementModifier = MovementModifier.word;
     }
 
     if (keyEvent.logicalKey == LogicalKeyboardKey.arrowLeft) {
@@ -293,12 +281,8 @@ ExecutionInstruction moveUpDownLeftAndRightWithArrowKeys({
       );
     }
   } else if (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp) {
-    _log.log('moveUpDownLeftAndRightWithArrowKeys', ' - handling up arrow key');
-
     didMove = editContext.commonOps.moveCaretUp(expand: keyEvent.isShiftPressed);
   } else if (keyEvent.logicalKey == LogicalKeyboardKey.arrowDown) {
-    _log.log('moveUpDownLeftAndRightWithArrowKeys', ' - handling down arrow key');
-
     didMove = editContext.commonOps.moveCaretDown(expand: keyEvent.isShiftPressed);
   }
 
@@ -310,7 +294,7 @@ ExecutionInstruction moveToLineStartOrEndWithCtrlAOrE({
   required RawKeyEvent keyEvent,
 }) {
   if (Platform.instance.isMac) {
-    ExecutionInstruction.continueExecution;
+    return ExecutionInstruction.continueExecution;
   }
 
   if (!keyEvent.isControlPressed) {
@@ -323,7 +307,6 @@ ExecutionInstruction moveToLineStartOrEndWithCtrlAOrE({
       expand: keyEvent.isShiftPressed,
       movementModifier: MovementModifier.line,
     );
-    _log.log('moveToLineStartOrEndWithCtrlAOrE', ' - handling Ctrl+A');
   }
 
   if (keyEvent.logicalKey == LogicalKeyboardKey.keyE) {
@@ -331,7 +314,6 @@ ExecutionInstruction moveToLineStartOrEndWithCtrlAOrE({
       expand: keyEvent.isShiftPressed,
       movementModifier: MovementModifier.line,
     );
-    _log.log('moveToLineStartOrEndWithCtrlAOrE', ' - handling Ctrl+E');
   }
 
   return didMove ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
@@ -356,7 +338,6 @@ ExecutionInstruction deleteLineWithCmdBksp({
   );
 
   if (didMove) {
-    _log.log('deleteLineWithCmdBksp', ' - handling CMD+BKSP');
     return editContext.commonOps.deleteSelection()
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
@@ -383,7 +364,6 @@ ExecutionInstruction deleteWordWithAltBksp({
   );
 
   if (didMove) {
-    _log.log('deleteWordWithAltBksp', ' - handling ALT+BKSP');
     return editContext.commonOps.deleteSelection()
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;

--- a/super_editor/test/src/_text_entry_test_tools.dart
+++ b/super_editor/test/src/_text_entry_test_tools.dart
@@ -1,4 +1,124 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Simulates common key combinations on a hardware keyboard.
+extension CommonKeyCombos on WidgetTester {
+  Future<void> pressEnter(WidgetTester tester) async {
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCmdEnter(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressNumpadEnter(WidgetTester tester) async {
+    await tester.sendKeyEvent(LogicalKeyboardKey.numpadEnter);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCmdNumpadEnter(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    await tester.sendKeyEvent(LogicalKeyboardKey.numpadEnter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressLeftArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressAltLeftArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCmdLeftArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressRightArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressAltRightArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pressCmdRightArrow(WidgetTester tester, {bool shift = false}) async {
+    if (shift) {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+
+    if (shift) {
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    }
+
+    await tester.pumpAndSettle();
+  }
+}
 
 /// Concrete version of [RawKeyEvent] used to manually simulate
 /// a specific key event sent from Flutter.

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -1,17 +1,96 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/super_editor.dart';
 
 import '../_document_test_tools.dart';
 import '../_text_entry_test_tools.dart';
 import '../infrastructure/_platform_test_tools.dart';
+import 'test_documents.dart';
 
 void main() {
   group(
-    'document_keyboard_actions.dart',
+    'Document keyboard actions',
     () {
+      group('jumps to', () {
+        testWidgets('beginning of line with CMD + LEFT ARROW', (tester) async {
+          // Start the user's selection somewhere after the beginning of the first
+          // line in the first node.
+          final editContext = await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
+
+          await tester.pressCmdLeftArrow(tester);
+
+          // Ensure that the caret moved to the beginning of the line.
+          expect(
+            editContext.composer.selection,
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('end of line with CMD + RIGHT ARROW', (tester) async {
+          // Start the user's selection somewhere before the end of the first line
+          // in the first node.
+          final editContext = await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
+
+          await tester.pressCmdRightArrow(tester);
+
+          // Ensure that the caret moved to the end of the line. This value
+          // is very fragile. If the text size or layout width changes, this value
+          // will also need to change.
+          expect(
+            editContext.composer.selection,
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 27),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('beginning of word with ALT + LEFT ARROW', (tester) async {
+          // Start the user's selection somewhere in the middle of a word.
+          final editContext = await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
+
+          await tester.pressAltLeftArrow(tester);
+
+          // Ensure that the caret moved to the beginning of the word.
+          expect(
+            editContext.composer.selection,
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 6),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('end of word with ALT + RIGHT ARROW', (tester) async {
+          // Start the user's selection somewhere in the middle of a word.
+          final editContext = await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
+
+          await tester.pressAltRightArrow(tester);
+
+          // Ensure that the caret moved to the beginning of the word.
+          expect(
+            editContext.composer.selection,
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 11),
+              ),
+            ),
+          );
+        });
+      });
+
       group(
         'CMD + A to select all',
         () {
@@ -420,4 +499,42 @@ void main() {
       });
     },
   );
+}
+
+/// Pumps a [SuperEditor] with a single-paragraph document, with focus, and returns
+/// the associated [EditContext] for further inspection and control.
+///
+/// This particular setup is intended for caret movement testing within a single
+/// paragraph node.
+Future<EditContext> _pumpCaretMovementTestSetup(
+  WidgetTester tester, {
+  required int textOffsetInFirstNode,
+}) async {
+  final composer = DocumentComposer(
+    initialSelection: DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: "1",
+        nodePosition: TextNodePosition(offset: textOffsetInFirstNode),
+      ),
+    ),
+  );
+  final editContext = createEditContext(
+    document: singleParagraphDoc(),
+    documentComposer: composer,
+  );
+
+  final focusNode = FocusNode()..requestFocus();
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperEditor(
+          focusNode: focusNode,
+          editor: editContext.editor,
+          composer: composer,
+        ),
+      ),
+    ),
+  );
+
+  return editContext;
 }

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
-import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:logging/logging.dart' as logging;
+import 'package:super_editor/src/infrastructure/_logging.dart';
 
 void groupWithLogging(String description, Level logLevel, Set<logging.Logger> loggers, VoidCallback body) {
   initLoggers(logLevel, loggers);


### PR DESCRIPTION
Fixed regression where caret line-jumping and word-jumping broke (Resolves #551)

The problem was that in #497 a `==` was used instead of an `=`, which failed to assign the movement modifier for lines and words.

This PR adds some tests to help prevent future regressions.

This PR also adds extension methods on `WidgetTester` to easily simulate common key combos.