### PR TITLE
Change SuperDesktopTextField to always use text cursor style (Resolves #383)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -392,7 +392,6 @@ class SuperTextFieldGestureInteractor extends StatefulWidget {
 }
 
 class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureInteractor> {
-  final _cursorStyle = ValueNotifier<MouseCursor>(SystemMouseCursors.basic);
 
   _SelectionType _selectionType = _SelectionType.position;
   Offset? _dragStartInViewport;
@@ -499,7 +498,6 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
       _dragEndInText = _getTextOffset(_dragEndInViewport!);
       _dragRectInViewport = Rect.fromPoints(_dragStartInViewport!, _dragEndInViewport!);
       _log.finer('_onPanUpdate - drag rect: $_dragRectInViewport');
-      _updateCursorStyle(details.localPosition);
       _updateDragSelection();
 
       _scrollIfNearBoundary();
@@ -585,10 +583,6 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
     setState(() {
       widget.textController.selection = const TextSelection.collapsed(offset: -1);
     });
-  }
-
-  void _onMouseMove(PointerEvent pointerEvent) {
-    _updateCursorStyle(pointerEvent.localPosition);
   }
 
   /// We prevent SingleChildScrollView from processing mouse events because
@@ -690,14 +684,6 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
     _textScroll.stopScrollingToEnd();
   }
 
-  void _updateCursorStyle(Offset cursorOffset) {
-    if (_isTextAtOffset(cursorOffset)) {
-      _cursorStyle.value = SystemMouseCursors.text;
-    } else {
-      _cursorStyle.value = SystemMouseCursors.basic;
-    }
-  }
-
   TextPosition? _getPositionAtOffset(Offset textFieldOffset) {
     final textOffset = _getTextOffset(textFieldOffset);
     final textBox = widget.textKey.currentContext!.findRenderObject() as RenderBox;
@@ -727,8 +713,7 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
   @override
   Widget build(BuildContext context) {
     return Listener(
-      onPointerSignal: _onPointerSignal,
-      onPointerHover: _onMouseMove,
+      onPointerSignal: _onPointerSignal,      
       child: GestureDetector(
         onSecondaryTapUp: _onRightClick,
         child: RawGestureDetector(
@@ -756,15 +741,10 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
               },
             ),
           },
-          child: ListenableBuilder(
-            listenable: _cursorStyle,
-            builder: (context) {
-              return MouseRegion(
-                cursor: _cursorStyle.value,
-                child: widget.child,
-              );
-            },
-          ),
+          child: MouseRegion(            
+            cursor: SystemMouseCursors.text, 
+            child: widget.child,
+          ),          
         ),
       ),
     );

--- a/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group('SuperDesktopTextField', () {
+    testWidgetsOnDesktop('has text cursor style while hovering text', (tester) async {
+      final gesture = await _pumpGestureTestApp(tester);
+
+      // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+      
+      // Hover the text inside SuperDesktopTextField
+      await gesture.moveTo(tester.getCenter(find.byType(SuperText)));
+      await tester.pump();
+
+      // Ensure the cursor type is 'text' when hovering the text
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+
+      // Move outside SuperDesktopTextField bounds
+      await gesture.moveTo(Offset.zero);
+
+      // Ensure the cursor type is 'basic' again
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+    });
+
+    testWidgetsOnDesktop('has text cursor style while hovering empty space', (tester) async {
+      final gesture = await _pumpGestureTestApp(tester);
+
+      // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+      
+      // Hover the empty space within SuperDesktopTextField        
+      await gesture.moveTo(tester.getTopRight(find.byType(SuperText)) + const Offset(10, 0));
+      await tester.pump();
+
+      // Ensure the cursor type is 'text' when hovering the empty space
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+
+      // Move outside SuperDesktopTextField bounds
+      await gesture.moveTo(Offset.zero);
+
+      // Ensure the cursor type is 'basic' again
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+    });
+
+    testWidgetsOnDesktop('has text cursor style while hovering padding region', (tester) async {
+      final gesture = await _pumpGestureTestApp(tester, padding: 20.0);
+
+      // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+      
+      // Hover the padding within SuperDesktopTextField
+      await gesture.moveTo(tester.getTopLeft(find.byType(SuperDesktopTextField)) + const Offset(10, 10));
+      await tester.pump();
+
+      // Ensure the cursor type is 'text' when hovering the padding
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+
+      // Move outside SuperDesktopTextField bounds
+      await gesture.moveTo(Offset.zero);
+
+      // Ensure the cursor type is 'basic' again
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+    });
+  });  
+}
+
+/// Creates a test app with the given [padding] applied to [SuperDesktopTextField]
+/// and starts a mouse gesture at (0, 0)
+Future<TestGesture> _pumpGestureTestApp(WidgetTester tester, {
+  double padding = 0.0
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(          
+      home: Scaffold(
+        body: Container(
+          width: 300,
+          padding: const EdgeInsets.all(20.0),
+          child: SuperDesktopTextField(              
+            padding: EdgeInsets.all(padding),
+            textController: AttributedTextEditingController(
+              text: AttributedText(text: "abc"),
+            ),
+            textStyleBuilder: (_) => const TextStyle(fontSize: 16),
+          ),        
+        ), 
+      ),
+    ),
+  );
+
+  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await gesture.addPointer(location: Offset.zero);
+  addTearDown(gesture.removePointer);      
+  await tester.pump();
+
+  return gesture;
+}
+

