### PR TITLE
refactor: replace Logger usages with logging package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 
 .idea
+.vscode
 
 ios_text_example/
 android_text_example/

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
-import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 
 import '../core/document.dart';
@@ -13,9 +12,6 @@ import 'layout_single_column/layout_single_column.dart';
 import 'paragraph.dart';
 import 'text.dart';
 import 'text_tools.dart';
-
-// ignore: unused_element
-final _log = Logger(scope: 'blockquote.dart');
 
 class BlockquoteComponentBuilder implements ComponentBuilder {
   const BlockquoteComponentBuilder();

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
-import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/blinking_caret.dart';
 
 import '../core/document_layout.dart';
-
-// ignore: unused_element
-final _log = Logger(scope: 'box_component.dart');
 
 /// Base implementation for a [DocumentNode] that only supports [UpstreamDownstreamNodeSelection]s.
 abstract class BlockNode extends DocumentNode {

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -12,8 +12,6 @@ import 'layout_single_column/layout_single_column.dart';
 import 'paragraph.dart';
 import 'text.dart';
 
-final _log = Logger(scope: 'list_items.dart');
-
 class ListItemNode extends TextNode {
   ListItemNode.ordered({
     required String id,
@@ -463,7 +461,9 @@ class IndentListItemCommand implements EditorCommand {
     final node = document.getNodeById(nodeId);
     final listItem = node as ListItemNode;
     if (listItem.indent >= 6) {
-      _log.log('IndentListItemCommand', 'WARNING: Editor does not support an indent level beyond 6.');
+      editorListItemsLog.info(
+        'WARNING: Editor does not support an indent level beyond 6.',
+      );
       return;
     }
 
@@ -580,12 +580,14 @@ class SplitListItemCommand implements EditorCommand {
     final text = listItemNode.text;
     final startText = text.copyText(0, splitPosition.offset);
     final endText = splitPosition.offset < text.text.length ? text.copyText(splitPosition.offset) : AttributedText();
-    _log.log('SplitListItemCommand', 'Splitting list item:');
-    _log.log('SplitListItemCommand', ' - start text: "$startText"');
-    _log.log('SplitListItemCommand', ' - end text: "$endText"');
+    editorListItemsLog.info('Splitting list item:');
+    editorListItemsLog.info(' - start text: "$startText"');
+    editorListItemsLog.info(' - end text: "$endText"');
 
     // Change the current node's content to just the text before the caret.
-    _log.log('SplitListItemCommand', ' - changing the original list item text due to split');
+    editorListItemsLog.info(
+      ' - changing the original list item text due to split',
+    );
     // TODO: figure out how node changes should work in terms of
     //       a DocumentEditorTransaction (#67)
     listItemNode.text = startText;
@@ -605,13 +607,15 @@ class SplitListItemCommand implements EditorCommand {
           );
 
     // Insert the new node after the current node.
-    _log.log('SplitListItemCommand', ' - inserting new node in document');
+    editorListItemsLog.info(' - inserting new node in document');
     transaction.insertNodeAfter(
       existingNode: node,
       newNode: newNode,
     );
 
-    _log.log('SplitListItemCommand', ' - inserted new node: ${newNode.id} after old one: ${node.id}');
+    editorListItemsLog.info(
+      ' - inserted new node: ${newNode.id} after old one: ${node.id}',
+    );
   }
 }
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -11,8 +11,6 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 
 import 'paragraph.dart';
 
-final _log = Logger(scope: 'multi_node_editing.dart');
-
 class DeleteSelectionCommand implements EditorCommand {
   DeleteSelectionCommand({
     required this.documentSelection,
@@ -22,7 +20,7 @@ class DeleteSelectionCommand implements EditorCommand {
 
   @override
   void execute(Document document, DocumentEditorTransaction transaction) {
-    _log.log('DeleteSelectionCommand', 'DocumentEditor: deleting selection: $documentSelection');
+    editorMultiNodeEditingLog.info('DocumentEditor: deleting selection: $documentSelection');
     final nodes = document.getNodesInside(documentSelection.base, documentSelection.extent);
 
     if (nodes.length == 1) {
@@ -66,7 +64,7 @@ class DeleteSelectionCommand implements EditorCommand {
       transaction: transaction,
     );
 
-    _log.log('DeleteSelectionCommand', ' - deleting partial selection within the starting node.');
+    editorMultiNodeEditingLog.info(' - deleting partial selection within the starting node.');
     _deleteSelectionWithinNodeFromPositionToEnd(
       document: document,
       node: startNode,
@@ -75,7 +73,7 @@ class DeleteSelectionCommand implements EditorCommand {
       replaceWithParagraph: false,
     );
 
-    _log.log('DeleteSelectionCommand', ' - deleting partial selection within ending node.');
+    editorMultiNodeEditingLog.info(' - deleting partial selection within ending node.');
     _deleteSelectionWithinNodeFromStartToPosition(
       document: document,
       node: endNode,
@@ -109,13 +107,13 @@ class DeleteSelectionCommand implements EditorCommand {
       return;
     }
 
-    _log.log('DeleteSelectionCommand', ' - combining last node text with first node text');
+    editorMultiNodeEditingLog.info(' - combining last node text with first node text');
     startNodeAfterDeletion.text = startNodeAfterDeletion.text.copyAndAppend(endNodeAfterDeletion.text);
 
-    _log.log('DeleteSelectionCommand', ' - deleting last node');
+    editorMultiNodeEditingLog.info(' - deleting last node');
     transaction.deleteNode(endNodeAfterDeletion);
 
-    _log.log('DeleteSelectionCommand', ' - done with selection deletion');
+    editorMultiNodeEditingLog.info(' - done with selection deletion');
   }
 
   void _deleteSelectionWithinSingleNode({
@@ -124,7 +122,7 @@ class DeleteSelectionCommand implements EditorCommand {
     required DocumentEditorTransaction transaction,
     required DocumentNode node,
   }) {
-    _log.log('_deleteSelectionWithinSingleNode', ' - deleting selection within single node');
+    editorMultiNodeEditingLog.info('_deleteSelectionWithinSingleNode', ' - deleting selection within single node');
     final basePosition = documentSelection.base.nodePosition;
     final extentPosition = documentSelection.extent.nodePosition;
 
@@ -142,12 +140,12 @@ class DeleteSelectionCommand implements EditorCommand {
         newNode: ParagraphNode(id: node.id, text: AttributedText()),
       );
     } else if (node is TextNode) {
-      _log.log('_deleteSelectionWithinSingleNode', ' - its a TextNode');
+      editorMultiNodeEditingLog.info('_deleteSelectionWithinSingleNode', ' - its a TextNode');
       final baseOffset = (basePosition as TextPosition).offset;
       final extentOffset = (extentPosition as TextPosition).offset;
       final startOffset = baseOffset < extentOffset ? baseOffset : extentOffset;
       final endOffset = baseOffset < extentOffset ? extentOffset : baseOffset;
-      _log.log('_deleteSelectionWithinSingleNode', ' - deleting from $startOffset to $endOffset');
+      editorMultiNodeEditingLog.info('_deleteSelectionWithinSingleNode', ' - deleting from $startOffset to $endOffset');
 
       node.text = node.text.removeRegion(
         startOffset: startOffset,
@@ -166,14 +164,14 @@ class DeleteSelectionCommand implements EditorCommand {
     final startIndex = document.getNodeIndex(startNode);
     final endIndex = document.getNodeIndex(endNode);
 
-    _log.log('_deleteNodesBetweenFirstAndLast', ' - start node index: $startIndex');
-    _log.log('_deleteNodesBetweenFirstAndLast', ' - end node index: $endIndex');
-    _log.log('_deleteNodesBetweenFirstAndLast', ' - initially ${document.nodes.length} nodes');
+    editorMultiNodeEditingLog.info(' - start node index: $startIndex');
+    editorMultiNodeEditingLog.info(' - end node index: $endIndex');
+    editorMultiNodeEditingLog.info(' - initially ${document.nodes.length} nodes');
 
     // Remove nodes from last to first so that indices don't get
     // screwed up during removal.
     for (int i = endIndex - 1; i > startIndex; --i) {
-      _log.log('_deleteNodesBetweenFirstAndLast', ' - deleting node $i: ${document.getNodeAt(i)?.id}');
+      editorMultiNodeEditingLog.info(' - deleting node $i: ${document.getNodeAt(i)?.id}');
       transaction.deleteNodeAt(i);
     }
   }
@@ -268,12 +266,12 @@ class DeleteSelectionCommand implements EditorCommand {
       //       depending on the first node still existing at the end of
       //       the deletion. This is a fragile relationship between the
       //       composer and the editor and needs to be addressed.
-      _log.log('_deleteBlockNode', ' - replacing block-level node with a ParagraphNode: ${node.id}');
+      editorMultiNodeEditingLog.info(' - replacing block-level node with a ParagraphNode: ${node.id}');
 
       final newNode = ParagraphNode(id: node.id, text: AttributedText());
       transaction.replaceNode(oldNode: node, newNode: newNode);
     } else {
-      _log.log('_deleteBlockNode', ' - deleting block level node');
+      editorMultiNodeEditingLog.info(' - deleting block level node');
       transaction.deleteNode(node);
     }
   }
@@ -288,17 +286,17 @@ class DeleteNodeCommand implements EditorCommand {
 
   @override
   void execute(Document document, DocumentEditorTransaction transaction) {
-    _log.log('DeleteNodeCommand', 'DocumentEditor: deleting node: $nodeId');
+    editorMultiNodeEditingLog.info('DocumentEditor: deleting node: $nodeId');
 
     final node = document.getNodeById(nodeId);
     if (node == null) {
-      _log.log('DeleteNodeCommand', 'No such node. Returning.');
+      editorMultiNodeEditingLog.info('No such node. Returning.');
       return;
     }
 
-    _log.log('DeleteNodeCommand', ' - deleting node');
+    editorMultiNodeEditingLog.info(' - deleting node');
     transaction.deleteNode(node);
 
-    _log.log('DeleteNodeCommand', ' - done with node deletion');
+    editorMultiNodeEditingLog.info(' - done with node deletion');
   }
 }

--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -11,8 +11,6 @@ import 'package:super_editor/src/infrastructure/composable_text.dart';
 /// Collection of generic text inspection behavior that does not belong
 /// to any particular `DocumentNode` or `Component`.
 
-final _log = Logger(scope: 'text_tools.dart');
-
 /// Returns the word of text that contains the given `docPosition`, or `null` if
 /// no text exists at the given `docPosition`.
 ///
@@ -21,8 +19,8 @@ DocumentSelection? getWordSelection({
   required DocumentPosition docPosition,
   required DocumentLayout docLayout,
 }) {
-  _log.log('getWordSelection', '_getWordSelection()');
-  _log.log('getWordSelection', ' - doc position: $docPosition');
+  editorTextToolsLog.info('_getWordSelection()');
+  editorTextToolsLog.info(' - doc position: $docPosition');
 
   final component = docLayout.getComponentByNodeId(docPosition.nodeId);
   if (component is! TextComposable) {
@@ -37,7 +35,7 @@ DocumentSelection? getWordSelection({
   final TextSelection wordTextSelection = (component as TextComposable).getWordSelectionAt(nodePosition);
   final wordNodeSelection = TextNodeSelection.fromTextSelection(wordTextSelection);
 
-  _log.log('getWordSelection', ' - word selection: $wordNodeSelection');
+  editorTextToolsLog.info(' - word selection: $wordNodeSelection');
   return DocumentSelection(
     base: DocumentPosition(
       nodeId: docPosition.nodeId,
@@ -83,8 +81,8 @@ DocumentSelection? getParagraphSelection({
   required DocumentPosition docPosition,
   required DocumentLayout docLayout,
 }) {
-  _log.log('getParagraphSelection', '_getWordSelection()');
-  _log.log('getParagraphSelection', ' - doc position: $docPosition');
+  editorTextToolsLog.info('_getWordSelection()');
+  editorTextToolsLog.info(' - doc position: $docPosition');
 
   final component = docLayout.getComponentByNodeId(docPosition.nodeId);
   if (component is! TextComposable) {

--- a/super_editor/lib/src/infrastructure/_logging.dart
+++ b/super_editor/lib/src/infrastructure/_logging.dart
@@ -10,6 +10,11 @@ class LogNames {
   static const editorLayout = 'editor.layout';
   static const editorDocument = 'editor.document';
   static const editorCommonOps = 'editor.ops';
+  static const editorBlockquote = 'editor.blockquote';
+  static const editorBoxComponent = 'editor.box_component';
+  static const editorListItems = 'editor.listItems';
+  static const editorMultiNodeEditing = 'editor.multi_node_editing';
+  static const editorTextTools = 'editor.text_tools';
 
   static const textField = 'textfield';
   static const scrollingTextField = 'textfield.scrolling';
@@ -28,6 +33,11 @@ final editorImeLog = logging.Logger(LogNames.editorIme);
 final editorLayoutLog = logging.Logger(LogNames.editorLayout);
 final editorDocLog = logging.Logger(LogNames.editorDocument);
 final editorOpsLog = logging.Logger(LogNames.editorCommonOps);
+final editorBlockquoteLog = logging.Logger(LogNames.editorBlockquote);
+final editorBoxComponentLog = logging.Logger(LogNames.editorBoxComponent);
+final editorListItemsLog = logging.Logger(LogNames.editorListItems);
+final editorMultiNodeEditingLog = logging.Logger(LogNames.editorMultiNodeEditing);
+final editorTextToolsLog = logging.Logger(LogNames.editorTextTools);
 
 final textFieldLog = logging.Logger(LogNames.textField);
 final scrollingTextFieldLog = logging.Logger(LogNames.scrollingTextField);
@@ -73,29 +83,4 @@ void deactivateLoggers(Set<logging.Logger> loggers) {
 void printLog(logging.LogRecord record) {
   print(
       '(${record.time.second}.${record.time.millisecond.toString().padLeft(3, '0')}) ${record.loggerName} > ${record.level.name}: ${record.message}');
-}
-
-// TODO: get rid of this custom Logger when all references are replaced with logging package
-class Logger {
-  static bool _printLogs = false;
-  static void setLoggingMode(bool enabled) {
-    _printLogs = enabled;
-  }
-
-  Logger({
-    required scope,
-  }) : _scope = scope;
-
-  final String _scope;
-
-  void log(String tag, String message, [Exception? exception]) {
-    if (!Logger._printLogs) {
-      return;
-    }
-
-    print('[$_scope] - $tag: $message');
-    if (exception != null) {
-      print(' - ${exception.toString()}');
-    }
-  }
 }


### PR DESCRIPTION
## Related
Related with a todo in `super_editor/lib/src/infrastructure/_logging.dart`:
> TODO: get rid of this custom Logger when all references are replaced with the logging package


## Context
I'm starting to look into `super editor` and trying to get familiar with the code and I found this `TODO` which seems like a good first contribution, although I didn't find any issue associated with it. So if its something you don't want to merge right now, that's ok 👍🏽 