### PR TITLE
Fix ENTER key not working on web (Resolves #587)

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -860,9 +860,9 @@ class SoftwareKeyboardHandler {
 
     if (delta.textInserted == "\n") {
       // On iOS, newlines are reported here and also to performAction().
-      // On Android, newlines are only reported here. So, on Android only,
+      // On Android and web, newlines are only reported here. So, on Android and web,
       // we forward the newline action to performAction.
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (defaultTargetPlatform == TargetPlatform.android || kIsWeb) {              
         editorImeLog.fine("Received a newline insertion on Android. Forwarding to newline input action.");
         performAction(TextInputAction.newline);
       } else {
@@ -890,9 +890,9 @@ class SoftwareKeyboardHandler {
 
     if (delta.replacementText == "\n") {
       // On iOS, newlines are reported here and also to performAction().
-      // On Android, newlines are only reported here. So, on Android only,
+      // On Android and web, newlines are only reported here. So, on Android and web,
       // we forward the newline action to performAction.
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (defaultTargetPlatform == TargetPlatform.android || kIsWeb) {
         editorImeLog.fine("Received a newline replacement on Android. Forwarding to newline input action.");
         performAction(TextInputAction.newline);
       } else {


### PR DESCRIPTION
Fix ENTER key not working on web. Resolves https://github.com/superlistapp/super_editor/issues/587

I modified `_DocumentImeInteractorState` to behave the same way for Android and web when pressing new lines.

This PR doesn't have tests because we can't override `kIsWeb`

One option would be to use a getter like this to determine if we are on web:

```dart
bool get isWeb => debugIsWebOverride ?? kIsWeb;
```