### PR TITLE
Fix SuperDesktopTextField exception when rendering text containing only emojis (Resolves #459)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
@@ -354,7 +354,8 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     // TODO: can we de-dup this with similar calculations in _user_interaction?
     final textLayout = _textLayout;
     final extentOffsetInText = textLayout.getOffsetAtPosition(position);
-    final extentLineHeight = textLayout.getCharacterBox(position).toRect().height;
+    final extentLineHeight = 
+        textLayout.getCharacterBox(position)?.toRect().height ?? textLayout.estimatedLineHeight;
     final extentGlobalOffset =
         (widget.textContentKey.currentContext!.findRenderObject() as RenderBox).localToGlobal(extentOffsetInText);
 
@@ -515,7 +516,8 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     _log.finer('Collapsed handle text position: $extentTextPosition');
     final extentHandleOffsetInText = _textPositionToTextOffset(extentTextPosition);
     _log.finer('Collapsed handle text offset: $extentHandleOffsetInText');
-    double extentLineHeight = _textLayout.getCharacterBox(extentTextPosition).toRect().height;
+    double extentLineHeight = 
+        _textLayout.getCharacterBox(extentTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     if (widget.editingController.textController.text.text.isEmpty) {
       extentLineHeight = _textLayout.getLineHeightAtPosition(extentTextPosition);
     }
@@ -558,13 +560,15 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     final upstreamTextPosition = selectionDirection == TextAffinity.downstream
         ? widget.editingController.textController.selection.base
         : widget.editingController.textController.selection.extent;
-    final upstreamLineHeight = _textLayout.getCharacterBox(upstreamTextPosition).toRect().height;
+    final upstreamLineHeight = 
+        _textLayout.getCharacterBox(upstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     final upstreamHandleOffsetInText = _textPositionToTextOffset(upstreamTextPosition) + Offset(0, upstreamLineHeight);
 
     final downstreamTextPosition = selectionDirection == TextAffinity.downstream
         ? widget.editingController.textController.selection.extent
         : widget.editingController.textController.selection.base;
-    final downstreamLineHeight = _textLayout.getCharacterBox(downstreamTextPosition).toRect().height;
+    final downstreamLineHeight = 
+        _textLayout.getCharacterBox(downstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     final downstreamHandleOffsetInText =
         _textPositionToTextOffset(downstreamTextPosition) + Offset(0, downstreamLineHeight);
 

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -445,7 +445,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     // TODO: can we de-dup this with similar calculations in _editing_controls?
     final extentPosition = widget.textController.selection.extent;
     final extentOffsetInText = _textLayout.getOffsetAtPosition(extentPosition);
-    final extentLineHeight = _textLayout.getCharacterBox(extentPosition).toRect().height;
+    final extentLineHeight = 
+        _textLayout.getCharacterBox(extentPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     final extentGlobalOffset =
         (widget.textKey.currentContext!.findRenderObject() as RenderBox).localToGlobal(extentOffsetInText);
     final extentOffsetInViewport = (context.findRenderObject() as RenderBox).globalToLocal(extentGlobalOffset);

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
+import 'package:super_editor/src/infrastructure/strings.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 class AttributedTextEditingController with ChangeNotifier {
@@ -714,7 +715,7 @@ class AttributedTextEditingController with ChangeNotifier {
           newExtent -= 1;
         }
       } else {
-        newExtent = max(selection.extentOffset - 1, 0);
+        newExtent = text.text.moveOffsetUpstreamByCharacter(selection.extentOffset) ?? 0;
       }
     } else {
       if (selection.extentOffset >= text.text.length && selection.isCollapsed) {
@@ -759,7 +760,7 @@ class AttributedTextEditingController with ChangeNotifier {
           newExtent += 1;
         }
       } else {
-        newExtent = min(selection.extentOffset + 1, text.text.length);
+        newExtent = text.text.moveOffsetDownstreamByCharacter(selection.extentOffset) ?? text.text.length;
       }
     }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
@@ -192,7 +192,7 @@ class _TextScrollViewState extends State<TextScrollView>
     }
 
     final lastCharacterPosition = TextPosition(offset: widget.textEditingController.text.text.length - 1);
-    return _textLayout.getCharacterBox(lastCharacterPosition).bottom - viewportHeight;
+    return (_textLayout.getCharacterBox(lastCharacterPosition)?.bottom ?? _textLayout.estimatedLineHeight) - viewportHeight;
   }
 
   @override
@@ -204,8 +204,8 @@ class _TextScrollViewState extends State<TextScrollView>
       }
 
       final characterBox = _textLayout.getCharacterBox(position);
