### PR TITLE
Exported string extensions from super_editor

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -8,6 +8,7 @@ export 'src/infrastructure/_listenable_builder.dart';
 export 'src/infrastructure/_logging.dart';
 export 'src/infrastructure/multi_tap_gesture.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';
+export 'src/infrastructure/strings.dart';
 export 'src/core/document.dart';
 export 'src/core/document_composer.dart';
 export 'src/core/document_editor.dart';


### PR DESCRIPTION
Exported string extensions from super_editor.

I'm adding this export while working on magic ink. We need to create a custom `TextComponent`, which internally relies on private string extensions that we created. External developers should be able to create `TextComponent` the same way we did internally, so now we're exporting those string extensions.