### PR TITLE
Upgraded all lints from 1.0.0 to 2.0.1

### DIFF
--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   test: ^1.19.4
 
 dev_dependencies:
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   mockito: ^5.0.4

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -31,7 +31,7 @@ dependency_overrides:
     path: ../super_text_layout
 
 dev_dependencies:
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   golden_toolkit: ^0.11.0
   mockito: ^5.0.4
 

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -22,6 +22,7 @@ dependency_overrides:
     path: ../super_editor
 
 dev_dependencies:
+  # TODO: upgrade lints to 2.0.1 when we release super_editor 0.2.1
   flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -21,7 +21,7 @@ dependency_overrides:
     path: ../attributed_text
 
 dev_dependencies:
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.11.0


### PR DESCRIPTION
Upgraded all lints from 1.0.0 to 2.0.1, except super_editor_markdown because it causes a build failure until we release super_editor v0.2.1