### PR TITLE
Moving flutter_lints to dev_dependencies in all relevant packages

### DIFF
--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -9,10 +9,9 @@ environment:
 dependencies:
   characters: ^1.2.0
   collection: ^1.15.0
-  flutter_lints: ^1.0.0
   logging: ^1.0.1
   test: ^1.19.4
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   mockito: ^5.0.4
-

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   http: ^0.13.1
   linkify: ^4.0.0
   logging: ^1.0.1
-  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   super_text:
@@ -32,6 +31,7 @@ dependency_overrides:
     path: ../super_text
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   golden_toolkit: ^0.11.0
   mockito: ^5.0.4
 

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
     git:
       url: https://github.com/superlistapp/super_editor.git
       path: super_editor
-  flutter_lints: ^1.0.0
   logging: ^1.0.1
   markdown: ^4.0.0
 
@@ -26,6 +25,7 @@ dependency_overrides:
     path: ../super_editor
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.11.0

--- a/super_text/pubspec.yaml
+++ b/super_text/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
 
   attributed_text: 0.1.1
-  flutter_lints: ^1.0.0
   logging: ^1.0.1
 
 dependency_overrides:
@@ -22,6 +21,7 @@ dependency_overrides:
     path: ../attributed_text
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.11.0


### PR DESCRIPTION
A bunch of packages in this repo currently have `flutter_lints: ^1.0.0` in their `dependencies`. This breaks version solving for any downstream packages that want to update to the new version `2.0.0` of `flutter_lints`:

```
Because rich_clipboard_example depends on super_editor_markdown from git which depends on flutter_lints ^1.0.0, flutter_lints ^1.0.0 is required.
So, because rich_clipboard_example depends on flutter_lints ^2.0.0, version solving failed.
```

This PR fixes the issue by moving all the `flutter_lints` dependencies in this repo to the `dev_dependencies` section. I intentionally didn't update `flutter_lints` to `^2.0.0` while I was at it because doing so produces enough analyzer warnings that it should be handled in a dedicated PR.