### PR TITLE
Add .moveNode() to MutableDocument & DocumentEditorTransaction

### DIFF
--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -100,10 +100,12 @@ class DocumentEditorTransaction {
     _document.deleteNodeAt(index);
   }
 
-  /// Moves the given [node] from its current index in the [Document] to the
-  /// given [toIndex].
-  void moveNode({required DocumentNode node, required int toIndex}) {
-    _document.moveNode(node: node, toIndex: toIndex);
+  /// Moves a [DocumentNode] matching the given [nodeId] from its current index
+  /// in the [Document] to the given [targetIndex].
+  ///
+  /// If none of the nodes in this document match [nodeId], throws an error.
+  void moveNode({required String nodeId, required int targetIndex}) {
+    _document.moveNode(nodeId: nodeId, targetIndex: targetIndex);
   }
 
   /// Replaces the given [oldNode] with the given [newNode]
@@ -279,11 +281,18 @@ class MutableDocument with ChangeNotifier implements Document {
     return isRemoved;
   }
 
-  /// Moves the given [node] from its current index in the [Document] to the
-  /// given [toIndex].
-  void moveNode({required DocumentNode node, required int toIndex}) {
+  /// Moves a [DocumentNode] matching the given [nodeId] from its current index
+  /// in the [Document] to the given [targetIndex].
+  ///
+  /// If none of the nodes in this document match [nodeId], throws an error.
+  void moveNode({required String nodeId, required int targetIndex}) {
+    final node = getNodeById(nodeId);
+    if (node == null) {
+      throw Exception('Could not find node with nodeId: $nodeId');
+    }
+
     if (nodes.remove(node)) {
-      nodes.insert(toIndex, node);
+      nodes.insert(targetIndex, node);
       notifyListeners();
     }
   }

--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -100,6 +100,12 @@ class DocumentEditorTransaction {
     _document.deleteNodeAt(index);
   }
 
+  /// Moves the given [node] from its current index in the [Document] to the
+  /// given [toIndex].
+  void moveNode({required DocumentNode node, required int toIndex}) {
+    _document.moveNode(node: node, toIndex: toIndex);
+  }
+
   /// Replaces the given [oldNode] with the given [newNode]
   void replaceNode({
     required DocumentNode oldNode,
@@ -271,6 +277,15 @@ class MutableDocument with ChangeNotifier implements Document {
     notifyListeners();
 
     return isRemoved;
+  }
+
+  /// Moves the given [node] from its current index in the [Document] to the
+  /// given [toIndex].
+  void moveNode({required DocumentNode node, required int toIndex}) {
+    if (nodes.remove(node)) {
+      nodes.insert(toIndex, node);
+      notifyListeners();
+    }
   }
 
   /// Replaces the given [oldNode] with the given [newNode]

--- a/super_editor/test/src/core/document_editor_test.dart
+++ b/super_editor/test/src/core/document_editor_test.dart
@@ -3,48 +3,103 @@ import 'package:super_editor/super_editor.dart';
 
 void main() {
   group('MutableDocument', () {
-    test('it moves node from its current index to the given index ', () {
-      final node = ParagraphNode(id: 'old', text: AttributedText());
-      final document = MutableDocument(
-        nodes: [
-          HorizontalRuleNode(id: '0'),
-          node,
-          HorizontalRuleNode(id: '2'),
-        ],
-      );
+    group('.moveNode()', () {
+      test('when the document is empty, throws an exception', () {
+        final document = MutableDocument(nodes: []);
+        expect(
+          () => document.moveNode(nodeId: 'does-not-exist', targetIndex: 0),
+          throwsException,
+        );
+      });
 
-      document.moveNode(node: node, toIndex: 0);
-      // Node exists at index 0
-      expect(
-        document.nodes,
-        [
-          node,
-          HorizontalRuleNode(id: '0'),
-          HorizontalRuleNode(id: '2'),
-        ],
-      );
+      test('when the node does not exist in the document, throws an exception', () {
+        final node = ParagraphNode(id: 'move-me', text: AttributedText());
+        final document = MutableDocument(
+          nodes: [
+            HorizontalRuleNode(id: '0'),
+            node,
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
 
-      document.moveNode(node: node, toIndex: 2);
-      // Node exists at index 2
-      expect(
-        document.nodes,
-        [
-          HorizontalRuleNode(id: '0'),
-          HorizontalRuleNode(id: '2'),
-          node,
-        ],
-      );
+        expect(
+          () => document.moveNode(nodeId: 'does-not-exist', targetIndex: 0),
+          throwsException,
+        );
+      });
 
-      document.moveNode(node: node, toIndex: 1);
-      // Node exists at index 1
-      expect(
-        document.nodes,
-        [
-          HorizontalRuleNode(id: '0'),
-          node,
-          HorizontalRuleNode(id: '2'),
-        ],
-      );
+      test('when the given target index is negative, throws a RangeError', () {
+        final node = ParagraphNode(id: 'move-me', text: AttributedText());
+        final document = MutableDocument(
+          nodes: [
+            HorizontalRuleNode(id: '0'),
+            node,
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
+
+        expect(
+          () => document.moveNode(nodeId: 'move-me', targetIndex: -1),
+          throwsRangeError,
+        );
+      });
+
+      test('when the given target index is out of document bounds, throws a RangeError', () {
+        final node = ParagraphNode(id: 'move-me', text: AttributedText());
+        final document = MutableDocument(
+          nodes: [
+            HorizontalRuleNode(id: '0'),
+            node,
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
+
+        expect(
+          () => document.moveNode(nodeId: 'move-me', targetIndex: 3),
+          throwsRangeError,
+        );
+      });
+
+      test('when the node exists in the document, and the targetIndex is valid, moves it to the given target index', () {
+        final node = ParagraphNode(id: 'move-me', text: AttributedText());
+        final document = MutableDocument(
+          nodes: [
+            HorizontalRuleNode(id: '0'),
+            node,
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
+
+        document.moveNode(nodeId: 'move-me', targetIndex: 0);
+        expect(
+          document.nodes,
+          [
+            node, // Node exists at index 0
+            HorizontalRuleNode(id: '0'),
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
+
+        document.moveNode(nodeId: 'move-me', targetIndex: 2);
+        expect(
+          document.nodes,
+          [
+            HorizontalRuleNode(id: '0'),
+            HorizontalRuleNode(id: '2'),
+            node, // Node exists at index 2
+          ],
+        );
+
+        document.moveNode(nodeId: 'move-me', targetIndex: 1);
+        expect(
+          document.nodes,
+          [
+            HorizontalRuleNode(id: '0'),
+            node, // Node exists at index 1
+            HorizontalRuleNode(id: '2'),
+          ],
+        );
+      });
     });
 
     test('it replaces one node by another ', () {

--- a/super_editor/test/src/core/document_editor_test.dart
+++ b/super_editor/test/src/core/document_editor_test.dart
@@ -3,6 +3,50 @@ import 'package:super_editor/super_editor.dart';
 
 void main() {
   group('MutableDocument', () {
+    test('it moves node from its current index to the given index ', () {
+      final node = ParagraphNode(id: 'old', text: AttributedText());
+      final document = MutableDocument(
+        nodes: [
+          HorizontalRuleNode(id: '0'),
+          node,
+          HorizontalRuleNode(id: '2'),
+        ],
+      );
+
+      document.moveNode(node: node, toIndex: 0);
+      // Node exists at index 0
+      expect(
+        document.nodes,
+        [
+          node,
+          HorizontalRuleNode(id: '0'),
+          HorizontalRuleNode(id: '2'),
+        ],
+      );
+
+      document.moveNode(node: node, toIndex: 2);
+      // Node exists at index 2
+      expect(
+        document.nodes,
+        [
+          HorizontalRuleNode(id: '0'),
+          HorizontalRuleNode(id: '2'),
+          node,
+        ],
+      );
+
+      document.moveNode(node: node, toIndex: 1);
+      // Node exists at index 1
+      expect(
+        document.nodes,
+        [
+          HorizontalRuleNode(id: '0'),
+          node,
+          HorizontalRuleNode(id: '2'),
+        ],
+      );
+    });
+
     test('it replaces one node by another ', () {
       final oldNode = ParagraphNode(id: 'old', text: AttributedText());
       final document = MutableDocument(


### PR DESCRIPTION
We want to have a way of moving a `DocumentNode` to an arbitrary index in the list of nodes with just one `notifyListeners()` call happening. 

The end result can be achieved with `document..deleteNode()..insertNode()` calls. But we only want to get a notification of the document after a `DocumentNode` has been moved, not a "partial state" where a node has been removed, and then the "final state" where the node exists on the right place of the document. This can't be achieved currently with the existing APIs.

Since there's no `moveNode()` method available, this PR introduces just that.