### PR TITLE
Added composable_text.dart to exported APIs in super_editor

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -2,6 +2,7 @@ library super_editor;
 
 export 'package:attributed_text/attributed_text.dart';
 export 'src/infrastructure/attributed_text_styles.dart';
+export 'src/infrastructure/composable_text.dart';
 export 'src/infrastructure/super_textfield/super_textfield.dart';
 export 'src/infrastructure/_listenable_builder.dart';
 export 'src/infrastructure/_logging.dart';


### PR DESCRIPTION
Added composable_text.dart to exported APIs in super_editor.

I added this while working on magic ink. I think we should have always exported `TextComposable`, but now we need it so that we can create a custom version of `TextComponent` that supports magic ink.