-      final scrolledCharacterTop = characterBox.top - _scrollController.offset;
-      final scrolledCharacterBottom = characterBox.bottom - _scrollController.offset;
+      final scrolledCharacterTop = (characterBox?.top ?? 0.0) - _scrollController.offset;
+      final scrolledCharacterBottom = (characterBox?.bottom ?? _textLayout.estimatedLineHeight) - _scrollController.offset;
       // Round the top/bottom values to avoid false negatives due to floating point accuracy.
       return scrolledCharacterTop.round() >= 0 && scrolledCharacterBottom.round() <= viewportHeight;
     } else {
@@ -250,7 +250,8 @@ class _TextScrollViewState extends State<TextScrollView>
 
   @override
   Rect getCharacterRectAtPosition(TextPosition position) {
-    return _textLayout.getCharacterBox(position).toRect();
+    return _textLayout.getCharacterBox(position)?.toRect() ?? 
+        Rect.fromLTRB(0, 0, 0, _textLayout.estimatedLineHeight);
   }
 
   @override
@@ -297,7 +298,7 @@ class _TextScrollViewState extends State<TextScrollView>
     // Note: we nudge the vertical offset down a few pixels to see if we
     // find a text position in the line below.
     final textPositionOneLineDown = _textLayout.getPositionNearestToOffset(Offset(0, bottomOfLastLine + 5));
-    final bottomOfCharacter = _textLayout.getCharacterBox(textPositionOneLineDown).bottom;
+    final bottomOfCharacter = (_textLayout.getCharacterBox(textPositionOneLineDown)?.bottom ?? _textLayout.estimatedLineHeight);
     return bottomOfCharacter;
   }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_caret.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_caret.dart
@@ -122,7 +122,7 @@ class _IOSCursorPainter extends CustomPainter {
     caretPaint.color = caretColor.withOpacity(blinkController.opacity);
 
     final textPosition = selection.extent;
-    double caretHeight = textLayout.getCharacterBox(textPosition).toRect().height;
+    double caretHeight = textLayout.getCharacterBox(textPosition)?.toRect().height ?? 0.0;
     caretHeight = caretHeight > 0 ? caretHeight : textLayout.getHeightForCaret(textPosition) ?? 0;
     caretHeight = caretHeight > 0 ? caretHeight : textLayout.getLineHeightAtPosition(textPosition);
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_editing_controls.dart
@@ -414,13 +414,15 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
         ? widget.editingController.textController.selection.base
         : widget.editingController.textController.selection.extent;
     final upstreamHandleOffsetInText = _textPositionToTextOffset(upstreamTextPosition);
-    final upstreamLineHeight = _textLayout.getCharacterBox(upstreamTextPosition).toRect().height;
+    final upstreamLineHeight = 
+        _textLayout.getCharacterBox(upstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
 
     final downstreamTextPosition = selectionDirection == TextAffinity.downstream
         ? widget.editingController.textController.selection.extent
         : widget.editingController.textController.selection.base;
     final downstreamHandleOffsetInText = _textPositionToTextOffset(downstreamTextPosition);
-    final downstreamLineHeight = _textLayout.getCharacterBox(downstreamTextPosition).toRect().height;
+    final downstreamLineHeight = 
+        _textLayout.getCharacterBox(downstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
 
     if (upstreamLineHeight == 0 || downstreamLineHeight == 0) {
       _log.finer('Not building expanded handles because the text layout reported a zero line-height');

--- a/super_editor/test/src/infrastructure/_platform_test_tools.dart
+++ b/super_editor/test/src/infrastructure/_platform_test_tools.dart
@@ -16,3 +16,13 @@ class LinuxPlatform implements Platform {
   @override
   bool get isMac => false;
 }
+
+class AndroidPlatform implements Platform {
+  @override
+  bool get isMac => false;
+}
+
+class IosPlatform implements Platform {
+  @override
+  bool get isMac => false;
+}

--- a/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
@@ -1785,6 +1785,34 @@ void main() {
         });
       });
     });
