### PR TITLE
Add test for caret blinking while typing in SuperTextField (Resolves #460)

### DIFF
--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -7,19 +7,15 @@ import 'package:flutter_test_robots/flutter_test_robots.dart';
 
 import '../test_tools.dart';
 
-void main() {
-  group("SuperTextField", () {
-    testWidgetsOnDesktop("keeps caret solid while typing", (tester) async{
+void main() { 
+  group("SuperTextField", () {    
+    // Duration to switch between visible and invisible
+    const flashPeriod = Duration(milliseconds: 500);
+
+    testWidgetsOnDesktop("caret blinks at rest", (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink
       BlinkController.indeterminateAnimationsEnabled = true;
-
-      // duration to switch between visible and invisible
-      const flashPeriod = Duration(milliseconds: 500);
-      
-      // interval between each key is pressed
-      // here we add one millissecond because BlinkController checks if the 
-      // ellapsed time is bigger than the flash period
-      final typingInterval = (flashPeriod ~/ 2) + const Duration(milliseconds: 1);
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -38,48 +34,65 @@ void main() {
       // Ensure caret is visible at start      
       expect(_isCaretVisible(tester), true);
 
-      // Trigger a frame with an ellapsed time greater than the flashPeriod,
+      // Trigger a frame with an ellapsed time equal to the flashPeriod,
       // so the caret should change from visible to invisible
-      await tester.pump(flashPeriod + const Duration(milliseconds: 1));
+      await tester.pump(flashPeriod);
 
       // Ensure caret is invisible after the flash period
       expect(_isCaretVisible(tester), false);
 
       // Trigger another frame to make caret visible again
-      await tester.pump(flashPeriod + const Duration(milliseconds: 1));
+      await tester.pump(flashPeriod);
 
       // Ensure caret is visible
       expect(_isCaretVisible(tester), true);
+    });
+
+    testWidgetsOnDesktop("keeps caret solid while typing", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink
+      BlinkController.indeterminateAnimationsEnabled = true;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);      
+      
+      // Interval between each key is pressed.      
+      final typingInterval = (flashPeriod ~/ 2);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(            
+            body: SuperTextField(              
+              textStyleBuilder: (_) => const TextStyle(fontSize: 16),                        
+            ),
+          ),
+        ),
+      );
+
+      // Press tab to focus SuperTextField
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
      
-      // Type and 'wait' for ~ half a period
+      // Type after half of the flash period
+      await tester.pump(typingInterval);
       await tester.typeKeyboardText("a");
-      await tester.pump(typingInterval);
-
-      // After typing caret should stay visible
+      // Ensure that typing keeps caret visible
       expect(_isCaretVisible(tester), true); 
 
-      // Type and 'wait' for ~ half a period to end the first full period
+      // Type after half of the flash period
+      await tester.pump(typingInterval);
       await tester.typeKeyboardText("b");
-      await tester.pump(typingInterval);
-
-      // Ensure typing prevented caret from disappearing
+      // Ensure that typing keeps caret visible
       expect(_isCaretVisible(tester), true); 
 
-      // Type and 'wait' for ~ half a period
+      // Type after half of the flash period
+      await tester.pump(typingInterval);
       await tester.typeKeyboardText("c");
-      await tester.pump(typingInterval);
-
-      // After typing caret should stay visible
+      // Ensure that typing keeps caret visible
       expect(_isCaretVisible(tester), true); 
 
-      // Type and 'wait' for ~ half a period to end the second full period
+      // Type after half of the flash period
+      await tester.pump(typingInterval);
       await tester.typeKeyboardText("d");
-      await tester.pump(typingInterval);
-
-      // Ensure typing prevented caret from disappearing
+      // Ensure that typing keeps caret visible
       expect(_isCaretVisible(tester), true); 
-
-      BlinkController.indeterminateAnimationsEnabled = false;
     });
   });
 }

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -15,6 +15,11 @@ void main() {
 
       // duration to switch between visible and invisible
       const flashPeriod = Duration(milliseconds: 500);
+      
+      // interval between each key is pressed
+      // here we add one millissecond because BlinkController checks if the 
+      // ellapsed time is bigger than the flash period
+      final typingInterval = (flashPeriod ~/ 2) + const Duration(milliseconds: 1);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -45,17 +50,33 @@ void main() {
 
       // Ensure caret is visible
       expect(_isCaretVisible(tester), true);
+     
+      // Type and 'wait' for ~ half a period
+      await tester.typeKeyboardText("a");
+      await tester.pump(typingInterval);
 
-      // Trigger another frame after half flash period
-      await tester.pump(const Duration(milliseconds: 250));
+      // After typing caret should stay visible
+      expect(_isCaretVisible(tester), true); 
 
-      await tester.typeKeyboardText("abc");
+      // Type and 'wait' for ~ half a period to end the first full period
+      await tester.typeKeyboardText("b");
+      await tester.pump(typingInterval);
 
-      // Trigger a frame that added to the previous frame 
-      // is bigger than the flash period
-      await tester.pump(const Duration(milliseconds: 300));
+      // Ensure typing prevented caret from disappearing
+      expect(_isCaretVisible(tester), true); 
 
-      // Ensure caret is visible
+      // Type and 'wait' for ~ half a period
+      await tester.typeKeyboardText("c");
+      await tester.pump(typingInterval);
+
+      // After typing caret should stay visible
+      expect(_isCaretVisible(tester), true); 
+
+      // Type and 'wait' for ~ half a period to end the second full period
+      await tester.typeKeyboardText("d");
+      await tester.pump(typingInterval);
+
+      // Ensure typing prevented caret from disappearing
       expect(_isCaretVisible(tester), true); 
 
       BlinkController.indeterminateAnimationsEnabled = false;

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group("SuperTextField", () {
+    testWidgetsOnDesktop("keeps caret solid while typing", (tester) async{
+      // Configure BlinkController to animate, otherwise it won't blink
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      // duration to switch between visible and invisible
+      const flashPeriod = Duration(milliseconds: 500);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(            
+            body: SuperTextField(              
+              textStyleBuilder: (_) => const TextStyle(fontSize: 16),                        
+            ),
+          ),
+        ),
+      );
+
+      // Press tab to focus SuperTextField
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      // Ensure caret is visible at start      
+      expect(_isCaretVisible(tester), true);
+
+      // Trigger a frame with an ellapsed time greater than the flashPeriod,
+      // so the caret should change from visible to invisible
+      await tester.pump(flashPeriod + const Duration(milliseconds: 1));
+
+      // Ensure caret is invisible after the flash period
+      expect(_isCaretVisible(tester), false);
+
+      // Trigger another frame to make caret visible again
+      await tester.pump(flashPeriod + const Duration(milliseconds: 1));
+
+      // Ensure caret is visible
+      expect(_isCaretVisible(tester), true);
+
+      // Trigger another frame after half flash period
+      await tester.pump(const Duration(milliseconds: 250));
+
+      await tester.typeKeyboardText("abc");
+
+      // Trigger a frame that added to the previous frame 
+      // is bigger than the flash period
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Ensure caret is visible
+      expect(_isCaretVisible(tester), true); 
+
+      BlinkController.indeterminateAnimationsEnabled = false;
+    });
+  });
+}
+
+bool _isCaretVisible(WidgetTester tester){
+  final customPaint = find.byWidgetPredicate((widget) => widget is CustomPaint && widget.painter is CaretPainter);
+  final caretPainter = tester.widget<CustomPaint>(customPaint.last).painter as CaretPainter;
+  return caretPainter.blinkController!.opacity == 1.0;  
+}

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -111,16 +111,15 @@ class _TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSt
 
 class CaretPainter extends CustomPainter {
   CaretPainter({
-    BlinkController? blinkController,
+    this.blinkController,
     required CaretStyle caretStyle,
     this.offset,
     required double? height,
-  })  : _blinkController = blinkController,
-        _caretStyle = caretStyle,        
+  })  : _caretStyle = caretStyle,        
         _height = height,
         super(repaint: blinkController);
-
-  final BlinkController? _blinkController;
+  @visibleForTesting
+  final BlinkController? blinkController;
   final CaretStyle _caretStyle;
   @visibleForTesting
   final Offset? offset;
@@ -140,13 +139,13 @@ class CaretPainter extends CustomPainter {
         //       update painter to support generic geometry
         _caretStyle.borderRadius.resolve(TextDirection.ltr).topLeft,
       ),
-      Paint()..color = _caretStyle.color.withOpacity(_blinkController?.opacity ?? 1.0),
+      Paint()..color = _caretStyle.color.withOpacity(blinkController?.opacity ?? 1.0),
     );
   }
 
   @override
   bool shouldRepaint(CaretPainter oldDelegate) {
-    return _blinkController != oldDelegate._blinkController ||
+    return blinkController != oldDelegate.blinkController ||
         _caretStyle != oldDelegate._caretStyle ||
         offset != oldDelegate.offset ||
         _height != oldDelegate._height;

--- a/super_text_layout/lib/src/infrastructure/blink_controller.dart
+++ b/super_text_layout/lib/src/infrastructure/blink_controller.dart
@@ -78,7 +78,7 @@ class BlinkController with ChangeNotifier {
   }
 
   void _onTick(Duration elapsedTime) {
-    if (elapsedTime - _lastBlinkTime > _flashPeriod) {
+    if (elapsedTime - _lastBlinkTime >= _flashPeriod) {
       _blink();
       _lastBlinkTime = elapsedTime;
     }


### PR DESCRIPTION
Add test for caret blinking while typing in SuperTextField. Resolves https://github.com/superlistapp/super_editor/issues/460

This issue was already solved with the introduction of `BlinkController`, so I tried to add a test to verify this behavior.

This test alone might not be enough to ensure the caret is solid while typing, because it does not check if `CaretPainter`  is repainting itself using the opacity from `BlinkController`. However, `BlinkController` has tests to ensure it notifies its listeners when it changes its visibility, so `CaretPainter` should be repainting.

I was able to simulate a failing test commenting the body of `jumpToOpaque`:

https://github.com/superlistapp/super_editor/blob/f7b0b5997c49253d1453d487ed6c5d7cb7d21f74/super_text_layout/lib/src/infrastructure/blink_controller.dart#L69-L77

I used the default `flashPeriod` (500 ms) in the test, but we don't have a way to configure `SuperTextField` flash period, so this test could break if the default `flashPeriod` is changed.