### PR TITLE
Change SuperTextField to place caret at the end of the text when tapping empty space (Resolves #654)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -149,15 +149,14 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
     final tapTextPosition = _getTextPositionAtOffset(details.localPosition);
     if (tapTextPosition == null) {
-      _log.warning('received a tap-down event on AndroidTextFieldInteractor that is not on top of any text');
+      // This situation indicates the user tapped in empty space
       widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.text.length);
-      return;
+    } else {
+      // Update the text selection to a collapsed selection where the user tapped.
+      widget.textController.selection = tapTextPosition.offset >= 0
+          ? TextSelection.collapsed(offset: tapTextPosition.offset)
+          : const TextSelection.collapsed(offset: 0);
     }
-
-    // Update the text selection to a collapsed selection where the user tapped.
-    widget.textController.selection = tapTextPosition.offset >= 0
-        ? TextSelection.collapsed(offset: tapTextPosition.offset)
-        : const TextSelection.collapsed(offset: 0);
 
     widget.editingOverlayController.showHandles();
   }

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -149,9 +149,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
     final tapTextPosition = _getTextPositionAtOffset(details.localPosition);
     if (tapTextPosition == null) {
-      // This shouldn't be possible, but we'll ignore the tap if we can't
-      // map it to a position within the text.
       _log.warning('received a tap-down event on AndroidTextFieldInteractor that is not on top of any text');
+      widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.text.length);
       return;
     }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -141,7 +141,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
 
     final tapTextPosition = _getTextPositionAtOffset(details.localPosition);
     if (tapTextPosition == null) {
-      _log.warning('received a tap-down event on IOSTextFieldInteractor that is not on top of any text');
+      // This situation indicates the user tapped in empty space
       widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.text.length);
       return;
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -141,9 +141,8 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
 
     final tapTextPosition = _getTextPositionAtOffset(details.localPosition);
     if (tapTextPosition == null) {
-      // This shouldn't be possible, but we'll ignore the tap if we can't
-      // map it to a position within the text.
       _log.warning('received a tap-down event on IOSTextFieldInteractor that is not on top of any text');
+      widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.text.length);
       return;
     }
 

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -7,9 +7,9 @@ import '../test_tools.dart';
 import 'super_textfield_inspector.dart';
 
 void main() {
-  group('SuperTextField touch interaction', () {
-    group('tapping in an empty space selects the end of the text', () {
-      testWidgetsOnMobile("when having no selection", (tester) async {
+  group('SuperTextField gestures', () {
+    group('tapping in empty space places the caret at the end of the text', () {
+      testWidgetsOnMobile("when the field does not have focus", (tester) async {
         await _pumpTestApp(tester);
 
         // Tap in a position without text
@@ -41,8 +41,8 @@ void main() {
       });
     });
 
-    group('tapping in an area containing text moves selection to tap position', () {
-      testWidgetsOnMobile("when having no selection", (tester) async {
+    group('tapping in an area containing text places the cart at tap position', () {
+      testWidgetsOnMobile("when the field does not have focus", (tester) async {
         await _pumpTestApp(tester);
 
         // Tap in a place containing text

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -12,7 +12,7 @@ void main() {
       testWidgetsOnMobile("when the field does not have focus", (tester) async {
         await _pumpTestApp(tester);
 
-        // Tap in a position without text
+        // Tap in a place without text
         await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
         await tester.pumpAndSettle();
 
@@ -23,13 +23,15 @@ void main() {
         );
       });
 
-      testWidgetsOnMobile("when having a valid selection", (tester) async {
-        await _pumpTestApp(
-          tester,
-          selection: const TextSelection.collapsed(offset: 0),
-        );
+      testWidgetsOnMobile("when the field already has focus", (tester) async {
+        await _pumpTestApp(tester);
 
-        // Tap in a position without text
+        // Tap in a place containing text
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        // Without this 'delay' onTapDown is not called the second time
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+        // Tap in a place without text
         await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
         await tester.pumpAndSettle();
 
@@ -41,7 +43,7 @@ void main() {
       });
     });
 
-    group('tapping in an area containing text places the cart at tap position', () {
+    group('tapping in an area containing text places the caret at tap position', () {
       testWidgetsOnMobile("when the field does not have focus", (tester) async {
         await _pumpTestApp(tester);
 
@@ -56,11 +58,13 @@ void main() {
         );
       });
 
-      testWidgetsOnMobile("when having a valid selection", (tester) async {
-        await _pumpTestApp(
-          tester,
-          selection: const TextSelection.collapsed(offset: 2),
-        );
+      testWidgetsOnMobile("when the field already has focus", (tester) async {
+        await _pumpTestApp(tester);
+
+        // Tap in a place without text
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
+        // Without this 'delay' onTapDown is not called the second time
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
 
         // Tap in a place containing text
         await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
@@ -76,10 +80,7 @@ void main() {
   });
 }
 
-Future<void> _pumpTestApp(
-  WidgetTester tester, {
-  TextSelection? selection,
-}) async {
+Future<void> _pumpTestApp(WidgetTester tester) async {
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
@@ -87,7 +88,6 @@ Future<void> _pumpTestApp(
           lineHeight: 16,
           textController: AttributedTextEditingController(
             text: AttributedText(text: "abc"),
-            selection: selection,
           ),
         ),
       ),

--- a/super_editor/test/super_textfield/super_textfield_touch_interaction_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_touch_interaction_test.dart
@@ -1,0 +1,96 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
+
+import '../test_tools.dart';
+import 'super_textfield_inspector.dart';
+
+void main() {
+  group('SuperTextField touch interaction', () {
+    group('tapping in an empty space selects the end of the text', () {
+      testWidgetsOnMobile("when having no selection", (tester) async {
+        await _pumpTestApp(tester);
+
+        // Tap in a position without text
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
+        await tester.pumpAndSettle();
+
+        // Ensure selection is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 3),
+        );
+      });
+
+      testWidgetsOnMobile("when having a valid selection", (tester) async {
+        await _pumpTestApp(
+          tester,
+          selection: const TextSelection.collapsed(offset: 0),
+        );
+
+        // Tap in a position without text
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
+        await tester.pumpAndSettle();
+
+        // Ensure selection is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 3),
+        );
+      });
+    });
+
+    group('tapping in an area containing text moves selection to tap position', () {
+      testWidgetsOnMobile("when having no selection", (tester) async {
+        await _pumpTestApp(tester);
+
+        // Tap in a place containing text
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure selection is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+
+      testWidgetsOnMobile("when having a valid selection", (tester) async {
+        await _pumpTestApp(
+          tester,
+          selection: const TextSelection.collapsed(offset: 2),
+        );
+
+        // Tap in a place containing text
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure selection is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  TextSelection? selection,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperTextField(
+          lineHeight: 16,
+          textController: AttributedTextEditingController(
+            text: AttributedText(text: "abc"),
+            selection: selection,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -27,6 +27,17 @@ void testWidgetsOnDesktop(
   testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
 }
 
+/// A widget test that runs a variant for every mobile platform, e.g.,
+/// Android and iOS
+void testWidgetsOnMobile(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgetsOnAndroid("$description (on Android)", test, skip: skip);
+  testWidgetsOnIos("$description (on iOS)", test, skip: skip);
+}
+
 /// A widget test that runs a variant for every platform, e.g.,
 /// Mac, Windows, Linux, Android and iOS.
 void testWidgetsOnAllPlatforms(


### PR DESCRIPTION
Change SuperTextField to place caret at the end of the text when tapping empty space. Resolves https://github.com/superlistapp/super_editor/issues/654

Tapping a part of the field without any text was changing selection only when `SuperTextField` had no valid selection. 

It was working when there was no selection because we are forcing a selection when `SuperAndroidTextField` is focused:

https://github.com/superlistapp/super_editor/blob/6602da8767efbd08707f18768bccb4c5bf070280/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart#L264-L272

This is also true for `SuperIOSTextField`