### PR TITLE
Auto link URLs (Resolves #406)

### DIFF
--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -31,6 +31,25 @@ class DocumentSelection {
   })  : base = position,
         extent = position;
 
+  /// Creates a selection from the [documentPosition] as the [base] position
+  /// with [extentOffset] as the [extent] position within the document.
+  factory DocumentSelection.extentFromDocumentPosition({
+    required DocumentPosition documentPosition,
+    int extentOffset = 0,
+  }) {
+    assert(documentPosition.nodePosition is TextNodePosition);
+
+    final nodePosition = documentPosition.nodePosition as TextNodePosition;
+    return DocumentSelection(
+      base: documentPosition.copyWith(
+        nodePosition: nodePosition,
+      ),
+      extent: documentPosition.copyWith(
+        nodePosition: nodePosition.copyWith(offset: nodePosition.offset + extentOffset),
+      ),
+    );
+  }
+
   /// Creates a selection from the [base] position to the [extent] position
   /// within the document.
   const DocumentSelection({

--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -31,25 +31,6 @@ class DocumentSelection {
   })  : base = position,
         extent = position;
 
-  /// Creates a selection from the [documentPosition] as the [base] position
-  /// with [extentOffset] as the [extent] position within the document.
-  factory DocumentSelection.extentFromDocumentPosition({
-    required DocumentPosition documentPosition,
-    int extentOffset = 0,
-  }) {
-    assert(documentPosition.nodePosition is TextNodePosition);
-
-    final nodePosition = documentPosition.nodePosition as TextNodePosition;
-    return DocumentSelection(
-      base: documentPosition.copyWith(
-        nodePosition: nodePosition,
-      ),
-      extent: documentPosition.copyWith(
-        nodePosition: nodePosition.copyWith(offset: nodePosition.offset + extentOffset),
-      ),
-    );
-  }
-
   /// Creates a selection from the [base] position to the [extent] position
   /// within the document.
   const DocumentSelection({

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2256,6 +2256,12 @@ class CommonEditorOperations {
       attributedText = documentNode.text;
     }
 
+    // Specifically exclude this case because this leads to getting
+    // the previous position having an offset of -1, which is invalid
+    if (textNodeCurrPosition.offset == 0) {
+      return;
+    }
+
     final text = attributedText.text;
 
     // Position which is at the previous offset of the current selection.

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2344,16 +2344,21 @@ class _PasteEditorCommand implements EditorCommand {
       if (!hasLinkAttribute) {
         // Attributions at paste offset doesn't have [LinkAttribute].
         // Add [LinkAttribute] to each url in the text if existed
-        splitContent.first.forEachWord(_pastePosition, ((word, documentSelection) {
+        for (final selectionWordEntry in splitContent.first.wordWithSelections(_pastePosition).entries) {
+          final documentSelection = selectionWordEntry.key;
+          final word = selectionWordEntry.value;
+
           final link = Uri.tryParse(word);
 
           if (link != null && link.hasScheme && link.hasAuthority) {
             // Valid url. Apply [LinkAttribution] to the url
             final linkAttribution = LinkAttribution(url: link);
-            AddTextAttributionsCommand(documentSelection: documentSelection, attributions: {linkAttribution})
-                .execute(document, transaction);
+            AddTextAttributionsCommand(
+              documentSelection: documentSelection,
+              attributions: {linkAttribution},
+            ).execute(document, transaction);
           }
-        }));
+        }
       }
 
       // At this point in the paste process, the document selection

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2276,7 +2276,7 @@ class CommonEditorOperations {
     final word = getTextFromTextSelection(text, textSelection);
 
     final link = Uri.tryParse(word);
-    if (link != null && link.hasScheme) {
+    if (link != null && link.hasScheme && link.hasAuthority) {
       // Valid url. Apply [LinkAttribution] to the url
       final linkAttribution = LinkAttribution(url: link);
 
@@ -2355,6 +2355,7 @@ class _PasteEditorCommand implements EditorCommand {
 
       // Check for url in the pasted text and apply [LinkAttribution] appropriately
       final hasLinkAttribute = attributionsAtPasteOffset.firstWhereOrNull((attr) => attr is LinkAttribution) != null;
+      print('hasLinkAttribute: $hasLinkAttribute');
       if (!hasLinkAttribute) {
         // Attributions at paste offset doesn't have [LinkAttribute].
         // Add [LinkAttribute] to each url in the text if existed
@@ -2363,7 +2364,7 @@ class _PasteEditorCommand implements EditorCommand {
           (word, documentSelection) {
             final link = Uri.tryParse(word);
 
-            if (link != null && link.hasScheme) {
+            if (link != null && link.hasScheme && link.hasAuthority) {
               // Valid url. Apply [LinkAttribution] to the url
               final linkAttribution = LinkAttribution(url: link);
               AddTextAttributionsCommand(documentSelection: documentSelection, attributions: {linkAttribution})

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2233,7 +2233,7 @@ class CommonEditorOperations {
   /// a link if it is a url
   ///
   /// Does nothing if previous word is already a link
-  void convertPreviousWordToLinkIfIsUrl(DocumentComposer composer, DocumentEditor editor) {
+  void convertPreviousWordToLinkIfItIsUrl(DocumentComposer composer, DocumentEditor editor) {
     if (composer.selection == null) {
       return;
     }

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2233,7 +2233,7 @@ class CommonEditorOperations {
   /// a link if it is a url
   ///
   /// Does nothing if previous word is already a link
-  void convertPreviousWordToLinkIfItIsUrl(DocumentComposer composer, DocumentEditor editor) {
+  void convertPreviousUrlToLink(DocumentComposer composer, DocumentEditor editor) {
     if (composer.selection == null) {
       return;
     }

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -806,6 +806,10 @@ class SoftwareKeyboardHandler {
       TextPosition(offset: delta.insertionOffset, affinity: delta.selection.affinity),
       delta.textInserted,
     );
+
+    if (delta.textInserted == ' ') {
+      commonOps.convertPreviousWordToLinkIfItIsUrl(composer, editor);
+    }
   }
 
   void _applyReplacement(TextEditingDeltaReplacement delta) {

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -809,8 +809,8 @@ class SoftwareKeyboardHandler {
 
     if (delta.textInserted == ' ') {
       // Check for the word before the space. If that is a url, make that a link
-      final position = composer.selection!.extent.nodePosition as TextNodePosition;
-      commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
+      final currentPosition = composer.selection!.extent.nodePosition as TextNodePosition;
+      commonOps.turnWordAtPositionToLink(currentPosition.copyWith(offset: currentPosition.offset - 1));
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -808,7 +808,9 @@ class SoftwareKeyboardHandler {
     );
 
     if (delta.textInserted == ' ') {
-      commonOps.convertPreviousUrlToLink(composer, editor);
+      // Check for the word before the space. If that is a url, make that a link
+      final position = composer.selection!.extent.nodePosition as TextNodePosition;
+      commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -806,12 +806,6 @@ class SoftwareKeyboardHandler {
       TextPosition(offset: delta.insertionOffset, affinity: delta.selection.affinity),
       delta.textInserted,
     );
-
-    if (delta.textInserted == ' ') {
-      // Check for the word before the space. If that is a url, make that a link
-      final currentPosition = composer.selection!.extent.nodePosition as TextNodePosition;
-      commonOps.turnWordAtPositionToLink(currentPosition.copyWith(offset: currentPosition.offset - 1));
-    }
   }
 
   void _applyReplacement(TextEditingDeltaReplacement delta) {
@@ -893,6 +887,10 @@ class SoftwareKeyboardHandler {
     commonOps.convertParagraphByPatternMatching(
       composer.selection!.extent.nodeId,
     );
+
+    if (textInserted == ' ') {
+      commonOps.tokenizeUpstreamWord(composer.selection!.extent);
+    }
   }
 
   void replace(TextRange replacedRange, String replacementText) {

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -808,7 +808,7 @@ class SoftwareKeyboardHandler {
     );
 
     if (delta.textInserted == ' ') {
-      commonOps.convertPreviousWordToLinkIfItIsUrl(composer, editor);
+      commonOps.convertPreviousUrlToLink(composer, editor);
     }
   }
 

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -361,7 +361,7 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
       editContext.composer.selection!.extent.nodeId,
     );
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousWordToLinkIfItIsUrl(
+    editContext.commonOps.convertPreviousUrlToLink(
       editContext.composer,
       editContext.editor,
     );

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -362,8 +362,8 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
     );
 
     // Check for the word before the space. If that is a url, make that a link
-    final position = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
-    editContext.commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
+    final currentPosition = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
+    editContext.commonOps.turnWordAtPositionToLink(currentPosition.copyWith(offset: currentPosition.offset - 1));
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -360,11 +360,10 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
     editContext.commonOps.convertParagraphByPatternMatching(
       editContext.composer.selection!.extent.nodeId,
     );
+
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousUrlToLink(
-      editContext.composer,
-      editContext.editor,
-    );
+    final position = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
+    editContext.commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -361,9 +361,7 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
       editContext.composer.selection!.extent.nodeId,
     );
 
-    // Check for the word before the space. If that is a url, make that a link
-    final currentPosition = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
-    editContext.commonOps.turnWordAtPositionToLink(currentPosition.copyWith(offset: currentPosition.offset - 1));
+    editContext.commonOps.tokenizeUpstreamWord(editContext.composer.selection!.extent);
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -360,6 +360,11 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
     editContext.commonOps.convertParagraphByPatternMatching(
       editContext.composer.selection!.extent.nodeId,
     );
+    // Check for the word before the space. If that is a url, make that a link
+    editContext.commonOps.convertPreviousWordToLinkIfIsUrl(
+      editContext.composer,
+      editContext.editor,
+    );
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -361,7 +361,7 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
       editContext.composer.selection!.extent.nodeId,
     );
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousWordToLinkIfIsUrl(
+    editContext.commonOps.convertPreviousWordToLinkIfItIsUrl(
       editContext.composer,
       editContext.editor,
     );

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1138,6 +1138,14 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
 
   final didInsertCharacter = editContext.commonOps.insertCharacter(character);
 
+  if (didInsertCharacter && character == ' ') {
+    // Check for the word before the space. If that is a url, make that a link
+    editContext.commonOps.convertPreviousWordToLinkIfIsUrl(
+      editContext.composer,
+      editContext.editor,
+    );
+  }
+
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1140,7 +1140,7 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
 
   if (didInsertCharacter && character == ' ') {
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousWordToLinkIfItIsUrl(
+    editContext.commonOps.convertPreviousUrlToLink(
       editContext.composer,
       editContext.editor,
     );

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -189,32 +189,30 @@ extension DocumentSelectionWithText on Document {
 }
 
 extension WordsDocumentPosition on String {
-  /// Given [documentPosition] as the starting position of the text in the [Document],
-  /// invoke [action] with each [word] and its corresponding [documentSelection]
+  /// Returns a [Map] of which entries represent list of words in the text, with
+  /// keys are [DocumentSelection] and values are their corresponding [String] words
   ///
-  /// For Matt: I'm not sure if this is the version after refactoring you would expect,
-  /// but I believe this one is better than the last one. The reason I can't return an
-  /// [Iterable] as you said is I need to invoke action on 2 variables, and creating a
-  /// wrapper class only for this method is really confusing.
-  void forEachWord(
-    DocumentPosition documentPosition,
-    void Function(String word, DocumentSelection documentSelection) action,
-  ) {
+  /// The [documentPosition] should be the starting position of the text in
+  /// the [Document],
+
+  Map<DocumentSelection, String> wordWithSelections(DocumentPosition documentPosition) {
     final textPosition = documentPosition.nodePosition as TextNodePosition;
 
-    for (final wordTextSelection in wordTextSelections) {
-      final word = wordTextSelection.textInside(this);
-      final documentSelection = documentPositionToDocumentSelection(
-        documentPosition: documentPosition.copyWith(
-          nodePosition: textPosition.copyWith(
-            offset: textPosition.offset + wordTextSelection.start,
+    return Map.fromEntries(
+      wordTextSelections.map((wordTextSelection) {
+        final word = wordTextSelection.textInside(this);
+        final documentSelection = documentPositionToDocumentSelection(
+          documentPosition: documentPosition.copyWith(
+            nodePosition: textPosition.copyWith(
+              offset: textPosition.offset + wordTextSelection.start,
+            ),
           ),
-        ),
-        extentOffset: wordTextSelection.end - wordTextSelection.start,
-      );
+          extentOffset: wordTextSelection.end - wordTextSelection.start,
+        );
 
-      action(word, documentSelection);
-    }
+        return MapEntry(documentSelection, word);
+      }),
+    );
   }
 
   /// Returns list of [TextSelection] on each word in text

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -191,22 +191,26 @@ extension DocumentSelectionWithText on Document {
 extension WordsDocumentPosition on String {
   /// Given [documentPosition] as the starting position of the text in the [Document],
   /// invoke [action] with each [word] and its corresponding [documentSelection]
+  ///
+  /// For Matt: I'm not sure if this is the version after refactoring you would expect,
+  /// but I believe this one is better than the last one. The reason I can't return an
+  /// [Iterable] as you said is I need to invoke action on 2 variables, and creating a
+  /// wrapper class only for this method is really confusing.
   void forEachWord(
     DocumentPosition documentPosition,
     void Function(String word, DocumentSelection documentSelection) action,
   ) {
-    final textSelections = textSelectionsOnWord();
     final textPosition = documentPosition.nodePosition as TextNodePosition;
 
-    for (final textSelection in textSelections) {
-      final word = textSelection.textInside(this);
+    for (final wordTextSelection in wordTextSelections) {
+      final word = wordTextSelection.textInside(this);
       final documentSelection = documentPositionToDocumentSelection(
         documentPosition: documentPosition.copyWith(
           nodePosition: textPosition.copyWith(
-            offset: textPosition.offset + textSelection.start,
+            offset: textPosition.offset + wordTextSelection.start,
           ),
         ),
-        extentOffset: textSelection.end - textSelection.start,
+        extentOffset: wordTextSelection.end - wordTextSelection.start,
       );
 
       action(word, documentSelection);
@@ -214,7 +218,7 @@ extension WordsDocumentPosition on String {
   }
 
   /// Returns list of [TextSelection] on each word in text
-  List<TextSelection> textSelectionsOnWord() {
+  List<TextSelection> get wordTextSelections {
     final List<TextSelection> textSelections = [];
     var offset = 0;
 

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1140,7 +1140,7 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
 
   if (didInsertCharacter && character == ' ') {
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousWordToLinkIfIsUrl(
+    editContext.commonOps.convertPreviousWordToLinkIfItIsUrl(
       editContext.composer,
       editContext.editor,
     );

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1140,8 +1140,8 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
 
   if (didInsertCharacter && character == ' ') {
     // Check for the word before the space. If that is a url, make that a link
-    final position = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
-    editContext.commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
+    final currentPosition = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
+    editContext.commonOps.turnWordAtPositionToLink(currentPosition.copyWith(offset: currentPosition.offset - 1));
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -244,6 +244,18 @@ class TextNodePosition extends TextPosition implements NodePosition {
 
   @override
   int get hashCode => super.hashCode ^ super.offset.hashCode;
+
+  /// Creates a new [TextNodePosition] based on the current position, with the
+  /// provided parameters overridden.
+  TextNodePosition copyWith({
+    int? offset,
+    TextAffinity? affinity,
+  }) {
+    return TextNodePosition(
+      offset: offset ?? this.offset,
+      affinity: affinity ?? this.affinity,
+    );
+  }
 }
 
 /// Mixin for all [SingleColumnLayoutComponentViewModel]s that represent

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1140,10 +1140,8 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
 
   if (didInsertCharacter && character == ' ') {
     // Check for the word before the space. If that is a url, make that a link
-    editContext.commonOps.convertPreviousUrlToLink(
-      editContext.composer,
-      editContext.editor,
-    );
+    final position = editContext.composer.selection!.extent.nodePosition as TextNodePosition;
+    editContext.commonOps.turnWordAtPositionToLink(position.copyWith(offset: position.offset - 1));
   }
 
   return didInsertCharacter ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -156,7 +156,7 @@ TextDirection getParagraphDirection(String text) {
   }
 }
 
-/// Returns list of ranges of each word in text
+/// Returns list of [TextSelection] on each word in text
 List<TextSelection> getTextSelectionsForEachWord(String text) {
   final List<TextSelection> textSelections = [];
   var offset = 0;
@@ -174,4 +174,9 @@ List<TextSelection> getTextSelectionsForEachWord(String text) {
     offset += textSelection.end - textSelection.start + 1;
   }
   return textSelections;
+}
+
+/// Returns a string from a given [text] in a [textSelection] range
+String getTextFromTextSelection(String text, TextSelection textSelection) {
+  return text.substring(textSelection.start, textSelection.end);
 }

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -156,23 +156,22 @@ TextDirection getParagraphDirection(String text) {
   }
 }
 
-List<TextSelection> wordsInText(String text, DocumentPosition position) {
+/// Returns list of ranges of each word in text
+List<TextSelection> getTextSelectionsForEachWord(String text) {
   final List<TextSelection> textSelections = [];
-  var currentPosition = position.nodePosition as TextNodePosition;
-  var currentIndex = 0;
+  var offset = 0;
 
-  while (currentIndex < text.length) {
-    if (text[currentIndex] == ' ') {
-      currentIndex++;
+  while (offset < text.length) {
+    if (text[offset] == ' ') {
+      offset++;
       continue;
     }
 
-    currentPosition = currentPosition.copyWith(offset: currentPosition.offset + currentIndex);
-
+    final currentPosition = TextPosition(offset: offset);
     final textSelection = expandPositionToWord(text: text, textPosition: currentPosition);
     textSelections.add(textSelection);
 
-    currentIndex += textSelection.end - textSelection.start + 1;
+    offset += textSelection.end - textSelection.start + 1;
   }
   return textSelections;
 }

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -62,7 +62,7 @@ TextSelection expandPositionToWord({
 
   int start = min(textPosition.offset, text.length - 1);
   int end = min(textPosition.offset, text.length - 1);
-  while (start > 0 && text[start] != ' ') {
+  while (start > 0 && text[start - 1] != ' ') {
     start -= 1;
   }
   while (end < text.length && text[end] != ' ') {
@@ -154,4 +154,25 @@ TextDirection getParagraphDirection(String text) {
   } else {
     return TextDirection.ltr;
   }
+}
+
+List<TextSelection> wordsInText(String text, DocumentPosition position) {
+  final List<TextSelection> textSelections = [];
+  var currentPosition = position.nodePosition as TextNodePosition;
+  var currentIndex = 0;
+
+  while (currentIndex < text.length) {
+    if (text[currentIndex] == ' ') {
+      currentIndex++;
+      continue;
+    }
+
+    currentPosition = currentPosition.copyWith(offset: currentPosition.offset + currentIndex);
+
+    final textSelection = expandPositionToWord(text: text, textPosition: currentPosition);
+    textSelections.add(textSelection);
+
+    currentIndex += textSelection.end - textSelection.start + 1;
+  }
+  return textSelections;
 }

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -156,27 +156,26 @@ TextDirection getParagraphDirection(String text) {
   }
 }
 
-/// Returns list of [TextSelection] on each word in text
-List<TextSelection> getTextSelectionsForEachWord(String text) {
-  final List<TextSelection> textSelections = [];
-  var offset = 0;
+/// Convert a [documentPosition] to a [DocumentSelection] with an [extentOffset]
+///
+/// Giving a negative [extentOffset] would result in a selection expanded
+/// in downstream direction.
+///
+/// Giving a positive [extentOffset] would result in a selection expanded
+/// in upstream direction.
+///
+/// Return a collapsed selection by
+DocumentSelection documentPositionToDocumentSelection({
+  required DocumentPosition documentPosition,
+  int extentOffset = 0,
+}) {
+  assert(documentPosition.nodePosition is TextNodePosition);
 
-  while (offset < text.length) {
-    if (text[offset] == ' ') {
-      offset++;
-      continue;
-    }
-
-    final currentPosition = TextPosition(offset: offset);
-    final textSelection = expandPositionToWord(text: text, textPosition: currentPosition);
-    textSelections.add(textSelection);
-
-    offset += textSelection.end - textSelection.start + 1;
-  }
-  return textSelections;
-}
-
-/// Returns a string from a given [text] in a [textSelection] range
-String getTextFromTextSelection(String text, TextSelection textSelection) {
-  return text.substring(textSelection.start, textSelection.end);
+  final nodePosition = documentPosition.nodePosition as TextNodePosition;
+  return DocumentSelection(
+    base: documentPosition,
+    extent: documentPosition.copyWith(
+      nodePosition: nodePosition.copyWith(offset: nodePosition.offset + extentOffset),
+    ),
+  );
 }

--- a/super_editor/test/src/default_editor/common_editor_operations_test.dart
+++ b/super_editor/test/src/default_editor/common_editor_operations_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
@@ -189,6 +190,18 @@ void main() {
           documentLayoutResolver: () => FakeDocumentLayout(),
         );
 
+        // Render document in a `SuperEditor`
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                composer: composer,
+              ),
+            ),
+          ),
+        );
+
         // The Clipboard requires a platform response, which doesn't exist
         // for widget tests. Pretend that we're the platform and handle
         // the incoming clipboard call.
@@ -266,6 +279,18 @@ void main() {
           editor: editor,
           composer: composer,
           documentLayoutResolver: () => FakeDocumentLayout(),
+        );
+
+        // Render document in a `SuperEditor`
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                composer: composer,
+              ),
+            ),
+          ),
         );
 
         // The Clipboard requires a platform response, which doesn't exist

--- a/super_editor/test/src/default_editor/common_editor_operations_test.dart
+++ b/super_editor/test/src/default_editor/common_editor_operations_test.dart
@@ -162,7 +162,9 @@ void main() {
     });
     group("pasting", () {
       test("it converts url in the pasted text into a link", () async {
+        // Note: We need to ensure initialized because we access the Clipboard.
         TestWidgetsFlutterBinding.ensureInitialized();
+
         final document = MutableDocument(nodes: [
           ParagraphNode(
             id: 'paragraph',
@@ -228,6 +230,8 @@ void main() {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.
         // This test prevents that regression
+
+        // Note: We need to ensure initialized because we access the Clipboard.
         TestWidgetsFlutterBinding.ensureInitialized();
 
         final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));

--- a/super_editor/test/src/default_editor/common_editor_operations_test.dart
+++ b/super_editor/test/src/default_editor/common_editor_operations_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 
@@ -156,6 +158,140 @@ void main() {
         expect(doc.nodes.first, isA<ParagraphNode>());
         expect(doc.nodes.first.id, "1");
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 0));
+      });
+    });
+    group("pasting", () {
+      test("it converts url in the pasted text into a link", () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        final document = MutableDocument(nodes: [
+          ParagraphNode(
+            id: 'paragraph',
+            text: AttributedText(
+              text: 'This  a link',
+            ),
+          ),
+        ]);
+        final editor = DocumentEditor(document: document);
+
+        // Select block of text containing a url
+        final composer = DocumentComposer(
+          initialSelection: const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "paragraph",
+              nodePosition: TextNodePosition(offset: 5),
+            ),
+          ),
+        );
+        final commonOps = CommonEditorOperations(
+          editor: editor,
+          composer: composer,
+          documentLayoutResolver: () => FakeDocumentLayout(),
+        );
+
+        // The Clipboard requires a platform response, which doesn't exist
+        // for widget tests. Pretend that we're the platform and handle
+        // the incoming clipboard call.
+        SystemChannels.platform.setMockMethodCallHandler((call) async {
+          if (call.method == 'Clipboard.getData') {
+            return {
+              'text': 'text: https://flutter.dev is',
+            };
+          }
+        });
+
+        commonOps.paste();
+
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          // We have to run these expectations in the next frame
+          // so that the async paste operation has time to complete.
+          final textNode = editor.document.nodes.first as TextNode;
+
+          expect(textNode.text.text, 'This text: https://flutter.dev is a link');
+          // A [LinkAttribution] should be added at the url
+          expect(
+            textNode.text.spans.getAttributionSpansInRange(
+              attributionFilter: (_) => true,
+              start: 0,
+              end: 40,
+            ),
+            {
+              AttributionSpan(
+                attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+                start: 11,
+                end: 29,
+              )
+            },
+          );
+        });
+      });
+      test("it does NOT convert url in the pasted text if the pasted position is already a link", () async {
+        // Adding [LinkAttribution] to a position that already has it
+        // could cause spans mismatching, which potentially leads to errors.
+        // This test prevents that regression
+        TestWidgetsFlutterBinding.ensureInitialized();
+
+        final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
+
+        final document = MutableDocument(nodes: [
+          ParagraphNode(
+            id: 'paragraph',
+            text: AttributedText(
+              text: 'This text: https://flutter.dev is already a link',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(attribution: linkAttribution, offset: 11, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: linkAttribution, offset: 30, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+        final editor = DocumentEditor(document: document);
+
+        // Place the selection within the link attributed span's range
+        final composer = DocumentComposer(
+          initialSelection: const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "paragraph",
+              nodePosition: TextNodePosition(offset: 28),
+            ),
+          ),
+        );
+        final commonOps = CommonEditorOperations(
+          editor: editor,
+          composer: composer,
+          documentLayoutResolver: () => FakeDocumentLayout(),
+        );
+
+        // The Clipboard requires a platform response, which doesn't exist
+        // for widget tests. Pretend that we're the platform and handle
+        // the incoming clipboard call.
+        SystemChannels.platform.setMockMethodCallHandler((call) async {
+          if (call.method == 'Clipboard.getData') {
+            return {
+              'text': '[block] https://flutter.dev [block]',
+            };
+          }
+        });
+
+        commonOps.paste();
+
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          // We have to run these expectations in the next frame
+          // so that the async paste operation has time to complete.
+          final textNode = editor.document.nodes.first as TextNode;
+
+          expect(textNode.text.text, 'This text: https://flutter.[block] https://flutter.dev [block]dev is a link');
+          // A [LinkAttribution] should be added at the url
+          expect(
+            textNode.text.spans.hasAttributionsWithin(
+              attributions: {LinkAttribution(url: Uri.parse('https://flutter.dev'))},
+              start: 11,
+              end: 30 + 35,
+            ),
+            true,
+          );
+        });
       });
     });
   });

--- a/super_editor/test/src/default_editor/common_editor_operations_test.dart
+++ b/super_editor/test/src/default_editor/common_editor_operations_test.dart
@@ -160,7 +160,7 @@ void main() {
       });
     });
     group("pasting", () {
-      testWidgets("automatically converts a URL to a link", (tester) async {
+      testWidgets("automatically converts a URL in the pasted text to a link", (tester) async {
         // Note: We need to ensure initialized because we access the Clipboard.
         TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -226,6 +226,7 @@ void main() {
           },
         );
       });
+
       testWidgets("does nothing to an existing link", (tester) async {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
 
     group('inserting a space character', () {
-      test('it turns the URL before the space into a link', () {
+      test('automatically converts a URL into a link', () {
         // The `https://flutter.devis` typo was done on purpose
         // because a space will be added after the `dev`
 
@@ -137,6 +137,7 @@ void main() {
           },
         );
       });
+
       test('it does nothing to an existing link', () {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -73,6 +73,142 @@ void main() {
       });
     });
 
+    group('inserting a space character', () {
+      test('it turns the previous url into a link', () {
+        final document = MutableDocument(nodes: [
+          ParagraphNode(
+            id: "1",
+            text: AttributedText(text: 'This text: https://flutter.devis a link'),
+          ),
+        ]);
+        final editor = DocumentEditor(document: document);
+        final composer = DocumentComposer(
+          initialSelection: const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "1",
+              nodePosition: TextNodePosition(offset: 30),
+            ),
+          ),
+        );
+        final commonOps = CommonEditorOperations(
+          editor: editor,
+          composer: composer,
+          documentLayoutResolver: () => FakeDocumentLayout(),
+        );
+        final softwareKeyboardHandler = SoftwareKeyboardHandler(
+          editor: editor,
+          composer: composer,
+          commonOps: commonOps,
+        );
+
+        // Insert the "space" character
+        softwareKeyboardHandler.applyDeltas([
+          const TextEditingDeltaInsertion(
+            textInserted: ' ',
+            insertionOffset: 30,
+            selection: TextSelection.collapsed(offset: 30),
+            composing: TextRange(start: -1, end: -1),
+            oldText: 'This text: https://flutter.devis a link',
+          ),
+        ]);
+
+        final paragraphNode = document.nodes.first as ParagraphNode;
+
+        // The handler should insert a space
+        expect(paragraphNode.text.text, 'This text: https://flutter.dev is a link');
+
+        // The handler should add a [LinkAttribution] at the url
+        expect(
+          paragraphNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 0,
+            end: 40,
+          ),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+              start: 11,
+              end: 29,
+            )
+          },
+        );
+      });
+      test('it does NOT turn the previous url into a link if that is already a link', () {
+        // Adding [LinkAttribution] to a position that already has it
+        // could cause spans mismatching, which potentially leads to errors.
+        // This test prevents that regression
+        final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
+
+        final document = MutableDocument(nodes: [
+          ParagraphNode(
+            id: "1",
+            text: AttributedText(
+              text: 'This text: https://flutter.devis a link',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(
+                    attribution: linkAttribution,
+                    offset: 11,
+                    markerType: SpanMarkerType.start,
+                  ),
+                  SpanMarker(
+                    attribution: linkAttribution,
+                    offset: 29,
+                    markerType: SpanMarkerType.end,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ]);
+        final editor = DocumentEditor(document: document);
+        final composer = DocumentComposer(
+          initialSelection: const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "1",
+              nodePosition: TextNodePosition(offset: 30),
+            ),
+          ),
+        );
+        final commonOps = CommonEditorOperations(
+          editor: editor,
+          composer: composer,
+          documentLayoutResolver: () => FakeDocumentLayout(),
+        );
+        final softwareKeyboardHandler = SoftwareKeyboardHandler(
+          editor: editor,
+          composer: composer,
+          commonOps: commonOps,
+        );
+
+        // Insert the "space" character
+        softwareKeyboardHandler.applyDeltas([
+          const TextEditingDeltaInsertion(
+            textInserted: ' ',
+            insertionOffset: 30,
+            selection: TextSelection.collapsed(offset: 30),
+            composing: TextRange(start: -1, end: -1),
+            oldText: 'This text: https://flutter.devis a link',
+          ),
+        ]);
+
+        final paragraphNode = document.nodes.first as ParagraphNode;
+
+        // The handler should insert a space
+        expect(paragraphNode.text.text, 'This text: https://flutter.dev is a link');
+
+        // The handler should add a [LinkAttribution] at the url
+        expect(
+          paragraphNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 0,
+            end: 40,
+          ),
+          {AttributionSpan(attribution: linkAttribution, start: 11, end: 29)},
+        );
+      });
+    });
+
     group('text serialization and selected content', () {
       test('within a single node is reported as a TextEditingValue', () {
         const text = "This is a paragraph of text.";

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -74,7 +74,10 @@ void main() {
     });
 
     group('inserting a space character', () {
-      test('it turns the previous url into a link', () {
+      test('it turns the URL before the space into a link', () {
+        // The `https://flutter.devis` typo was done on purpose
+        // because a space will be added after the `dev`
+
         final document = MutableDocument(nodes: [
           ParagraphNode(
             id: "1",
@@ -101,7 +104,8 @@ void main() {
           commonOps: commonOps,
         );
 
-        // Insert the "space" character
+        // Place caret at "This text: http://flutter.dev|is..."
+        // then insert a "space" character
         softwareKeyboardHandler.applyDeltas([
           const TextEditingDeltaInsertion(
             textInserted: ' ',
@@ -133,12 +137,14 @@ void main() {
           },
         );
       });
-      test('it does NOT turn the previous url into a link if that is already a link', () {
+      test('it does nothing to an existing link', () {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.
         // This test prevents that regression
         final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
 
+        // The `https://flutter.devis` typo was done on purpose
+        // because a space will be added after the `dev`
         final document = MutableDocument(nodes: [
           ParagraphNode(
             id: "1",
@@ -181,7 +187,8 @@ void main() {
           commonOps: commonOps,
         );
 
-        // Insert the "space" character
+        // Place caret at "This text: http://flutter.dev|is..."
+        // then insert a "space" character
         softwareKeyboardHandler.applyDeltas([
           const TextEditingDeltaInsertion(
             textInserted: ' ',
@@ -197,7 +204,7 @@ void main() {
         // The handler should insert a space
         expect(paragraphNode.text.text, 'This text: https://flutter.dev is a link');
 
-        // The handler should add a [LinkAttribution] at the url
+        // The handler should not change the existing link atrribution
         expect(
           paragraphNode.text.spans.getAttributionSpansInRange(
             attributionFilter: (_) => true,

--- a/super_editor/test/src/default_editor/test_text_tools.dart
+++ b/super_editor/test/src/default_editor/test_text_tools.dart
@@ -4,25 +4,25 @@ import 'package:super_editor/src/default_editor/text_tools.dart';
 
 void main() {
   group('text_tools.dart', () {
-    test('expand position to word', () {
-      // Notice there is a space at first
-      const text = ' SuperEditor is awesome';
-
-      // Place a collapsed selection at "| SuperEditor is awesome"
-      expect(
-        const TextSelection.collapsed(offset: 0),
-        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 0)),
-      );
-      // Place a collapsed selection at " |SuperEditor is awesome"
-      expect(
-        const TextSelection(baseOffset: 1, extentOffset: 12),
-        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 1)),
-      );
-      // Place a collapsed selection at " SuperEditor| is awesome"
-      expect(
-        const TextSelection(baseOffset: 1, extentOffset: 13),
-        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 12)),
-      );
+    group('expand position to word', () {
+      test('does not expand when there is no word next to the caret', () {
+        // Notice there is a space at first
+        const text = ' SuperEditor is awesome';
+        // Place a collapsed selection at "| SuperEditor is awesome"
+        expect(
+          const TextSelection.collapsed(offset: 0),
+          expandPositionToWord(text: text, textPosition: const TextPosition(offset: 0)),
+        );
+      });
+      test('expand when there is a word next to the caret', () {
+        // Notice there is a space at first
+        const text = ' SuperEditor is awesome';
+        // Place a collapsed selection at " |SuperEditor is awesome"
+        expect(
+          const TextSelection(baseOffset: 1, extentOffset: 12),
+          expandPositionToWord(text: text, textPosition: const TextPosition(offset: 1)),
+        );
+      });
     });
   });
 }

--- a/super_editor/test/src/default_editor/test_text_tools.dart
+++ b/super_editor/test/src/default_editor/test_text_tools.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/default_editor/text_tools.dart';
+
+void main() {
+  group('text_tools.dart', () {
+    test('expand position to word', () {
+      // Notice there is a space at first
+      const text = ' SuperEditor is awesome';
+
+      // Place a collapsed selection at "| SuperEditor is awesome"
+      expect(
+        const TextSelection.collapsed(offset: 0),
+        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 0)),
+      );
+      // Place a collapsed selection at " |SuperEditor is awesome"
+      expect(
+        const TextSelection(baseOffset: 1, extentOffset: 12),
+        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 1)),
+      );
+      // Place a collapsed selection at " SuperEditor| is awesome"
+      expect(
+        const TextSelection(baseOffset: 1, extentOffset: 13),
+        expandPositionToWord(text: text, textPosition: const TextPosition(offset: 12)),
+      );
+    });
+  });
+}

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -347,106 +347,45 @@ void main() {
 
         // The handler should add a [LinkAttribution] at the url
         expect(
-          textNode.text.spans.hasAttributionsWithin(
-            attributions: {LinkAttribution(url: Uri.parse('https://flutter.dev'))},
-            start: 11,
-            end: 30,
-          ),
-          true,
-        );
-
-        // The handler should not change any attribution of the remaining text
-        expect(
           textNode.text.spans.getAttributionSpansInRange(
             attributionFilter: (_) => true,
             start: 0,
-            end: 10,
+            end: 40,
           ),
-          <dynamic>{},
-        );
-        expect(
-          textNode.text.spans.getAttributionSpansInRange(
-            attributionFilter: (_) => true,
-            start: 31,
-            end: 42,
-          ),
-          <dynamic>{},
-        );
-      });
-
-      test('it does NOT turn the previous word into a link if that word is NOT a url', () {
-        final editContext = _createEditContext();
-
-        // Add a paragraph to the document.
-        (editContext.editor.document as MutableDocument).nodes.add(
-              ParagraphNode(
-                id: 'paragraph',
-                text: AttributedText(text: 'This [text] is not a link'),
-              ),
-            );
-
-        // Select the last character of the url
-        editContext.composer.selection = const DocumentSelection.collapsed(
-          position: DocumentPosition(
-            nodeId: 'paragraph',
-            nodePosition: TextNodePosition(offset: 10),
-          ),
-        );
-
-        // Press the "space" key
-        var result = anyCharacterToInsertInTextContent(
-          editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
-            character: ' ',
-            data: FakeRawKeyEventData(
-              logicalKey: LogicalKeyboardKey.space,
-              physicalKey: PhysicalKeyboardKey.space,
-            ),
-          ),
-        );
-
-        // The handler should insert a character
-        expect(result, ExecutionInstruction.haltExecution);
-
-        final textNode = editContext.editor.document.nodes.first as TextNode;
-
-        // The handler should insert a space
-        expect(
-          textNode.text.text,
-          'This [text ] is not a link',
-        );
-
-        // The handler should not change any existing attribution
-        expect(
-          textNode.text.spans.getAttributionSpansInRange(
-            attributionFilter: (_) => true,
-            start: 0,
-            end: 25,
-          ),
-          <dynamic>{},
+          {
+            AttributionSpan(
+              attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+              start: 11,
+              end: 29,
+            )
+          },
         );
       });
       test('it does NOT turn the previous word into a link if that word is already a link', () {
         final editContext = _createEditContext();
+        final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
 
         // Add a paragraph to the document.
         (editContext.editor.document as MutableDocument).nodes.add(
               ParagraphNode(
                 id: 'paragraph',
                 text: AttributedText(
-                    text: 'This text: https://flutter.dev is a link',
-                    spans: AttributedSpans(attributions: [
+                  text: 'This text: https://flutter.dev is a link',
+                  spans: AttributedSpans(
+                    attributions: [
                       SpanMarker(
-                        attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+                        attribution: linkAttribution,
                         offset: 11,
                         markerType: SpanMarkerType.start,
                       ),
                       SpanMarker(
-                        attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
-                        offset: 30,
+                        attribution: linkAttribution,
+                        offset: 29,
                         markerType: SpanMarkerType.end,
                       ),
-                    ])),
+                    ],
+                  ),
+                ),
               ),
             );
 
@@ -487,7 +426,7 @@ void main() {
             start: 0,
             end: 43,
           ),
-          {LinkAttribution(url: Uri.parse('https://flutter.dev'))},
+          {AttributionSpan(attribution: linkAttribution, start: 11, end: 29)},
         );
       });
     });

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -301,6 +301,196 @@ void main() {
         );
       });
     });
+
+    group('Inserting a space character', () {
+      test('it turns the previous word into a link if that word is a url', () {
+        final editContext = _createEditContext();
+
+        // Add a paragraph to the document.
+        (editContext.editor.document as MutableDocument).nodes.add(
+              ParagraphNode(
+                id: 'paragraph',
+                text: AttributedText(text: 'This text: https://flutter.devis a link'),
+              ),
+            );
+
+        // Select the last character of the url
+        editContext.composer.selection = const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: 'paragraph',
+            nodePosition: TextNodePosition(offset: 30),
+          ),
+        );
+
+        // Press the "space" key
+        var result = anyCharacterToInsertInTextContent(
+          editContext: editContext,
+          keyEvent: const FakeRawKeyEvent(
+            character: ' ',
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+          ),
+        );
+
+        // The handler should insert a character
+        expect(result, ExecutionInstruction.haltExecution);
+
+        final textNode = editContext.editor.document.nodes.first as TextNode;
+
+        // The handler should insert a space
+        expect(
+          textNode.text.text,
+          'This text: https://flutter.dev is a link',
+        );
+
+        // The handler should add a [LinkAttribution] at the url
+        expect(
+          textNode.text.spans.hasAttributionsWithin(
+            attributions: {LinkAttribution(url: Uri.parse('https://flutter.dev'))},
+            start: 11,
+            end: 30,
+          ),
+          true,
+        );
+
+        // The handler should not change any attribution of the remaining text
+        expect(
+          textNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 0,
+            end: 10,
+          ),
+          <dynamic>{},
+        );
+        expect(
+          textNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 31,
+            end: 42,
+          ),
+          <dynamic>{},
+        );
+      });
+
+      test('it does NOT turn the previous word into a link if that word is NOT a url', () {
+        final editContext = _createEditContext();
+
+        // Add a paragraph to the document.
+        (editContext.editor.document as MutableDocument).nodes.add(
+              ParagraphNode(
+                id: 'paragraph',
+                text: AttributedText(text: 'This [text] is not a link'),
+              ),
+            );
+
+        // Select the last character of the url
+        editContext.composer.selection = const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: 'paragraph',
+            nodePosition: TextNodePosition(offset: 10),
+          ),
+        );
+
+        // Press the "space" key
+        var result = anyCharacterToInsertInTextContent(
+          editContext: editContext,
+          keyEvent: const FakeRawKeyEvent(
+            character: ' ',
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+          ),
+        );
+
+        // The handler should insert a character
+        expect(result, ExecutionInstruction.haltExecution);
+
+        final textNode = editContext.editor.document.nodes.first as TextNode;
+
+        // The handler should insert a space
+        expect(
+          textNode.text.text,
+          'This [text ] is not a link',
+        );
+
+        // The handler should not change any existing attribution
+        expect(
+          textNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 0,
+            end: 25,
+          ),
+          <dynamic>{},
+        );
+      });
+      test('it does NOT turn the previous word into a link if that word is already a link', () {
+        final editContext = _createEditContext();
+
+        // Add a paragraph to the document.
+        (editContext.editor.document as MutableDocument).nodes.add(
+              ParagraphNode(
+                id: 'paragraph',
+                text: AttributedText(
+                    text: 'This text: https://flutter.dev is a link',
+                    spans: AttributedSpans(attributions: [
+                      SpanMarker(
+                        attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+                        offset: 11,
+                        markerType: SpanMarkerType.start,
+                      ),
+                      SpanMarker(
+                        attribution: LinkAttribution(url: Uri.parse('https://flutter.dev')),
+                        offset: 30,
+                        markerType: SpanMarkerType.end,
+                      ),
+                    ])),
+              ),
+            );
+
+        // Select the last character of the url
+        editContext.composer.selection = const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: 'paragraph',
+            nodePosition: TextNodePosition(offset: 30),
+          ),
+        );
+
+        // Press the "space" key
+        var result = anyCharacterToInsertInTextContent(
+          editContext: editContext,
+          keyEvent: const FakeRawKeyEvent(
+            character: ' ',
+            data: FakeRawKeyEventData(
+              logicalKey: LogicalKeyboardKey.space,
+              physicalKey: PhysicalKeyboardKey.space,
+            ),
+          ),
+        );
+
+        // The handler should insert a character
+        expect(result, ExecutionInstruction.haltExecution);
+
+        final textNode = editContext.editor.document.nodes.first as TextNode;
+        // The handler should insert a space
+        expect(
+          textNode.text.text,
+          'This text: https://flutter.dev  is a link',
+        );
+
+        // The handler should not change any existing attribution
+        expect(
+          textNode.text.spans.getAttributionSpansInRange(
+            attributionFilter: (_) => true,
+            start: 0,
+            end: 43,
+          ),
+          {LinkAttribution(url: Uri.parse('https://flutter.dev'))},
+        );
+      });
+    });
   });
 }
 

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -303,7 +303,7 @@ void main() {
     });
 
     group('Inserting a space character', () {
-      test('it turns the previous word into a link if that word is a url', () {
+      test('it turns the previous url into a link', () {
         final editContext = _createEditContext();
 
         // Add a paragraph to the document.
@@ -361,7 +361,10 @@ void main() {
           },
         );
       });
-      test('it does NOT turn the previous word into a link if that word is already a link', () {
+      test('it does NOT turn the previous url into a link if that is already a link', () {
+        // Adding [LinkAttribution] to a position that already has it
+        // could cause spans mismatching, which potentially leads to errors.
+        // This test prevents that regression
         final editContext = _createEditContext();
         final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
 
@@ -370,7 +373,7 @@ void main() {
               ParagraphNode(
                 id: 'paragraph',
                 text: AttributedText(
-                  text: 'This text: https://flutter.dev is a link',
+                  text: 'This text: https://flutter.devis a link',
                   spans: AttributedSpans(
                     attributions: [
                       SpanMarker(
@@ -416,7 +419,7 @@ void main() {
         // The handler should insert a space
         expect(
           textNode.text.text,
-          'This text: https://flutter.dev  is a link',
+          'This text: https://flutter.dev is a link',
         );
 
         // The handler should not change any existing attribution
@@ -424,7 +427,7 @@ void main() {
           textNode.text.spans.getAttributionSpansInRange(
             attributionFilter: (_) => true,
             start: 0,
-            end: 43,
+            end: 40,
           ),
           {AttributionSpan(attribution: linkAttribution, start: 11, end: 29)},
         );

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -303,7 +303,7 @@ void main() {
     });
 
     group('Inserting a space character', () {
-      test('converts the URL before the space to a link', () {
+      test('automatically converts a URL into a link', () {
         final editContext = _createEditContext();
 
         // Add a paragraph to the document.
@@ -363,6 +363,7 @@ void main() {
           },
         );
       });
+
       test('it does nothing to an existing link', () {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -303,10 +303,12 @@ void main() {
     });
 
     group('Inserting a space character', () {
-      test('it turns the previous url into a link', () {
+      test('converts the URL before the space to a link', () {
         final editContext = _createEditContext();
 
         // Add a paragraph to the document.
+        // The `https://flutter.devis` typo was done on purpose
+        // because a space will be added after the `dev`
         (editContext.editor.document as MutableDocument).nodes.add(
               ParagraphNode(
                 id: 'paragraph',
@@ -314,7 +316,7 @@ void main() {
               ),
             );
 
-        // Select the last character of the url
+        // Place caret at "This text: http://flutter.dev|is..."
         editContext.composer.selection = const DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'paragraph',
@@ -361,7 +363,7 @@ void main() {
           },
         );
       });
-      test('it does NOT turn the previous url into a link if that is already a link', () {
+      test('it does nothing to an existing link', () {
         // Adding [LinkAttribution] to a position that already has it
         // could cause spans mismatching, which potentially leads to errors.
         // This test prevents that regression
@@ -369,6 +371,8 @@ void main() {
         final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
 
         // Add a paragraph to the document.
+        // The `https://flutter.devis` typo was done on purpose
+        // because a space will be added after the `dev`
         (editContext.editor.document as MutableDocument).nodes.add(
               ParagraphNode(
                 id: 'paragraph',
@@ -392,7 +396,7 @@ void main() {
               ),
             );
 
-        // Select the last character of the url
+        // Place caret at "This text: http://flutter.dev|is..."
         editContext.composer.selection = const DocumentSelection.collapsed(
           position: DocumentPosition(
             nodeId: 'paragraph',

--- a/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
@@ -278,7 +278,7 @@ void main() {
 
       group('paste shortcut', () {
         group('Mac', () {
-          test('cmd+v pastes clipboard text', () async {
+          testWidgets('cmd+v pastes clipboard text', (tester) async {
             Platform.setTestInstance(MacPlatform());
 
             final controller = AttributedTextEditingController(
@@ -414,9 +414,10 @@ void main() {
         });
 
         group('Windows + Linux', () {
-          test('control+v pastes clipboard text', () async {
+          testWidgets('control+v pastes clipboard text', (tester) async {
             Platform.setTestInstance(WindowsPlatform());
 
+            // Note: this is a widget test because we access the Clipboard.
             final controller = AttributedTextEditingController(
               text: AttributedText(text: 'Pasted content: '),
               selection: const TextSelection.collapsed(offset: 16),
@@ -523,7 +524,7 @@ void main() {
 
             Platform.setTestInstance(null);
           });
-          test('it does nothing when caret is not focused on any text', () async {
+          testWidgets('it does nothing when caret is not focused on any text', (tester) async {
             Platform.setTestInstance(WindowsPlatform());
 
             final controller = AttributedTextEditingController(

--- a/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/src/infrastructure/super_textfield/desktop/super_desktop_textfield_keyboard_test.dart
@@ -278,10 +278,9 @@ void main() {
 
       group('paste shortcut', () {
         group('Mac', () {
-          testWidgets('cmd+v pastes clipboard text', (tester) async {
+          test('cmd+v pastes clipboard text', () async {
             Platform.setTestInstance(MacPlatform());
 
-            // Note: this is a widget test because we access the Clipboard.
             final controller = AttributedTextEditingController(
               text: AttributedText(text: 'Pasted content: '),
               selection: const TextSelection.collapsed(offset: 16),
@@ -415,10 +414,9 @@ void main() {
         });
 
         group('Windows + Linux', () {
-          testWidgets('control+v pastes clipboard text', (tester) async {
+          test('control+v pastes clipboard text', () async {
             Platform.setTestInstance(WindowsPlatform());
 
-            // Note: this is a widget test because we access the Clipboard.
             final controller = AttributedTextEditingController(
               text: AttributedText(text: 'Pasted content: '),
               selection: const TextSelection.collapsed(offset: 16),
@@ -525,7 +523,7 @@ void main() {
 
             Platform.setTestInstance(null);
           });
-          testWidgets('it does nothing when caret is not focused on any text', (tester) async {
+          test('it does nothing when caret is not focused on any text', () async {
             Platform.setTestInstance(WindowsPlatform());
 
             final controller = AttributedTextEditingController(


### PR DESCRIPTION
Auto link URLs (Resolves #406 )

Recognizing URLs in the document and converting them into links when typing and pasting

For example: 
- When the handle is at the last position in the text 'https://flutter.dev/' (could usually be from the user typing the text), pressing a space key or an enter will convert that into a link.
- When the user pastes a block of text 'some text https://flutter.dev/ some text', the part 'https://flutter.dev/' will be converted into a link.

To verify a `Uri` parsed from a text, that `Uri` needs to `hasScheme` and `hasAuthority`

MacOS: 

https://user-images.githubusercontent.com/39979207/168480121-f7122be8-a609-4ea4-aa70-1cbf0921efa1.mov


iOS:

https://user-images.githubusercontent.com/39979207/168480378-07da102c-8d2c-47e5-a89c-34ab244b7b65.mp4