+  
+    testWidgets("can move the selection when text contains only emojis", (tester) async {      
+      final controller = AttributedTextEditingController(
+        text: AttributedText(text: '🐢'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(            
+            body: SuperDesktopTextField(
+              textController: controller,
+              textStyleBuilder: (_) => const TextStyle(fontSize: 16),
+            ),
+          ),
+        ),
+      );
+
+      // Focus the text field
+      await tester.tap(find.byType(SuperDesktopTextField));
+      await tester.pumpAndSettle();
+
+      // Press left arrow key to move the selection to the begining of the text
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();      
+
+      // As long as this test completes without an error, it should be the case
+      // that the selection is at the begining of the text
+    });
   });
 }
 

--- a/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
@@ -208,7 +208,7 @@ void main() {
           // We give a tiny bit of wiggle room on the value because when this test
           // is run on Windows and Linux CI, there is some kind of precision error
           // that results in a tiny positive number instead of zero.
-          expect(textLayout.getCharacterBox(const TextPosition(offset: 16)).top, lessThan(0.1));
+          expect(textLayout.getCharacterBox(const TextPosition(offset: 16))?.top, lessThan(0.1));
 
           // On Linux CI, the "top" is a very tiny negative number, so we check for that value
           // instead of the check that we actually want to do.
@@ -218,7 +218,7 @@ void main() {
           //   Actual: <-7.152557373046875e-7>
           //    Which: is not a value greater than or equal to <0>
           // expect(textLayout.getCharacterBox(const TextPosition(offset: 16)).top, greaterThanOrEqualTo(0));
-          expect(textLayout.getCharacterBox(const TextPosition(offset: 16)).top, greaterThanOrEqualTo(-0.000001));
+          expect(textLayout.getCharacterBox(const TextPosition(offset: 16))?.top, greaterThanOrEqualTo(-0.000001));
         }, skip: true);
 
         testWidgetsOnDesktop('SHIFT + LEFT ARROW expands left by character', (tester) async {
@@ -323,7 +323,7 @@ void main() {
           // We should have gone from line 1 to line 2. Make double sure by
           // checking that the bounding box for the character that's now selected
           // does not sit at the top of the text box.
-          expect(SuperTextFieldInspector.findProseTextLayout().getCharacterBox(const TextPosition(offset: 18)).top,
+          expect(SuperTextFieldInspector.findProseTextLayout().getCharacterBox(const TextPosition(offset: 18))?.top,
               isNonZero);
         });
 

--- a/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
@@ -1785,34 +1785,6 @@ void main() {
         });
       });
     });
-  
-    testWidgets("can move the selection when text contains only emojis", (tester) async {      
-      final controller = AttributedTextEditingController(
-        text: AttributedText(text: '🐢'),
-      );
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(            
-            body: SuperDesktopTextField(
-              textController: controller,
-              textStyleBuilder: (_) => const TextStyle(fontSize: 16),
-            ),
-          ),
-        ),
-      );
-
-      // Focus the text field
-      await tester.tap(find.byType(SuperDesktopTextField));
-      await tester.pumpAndSettle();
-
-      // Press left arrow key to move the selection to the begining of the text
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pumpAndSettle();      
-
-      // As long as this test completes without an error, it should be the case
-      // that the selection is at the begining of the text
-    });
   });
 }
 

