### PR TITLE
Fix BlinkController not notifying its listeners when it stops blinking (Resolves #523)

### DIFF
--- a/super_text_layout/lib/src/infrastructure/blink_controller.dart
+++ b/super_text_layout/lib/src/infrastructure/blink_controller.dart
@@ -62,6 +62,7 @@ class BlinkController with ChangeNotifier {
   void stopBlinking() {
     _isVisible = true; // If we're not blinking then we need to be visible
     _ticker.stop();
+    notifyListeners();
   }
 
   /// Make the object completely opaque, and restart the blink timer.

--- a/super_text_layout/lib/src/infrastructure/blink_controller.dart
+++ b/super_text_layout/lib/src/infrastructure/blink_controller.dart
@@ -57,6 +57,7 @@ class BlinkController with ChangeNotifier {
       ..stop()
       ..start();
     _lastBlinkTime = Duration.zero;
+    notifyListeners();
   }
 
   void stopBlinking() {

--- a/super_text_layout/test/blink_controller_test.dart
+++ b/super_text_layout/test/blink_controller_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/src/scheduler/ticker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_text_layout/src/infrastructure/blink_controller.dart';
+
+void main() {
+  group("BlinkController", () {
+    testWidgets("should notify its listeners when it stops blinking", (tester) async {
+      bool hasNotifiedItsListener = false;
+
+      final blinkController = BlinkController(tickerProvider: tester);
+      blinkController.addListener(() { 
+        hasNotifiedItsListener = true;
+      });      
+      
+      blinkController.stopBlinking();
+      
+      // Ensure that the callback was called
+      expect(hasNotifiedItsListener, true);
+    });
+
+    testWidgets("should notify its listeners when it starts blinking", (tester) async {
+      // duration to switch between visible and invisible
+      const flashPeriod = Duration(milliseconds: 500);
+
+      bool hasNotifiedItsListeners = false;      
+      
+      // Create a fake ticker provider to be able to manually trigger a tick
+      final tickerProvider = _TestSingleTickerProvider();          
+      final blinkController = BlinkController(
+        tickerProvider: tickerProvider, 
+        flashPeriod: flashPeriod
+      );
+      blinkController.addListener(() { 
+        hasNotifiedItsListeners = true;
+      });      
+      
+      blinkController.startBlinking();
+      // Trigger a tick with an ellapsed time greater than the flashPeriod,
+      // so the controller should change its visible state and notify its listeners
+      tickerProvider.tick(flashPeriod + const Duration(milliseconds: 1));  
+    
+      // Ensure that the callback was called
+      expect(hasNotifiedItsListeners, true);
+    });
+  });
+}
+
+/// Ticker provider that creates a muted ticker
+/// 
+/// The tick method must be called manually
+class _TestSingleTickerProvider implements TickerProvider {
+  Ticker? _ticker;
+  TickerCallback? _onTick;
+
+  @override
+  Ticker createTicker(TickerCallback onTick) {
+    if (_ticker != null) {
+      throw Exception('Only one ticker is supported');
+    }
+    _ticker = Ticker(onTick)
+      ..muted = true;    
+    _onTick = onTick;
+    return _ticker!;
+  }
+
+  void tick(Duration duration) {
+    if (_onTick == null) {
+      throw Exception('Cannot tick if the ticker was not created');
+    }
+    _onTick!.call(duration);
+  }
+}
+

--- a/super_text_layout/test/blink_controller_test.dart
+++ b/super_text_layout/test/blink_controller_test.dart
@@ -1,10 +1,9 @@
-import 'package:flutter/src/scheduler/ticker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_text_layout/src/infrastructure/blink_controller.dart';
 
 void main() {
   group("BlinkController", () {
-    testWidgets("should notify its listeners when it stops blinking", (tester) async {
+    testWidgets("notifies listeners when it stops blinking", (tester) async {
       bool hasNotifiedItsListener = false;
 
       final blinkController = BlinkController(tickerProvider: tester);
@@ -18,56 +17,64 @@ void main() {
       expect(hasNotifiedItsListener, true);
     });
 
-    testWidgets("should notify its listeners when it starts blinking", (tester) async {
-      // duration to switch between visible and invisible
-      const flashPeriod = Duration(milliseconds: 500);
+    testWidgets("notifies listeners when it starts blinking", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink
+      BlinkController.indeterminateAnimationsEnabled = true;
 
       bool hasNotifiedItsListeners = false;      
       
-      // Create a fake ticker provider to be able to manually trigger a tick
-      final tickerProvider = _TestSingleTickerProvider();          
       final blinkController = BlinkController(
-        tickerProvider: tickerProvider, 
-        flashPeriod: flashPeriod
-      );
+        tickerProvider: tester
+      );      
+      blinkController.stopBlinking();
+
       blinkController.addListener(() { 
         hasNotifiedItsListeners = true;
       });      
       
       blinkController.startBlinking();
-      // Trigger a tick with an ellapsed time greater than the flashPeriod,
-      // so the controller should change its visible state and notify its listeners
-      tickerProvider.tick(flashPeriod + const Duration(milliseconds: 1));  
-    
+
       // Ensure that the callback was called
       expect(hasNotifiedItsListeners, true);
+
+      // Release the ticker      
+      blinkController.stopBlinking();
+      BlinkController.indeterminateAnimationsEnabled = false;
+    });
+
+    testWidgets("notifies listeners every time it blinks", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink
+      BlinkController.indeterminateAnimationsEnabled = true;
+      // duration to switch between visible and invisible
+      const flashPeriod = Duration(milliseconds: 500);
+
+      int notificationCount = 0;
+      
+      final blinkController = BlinkController(
+        tickerProvider: tester, 
+        flashPeriod: flashPeriod
+      );
+      blinkController.addListener(() { 
+        notificationCount++;
+      });      
+      
+      blinkController.startBlinking();
+
+      // Ensure that the callback was called before the first blink 
+      expect(notificationCount, 1);
+      
+      // Trigger the first frame, otherwise we get a zero elapsedTime in the _onTick method
+      await tester.pump();
+      // Trigger a frame with an ellapsed time greater than the flashPeriod,
+      // so the controller should change its visible state and notify its listeners
+      await tester.pump(flashPeriod + const Duration(milliseconds: 1));
+    
+      // Ensure that the callback was called a second time
+      expect(notificationCount, 2);
+
+      // Release the ticker      
+      blinkController.stopBlinking();
+      BlinkController.indeterminateAnimationsEnabled = false;
     });
   });
 }
-
-/// Ticker provider that creates a muted ticker
-/// 
-/// The tick method must be called manually
-class _TestSingleTickerProvider implements TickerProvider {
-  Ticker? _ticker;
-  TickerCallback? _onTick;
-
-  @override
-  Ticker createTicker(TickerCallback onTick) {
-    if (_ticker != null) {
-      throw Exception('Only one ticker is supported');
-    }
-    _ticker = Ticker(onTick)
-      ..muted = true;    
-    _onTick = onTick;
-    return _ticker!;
-  }
-
-  void tick(Duration duration) {
-    if (_onTick == null) {
-      throw Exception('Cannot tick if the ticker was not created');
-    }
-    _onTick!.call(duration);
-  }
-}
-


### PR DESCRIPTION
`BlinkController` was not calling `notifyListeners` when `stopBlinking` was called. Resolves https://github.com/superlistapp/super_editor/issues/523

As `_CaretPainter` uses its blinkController as a repaint `Listenable`, it's necessary to call `notifyListeners` to cause `_CaretPainter` to repaint.

I added tests to ensure both `stopBlinking` and `startBlinking` cause the listeners to be notified