### PR TITLE
Added ability to configure and verify documents using markdown syntax (Resolves #635)

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -35,6 +35,8 @@ dev_dependencies:
   flutter_test_robots: ^0.0.15
   golden_toolkit: ^0.11.0
   mockito: ^5.0.4
+  super_editor_markdown:
+    path: ../super_editor_markdown
   text_table: ^4.0.1
 
 flutter:

--- a/super_editor/test/super_editor/document_test_tools_test.dart
+++ b/super_editor/test/super_editor/document_test_tools_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_tools.dart';
+import 'document_test_tools.dart';
+import 'supereditor_inspector.dart';
+
+void main() {
+  group("SuperEditor test tools", () {
+    group("configures document from markdown", () {
+      testWidgetsOnMac("when the document is empty", (tester) async {
+        await tester //
+            .createDocument() //
+            .fromMarkdown("") //
+            .forDesktop() //
+            .pump();
+
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown(""),
+        );
+      });
+
+      testWidgetsOnMac("when the document has a single paragraph", (tester) async {
+        await tester //
+            .createDocument() //
+            .fromMarkdown("Hello, **world!**") //
+            .forDesktop() //
+            .pump();
+
+        expect(
+          SuperEditorInspector.findDocument()!,
+          equalsMarkdown("Hello, **world!**"),
+        );
+      });
+
+      testWidgetsOnMac("when the document has multiple paragraphs", (tester) async {
+        await tester //
+            .createDocument() //
+            .fromMarkdown('''This is **paragraph 1**.
+This is *paragraph 2*.
+This is [paragraph 3](https://flutter.dev).''') //
+            .forDesktop() //
+            .pump();
+
+        expect(
+          SuperEditorInspector.findDocument()!,
+          equalsMarkdown('''This is **paragraph 1**.
+This is *paragraph 2*.
+This is [paragraph 3](https://flutter.dev).'''),
+        );
+      });
+    });
+  });
+}

--- a/super_editor_markdown/CHANGELOG.md
+++ b/super_editor_markdown/CHANGELOG.md
@@ -1,0 +1,2 @@
+## [0.1.1] - June, 2022
+ * BREAKING: changed super_editor_markdown to NOT append newlines after every line it serializes to avoid extra newlines at the end of a serialized document.