--- a/super_editor/test/super_textfield/super_desktop_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_text_layout_test.dart
@@ -1,0 +1,460 @@
+import 'package:flutter/material.dart' hide SelectableText;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/super_editor.dart';
+
+import 'super_textfield_inspector.dart';
+import 'super_textfield_robot.dart';
+
+void main() {
+  group('SuperDesktopTextField', () {
+    group('containing only one emoji', (){
+      testWidgets("moves left with LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
+
+        // Place caret after the emoji      
+        await tester.placeCaretInSuperTextField(2);   
+
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );   
+
+        // Press left arrow key to move the selection to the beginning of the text
+        await tester.pressLeftArrow();      
+
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
+      });
+
+      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
+
+        // Place caret after the emoji      
+        await tester.placeCaretInSuperTextField(2); 
+
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );      
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();      
+
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 2,
+            extentOffset: 0,
+          ),
+        );         
+      });
+    
+      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
+
+        // Place caret before the emoji      
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
+
+        // Ensure caret is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );         
+      });    
+
+      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
+
+        // Place caret before the emoji
+        await tester.placeCaretInSuperTextField(0);    
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
+
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
+          ),
+        );         
+      });
+
+      testWidgets("selects the content double tap", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
+
+        await tester.doubleTapAtSuperTextField(0);             
+
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
+          ),
+        );         
+      });
+    });
+
+    group('containing only two consecutive emojis', (){
+      testWidgets("moves left with LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret after the second emoji      
+        await tester.placeCaretInSuperTextField(4);   
+
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );   
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is between the two emojis
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );    
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
+      });
+
+      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret after the second emoji    
+        await tester.placeCaretInSuperTextField(4); 
+
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );      
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();   
+
+        // Ensure that the last emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 4,
+            extentOffset: 2,
+          ),
+        );    
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow(); 
+
+        // Ensure the whole text is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 4,
+            extentOffset: 0,
+          ),
+        );         
+      });    
+    
+      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret before the first emoji  
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
+
+        // Ensure caret is between the two emojis
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        ); 
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();  
+
+        // Ensure caret is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );         
+      });    
+    
+      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret before the first emoji
+        await tester.placeCaretInSuperTextField(0);    
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
+
+        // Ensure the first emoji is selected
+         expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
+          ),
+        );
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow(); 
+
+        // Ensure we selected the whole text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 4,
+          ),
+        );         
+      });    
+    });  
+
+    group('containing emojis and non-emojis', (){
+      testWidgets("moves left with LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at |b   
+        await tester.placeCaretInSuperTextField(3);   
+
+        // Ensure we are after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );   
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure we are between the emoji and the 'a'
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 1),
+        );    
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
+      });
+    
+      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at |b
+        await tester.placeCaretInSuperTextField(3); 
+
+        // Ensure we are after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );      
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();   
+
+        // Ensure we selected the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 3,
+            extentOffset: 1,
+          ),
+        );    
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow(); 
+
+        // Ensure "a🐢" is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 3,
+            extentOffset: 0,
+          ),
+        );         
+      });    
+    
+      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at the beginning of the text    
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
+
+        // Ensure we are at a|
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 1),
+        ); 
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();  
+
+        // Ensure caret is after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );         
+      });    
+    
+      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);    
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
+
+        // Ensure 'a' is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 1,
+          ),
+        );
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow(); 
+
+        // Ensure "a🐢" is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 3,
+          ),
+        );         
+      });
+    });
+  });
+}
+
+Future<void> _pumpSuperTextFieldEmojiTest(
+  WidgetTester tester, {
+  required String text
+}) async {
+  final controller = AttributedTextEditingController(
+    text: AttributedText(text: text),
+  );
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(            
+        body: SuperTextField(
+          configuration: SuperTextFieldPlatformConfiguration.desktop,
+          textController: controller,
+          textStyleBuilder: (_) => const TextStyle(fontSize: 16),
+        ),
+      ),
+    ),
+  );
+}
+
+/// Compute the center (x,y) for the given document [position]
+// Offset _getOffsetForPosition(GlobalKey docKey, DocumentPosition position){
+//   final docBox = docKey.currentContext!.findRenderObject() as RenderBox;
+//   final docLayout = docKey.currentState as DocumentLayout;
+//   final characterBox = docLayout.getRectForPosition(position);
+//   return docBox.localToGlobal(characterBox!.center);
+// }
+
+// extension on WidgetTester {
+//   Future<void> doubleTapAt(int offset) async {
+//     await tapAt(offset);
+//     await pump(kDoubleTapMinTime);
+//     await tapAt(offset);
+//   }  
+// }

--- a/super_editor/test/super_textfield/super_desktop_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_text_layout_test.dart
@@ -14,8 +14,10 @@ void main() {
           text: '🐢',
         );
 
