### PR TITLE
Fixed compound-character IME crash (Resolves #586)

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -135,10 +135,15 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
     if (selection == null) {
       _detachFromIme();
     } else {
-      if (isAttachedToIme) {
+      if (isAttachedToIme && !_isApplyingDeltas) {
+        // Note: ^ We don't re-serialize and send to IME while we're in the middle
+        // of applying deltas because we might be in an inconsistent state. A sync
+        // will be done when all the deltas have been applied.
         _inputConnection!.show();
+        editorImeLog.fine(
+            "Document composer changed while attached to IME. Re-serializing the document and sending to the IME.");
         _syncImeWithDocumentAndComposer();
-      } else {
+      } else if (!isAttachedToIme) {
         _attachToIme();
       }
     }
@@ -211,6 +216,7 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
   @override
   TextEditingValue get currentTextEditingValue => _currentTextEditingValue;
   TextEditingValue _currentTextEditingValue = const TextEditingValue();
+  DocumentImeSerializer? _currentImeSerialization;
   TextEditingValue? _lastTextEditingValueSentToOs;
   set currentTextEditingValue(TextEditingValue newValue) {
     _currentTextEditingValue = newValue;
@@ -227,14 +233,35 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
 
   bool _isApplyingDeltas = false;
 
-  void _syncImeWithDocumentAndComposer([TextRange? composingRegion]) {
+  void _syncImeWithDocumentAndComposer([TextRange? newComposingRegion]) {
     final selection = widget.editContext.composer.selection;
     if (selection != null) {
-      editorImeLog.fine("Syncing IME with Doc and Composer");
-      currentTextEditingValue = DocumentImeSerializer(
+      editorImeLog.fine("Syncing IME with Doc and Composer, given composing region: $newComposingRegion");
+
+      final newDocSerialization = DocumentImeSerializer(
         widget.editContext.editor.document,
         selection,
-      ).toTextEditingValue().copyWith(composing: composingRegion ?? currentTextEditingValue.composing);
+      );
+
+      editorImeLog.fine("Previous doc serialization did prepend? ${_currentImeSerialization?.didPrependPlaceholder}");
+      editorImeLog.fine("Desired composing region: $newComposingRegion");
+      editorImeLog.fine("Did new doc prepend placeholder? ${newDocSerialization.didPrependPlaceholder}");
+      TextRange composingRegion = newComposingRegion ?? currentTextEditingValue.composing;
+      if (_currentImeSerialization != null &&
+          _currentImeSerialization!.didPrependPlaceholder &&
+          composingRegion.isValid &&
+          !newDocSerialization.didPrependPlaceholder) {
+        // The IME's desired composing region includes the prepended placeholder.
+        // The updated IME value doesn't have a prepended placeholder, adjust
+        // the composing region bounds.
+        composingRegion = TextRange(
+          start: composingRegion.start - 2,
+          end: composingRegion.end - 2,
+        );
+      }
+
+      _currentImeSerialization = newDocSerialization;
+      currentTextEditingValue = newDocSerialization.toTextEditingValue().copyWith(composing: composingRegion);
     }
   }
 
@@ -260,6 +287,7 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
     widget.softwareKeyboardHandler.applyDeltas(textEditingDeltas);
     _isApplyingDeltas = false;
 
+    editorImeLog.fine("Done applying deltas. Serializing the document and sending to IME.");
     _syncImeWithDocumentAndComposer(textEditingDeltas.last.composing);
 
     editorImeLog.fine("IME value after applying deltas: $currentTextEditingValue");
@@ -483,11 +511,11 @@ class DocumentImeSerializer {
         _selection.extent.nodePosition == selectedNode.beginningPosition;
   }
 
-  bool get _didPrependPlaceholder => _prependedPlaceholder.isNotEmpty;
+  bool get didPrependPlaceholder => _prependedPlaceholder.isNotEmpty;
 
   DocumentSelection? imeToDocumentSelection(TextSelection imeSelection) {
     editorImeLog.fine("Creating doc selection from IME selection: $imeSelection");
-    if (_didPrependPlaceholder &&
+    if (didPrependPlaceholder &&
         ((!imeSelection.isCollapsed && imeSelection.start < _prependedPlaceholder.length) ||
             (imeSelection.isCollapsed && imeSelection.extentOffset <= _prependedPlaceholder.length))) {
       // The IME is trying to select our artificial prepended character.

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -76,8 +76,6 @@ void main() {
       });
 
       testWidgets('can type compound character in an empty paragraph', (tester) async {
-        initLoggers(Level.FINER, {editorImeLog});
-
         // Inserting special characters, or compound characters, like ü, requires
         // multiple key presses, which are combined by the IME, based on the
         // composing region.

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
 import 'package:super_editor/super_editor.dart';
 
 import '../_document_test_tools.dart';
+import 'test_documents.dart';
 
 void main() {
   group('IME input', () {
@@ -70,6 +73,101 @@ void main() {
         ]);
 
         expect((document.nodes.first as ParagraphNode).text.text, "This is a sentence. ");
+      });
+
+      testWidgets('can type compound character in an empty paragraph', (tester) async {
+        initLoggers(Level.FINER, {editorImeLog});
+
+        // Inserting special characters, or compound characters, like ü, requires
+        // multiple key presses, which are combined by the IME, based on the
+        // composing region.
+        //
+        // A blank paragraph is serialized with a leading ". " to trick IMEs into
+        // auto-capitalizing the first character the user types, while still reporting
+        // a `backspace` operation, if the user presses backspace on a software keyboard.
+        //
+        // This test ensures that when we go from an empty paragraph with a hidden ". ", to
+        // a character with a composing region, like "¨", we report the correct composing region.
+        // For example, due to our hidden ". ", when the user enters a "¨", the IME thinks
+        // the composing region is [2,3], like ". ¨", but the text is actually "¨", so we
+        // need to adjust the composing region to [0,1].
+        final editContext = createEditContext(
+          // Use a two-paragraph document so that the selection in the 2nd
+          // paragraph sends a hidden placeholder to the IME for backspace.
+          document: twoParagraphEmptyDoc(),
+          documentComposer: DocumentComposer(
+            initialSelection: const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                // Start the caret in the 2nd paragraph so that we send a
+                // hidden placeholder to the IME to report backspaces.
+                nodeId: "2",
+                nodePosition: TextNodePosition(
+                  offset: 0,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editContext.editor,
+                composer: editContext.composer,
+                inputSource: DocumentInputSource.ime,
+                gestureMode: DocumentGestureMode.mouse,
+                autofocus: true,
+              ),
+            ),
+          ),
+        );
+
+        // Send the deltas that should produce a ü.
+        //
+        // We have to use implementation details to send the simulated IME deltas
+        // because Flutter doesn't have any testing tools for IME deltas.
+        final imeInteractor = find.byType(DocumentImeInteractor).evaluate().first;
+        final deltaClient = (imeInteractor as StatefulElement).state as DeltaTextInputClient;
+
+        // Ensure that the delta client starts with the expected invisible placeholder
+        // characters.
+        expect(deltaClient.currentTextEditingValue!.text, ". ");
+        expect(deltaClient.currentTextEditingValue!.selection, const TextSelection.collapsed(offset: 2));
+        expect(deltaClient.currentTextEditingValue!.composing, const TextRange(start: -1, end: -1));
+
+        // Insert the "opt+u" character.
+        deltaClient.updateEditingValueWithDeltas([
+          const TextEditingDeltaInsertion(
+            oldText: ". ",
+            textInserted: "¨",
+            insertionOffset: 2,
+            selection: TextSelection.collapsed(offset: 3),
+            composing: TextRange(start: 2, end: 3),
+          ),
+        ]);
+
+        // Ensure that the empty paragraph now reads "¨".
+        expect((editContext.editor.document.nodes[1] as ParagraphNode).text.text, "¨");
+
+        // Ensure that the reported composing region respects the removal of the
+        // invisible placeholder characters. THIS IS WHERE THE ORIGINAL BUG HAPPENED.
+        expect(deltaClient.currentTextEditingValue!.text, "¨");
+        expect(deltaClient.currentTextEditingValue!.composing, const TextRange(start: 0, end: 1));
+
+        // Insert the "u" character to create the compound character.
+        deltaClient.updateEditingValueWithDeltas([
+          const TextEditingDeltaReplacement(
+            oldText: "¨",
+            replacementText: "ü",
+            replacedRange: TextRange(start: 0, end: 1),
+            selection: TextSelection.collapsed(offset: 1),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ]);
+
+        // Ensure that the empty paragraph now reads "ü".
+        expect((editContext.editor.document.nodes[1] as ParagraphNode).text.text, "ü");
       });
     });
 

--- a/super_editor/test/src/default_editor/test_documents.dart
+++ b/super_editor/test/src/default_editor/test_documents.dart
@@ -22,6 +22,19 @@ MutableDocument hrThenParagraphDoc() => MutableDocument(
       ],
     );
 
+MutableDocument singleParagraphEmptyDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(id: "1", text: AttributedText(text: "")),
+      ],
+    );
+
+MutableDocument twoParagraphEmptyDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(id: "1", text: AttributedText(text: "")),
+        ParagraphNode(id: "2", text: AttributedText(text: "")),
+      ],
+    );
+
 MutableDocument singleParagraphDoc() => MutableDocument(
       nodes: [
         ParagraphNode(


### PR DESCRIPTION
Fixed compound-character IME crash (Resolves #586)

The root problem was that we conditionally include invisible prepending characters, e.g., ". ", when editing an empty paragraph with content above it. We do this so that the IME reports backspace button presses, and still auto-capitalizes the first character of the paragraph. I describe in #586 why this became a problem.

This PR resolves the composing region mismatch that caused the crash, and also adds a test to prevent a regression.



https://user-images.githubusercontent.com/7259036/170907332-053c0e46-547e-4376-9779-02051eaadc0d.mov