--- a/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
@@ -22,6 +22,7 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       
       // Hover over the text inside SuperDesktopTextField
+      // TODO: add the ability to SuperTextFieldInspector to lookup an offset for a content position
       await gesture.moveTo(tester.getTopLeft(find.byType(SuperText)));
       await tester.pump();
 
@@ -48,7 +49,7 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       
       // Hover over the empty space within SuperDesktopTextField      
-      await gesture.moveTo(tester.getTopRight(find.byType(SuperText)) + const Offset(10, 0));      
+      await gesture.moveTo(tester.getBottomRight(find.byType(SuperDesktopTextField)) - const Offset(10, 10));      
       await tester.pump();
 
       // Ensure the cursor type is 'text' when hovering the empty space

--- a/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
@@ -9,14 +9,20 @@ import '../test_tools.dart';
 
 void main() {
   group('SuperDesktopTextField', () {
-    testWidgetsOnDesktop('has text cursor style while hovering text', (tester) async {
-      final gesture = await _pumpGestureTestApp(tester);
+    testWidgetsOnDesktop('has text cursor style while hovering over text', (tester) async {
+      await _pumpGestureTestApp(tester);
+
+      // Start a gesture outside SuperDesktopTextField bounds
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);      
+      await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       
-      // Hover the text inside SuperDesktopTextField
-      await gesture.moveTo(tester.getCenter(find.byType(SuperText)));
+      // Hover over the text inside SuperDesktopTextField
+      await gesture.moveTo(tester.getTopLeft(find.byType(SuperText)));
       await tester.pump();
 
       // Ensure the cursor type is 'text' when hovering the text
@@ -29,14 +35,20 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
     });
 
-    testWidgetsOnDesktop('has text cursor style while hovering empty space', (tester) async {
-      final gesture = await _pumpGestureTestApp(tester);
+    testWidgetsOnDesktop('has text cursor style while hovering over empty space', (tester) async {
+      await _pumpGestureTestApp(tester);
+
+      // Start a gesture outside SuperDesktopTextField bounds
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);      
+      await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       
-      // Hover the empty space within SuperDesktopTextField        
-      await gesture.moveTo(tester.getTopRight(find.byType(SuperText)) + const Offset(10, 0));
+      // Hover over the empty space within SuperDesktopTextField      
+      await gesture.moveTo(tester.getTopRight(find.byType(SuperText)) + const Offset(10, 0));      
       await tester.pump();
 
       // Ensure the cursor type is 'text' when hovering the empty space
@@ -49,13 +61,19 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
     });
 
-    testWidgetsOnDesktop('has text cursor style while hovering padding region', (tester) async {
-      final gesture = await _pumpGestureTestApp(tester, padding: 20.0);
+    testWidgetsOnDesktop('has text cursor style while hovering over padding region', (tester) async {
+      await _pumpGestureTestApp(tester, padding: 20.0);
+
+      // Start a gesture outside SuperDesktopTextField bounds
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);      
+      await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       
-      // Hover the padding within SuperDesktopTextField
+      // Hover over the padding within SuperDesktopTextField
       await gesture.moveTo(tester.getTopLeft(find.byType(SuperDesktopTextField)) + const Offset(10, 10));
       await tester.pump();
 
@@ -72,8 +90,7 @@ void main() {
 }
 
 /// Creates a test app with the given [padding] applied to [SuperDesktopTextField]
-/// and starts a mouse gesture at (0, 0)
-Future<TestGesture> _pumpGestureTestApp(WidgetTester tester, {
+Future<void> _pumpGestureTestApp(WidgetTester tester, {
   double padding = 0.0
 }) async {
   await tester.pumpWidget(
@@ -93,12 +110,5 @@ Future<TestGesture> _pumpGestureTestApp(WidgetTester tester, {
       ),
     ),
   );
-
-  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-  await gesture.addPointer(location: Offset.zero);
-  addTearDown(gesture.removePointer);      
-  await tester.pump();
-
-  return gesture;
 }
 


### PR DESCRIPTION
Change SuperDesktopTextField to always use text cursor style. Resolves https://github.com/superlistapp/super_editor/issues/383

I removed both `ValueNotifier` and `ListenableBuilder` because the cursor style won't be changing anymore.

Tests were added to ensure the cursor style is `SystemMouseCursors.text` when hovering the text, empty space and padding.