### PR TITLE
Fix SuperTextField newline not working on mobile and web (Resolves #653)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -190,6 +190,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     if (widget.textInputAction != oldWidget.textInputAction && _textEditingController.isAttachedToIme) {
       _textEditingController.updateTextInputConfiguration(
         textInputAction: widget.textInputAction,
+        textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
       );
     }
 
@@ -272,6 +273,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
           _textEditingController.attachToIme(
             textInputAction: widget.textInputAction,
+            textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
           );
 
           _showEditingControlsOverlay();

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -81,6 +81,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     bool autocorrect = true,
     bool enableSuggestions = true,
     TextInputAction textInputAction = TextInputAction.done,
+    TextInputType textInputType = TextInputType.text,
   }) {
     if (isAttachedToIme) {
       // We're already connected to the IME.
@@ -94,6 +95,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
           enableDeltaModel: true,
           enableSuggestions: enableSuggestions,
           inputAction: textInputAction,
+          inputType: textInputType,
         ));
     _inputConnection!
       ..show()
@@ -105,6 +107,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     bool autocorrect = true,
     bool enableSuggestions = true,
     TextInputAction textInputAction = TextInputAction.done,
+    TextInputType textInputType = TextInputType.text,
   }) {
     if (!isAttachedToIme) {
       // We're not attached to the IME, so there is nothing to update.
@@ -122,6 +125,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
           enableDeltaModel: true,
           enableSuggestions: enableSuggestions,
           inputAction: textInputAction,
+          inputType: textInputType,
         ));
     _inputConnection!
       ..show()

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -287,6 +287,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
           _textEditingController.attachToIme(
             textInputAction: widget.textInputAction,
+            textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
           );
 
           _showHandles();

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -215,6 +215,7 @@ class SuperTextFieldState extends State<SuperTextField> {
           minLines: widget.minLines,
           maxLines: widget.maxLines,
           lineHeight: widget.lineHeight,
+          textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
         );
       case SuperTextFieldPlatformConfiguration.iOS:
         return SuperIOSTextField(
@@ -231,6 +232,7 @@ class SuperTextFieldState extends State<SuperTextField> {
           minLines: widget.minLines,
           maxLines: widget.maxLines,
           lineHeight: widget.lineHeight,
+          textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
         );
     }
   }
@@ -252,6 +254,8 @@ class SuperTextFieldState extends State<SuperTextField> {
         return SuperTextFieldPlatformConfiguration.desktop;
     }
   }
+
+  bool get _isMultiline => widget.minLines != 1 || widget.maxLines != 1;
 }
 
 /// Configures a [SuperTextField] for the given platform.

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -176,6 +176,26 @@ class SuperTextFieldState extends State<SuperTextField> {
   @visibleForTesting
   ProseTextLayout get textLayout => (_platformFieldKey.currentState as ProseTextBlock).textLayout;
 
+  bool get _isMultiline => widget.minLines != 1 || widget.maxLines != 1;
+
+  SuperTextFieldPlatformConfiguration get _configuration {
+    if (widget.configuration != null) {
+      return widget.configuration!;
+    }
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return SuperTextFieldPlatformConfiguration.android;
+      case TargetPlatform.iOS:
+        return SuperTextFieldPlatformConfiguration.iOS;
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return SuperTextFieldPlatformConfiguration.desktop;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     switch (_configuration) {
@@ -236,26 +256,6 @@ class SuperTextFieldState extends State<SuperTextField> {
         );
     }
   }
-
-  SuperTextFieldPlatformConfiguration get _configuration {
-    if (widget.configuration != null) {
-      return widget.configuration!;
-    }
-
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        return SuperTextFieldPlatformConfiguration.android;
-      case TargetPlatform.iOS:
-        return SuperTextFieldPlatformConfiguration.iOS;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        return SuperTextFieldPlatformConfiguration.desktop;
-    }
-  }
-
-  bool get _isMultiline => widget.minLines != 1 || widget.maxLines != 1;
 }
 
 /// Configures a [SuperTextField] for the given platform.

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -104,82 +104,84 @@ void main() {
       });
     });
 