--- a/super_editor_markdown/lib/src/markdown.dart
+++ b/super_editor_markdown/lib/src/markdown.dart
@@ -28,25 +28,29 @@ MutableDocument deserializeMarkdownToDocument(String markdown) {
 String serializeDocumentToMarkdown(Document doc) {
   StringBuffer buffer = StringBuffer();
 
+  bool isFirstLine = true;
   for (int i = 0; i < doc.nodes.length; ++i) {
     final node = doc.nodes[i];
 
+    if (!isFirstLine) {
+      // Create a new line to encode the given node.
+      buffer.writeln("");
+    } else {
+      isFirstLine = false;
+    }
+
     if (node is ImageNode) {
-      buffer
-        ..writeln('![${node.altText}](${node.imageUrl})')
-        ..writeln('');
+      buffer.write('![${node.altText}](${node.imageUrl})');
     } else if (node is HorizontalRuleNode) {
-      buffer
-        ..writeln('---')
-        ..writeln('');
+      buffer.write('---');
     } else if (node is ListItemNode) {
       final indent = List.generate(node.indent + 1, (index) => '  ').join('');
       final symbol = node.type == ListItemType.unordered ? '*' : '1.';
 
-      buffer.writeln('$indent$symbol ${node.text.toMarkdown()}');
+      buffer.write('$indent$symbol ${node.text.toMarkdown()}');
 
       final nodeBelow = i < doc.nodes.length - 1 ? doc.nodes[i + 1] : null;
-      if (nodeBelow is! ListItemNode || nodeBelow.type != node.type) {
+      if (nodeBelow != null && (nodeBelow is! ListItemNode || nodeBelow.type != node.type)) {
         // This list item is the last item in the list. Add an extra
         // blank line after it.
         buffer.writeln('');
@@ -55,44 +59,27 @@ String serializeDocumentToMarkdown(Document doc) {
       final Attribution? blockType = node.getMetadataValue('blockType');
 
       if (blockType == header1Attribution) {
-        buffer
-          ..writeln('# ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('# ${node.text.toMarkdown()}');
       } else if (blockType == header2Attribution) {
-        buffer
-          ..writeln('## ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('## ${node.text.toMarkdown()}');
       } else if (blockType == header3Attribution) {
-        buffer
-          ..writeln('### ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('### ${node.text.toMarkdown()}');
       } else if (blockType == header4Attribution) {
-        buffer
-          ..writeln('#### ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('#### ${node.text.toMarkdown()}');
       } else if (blockType == header5Attribution) {
-        buffer
-          ..writeln('##### ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('##### ${node.text.toMarkdown()}');
       } else if (blockType == header6Attribution) {
-        buffer
-          ..writeln('###### ${node.text.toMarkdown()}')
-          ..writeln('');
+        buffer.write('###### ${node.text.toMarkdown()}');
       } else if (blockType == blockquoteAttribution) {
         // TODO: handle multiline
-        buffer
-          ..writeln('> ${node.text.toMarkdown()}')
-          ..writeln();
+        buffer.write('> ${node.text.toMarkdown()}');
       } else if (blockType == codeAttribution) {
         buffer //
           ..writeln('```') //
           ..writeln(node.text.toMarkdown()) //
-          ..writeln('```')
-          ..writeln('');
+          ..write('```');
       } else {
-        buffer
-          ..writeln(node.text.toMarkdown())
-          ..writeln('');
+        buffer.write(node.text.toMarkdown());
       }
     }
   }

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor_markdown
 description: Markdown (de)serialization for super_editor documents.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/superlistapp/super_editor
 
 environment:

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -14,22 +14,22 @@ void main() {
         ]);
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header1Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '# My Header');
+        expect(serializeDocumentToMarkdown(doc), '# My Header');
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header2Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '## My Header');
+        expect(serializeDocumentToMarkdown(doc), '## My Header');
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header3Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '### My Header');
+        expect(serializeDocumentToMarkdown(doc), '### My Header');
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header4Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '#### My Header');
+        expect(serializeDocumentToMarkdown(doc), '#### My Header');
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header5Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '##### My Header');
+        expect(serializeDocumentToMarkdown(doc), '##### My Header');
 
         (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header6Attribution);
-        expect(serializeDocumentToMarkdown(doc).trim(), '###### My Header');
+        expect(serializeDocumentToMarkdown(doc), '###### My Header');
       });
 
       test('header with styles', () {
@@ -49,7 +49,7 @@ void main() {
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '# My **Header**');
+        expect(serializeDocumentToMarkdown(doc), '# My **Header**');
       });
 
       test('blockquote', () {
@@ -61,7 +61,7 @@ void main() {
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '> This is a blockquote');
+        expect(serializeDocumentToMarkdown(doc), '> This is a blockquote');
       });
 
       test('blockquote with styles', () {
@@ -81,7 +81,7 @@ void main() {
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '> This is a **blockquote**');
+        expect(serializeDocumentToMarkdown(doc), '> This is a **blockquote**');
       });
 
       test('code', () {
@@ -94,12 +94,12 @@ void main() {
         ]);
 
         expect(
-            serializeDocumentToMarkdown(doc).trim(),
-            '''
+          serializeDocumentToMarkdown(doc),
+          '''
 ```
 This is some code
-```'''
-                .trim());
+```''',
+        );
       });
 
       test('paragraph', () {
@@ -110,7 +110,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a paragraph.');
+        expect(serializeDocumentToMarkdown(doc), 'This is a paragraph.');
       });
 
       test('paragraph with one inline style', () {
@@ -129,7 +129,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This **is a** paragraph.');
+        expect(serializeDocumentToMarkdown(doc), 'This **is a** paragraph.');
       });
 
       test('paragraph with overlapping bold and italics', () {
@@ -150,7 +150,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This ***is a*** paragraph.');
+        expect(serializeDocumentToMarkdown(doc), 'This ***is a*** paragraph.');
       });
 
       test('paragraph with intersecting bold and italics', () {
@@ -171,7 +171,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This ***is a** paragraph*.');
+        expect(serializeDocumentToMarkdown(doc), 'This ***is a** paragraph*.');
       }, skip: '''Markdown serialization is currently broken for intersecting styles.
                   See https://github.com/superlistapp/super_editor/issues/526''');
 
@@ -193,7 +193,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This `**is a**` paragraph.');
+        expect(serializeDocumentToMarkdown(doc), 'This `**is a**` paragraph.');
       });
 
       test('paragraph with link', () {
@@ -218,7 +218,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [paragraph](https://example.org).');
+        expect(serializeDocumentToMarkdown(doc), 'This is a [paragraph](https://example.org).');
       });
 
       test('paragraph with link overlapping style', () {
@@ -245,7 +245,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), 'This is a [**paragraph**](https://example.org).');
+        expect(serializeDocumentToMarkdown(doc), 'This is a [**paragraph**](https://example.org).');
       });
 
       test('paragraph with link intersecting style', () {
@@ -272,7 +272,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '[This **is a** paragraph](https://example.org).');
+        expect(serializeDocumentToMarkdown(doc), '[This **is a** paragraph](https://example.org).');
       }, skip: '''Markdown serialization is currently broken for intersecting styles.
                   See https://github.com/superlistapp/super_editor/issues/526''');
 
