### PR TITLE
[IME] Do not clear document selection when document loses focus

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -204,8 +204,6 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
 
     editorImeLog.info('Detaching TextInputClient from TextInput.');
 
-    widget.editContext.composer.selection = null;
-
     _inputConnection!.close();
   }
 

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logging/logging.dart';
 import 'package:super_editor/super_editor.dart';
 
 import '../_document_test_tools.dart';
@@ -166,6 +165,9 @@ void main() {
 
         // Ensure that the empty paragraph now reads "ü".
         expect((editContext.editor.document.nodes[1] as ParagraphNode).text.text, "ü");
+
+        // HACK: why is this making the test to pass?
+        await tester.pump();
       });
     });
 


### PR DESCRIPTION
Before this PR, document selection would be cleared by the IME document interactor whenever the document would lose focus. 

This behavior differs from the physical-keyboard document interactor and as shown in #609, it breaks existing functionality.

By removing the clearance of the document selection it solves the issue, but I'm not aware of potential consequences. 

Fixes #609.