-        // Place caret after the emoji      
-        await tester.placeCaretInSuperTextField(2);   
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
 
         // Ensure we are at the end of the text
         expect(
@@ -38,8 +40,10 @@ void main() {
           text: '🐢',
         );
 
-        // Place caret after the emoji      
-        await tester.placeCaretInSuperTextField(2); 
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow(); 
 
         // Ensure we are at the end of the text
         expect(
@@ -134,9 +138,13 @@ void main() {
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢🐢',
         );
-
-        // Place caret after the second emoji      
-        await tester.placeCaretInSuperTextField(4);   
+                
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
+        // Move caret to the right   
+        await tester.pressRightArrow();
 
         // Ensure we are at the end of the text
         expect(
@@ -168,8 +176,12 @@ void main() {
           text: '🐢🐢',
         );
 
-        // Place caret after the second emoji    
-        await tester.placeCaretInSuperTextField(4); 
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
+        // Move caret to the right   
+        await tester.pressRightArrow();
 
         // Ensure we are at the end of the text
         expect(

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -40,14 +40,12 @@ extension SuperTextFieldRobot on WidgetTester {
     throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
   }
 
-  /// Double taps to select a character at the given [offset].
+  /// Double taps in a [SuperTextField] at the given [offset]
   ///
-  /// {@template supertextfield_finder}
-  /// By default, this method expects a single [SuperTextField] in the widget tree and
-  /// finds it `byType`. To specify one [SuperTextField] among many, pass a [superTextFieldFinder].
-  /// {@endtemplate}
+  /// {@macro supertextfield_finder} 
   Future<void> doubleTapAtSuperTextField(int offset,
     [Finder? superTextFieldFinder, TextAffinity affinity = TextAffinity.downstream]) async {
+    // TODO: De-duplicate this behavior with placeCaretInSuperTextField
     final fieldFinder = _findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
     final match = fieldFinder.evaluate().single.widget;
 

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -106,7 +106,7 @@ extension SuperTextFieldRobot on WidgetTester {
     );
 
     if (adjustedOffset.dx == textFieldBox.size.width) {
-      adjustedOffset += const Offset(-8, 0);
+      adjustedOffset += const Offset(-10, 0);
     }
 
     if (!textFieldBox.size.contains(adjustedOffset)) {

--- a/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
@@ -3,17 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:super_editor/super_editor.dart';
 
+import '../test_tools.dart';
 import 'super_textfield_inspector.dart';
 import 'super_textfield_robot.dart';
 
 void main() {
-  group('SuperDesktopTextField', () {
+  group('SuperTextField with keyboard', () {
     group('containing only one emoji', (){
-      testWidgets("moves left with LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢',
         );
 
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -35,11 +37,12 @@ void main() {
         );         
       });
 
-      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢',
         );
 
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -64,7 +67,7 @@ void main() {
         );         
       });
     
-      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢',
         );
@@ -88,7 +91,7 @@ void main() {
         );         
       });    
 
-      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢',
         );
@@ -115,7 +118,7 @@ void main() {
         );         
       });
 
-      testWidgets("selects the content double tap", (tester) async {           
+      testWidgetsOnAllPlatforms("selects the emoji on double tap", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢',
         );
@@ -134,11 +137,12 @@ void main() {
     });
 
     group('containing only two consecutive emojis', (){
-      testWidgets("moves left with LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢🐢',
         );
-                
+
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -171,11 +175,12 @@ void main() {
         );         
       });
 
-      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢🐢',
         );
 
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -214,7 +219,7 @@ void main() {
         );         
       });    
     
-      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢🐢',
         );
@@ -247,7 +252,7 @@ void main() {
         );         
       });    
     
-      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: '🐢🐢',
         );
@@ -288,7 +293,7 @@ void main() {
     });  
 
     group('containing emojis and non-emojis', (){
-      testWidgets("moves left with LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("moves caret upstream around the text", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: 'a🐢b',
         );
@@ -321,7 +326,7 @@ void main() {
         );         
       });
     
-      testWidgets("expands selection with SHIFT + LEFT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection upstream around the text", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: 'a🐢b',
         );
@@ -360,7 +365,7 @@ void main() {
         );         
       });    
     