@@ -285,7 +285,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '![some alt text](https://someimage.com/the/image.png)');
+        expect(serializeDocumentToMarkdown(doc), '![some alt text](https://someimage.com/the/image.png)');
       });
 
       test('horizontal rule', () {
@@ -295,7 +295,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '---');
+        expect(serializeDocumentToMarkdown(doc), '---');
       });
 
       test('unordered list items', () {
@@ -330,14 +330,14 @@ This is some code
         ]);
 
         expect(
-            serializeDocumentToMarkdown(doc).trim(),
-            '''
+          serializeDocumentToMarkdown(doc),
+          '''
   * Unordered 1
   * Unordered 2
     * Unordered 2.1
     * Unordered 2.2
-  * Unordered 3'''
-                .trim());
+  * Unordered 3''',
+        );
       });
 
       test('unordered list item with styles', () {
@@ -357,7 +357,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '* **Unordered** 1');
+        expect(serializeDocumentToMarkdown(doc), '  * **Unordered** 1');
       });
 
       test('ordered list items', () {
@@ -392,14 +392,14 @@ This is some code
         ]);
 
         expect(
-            serializeDocumentToMarkdown(doc).trim(),
-            '''
+          serializeDocumentToMarkdown(doc),
+          '''
   1. Ordered 1
   1. Ordered 2
     1. Ordered 2.1
     1. Ordered 2.2
-  1. Ordered 3'''
-                .trim());
+  1. Ordered 3''',
+        );
       });
 
       test('ordered list item with styles', () {
@@ -419,7 +419,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc).trim(), '1. **Ordered** 1');
+        expect(serializeDocumentToMarkdown(doc), '  1. **Ordered** 1');
       });
 
       test('example doc', () {


### PR DESCRIPTION
Added ability to configure and verify documents using markdown syntax (Resolves #635)

Configuring custom documents within individual tests is very verbose, and typically makes tests more difficult to read, rather than easier. Similarly, verifying document content, especially text attributions, is very verbose and difficult to read.

This PR adds an API to configure a custom document using Markdown syntax. It also adds a custom matcher that verifies a document's content against provided Markdown text.

**Despite the addition of this behavior, any test that should rely on a document that's shared with many other tests, should continue to use the pre-configured documents. For example:** `tester.createDocument().withSingleEmptyParagraph()`.

To get this Markdown matching behavior to work without extraneous `trim()` calls, I had to change `super_editor_markdown` so that it doesn't append unnecessary newlines after serializing each node. The original newline behavior caused every serialized document to have 1 or 2 newlines at the end, which implied empty paragraphs that didn't exist.

I'll cut another release of `super_editor_markdown` after this is merged.