-    group("configures inner textfield textInputAction for newline when it's multiline", () {
-      testWidgetsOnAndroid('on Android', (tester) async {
-        await tester.pumpWidget(
-          _buildScaffold(
-            child: const SuperTextField(
-              minLines: 10,
-              maxLines: 10,
-              lineHeight: 16,
+    group("on mobile", () {
+      group("configures inner textfield textInputAction for newline when it's multiline", () {        
+        testWidgetsOnAndroid('(on Android)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                minLines: 10,
+                maxLines: 10,
+                lineHeight: 16,
+              ),
             ),
-          ),
-        );
+          );
 
-        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
 
-        // Ensure inner textfield action is configured to newline
-        // so we are able to receive new lines
-        expect(innerTextField.textInputAction, TextInputAction.newline);
-      });
+          // Ensure inner textfield action is configured to newline
+          // so we are able to receive new lines
+          expect(innerTextField.textInputAction, TextInputAction.newline);
+        });
 
-      testWidgetsOnIos('on iOS', (tester) async {
-        await tester.pumpWidget(
-          _buildScaffold(
-            child: const SuperTextField(
-              minLines: 10,
-              maxLines: 10,
-              lineHeight: 16,
+        testWidgetsOnIos('(on iOS)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                minLines: 10,
+                maxLines: 10,
+                lineHeight: 16,
+              ),
             ),
-          ),
-        );
+          );
 
-        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
 
-        // Ensure inner textfield action is configured to newline
-        // so we are able to receive new lines
-        expect(innerTextField.textInputAction, TextInputAction.newline);
+          // Ensure inner textfield action is configured to newline
+          // so we are able to receive new lines
+          expect(innerTextField.textInputAction, TextInputAction.newline);
+        });
       });
+      
+      group("configures inner textfield textInputAction for done when it's singleline", () {
+        testWidgetsOnAndroid('(on Android)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                minLines: 1,
+                maxLines: 1,
+                lineHeight: 16,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+
+          // Ensure inner textfield action is configured to done
+          // because we should NOT receive new lines
+          expect(innerTextField.textInputAction, TextInputAction.done);
+        });
+
+        testWidgetsOnIos('(on iOS)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                minLines: 1,
+                maxLines: 1,
+                lineHeight: 16,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+          // Ensure inner textfield action is configured to done
+          // because we should NOT receive new lines
+          expect(innerTextField.textInputAction, TextInputAction.done);
+        });
+      });    
     });
 
-    group("configures inner textfield textInputAction for done when it's singleline", () {
-      testWidgetsOnAndroid('on Android', (tester) async {
-        await tester.pumpWidget(
-          _buildScaffold(
-            child: const SuperTextField(
-              minLines: 1,
-              maxLines: 1,
-              lineHeight: 16,
-            ),
-          ),
-        );
-
-        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
-
-        // Ensure inner textfield action is configured to done
-        // because we should NOT receive new lines
-        expect(innerTextField.textInputAction, TextInputAction.done);
-      });
-
-      testWidgetsOnIos('on iOS', (tester) async {
-        await tester.pumpWidget(
-          _buildScaffold(
-            child: const SuperTextField(
-              minLines: 1,
-              maxLines: 1,
-              lineHeight: 16,
-            ),
-          ),
-        );
-
-        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
-
-        // Ensure inner textfield action is configured to done
-        // because we should NOT receive new lines
-        expect(innerTextField.textInputAction, TextInputAction.done);
-      });
-    });
-    
     group("selection", () {
       testWidgetsOnAllPlatforms("is inserted automatically when the field is initialized with focus", (tester) async {
         await tester.pumpWidget(

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -104,6 +104,82 @@ void main() {
       });
     });
 
+    group("configures inner textfield textInputAction for newline when it's multiline", () {
+      testWidgetsOnAndroid('on Android', (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 10,
+              maxLines: 10,
+              lineHeight: 16,
+            ),
+          ),
+        );
+
+        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+
+        // Ensure inner textfield action is configured to newline
+        // so we are able to receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.newline);
+      });
+
+      testWidgetsOnIos('on iOS', (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 10,
+              maxLines: 10,
+              lineHeight: 16,
+            ),
+          ),
+        );
+
+        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+        // Ensure inner textfield action is configured to newline
+        // so we are able to receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.newline);
+      });
+    });
+
+    group("configures inner textfield textInputAction for done when it's singleline", () {
+      testWidgetsOnAndroid('on Android', (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 1,
+              maxLines: 1,
+              lineHeight: 16,
+            ),
+          ),
+        );
+
+        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+
+        // Ensure inner textfield action is configured to done
+        // because we should NOT receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.done);
+      });
+
+      testWidgetsOnIos('on iOS', (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 1,
+              maxLines: 1,
+              lineHeight: 16,
+            ),
+          ),
+        );
+
+        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+        // Ensure inner textfield action is configured to done
+        // because we should NOT receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.done);
+      });
+    });
+    
     group("selection", () {
       testWidgetsOnAllPlatforms("is inserted automatically when the field is initialized with focus", (tester) async {
         await tester.pumpWidget(


### PR DESCRIPTION
Fix SuperTextField newline not working on mobile. Resolves https://github.com/superlistapp/super_editor/issues/653

There were two issues:

* We were not configuring `textInputAction`  to `TextInputAction.newline`  when the textfield was configured for multi-line
* We were not configuring `textInputType` to `TextInputType.multiline` when the textfield was configured for multi-line

I couldn't write an ideal test because we can't simulate the behavior on the tests (on Android and web, clicking the action button will generate an insertion delta of a new line) 