### PR TITLE
Make SuperTextField handle DONE action (Resolves #661)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -160,8 +160,9 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
-      ..addListener(_onTextOrSelectionChange);
-
+      ..addListener(_onTextOrSelectionChange)
+      ..onPerformActionPressed = _onPerformActionPressed;
+    
     _textScrollController = TextScrollController(
       textController: _textEditingController,
       tickerProvider: this,
@@ -195,13 +196,17 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     }
 
     if (widget.textController != oldWidget.textController) {
-      _textEditingController.removeListener(_onTextOrSelectionChange);
+      _textEditingController
+        ..removeListener(_onTextOrSelectionChange)
+        ..onPerformActionPressed = null;
       if (widget.textController != null) {
         _textEditingController = widget.textController!;
       } else {
         _textEditingController = ImeAttributedTextEditingController();
       }
-      _textEditingController.addListener(_onTextOrSelectionChange);
+      _textEditingController
+        ..addListener(_onTextOrSelectionChange)
+        ..onPerformActionPressed = _onPerformActionPressed;
     }
 
     if (widget.showDebugPaint != oldWidget.showDebugPaint) {
@@ -336,6 +341,14 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       _controlsOverlayEntry!.remove();
       _controlsOverlayEntry = null;
     }
+  }
+
+  /// Handles actions from the IME
+  void _onPerformActionPressed(TextInputAction action) {
+    if (action == TextInputAction.done) {
+      _focusNode.unfocus();
+    }
+    widget.onPerformActionPressed?.call(action);
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -352,6 +352,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
         _focusNode.previousFocus();
         break;
       default:
+        _log.warning("User pressed unhandled action button: $action");
     }
   }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -37,7 +37,6 @@ class SuperAndroidTextField extends StatefulWidget {
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
-    this.onPerformActionPressed,
   })  : assert(minLines == null || minLines == 1 || lineHeight != null, 'minLines > 1 requires a non-null lineHeight'),
         assert(maxLines == null || maxLines == 1 || lineHeight != null, 'maxLines > 1 requires a non-null lineHeight'),
         super(key: key);
