### PR TITLE
Fixed span merge bug in addAttribution() (Resolves #582)

### DIFF
--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -14,4 +14,5 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
+  meta: ^1.8.0
   mockito: ^5.0.4

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -5,23 +5,40 @@ import 'package:test/test.dart';
 
 void main() {
   group('Attributed Text', () {
-    test('Bug 582 - combining spans', () {
-      initAllLogs(Level.FINEST);
-      final text = AttributedText(text: '01234567');
-      text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
-      text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
+    group('Bug 582 - combining spans', () {
+      test('as reported in ticket', () {
+        final text = AttributedText(text: '01234567');
+        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
+        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
 
-      print("$text");
+        // Ensure that the spans were merged into a single span.
+        expect(text.spans.markers.length, 2);
+        expect(
+          text.spans.markers.first,
+          SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+        );
+        expect(
+          text.spans.markers.last,
+          SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+        );
+      });
 
-      expect(text.spans.markers.length, 2);
-      expect(
-        text.spans.markers.first,
-        SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-      );
-      expect(
-        text.spans.markers.last,
-        SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
-      );
+      test('in reverse order', () {
+        final text = AttributedText(text: '01234567');
+        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
+        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
+
+        // Ensure that the spans were merged into a single span.
+        expect(text.spans.markers.length, 2);
+        expect(
+          text.spans.markers.first,
+          SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+        );
+        expect(
+          text.spans.markers.last,
+          SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+        );
+      });
     });
 
     test('Bug 145 - insert character at beginning of styled text', () {

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -1,8 +1,29 @@
 import 'package:attributed_text/attributed_text.dart';
+import 'package:attributed_text/src/logging.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Attributed Text', () {
+    test('Bug 582 - combining spans', () {
+      initAllLogs(Level.FINEST);
+      final text = AttributedText(text: '01234567');
+      text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
+      text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
+
+      print("$text");
+
+      expect(text.spans.markers.length, 2);
+      expect(
+        text.spans.markers.first,
+        SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+      );
+      expect(
+        text.spans.markers.last,
+        SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+      );
+    });
+
     test('Bug 145 - insert character at beginning of styled text', () {
       final initialText = AttributedText(
         text: 'abcdefghij',

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -1,6 +1,4 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:attributed_text/src/logging.dart';
-import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,8 +6,8 @@ void main() {
     group('Bug 582 - combining spans', () {
       test('as reported in ticket', () {
         final text = AttributedText(text: '01234567');
-        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
-        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
+        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
+        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
 
         // Ensure that the spans were merged into a single span.
         expect(text.spans.markers.length, 2);
@@ -25,8 +23,8 @@ void main() {
 
       test('in reverse order', () {
         final text = AttributedText(text: '01234567');
-        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 4, end: 8);
-        text.spans.addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 4);
+        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
+        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
 
         // Ensure that the spans were merged into a single span.
         expect(text.spans.markers.length, 2);


### PR DESCRIPTION
Fixed span merge bug in addAttribution() (Resolves #582)

The problem was the case when an existing span ends exactly where a new span begins. The specific behavior in the `addAttribution()` method requires this situation to be handled explicitly, by removing the existing end marker. This PR does that.

This PR also renames `_attributions` to `markers` for clarity. And `markers` is public for testing verification.