### PR TITLE
SuperTextField caret is visible when there's no selection (Resolves #649)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_editing_controls.dart
@@ -280,7 +280,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _updateSelectionForNewDragHandleLocation() {
     final textBox = (widget.textContentKey.currentContext!.findRenderObject() as RenderBox);
     final textOffset = textBox.globalToLocal(_globalDragOffset! + _touchHandleOffsetFromLineOfText!);
-    final textLayout = widget.textContentKey.currentState as ProseTextLayout;
+    final textLayout = widget.textContentKey.currentState!.textLayout;
     if (_isDraggingCollapsed) {
       widget.editingController.textController.selection = TextSelection.collapsed(
         offset: textLayout.getPositionNearestToOffset(textOffset).offset,
@@ -354,8 +354,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     // TODO: can we de-dup this with similar calculations in _user_interaction?
     final textLayout = _textLayout;
     final extentOffsetInText = textLayout.getOffsetAtPosition(position);
-    final extentLineHeight = 
-        textLayout.getCharacterBox(position)?.toRect().height ?? textLayout.estimatedLineHeight;
+    final extentLineHeight = textLayout.getCharacterBox(position)?.toRect().height ?? textLayout.estimatedLineHeight;
     final extentGlobalOffset =
         (widget.textContentKey.currentContext!.findRenderObject() as RenderBox).localToGlobal(extentOffsetInText);
 
@@ -516,7 +515,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     _log.finer('Collapsed handle text position: $extentTextPosition');
     final extentHandleOffsetInText = _textPositionToTextOffset(extentTextPosition);
     _log.finer('Collapsed handle text offset: $extentHandleOffsetInText');
-    double extentLineHeight = 
+    double extentLineHeight =
         _textLayout.getCharacterBox(extentTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     if (widget.editingController.textController.text.text.isEmpty) {
       extentLineHeight = _textLayout.getLineHeightAtPosition(extentTextPosition);
@@ -560,14 +559,14 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     final upstreamTextPosition = selectionDirection == TextAffinity.downstream
         ? widget.editingController.textController.selection.base
         : widget.editingController.textController.selection.extent;
-    final upstreamLineHeight = 
+    final upstreamLineHeight =
         _textLayout.getCharacterBox(upstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     final upstreamHandleOffsetInText = _textPositionToTextOffset(upstreamTextPosition) + Offset(0, upstreamLineHeight);
 
     final downstreamTextPosition = selectionDirection == TextAffinity.downstream
         ? widget.editingController.textController.selection.extent
         : widget.editingController.textController.selection.base;
-    final downstreamLineHeight = 
+    final downstreamLineHeight =
         _textLayout.getCharacterBox(downstreamTextPosition)?.toRect().height ?? _textLayout.estimatedLineHeight;
     final downstreamHandleOffsetInText =
         _textPositionToTextOffset(downstreamTextPosition) + Offset(0, downstreamLineHeight);
@@ -638,8 +637,10 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
           onPanUpdate: _onPanUpdate,
           onPanEnd: _onPanEnd,
           onPanCancel: _onPanCancel,
-          child: Container(
-            color: widget.showDebugPaint ? Colors.green : Colors.transparent,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: widget.showDebugPaint ? Colors.green : Colors.transparent,
+            ),
             child: showHandle
                 ? AnimatedOpacity(
                     opacity: handleType == HandleType.collapsed && widget.editingController.isCollapsedHandleAutoHidden

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -157,12 +157,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   @override
   void initState() {
     super.initState();
-    _focusNode = (widget.focusNode ?? FocusNode())
-      ..unfocus()
-      ..addListener(_onFocusChange);
-    if (_focusNode.hasFocus) {
-      _showEditingControlsOverlay();
-    }
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange);
@@ -271,6 +266,10 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       if (!_textEditingController.isAttachedToIme) {
         _log.info('Attaching TextInputClient to TextInput');
         setState(() {
+          if (!_textEditingController.selection.isValid) {
+            _textEditingController.selection = TextSelection.collapsed(offset: _textEditingController.text.text.length);
+          }
+
           _textEditingController.attachToIme(
             textInputAction: widget.textInputAction,
           );
@@ -408,7 +407,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           color: widget.caretColor,
         ),
         selection: _textEditingController.selection,
-        hasCaret: true,
+        hasCaret: _focusNode.hasFocus,
       ),
     );
   }

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -1384,9 +1384,9 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (defaultTargetPlatform == TargetPlatform.linux && keyEvent.isAltPressed && 
-        (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp || keyEvent.logicalKey == LogicalKeyboardKey.arrowDown)
-    ) {
+    if (defaultTargetPlatform == TargetPlatform.linux &&
+        keyEvent.isAltPressed &&
+        (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp || keyEvent.logicalKey == LogicalKeyboardKey.arrowDown)) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
@@ -1395,9 +1395,8 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
       MovementModifier? movementModifier;
       if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
-          keyEvent.isControlPressed
-      ) {        
-        movementModifier = MovementModifier.word;        
+          keyEvent.isControlPressed) {
+        movementModifier = MovementModifier.word;
       } else if (defaultTargetPlatform == TargetPlatform.macOS && keyEvent.isMetaPressed) {
         movementModifier = MovementModifier.line;
       } else if (defaultTargetPlatform == TargetPlatform.macOS && keyEvent.isAltPressed) {
@@ -1415,9 +1414,8 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
       MovementModifier? movementModifier;
       if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
-          keyEvent.isControlPressed
-      ) {        
-        movementModifier = MovementModifier.word;        
+          keyEvent.isControlPressed) {
+        movementModifier = MovementModifier.word;
       } else if (defaultTargetPlatform == TargetPlatform.macOS && keyEvent.isMetaPressed) {
         movementModifier = MovementModifier.line;
       } else if (defaultTargetPlatform == TargetPlatform.macOS && keyEvent.isAltPressed) {
@@ -1448,7 +1446,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 
     return TextFieldKeyboardHandlerResult.handled;
   }
-  
+
   static TextFieldKeyboardHandlerResult moveToLineStartWithHome({
     required AttributedTextEditingController controller,
     required ProseTextLayout textLayout,
@@ -1456,7 +1454,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
   }) {
     if (defaultTargetPlatform != TargetPlatform.windows && defaultTargetPlatform != TargetPlatform.linux) {
       return TextFieldKeyboardHandlerResult.notHandled;
-    }  
+    }
 
     if (keyEvent.logicalKey == LogicalKeyboardKey.home) {
       controller.moveCaretHorizontally(
@@ -1464,7 +1462,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
         expandSelection: keyEvent.isShiftPressed,
         moveLeft: true,
         movementModifier: MovementModifier.line,
-      );   
+      );
       return TextFieldKeyboardHandlerResult.handled;
     }
 
@@ -1478,7 +1476,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
   }) {
     if (defaultTargetPlatform != TargetPlatform.windows && defaultTargetPlatform != TargetPlatform.linux) {
       return TextFieldKeyboardHandlerResult.notHandled;
-    }  
+    }
 
     if (keyEvent.logicalKey == LogicalKeyboardKey.end) {
       controller.moveCaretHorizontally(
@@ -1486,7 +1484,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
         expandSelection: keyEvent.isShiftPressed,
         moveLeft: false,
         movementModifier: MovementModifier.line,
-      );   
+      );
       return TextFieldKeyboardHandlerResult.handled;
     }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -162,9 +162,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   @override
   void initState() {
     super.initState();
-    _focusNode = (widget.focusNode ?? FocusNode())
-      ..unfocus()
-      ..addListener(_onFocusChange);
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
     if (_focusNode.hasFocus) {
       _showHandles();
     }
@@ -283,6 +281,10 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       if (!_textEditingController.isAttachedToIme) {
         _log.info('Attaching TextInputClient to TextInput');
         setState(() {
+          if (!_textEditingController.selection.isValid) {
+            _textEditingController.selection = TextSelection.collapsed(offset: _textEditingController.text.text.length);
+          }
+
           _textEditingController.attachToIme(
             textInputAction: widget.textInputAction,
           );
@@ -433,7 +435,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           color: _floatingCursorController.isShowingFloatingCursor ? Colors.grey : widget.caretColor,
         ),
         selection: _textEditingController.selection,
-        hasCaret: true,
+        hasCaret: _focusNode.hasFocus,
       ),
     );
   }

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -7,22 +7,21 @@ import 'package:flutter_test_robots/flutter_test_robots.dart';
 
 import '../test_tools.dart';
 
-void main() { 
-  group("SuperTextField", () {    
+void main() {
+  group("SuperTextField caret", () {
     // Duration to switch between visible and invisible
     const flashPeriod = Duration(milliseconds: 500);
 
-    testWidgetsOnDesktop("caret blinks at rest", (tester) async {
+    testWidgetsOnDesktop("blinks at rest", (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink
       BlinkController.indeterminateAnimationsEnabled = true;
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(            
-            body: SuperTextField(              
-              textStyleBuilder: (_) => const TextStyle(fontSize: 16),                        
-            ),
+        _buildScaffold(
+          child: SuperTextField(
+            textStyleBuilder: (_) => const TextStyle(fontSize: 16),
+            lineHeight: 16,
           ),
         ),
       );
@@ -31,7 +30,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pump();
 
-      // Ensure caret is visible at start      
+      // Ensure caret is visible at start
       expect(_isCaretVisible(tester), true);
 
       // Trigger a frame with an ellapsed time equal to the flashPeriod,
@@ -48,20 +47,19 @@ void main() {
       expect(_isCaretVisible(tester), true);
     });
 
-    testWidgetsOnDesktop("keeps caret solid while typing", (tester) async {
+    testWidgetsOnDesktop("does NOT blink while typing", (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink
       BlinkController.indeterminateAnimationsEnabled = true;
-      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);      
-      
-      // Interval between each key is pressed.      
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      // Interval between each key is pressed.
       final typingInterval = (flashPeriod ~/ 2);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(            
-            body: SuperTextField(              
-              textStyleBuilder: (_) => const TextStyle(fontSize: 16),                        
-            ),
+        _buildScaffold(
+          child: SuperTextField(
+            textStyleBuilder: (_) => const TextStyle(fontSize: 16),
+            lineHeight: 16,
           ),
         ),
       );
@@ -69,36 +67,90 @@ void main() {
       // Press tab to focus SuperTextField
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pump();
-     
+
       // Type after half of the flash period
       await tester.pump(typingInterval);
       await tester.typeKeyboardText("a");
       // Ensure that typing keeps caret visible
-      expect(_isCaretVisible(tester), true); 
+      expect(_isCaretVisible(tester), true);
 
       // Type after half of the flash period
       await tester.pump(typingInterval);
       await tester.typeKeyboardText("b");
       // Ensure that typing keeps caret visible
-      expect(_isCaretVisible(tester), true); 
+      expect(_isCaretVisible(tester), true);
 
       // Type after half of the flash period
       await tester.pump(typingInterval);
       await tester.typeKeyboardText("c");
       // Ensure that typing keeps caret visible
-      expect(_isCaretVisible(tester), true); 
+      expect(_isCaretVisible(tester), true);
 
       // Type after half of the flash period
       await tester.pump(typingInterval);
       await tester.typeKeyboardText("d");
       // Ensure that typing keeps caret visible
-      expect(_isCaretVisible(tester), true); 
+      expect(_isCaretVisible(tester), true);
+    });
+
+    testWidgetsOnAllPlatforms("is NOT displayed without a text selection", (tester) async {
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: const SuperTextField(
+            lineHeight: 16,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(_isCaretPresent(tester), isFalse);
+    });
+
+    testWidgetsOnAllPlatforms("is displayed with focus and a text selection", (tester) async {
+      final controller = AttributedTextEditingController(
+        selection: const TextSelection.collapsed(offset: 0),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            focusNode: FocusNode()..requestFocus(),
+            textController: controller,
+            lineHeight: 16,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(_isCaretPresent(tester), isTrue);
     });
   });
 }
 
-bool _isCaretVisible(WidgetTester tester){
+Widget _buildScaffold({
+  required Widget child,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 300,
+        child: child,
+      ),
+    ),
+  );
+}
+
+bool _isCaretPresent(WidgetTester tester) {
+  final caretMatches = find.byType(TextLayoutCaret).evaluate();
+  if (caretMatches.isEmpty) {
+    return false;
+  }
+  final caretState = (caretMatches.single as StatefulElement).state as TextLayoutCaretState;
+  return caretState.isCaretPresent;
+}
+
+bool _isCaretVisible(WidgetTester tester) {
   final customPaint = find.byWidgetPredicate((widget) => widget is CustomPaint && widget.painter is CaretPainter);
   final caretPainter = tester.widget<CustomPaint>(customPaint.last).painter as CaretPainter;
-  return caretPainter.blinkController!.opacity == 1.0;  
+  return caretPainter.blinkController!.opacity == 1.0;
 }

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -2,6 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import '../test_tools.dart';
+import 'super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField", () {
@@ -99,6 +103,42 @@ void main() {
         });
       });
     });
+
+    group("selection", () {
+      testWidgetsOnAllPlatforms("is inserted automatically when the field is initialized with focus", (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              focusNode: FocusNode()..requestFocus(),
+              lineHeight: 16,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(_isCaretPresent(tester), isTrue);
+      });
+
+      testWidgetsOnAllPlatforms("is inserted automatically when the field is given focus", (tester) async {
+        final focusNode = FocusNode();
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              focusNode: focusNode,
+              lineHeight: 16,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(_isCaretPresent(tester), isFalse);
+
+        focusNode.requestFocus();
+        await tester.pumpAndSettle();
+
+        expect(_isCaretPresent(tester), isTrue);
+      });
+    });
   });
 }
 
@@ -107,7 +147,19 @@ Widget _buildScaffold({
 }) {
   return MaterialApp(
     home: Scaffold(
-      body: child,
+      body: SizedBox(
+        width: 300,
+        child: child,
+      ),
     ),
   );
+}
+
+bool _isCaretPresent(WidgetTester tester) {
+  final caretMatches = find.byType(TextLayoutCaret).evaluate();
+  if (caretMatches.isEmpty) {
+    return false;
+  }
+  final caretState = (caretMatches.single as StatefulElement).state as TextLayoutCaretState;
+  return caretState.isCaretPresent;
 }

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -22,10 +22,11 @@ class TextLayoutCaret extends StatefulWidget {
   final LayerLink? caretTracker;
 
   @override
-  State<TextLayoutCaret> createState() => _TextLayoutCaretState();
+  State<TextLayoutCaret> createState() => TextLayoutCaretState();
 }
 
-class _TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderStateMixin {
+@visibleForTesting
+class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderStateMixin {
   late BlinkController _blinkController;
 
   @override
@@ -72,10 +73,13 @@ class _TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSt
     super.dispose();
   }
 
+  @visibleForTesting
+  bool get isCaretPresent => widget.position != null && widget.position!.offset >= 0;
+
   @override
   Widget build(BuildContext context) {
-    final offset = widget.position != null ? widget.textLayout.getOffsetForCaret(widget.position!) : null;
-    final height = widget.position != null
+    final offset = isCaretPresent ? widget.textLayout.getOffsetForCaret(widget.position!) : null;
+    final height = isCaretPresent
         ? widget.textLayout.getHeightForCaret(widget.position!) ??
             widget.textLayout.getLineHeightAtPosition(widget.position!)
         : null;
@@ -115,15 +119,16 @@ class CaretPainter extends CustomPainter {
     required CaretStyle caretStyle,
     this.offset,
     required double? height,
-  })  : _caretStyle = caretStyle,        
+  })  : _caretStyle = caretStyle,
         _height = height,
         super(repaint: blinkController);
+
   @visibleForTesting
   final BlinkController? blinkController;
   final CaretStyle _caretStyle;
   @visibleForTesting
   final Offset? offset;
-  final double? _height;  
+  final double? _height;
 
   @override
   void paint(Canvas canvas, Size size) {


### PR DESCRIPTION
SuperTextField caret is visible when there's no selection (Resolves #649)

I noticed on my webpage that all my text fields showed a blinking cursor. I think this bug came in with the recent `super_text_layout` refactor.

I adjusted the conditions under which a caret is displayed, and I added tests to make sure this doesn't happen again.