@@ -120,10 +119,6 @@ class SuperAndroidTextField extends StatefulWidget {
   /// Whether to paint debug guides.
   final bool showDebugPaint;
 
-  /// Callback invoked when the user presses the "action" button
-  /// on the keyboard, e.g., "done", "call", "emergency", etc.
-  final Function(TextInputAction)? onPerformActionPressed;
-
   /// Builder that creates the popover toolbar widget that appears when text is selected.
   final Widget Function(BuildContext, AndroidEditingOverlayController) popoverToolbarBuilder;
 
@@ -161,8 +156,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange)
-      ..onPerformActionPressed = _onPerformActionPressed;
-    
+      ..onPerformActionPressed ??= _onPerformActionPressed;
+
     _textScrollController = TextScrollController(
       textController: _textEditingController,
       tickerProvider: this,
@@ -196,9 +191,10 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     }
 
     if (widget.textController != oldWidget.textController) {
-      _textEditingController
-        ..removeListener(_onTextOrSelectionChange)
-        ..onPerformActionPressed = null;
+      _textEditingController.removeListener(_onTextOrSelectionChange);
+      if (_textEditingController.onPerformActionPressed == _onPerformActionPressed) {
+        _textEditingController.onPerformActionPressed = null;
+      }
       if (widget.textController != null) {
         _textEditingController = widget.textController!;
       } else {
@@ -206,7 +202,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       }
       _textEditingController
         ..addListener(_onTextOrSelectionChange)
-        ..onPerformActionPressed = _onPerformActionPressed;
+        ..onPerformActionPressed ??= _onPerformActionPressed;
     }
 
     if (widget.showDebugPaint != oldWidget.showDebugPaint) {
@@ -265,7 +261,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   @override
   ProseTextLayout get textLayout => _textContentKey.currentState!.textLayout;
 
-  bool get _isMultiline => widget.minLines != 1 || widget.maxLines != 1;
+  bool get _isMultiline => (widget.minLines ?? 1) != 1 || (widget.maxLines ?? 1) != 1;
 
   void _onFocusChange() {
     if (_focusNode.hasFocus) {
@@ -345,10 +341,18 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   /// Handles actions from the IME
   void _onPerformActionPressed(TextInputAction action) {
-    if (action == TextInputAction.done) {
-      _focusNode.unfocus();
+    switch (action) {
+      case TextInputAction.done:
+        _focusNode.unfocus();
+        break;
+      case TextInputAction.next:
+        _focusNode.nextFocus();
+        break;
+      case TextInputAction.previous:
+        _focusNode.previousFocus();
+        break;
+      default:
     }
-    widget.onPerformActionPressed?.call(action);
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -194,6 +194,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
   void Function(TextInputAction)? _onPerformActionPressed;
   set onPerformActionPressed(Function(TextInputAction)? callback) => _onPerformActionPressed = callback;
+  Function(TextInputAction)? get onPerformActionPressed => _onPerformActionPressed;
 
   @override
   TextEditingValue? get currentTextEditingValue => TextEditingValue(
@@ -289,7 +290,11 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
   @override
   void performAction(TextInputAction action) {
-    _onPerformActionPressed?.call(action);
+    if (_realController is ImeAttributedTextEditingController && (_realController as ImeAttributedTextEditingController).onPerformActionPressed != null) {
+      (_realController as ImeAttributedTextEditingController).onPerformActionPressed!(action);
+    } else {
+      _onPerformActionPressed?.call(action);
+    }
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -290,11 +290,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
   @override
   void performAction(TextInputAction action) {
-    if (_realController is ImeAttributedTextEditingController && (_realController as ImeAttributedTextEditingController).onPerformActionPressed != null) {
-      (_realController as ImeAttributedTextEditingController).onPerformActionPressed!(action);
-    } else {
-      _onPerformActionPressed?.call(action);
-    }
+    _onPerformActionPressed?.call(action);
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -169,7 +169,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange)
-      ..onIOSFloatingCursorChange = _onFloatingCursorChange;
+      ..onIOSFloatingCursorChange = _onFloatingCursorChange
+      ..onPerformActionPressed = _onPerformActionPressed;
 
     _textScrollController = TextScrollController(
       textController: _textEditingController,
@@ -203,7 +204,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     if (widget.textController != oldWidget.textController) {
       _textEditingController
         ..removeListener(_onTextOrSelectionChange)
-        ..onIOSFloatingCursorChange = null;
+        ..onIOSFloatingCursorChange = null
+        ..onPerformActionPressed = null;
 
       if (widget.textController != null) {
         _textEditingController = widget.textController!;
@@ -213,7 +215,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
       _textEditingController
         ..addListener(_onTextOrSelectionChange)
-        ..onIOSFloatingCursorChange = _onFloatingCursorChange;
+        ..onIOSFloatingCursorChange = _onFloatingCursorChange
+        ..onPerformActionPressed = _onPerformActionPressed;
     }
 
     if (widget.showDebugPaint != oldWidget.showDebugPaint) {
@@ -354,6 +357,14 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
   void _onFloatingCursorChange(RawFloatingCursorPoint point) {
     _floatingCursorController.updateFloatingCursor(_textContentKey.currentState!.textLayout, point);
+  }
+
+  /// Handles actions from the IME
+  void _onPerformActionPressed(TextInputAction action) {
+    if (action == TextInputAction.done) {
+      _focusNode.unfocus();
+    }
+    widget.onPerformActionPressed?.call(action);
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -369,6 +369,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         _focusNode.previousFocus();
         break;
       default:
+        _log.warning("User pressed unhandled action button: $action");
     } 
   }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -176,7 +176,7 @@ class SuperTextFieldState extends State<SuperTextField> {
   @visibleForTesting
   ProseTextLayout get textLayout => (_platformFieldKey.currentState as ProseTextBlock).textLayout;
 
-  bool get _isMultiline => widget.minLines != 1 || widget.maxLines != 1;
+  bool get _isMultiline => (widget.minLines ?? 1) != 1 || (widget.maxLines ?? 1) != 1;
 
   SuperTextFieldPlatformConfiguration get _configuration {
     if (widget.configuration != null) {

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -155,7 +155,9 @@ class SuperTextFieldState extends State<SuperTextField> {
     super.initState();
 
     _controller = widget.textController != null
-        ? ImeAttributedTextEditingController(controller: widget.textController, disposeClientController: false)
+        ? widget.textController is ImeAttributedTextEditingController
+            ? (widget.textController as ImeAttributedTextEditingController)
+            : ImeAttributedTextEditingController(controller: widget.textController, disposeClientController: false)
         : ImeAttributedTextEditingController();
   }
 
@@ -165,7 +167,9 @@ class SuperTextFieldState extends State<SuperTextField> {
 
     if (widget.textController != oldWidget.textController) {
       _controller = widget.textController != null
-          ? ImeAttributedTextEditingController(controller: widget.textController, disposeClientController: false)
+          ? widget.textController is ImeAttributedTextEditingController
+              ? (widget.textController as ImeAttributedTextEditingController)
+              : ImeAttributedTextEditingController(controller: widget.textController, disposeClientController: false)
           : ImeAttributedTextEditingController();
     }
   }

--- a/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
@@ -7,21 +7,9 @@ import '../test_tools.dart';
 void main() {
   group("SuperTextField input actions", () {
     testWidgetsOnMobile("unfocus on DONE", (tester) async {
-      FocusNode focusNode = FocusNode();      
+      FocusNode focusNode = FocusNode();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 300,
-              child: SuperTextField(
-                focusNode: focusNode,
-                lineHeight: 16,                
-              ),
-            ),
-          ),
-        ),
-      );
+      await _pumpSingleFieldTestApp(tester, focusNode: focusNode);
 
       // Focus SuperTextField. This should show the software keyboard
       focusNode.requestFocus();
@@ -33,9 +21,230 @@ void main() {
       // Simulate a tap at the action button
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
-      
+
       // Ensure focus was removed
       expect(focusNode.hasFocus, false);
     });
+
+    testWidgetsOnMobile("moves focus to next focusable item on NEXT", (tester) async {
+      FocusNode focusNodeFirstField = FocusNode();
+      FocusNode focusNodeSecondField = FocusNode();
+
+      // We use a widget tree with three textfields because TextInputAction.previous
+      // moves focus to the last focusable item in the scope when the first item is focused
+      await _pumpTripleFieldTestApp(
+        tester,
+        focusNodeFirstField: focusNodeFirstField,
+        focusNodeSecondField: focusNodeSecondField,
+      );
+
+      // Focus first field
+      focusNodeFirstField.requestFocus();
+      await tester.pump();
+
+      // Ensure we have focus
+      expect(focusNodeFirstField.hasFocus, true);
+
+      // Simulate a tap at the action button
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pump();
+
+      // Ensure focus has moved to next field
+      expect(focusNodeSecondField.hasFocus, true);
+    });
+
+    testWidgetsOnMobile("moves focus to previous focusable item on PREVIOUS", (tester) async {
+      FocusNode focusNodeFirstField = FocusNode();
+      FocusNode focusNodeSecondField = FocusNode();
+
+      // We use a widget tree with three textfields because TextInputAction.next
+      // moves focus to the first focusable item in the scope when the last item is focused
+      await _pumpTripleFieldTestApp(
+        tester,
+        focusNodeFirstField: focusNodeFirstField,
+        focusNodeSecondField: focusNodeSecondField,
+      );
+
+      // Focus second field
+      focusNodeSecondField.requestFocus();
+      await tester.pump();
+
+      // Ensure we have focus
+      expect(focusNodeSecondField.hasFocus, true);
+
+      // Simulate a tap at the action button
+      await tester.testTextInput.receiveAction(TextInputAction.previous);
+      await tester.pump();
+
+      // Ensure focus has moved to next field
+      expect(focusNodeFirstField.hasFocus, true);
+    });
+
+    group('having a textController with onPerformActionPressed set', () {
+      testWidgetsOnMobile("does nothing on DONE", (tester) async {
+        FocusNode focusNode = FocusNode();
+        bool callbackCalled = false;
+
+        ImeAttributedTextEditingController textController = ImeAttributedTextEditingController()
+          ..onPerformActionPressed = (action) {
+            callbackCalled = true;
+          };
+
+        await _pumpSingleFieldTestApp(
+          tester,
+          focusNode: focusNode,
+          textController: textController,
+        );
+
+        // Focus SuperTextField.
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // Ensure we have focus
+        expect(focusNode.hasFocus, true);
+
+        // Simulate a tap at the action button
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pump();
+
+        // Ensure our callback was called
+        expect(callbackCalled, true);
+
+        // Ensure we still have focus
+        expect(focusNode.hasFocus, true);
+      });
+
+      testWidgetsOnMobile("does nothing on NEXT", (tester) async {
+        FocusNode focusNode = FocusNode();
+        bool callbackCalled = false;
+
+        ImeAttributedTextEditingController textController = ImeAttributedTextEditingController()
+          ..onPerformActionPressed = (action) {
+            callbackCalled = true;
+          };
+
+        await _pumpTripleFieldTestApp(
+          tester,
+          focusNodeFirstField: focusNode,
+          textControllerFirstField: textController,
+        );
+
+        // Focus first field.
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // Ensure we have focus
+        expect(focusNode.hasFocus, true);
+
+        // Simulate a tap at the action button
+        await tester.testTextInput.receiveAction(TextInputAction.next);
+        await tester.pump();
+
+        // Ensure our callback was called
+        expect(callbackCalled, true);
+
+        // Ensure focus is still on first field
+        expect(focusNode.hasFocus, true);
+      });
+
+      testWidgetsOnMobile("does nothing on PREVIOUS", (tester) async {
+        FocusNode focusNode = FocusNode();
+        bool callbackCalled = false;
+
+        ImeAttributedTextEditingController textController = ImeAttributedTextEditingController()
+          ..onPerformActionPressed = (action) {
+            callbackCalled = true;
+          };
+
+        await _pumpTripleFieldTestApp(
+          tester,
+          focusNodeSecondField: focusNode,
+          textControllerSecondField: textController,
+        );
+
+        // Focus second field
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // Ensure we have focus
+        expect(focusNode.hasFocus, true);
+
+        // Simulate a tap at the action button
+        await tester.testTextInput.receiveAction(TextInputAction.previous);
+        await tester.pump();
+
+        // Ensure our callback was called
+        expect(callbackCalled, true);
+
+        // Ensure focus is still on second field
+        expect(focusNode.hasFocus, true);
+      });
+    });
   });
+}
+
+Future<void> _pumpSingleFieldTestApp(
+  WidgetTester tester, {
+  required FocusNode focusNode,
+  ImeAttributedTextEditingController? textController,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 300,
+          child: SuperTextField(
+            focusNode: focusNode,
+            textController: textController,
+            lineHeight: 16,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpTripleFieldTestApp(
+  WidgetTester tester, {
+  FocusNode? focusNodeFirstField,
+  FocusNode? focusNodeSecondField,
+  FocusNode? focusNodeThirdField,
+  ImeAttributedTextEditingController? textControllerFirstField,
+  ImeAttributedTextEditingController? textControllerSecondField,
+  ImeAttributedTextEditingController? textControllerThirdField,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            SizedBox(
+              width: 300,
+              child: SuperTextField(
+                focusNode: focusNodeFirstField,
+                textController: textControllerFirstField,
+                lineHeight: 16,
+              ),
+            ),
+            SizedBox(
+              width: 300,
+              child: SuperTextField(
+                focusNode: focusNodeSecondField,
+                textController: textControllerSecondField,
+                lineHeight: 16,
+              ),
+            ),
+            SizedBox(
+              width: 300,
+              child: SuperTextField(
+                focusNode: focusNodeThirdField,
+                textController: textControllerThirdField,
+                lineHeight: 16,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }

--- a/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
@@ -80,7 +80,7 @@ void main() {
       expect(focusNodeFirstField.hasFocus, true);
     });
 
-    group('having a textController with onPerformActionPressed set', () {
+    group('with custom onPerformActionPressed callback', () {
       testWidgetsOnMobile("does nothing on DONE", (tester) async {
         FocusNode focusNode = FocusNode();
         bool callbackCalled = false;

--- a/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_input_actions_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group("SuperTextField input actions", () {
+    testWidgetsOnMobile("unfocus on DONE", (tester) async {
+      FocusNode focusNode = FocusNode();      
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              child: SuperTextField(
+                focusNode: focusNode,
+                lineHeight: 16,                
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Focus SuperTextField. This should show the software keyboard
+      focusNode.requestFocus();
+      await tester.pump();
+
+      // Ensure we have focus
+      expect(focusNode.hasFocus, true);
+
+      // Simulate a tap at the action button
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      
+      // Ensure focus was removed
+      expect(focusNode.hasFocus, false);
+    });
+  });
+}


### PR DESCRIPTION
Make SuperTextField handle DONE action. Resolves https://github.com/superlistapp/super_editor/issues/661

Here I'm not sure if we should unfocus even if the widget has a `onPerformActionPressed` defined. I could change this if needed. 

```dart
  void _onPerformActionPressed(TextInputAction action) {
    if (action == TextInputAction.done) {
      _focusNode.unfocus();
    }
    widget.onPerformActionPressed?.call(action);
  }
```

Maybe we should expose `onPerformActionPressed` on `SuperTextField`'s public API to write a test to ensure it's beeing called.