### PR TITLE
Fix scrolling bug on demo website (Resolves #462)

### DIFF
--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -15,11 +15,9 @@ class FeaturedEditor extends StatefulWidget {
   const FeaturedEditor({
     Key? key,
     this.displayMode,
-    this.shadows = const [],
   }) : super(key: key);
 
   final DisplayMode? displayMode;
-  final List<BoxShadow> shadows;
 
   @override
   _FeaturedEditorState createState() => _FeaturedEditorState();
@@ -104,7 +102,7 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
       // Schedule a callback after this frame to locate the selection
       // bounds on the screen and display the toolbar near the selected
       // text.
-      WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         _updateToolbarOffset();
       });
     }
@@ -198,19 +196,12 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        boxShadow: widget.shadows,
-      ),
-      child: SuperEditor(
-        editor: _docEditor,
-        composer: _composer,
-        documentLayoutKey: _docLayoutKey,
-        focusNode: _editorFocusNode,
-        stylesheet: _getEditorStyleSheet(),
-      ),
+    return SuperEditor(
+      editor: _docEditor,
+      composer: _composer,
+      documentLayoutKey: _docLayoutKey,
+      focusNode: _editorFocusNode,
+      stylesheet: _getEditorStyleSheet(),
     );
   }
 

--- a/website/lib/homepage/home_page.dart
+++ b/website/lib/homepage/home_page.dart
@@ -93,15 +93,23 @@ class HomePage extends StatelessWidget {
           horizontal: 32,
           vertical: displayMode == DisplayMode.compact ? 16 : 0,
         ),
-        child: FeaturedEditor(
-          displayMode: displayMode,
-          shadows: [
-            BoxShadow(
-              offset: const Offset(0, 10),
-              color: Colors.black.withOpacity(0.79),
-              blurRadius: 75,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                offset: const Offset(0, 10),
+                color: Colors.black.withOpacity(0.79),
+                blurRadius: 75,
+              ),
+            ],
+          ),
+          child: SingleChildScrollView(
+            child: FeaturedEditor(
+              displayMode: displayMode,              
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/website/lib/homepage/inside_the_toolbox.dart
+++ b/website/lib/homepage/inside_the_toolbox.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 class InsideTheToolbox extends StatelessWidget {
   const InsideTheToolbox();
@@ -95,19 +96,23 @@ class InsideTheToolbox extends StatelessWidget {
           decoration: BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.circular(4),
-          ),
-          child: SuperSelectableText.plain(
-            text: 'This text is selectable. The caret and selection rendering is custom.',
-            textSelection: const TextSelection(
-              baseOffset: 13,
-              extentOffset: 23,
+          ),    
+          child: SuperTextWithSelection.single(
+            richText: const TextSpan(
+              text: 'This text is selectable. The caret and selection rendering is custom.',              
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 16,
+              ),
             ),
-            showCaret: true,
-            style: const TextStyle(
-              color: Colors.black,
-              fontSize: 16,
+            userSelection: const UserSelection(
+              selection: TextSelection(
+                baseOffset: 13,
+                extentOffset: 23,
+              ),
+              
             ),
-          ),
+          ),          
         ),
       ),
     );
@@ -245,9 +250,9 @@ class _AttributedTextDemoState extends State<_AttributedTextDemo> {
           _buildRowTitle('Strikethrough'),
           _buildCellSelector(_strikethroughRanges),
           _buildRowTitle('Attributed Text'),
-          SuperSelectableText(
+          SuperTextWithSelection.single(
             key: GlobalKey(),
-            textSpan: _richText,
+            richText: _richText,
           ),
         ],
       ),

--- a/website/pubspec.lock
+++ b/website/pubspec.lock
@@ -371,14 +371,12 @@ packages:
       relative: true
     source: path
     version: "0.2.0"
-  super_text:
-    dependency: transitive
+  super_text_layout:
+    dependency: "direct main"
     description:
-      path: super_text
-      ref: HEAD
-      resolved-ref: "9e032c23dfbfac51366ccb2103032e61c056e9fa"
-      url: "https://github.com/superlistapp/super_editor.git"
-    source: git
+      name: super_text_layout
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.1.0"
   term_glyph:
     dependency: transitive

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   super_editor:
     path: ../super_editor
+  super_text_layout: ^0.1.0
   url_launcher:
 
 dev_dependencies:


### PR DESCRIPTION
Fix scrolling bug on the demo website. Resolves https://github.com/superlistapp/super_editor/issues/462

On the demo website, adding content vertically was causing the editor's content to overflow the available space and be drawn outside its bounds.

I've wrapped `FeaturedEditor` with a `SingleChildScrollView` so `SuperEditor` can scroll its content.

I've also updated the demo to use `SuperTextWithSelection` instead of `SuperSelectableText` because the build was failing.