-      testWidgets("moves right with RIGHT ARROW", (tester) async {      
+      testWidgetsOnAllPlatforms("moves caret downstream around the text", (tester) async {      
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: 'a🐢b',
         );
@@ -393,7 +398,7 @@ void main() {
         );         
       });    
     
-      testWidgets("expands selection with SHIFT + RIGHT ARROW", (tester) async {           
+      testWidgetsOnAllPlatforms("expands selection downstream around the text", (tester) async {           
         await _pumpSuperTextFieldEmojiTest(tester, 
           text: 'a🐢b',
         );
@@ -454,19 +459,3 @@ Future<void> _pumpSuperTextFieldEmojiTest(
     ),
   );
 }
-
-/// Compute the center (x,y) for the given document [position]
-// Offset _getOffsetForPosition(GlobalKey docKey, DocumentPosition position){
-//   final docBox = docKey.currentContext!.findRenderObject() as RenderBox;
-//   final docLayout = docKey.currentState as DocumentLayout;
-//   final characterBox = docLayout.getRectForPosition(position);
-//   return docBox.localToGlobal(characterBox!.center);
-// }
-
-// extension on WidgetTester {
-//   Future<void> doubleTapAt(int offset) async {
-//     await tapAt(offset);
-//     await pump(kDoubleTapMinTime);
-//     await tapAt(offset);
-//   }  
-// }

--- a/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
@@ -16,6 +16,7 @@ void main() {
         );
 
         // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -43,6 +44,7 @@ void main() {
         );
 
         // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -143,6 +145,7 @@ void main() {
         );
 
         // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   
@@ -181,6 +184,7 @@ void main() {
         );
 
         // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
         // Place caret at the beginning of the text
         await tester.placeCaretInSuperTextField(0);
         // Move caret to the right   

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -27,6 +27,20 @@ void testWidgetsOnDesktop(
   testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
 }
 
+/// A widget test that runs a variant for every platform, e.g.,
+/// Mac, Windows, Linux, Android and iOS.
+void testWidgetsOnAllPlatforms(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgetsOnMac("$description (on MAC)", test, skip: skip);
+  testWidgetsOnWindows("$description (on Windows)", test, skip: skip);
+  testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
+  testWidgetsOnAndroid("$description (on Android)", test, skip: skip);
+  testWidgetsOnIos("$description (on iOS)", test, skip: skip);  
+}
+
 /// A widget test that runs a variant for Windows and Linux.
 ///
 /// This test method exists because many keyboard shortcuts are identical
@@ -169,6 +183,46 @@ void testOnLinux(
     try {
       realTest();
     } finally {
+      Platform.setTestInstance(null);
+    }
+  }, skip: skip);
+}
+
+/// A widget test that configures itself as a Android platform before executing the
+/// given [test], and nullifies the Android configuration when the test is done.
+void testWidgetsOnAndroid(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgets(description, (tester) async {
+    Platform.setTestInstance(AndroidPlatform());
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    try {
+      await test(tester);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+      Platform.setTestInstance(null);
+    }
+  }, skip: skip);
+}
+
+/// A widget test that configures itself as a iOS platform before executing the
+/// given [test], and nullifies the iOS configuration when the test is done.
+void testWidgetsOnIos(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgets(description, (tester) async {
+    Platform.setTestInstance(IosPlatform());
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    try {
+      await test(tester);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
       Platform.setTestInstance(null);
     }
   }, skip: skip);

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -20,6 +20,8 @@ dependency_overrides:
   # against changes that they're making to other mono-repo packages
   super_editor:
     path: ../super_editor
+  super_text_layout:
+    path: ../super_text_layout
 
 dev_dependencies:
   # TODO: upgrade lints to 2.0.1 when we release super_editor 0.2.1

--- a/super_text_layout/example/lib/rainbow_character_supertext.dart
+++ b/super_text_layout/example/lib/rainbow_character_supertext.dart
@@ -50,7 +50,8 @@ class _CharacterRainbowSuperTextState extends State<CharacterRainbowSuperText> w
               final textLength = widget.text.toPlainText().length;
               for (int i = 0; i < textLength; i += 1) {
                 // Get the bounding rectangle for the character
-                characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i)).toRect());
+                characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i))?.toRect() 
+                    ?? Rect.fromLTRB(0, 0, 0, textLayout.estimatedLineHeight));
                 // Select a color for this character
                 final colorWheelDegrees =
                     ((360.0 * (characterColors.length / textLength)) + _startingColor.value) % 360;

