### PR TITLE
Updating super_text_layout deps to use the new Pub version

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -48,15 +48,7 @@ dependencies:
     git:
       url: https://github.com/superlistapp/super_editor.git
       path: super_editor_markdown
-  # TODO: remove super_text dependency - it was added when super_text
-  #       introduced SuperText and reworked SuperSelectableText a bit.
-  #       without this dependency, the example app claims that it can't
-  #       resolve SuperSelectableText. But I can't find the reason why
-  #       importing super_editor.dart doesn't include SuperSelectableText.
-  super_text_layout:
-    git:
-      url: https://github.com/superlistapp/super_editor.git
-      path: super_text_layout
+  super_text_layout: ^0.1.0
 
 dependency_overrides:
   # Override to local mono-repo path so devs can test this repo

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -19,10 +19,7 @@ dependencies:
   logging: ^1.0.1
   flutter_test:
     sdk: flutter
-  super_text_layout:
-    git:
-      url: https://github.com/superlistapp/super_editor.git
-      path: super_text_layout
+  super_text_layout: ^0.1.0
   uuid: ^3.0.3
 
 dependency_overrides:

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -17,9 +17,8 @@ dependencies:
 dependency_overrides:
   # Override to local mono-repo path so devs can test this repo
   # against changes that they're making to other mono-repo packages
-# Commented out so that Pub will let us publish. Uncomment this for development.
-#  attributed_text:
-#    path: ../attributed_text
+  attributed_text:
+    path: ../attributed_text
 
 dev_dependencies:
   flutter_lints: ^1.0.0


### PR DESCRIPTION
Updating super_text_layout deps to use the new Pub version.

Now, `super_editor` uses the Pub version of `super_text_layout` for release.

I also reverted `super_text_layout` to use a dependency override for `attributed_text`, now that the `super_text_layout` Pub release is done.