### PR TITLE
Updated CHANGELOG and removed references to SuperSelectableText

### DIFF
--- a/super_text/CHANGELOG.md
+++ b/super_text/CHANGELOG.md
@@ -1,7 +1,7 @@
-## [0.1.0] - April, 2021
+## [0.1.0] - May, 2021
 
-The super_text package is extracted from super_editor.
+The `super_text` package is extracted from `super_editor`.
 
  * Introduces `SuperText` widget to render text with layers above and beneath the text
- * Introduces `SuperTextWithSelection` to easily paint text with traditional user selections
- * Retains `SuperSelectableText` from earlier super_editor work
+ * Introduces `SuperTextWithSelection` to easily paint text with traditional user selections, 
+   which replaces previous uses of `SuperSelectableText` from earlier super_editor work

--- a/super_text/lib/src/super_text.dart
+++ b/super_text/lib/src/super_text.dart
@@ -9,8 +9,8 @@ import 'text_layout.dart';
 /// beneath the text, which can be used to add text decorations, like
 /// selections and carets.
 ///
-/// To display a widget that includes standard text selection display, as well
-/// as typical selection gestures, see [SuperSelectableText].
+/// To display a widget that includes standard text selection display,
+/// see [SuperTextWithSelection].
 ///
 /// The layers in a [SuperText] are built by provided [SuperTextLayerBuilder]s.
 /// These builders are similar to a typical `WidgetBuilder`, except that
@@ -121,6 +121,7 @@ class SuperTextState extends State<SuperText> with ProseTextBlock {
   }
 }
 
+@visibleForTesting
 class SuperTextAnalytics extends InheritedWidget {
   static SuperTextAnalytics? of(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType<SuperTextAnalytics>();


### PR DESCRIPTION
Updated CHANGELOG and removed references to SuperSelectableText

I'm going to merge this without review because it only has minor non-code changes meant for package release.