--- a/super_text_layout/lib/src/text_layout.dart
+++ b/super_text_layout/lib/src/text_layout.dart
@@ -14,6 +14,16 @@ abstract class TextLayout {
   /// Returns the height of the character at the given [position].
   double getLineHeightAtPosition(TextPosition position);
 
+  /// Returns the estimated line height  
+  /// 
+  /// This is needed because if the text contains only emojis 
+  /// we can't get a [TextBox] from flutter to determine
+  /// the line height
+  /// 
+  /// WARNING: This method should be called only when absolutely necessary
+  /// and may be removed in the future
+  double get estimatedLineHeight;
+
   /// Returns the number of lines of text, given the current text layout.
   int getLineCount();
 
@@ -39,8 +49,12 @@ abstract class TextLayout {
   /// Returns a [List] of [TextBox]es that contain the given [selection].
   List<TextBox> getBoxesForSelection(TextSelection selection);
 
-  /// Returns a bounding [TextBox] for the character at the given [position].
-  TextBox getCharacterBox(TextPosition position);
+  /// Returns a bounding [TextBox] for the character at the given [position] or null 
+  /// if a character box couldn't be found.
+  /// 
+  /// The only situation where this could return null is when the text 
+  /// contains only emojis
+  TextBox? getCharacterBox(TextPosition position);
 
   /// Returns the [TextPosition] that corresponds to a text location
   /// that is one line above the given [textPosition], or [null] if
@@ -183,7 +197,8 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
   final RenderLayoutAwareParagraph _renderParagraph;
   late final int _textLength;
 
-  double get _estimatedLineHeight {
+  @override
+  double get estimatedLineHeight {
     final fontSize = _richText.style?.fontSize;
     final lineHeight = _richText.style?.height;
     return (fontSize ?? 16) * (lineHeight ?? 1.0);
@@ -237,7 +252,11 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
 
     // There is some text in this layout. Get the bounding box for the
     // character at the given position and return its height.
-    return getCharacterBox(position).toRect().height * lineHeightMultiplier;
+    final characterBox = getCharacterBox(position);
+    if (characterBox == null) {
+      return estimatedLineHeight;
+    }    
+    return characterBox.toRect().height * lineHeightMultiplier;    
   }
 
   @override
@@ -282,7 +301,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
   }
 
   @override
-  TextBox getCharacterBox(TextPosition position) {
+  TextBox? getCharacterBox(TextPosition position) {
     if (_renderParagraph.needsLayout) {
       return const TextBox.fromLTRBD(0, 0, 0, 0, TextDirection.ltr);
     }
@@ -332,8 +351,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
     // If we still don't have any boxes, it means that the text contains only
     // emojis and we can't get a measurement from Flutter
     if (boxes.isEmpty) {
-      final lineHeightEstimate = _renderParagraph.getFullHeightForCaret(const TextPosition(offset: 0)) ?? 0.0;
-      return TextBox.fromLTRBD(0, 0, 0, lineHeightEstimate, TextDirection.ltr);
+      return null;
     }
 
     return boxes.first;
@@ -350,7 +368,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
     // Note: add half the line height to the current offset to help deal with
     //       line heights that aren't accurate.
     final positionOffset =
-        renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, _estimatedLineHeight / 2);
+        renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, estimatedLineHeight / 2);
     final endOfLineOffset = Offset(0, positionOffset.dy);
     return renderParagraph.getPositionForOffset(endOfLineOffset);
   }
@@ -366,7 +384,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
     // Note: add half the line height to the current offset to help deal with
     //       line heights that aren't accurate.
     final positionOffset =
-        renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, _estimatedLineHeight / 2);
+        renderParagraph.getOffsetForCaret(currentPosition, Rect.zero) + Offset(0, estimatedLineHeight / 2);
     final endOfLineOffset = Offset(renderParagraph.size.width, positionOffset.dy);
     return renderParagraph.getPositionForOffset(endOfLineOffset);
   }
@@ -379,7 +397,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
 
     final renderParagraph = _renderParagraph;
     // TODO: use the character box instead of the estimated line height
-    final lineHeight = _estimatedLineHeight;
+    final lineHeight = estimatedLineHeight;
     // Note: add half the line height to the current offset to help deal with
     //       line heights that aren't accurate.
     final currentSelectionOffset =
@@ -402,7 +420,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
 
     final renderParagraph = _renderParagraph;
     // TODO: use the character box instead of the estimated line height
-    final lineHeight = _estimatedLineHeight;
+    final lineHeight = estimatedLineHeight;
     // Note: add half the line height to the current offset to help deal with
     //       line heights that aren't accurate.
     final currentSelectionOffset =

--- a/super_text_layout/lib/src/text_layout.dart
+++ b/super_text_layout/lib/src/text_layout.dart
@@ -49,7 +49,7 @@ abstract class TextLayout {
   /// Returns a [List] of [TextBox]es that contain the given [selection].
   List<TextBox> getBoxesForSelection(TextSelection selection);
 
-  /// Returns a bounding [TextBox] for the character at the given [position] or null 
+  /// Returns a bounding [TextBox] for the character at the given [position] or `null` 
   /// if a character box couldn't be found.
   /// 
   /// The only situation where this could return null is when the text 
@@ -348,8 +348,6 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
       ));
     }
 
-    // If we still don't have any boxes, it means that the text contains only
-    // emojis and we can't get a measurement from Flutter
     if (boxes.isEmpty) {
       return null;
     }

--- a/super_text_layout/lib/src/text_layout.dart
+++ b/super_text_layout/lib/src/text_layout.dart
@@ -329,6 +329,13 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
       ));
     }
 
+    // If we still don't have any boxes, it means that the text contains only
+    // emojis and we can't get a measurement from Flutter
+    if (boxes.isEmpty) {
+      final lineHeightEstimate = _renderParagraph.getFullHeightForCaret(const TextPosition(offset: 0)) ?? 0.0;
+      return TextBox.fromLTRBD(0, 0, 0, lineHeightEstimate, TextDirection.ltr);
+    }
+
     return boxes.first;
   }
 

--- a/super_text_layout/test_goldens/super_text_layers_test.dart
+++ b/super_text_layout/test_goldens/super_text_layers_test.dart
@@ -50,7 +50,7 @@ void main() {
           final textLength = threeLineTextSpan.toPlainText().length;
           for (int i = 0; i < textLength; i += 1) {
             // Get the bounding rectangle for the character
-            characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i)).toRect());
+            characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i))!.toRect());
             // Select a color for this character
             characterColors
                 .add(HSVColor.fromAHSV(1.0, 360.0 * (characterColors.length / textLength), 1.0, 1.0).toColor());
@@ -77,7 +77,7 @@ void main() {
           final textLength = threeLineTextSpan.toPlainText().length;
           for (int i = 0; i < textLength; i += 1) {
             // Get the bounding rectangle for the character
-            characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i)).toRect());
+            characterRects.add(textLayout.getCharacterBox(TextPosition(offset: i))!.toRect());
           }
 
           return Stack(


### PR DESCRIPTION
Fix `SuperDesktopTextField` exception when rendering text containing only emojis. Resolves https://github.com/superlistapp/super_editor/issues/459

Trying to move the selection using the keyboard when `SuperDesktopTextField` has text containing only emojis causes the exception `Bad state: No element`. The issue occurs in Windows and Web

After some investigation this is what I've found:

https://github.com/superlistapp/super_editor/blob/ca24005782b21a8640f20a0b0ed3b2a5dd206f01/super_text_layout/lib/src/caret_layer.dart#L76-L81

When the text contains only emojis the line `widget.textLayout.getHeightForCaret(widget.position!)` returns null and `widget.textLayout.getLineHeightAtPosition(widget.position!)` is called , calling `getCharacterBox` on `RenderParagraphProseTextLayout`.

At `getCharacterBox` we walk forward and backward trying to find a character with a box, but we don't handle the case in which we don't find one:

https://github.com/superlistapp/super_editor/blob/ca24005782b21a8640f20a0b0ed3b2a5dd206f01/super_text_layout/lib/src/text_layout.dart#L312-L332

The `getCharacterBox` method is only called to get the line height in this case.

For some reason, if the text contains 3 or more emojis, then `getHeightForCaret` returns a non-null value and the error doesn't happen.

I modified `getCharacterBox` to behave as if the text is empty when it doesn't find any boxes, but I'm not sure if that's the correct solution for this.
