### PR TITLE
Force SuperTextField to show keyboard on tap (Resolves #673)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -67,7 +67,7 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
   /// [TextController] used to read the current selection to display
   /// editing controls, and used to update the selection based on
   /// user interactions.
-  final AttributedTextEditingController textController;
+  final ImeAttributedTextEditingController textController;
 
   final AndroidEditingOverlayController editingOverlayController;
 
@@ -148,10 +148,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
-    if (widget.focusNode.hasFocus &&
-        (widget.textController is ImeAttributedTextEditingController) &&
-        (widget.textController as ImeAttributedTextEditingController).isAttachedToIme) {
-      (widget.textController as ImeAttributedTextEditingController).showKeyboard();
+    if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
+      widget.textController.showKeyboard();
     } else {
       widget.focusNode.requestFocus();
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -148,7 +148,13 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
-    widget.focusNode.requestFocus();
+    if (widget.focusNode.hasFocus &&
+        (widget.textController is ImeAttributedTextEditingController) &&
+        (widget.textController as ImeAttributedTextEditingController).isAttachedToIme) {
+      (widget.textController as ImeAttributedTextEditingController).showKeyboard();
+    } else {
+      widget.focusNode.requestFocus();
+    }
 
     // If the user tapped on a collapsed caret, or tapped on an
     // expanded selection, toggle the toolbar appearance.

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -63,7 +63,7 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
   /// [TextController] used to read the current selection to display
   /// editing controls, and used to update the selection based on
   /// user interactions.
-  final AttributedTextEditingController textController;
+  final ImeAttributedTextEditingController textController;
 
   final IOSEditingOverlayController editingOverlayController;
 
@@ -143,10 +143,8 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
-    if (widget.focusNode.hasFocus &&
-        (widget.textController is ImeAttributedTextEditingController) &&
-        (widget.textController as ImeAttributedTextEditingController).isAttachedToIme) {
-      (widget.textController as ImeAttributedTextEditingController).showKeyboard();
+    if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
+      widget.textController.showKeyboard();
     } else {
       widget.focusNode.requestFocus();
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -143,7 +143,13 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
-    widget.focusNode.requestFocus();
+    if (widget.focusNode.hasFocus &&
+        (widget.textController is ImeAttributedTextEditingController) &&
+        (widget.textController as ImeAttributedTextEditingController).isAttachedToIme) {
+      (widget.textController as ImeAttributedTextEditingController).showKeyboard();
+    } else {
+      widget.focusNode.requestFocus();
+    }
 
     // If the user tapped on a collapsed caret, or tapped on an
     // expanded selection, toggle the toolbar appearance.

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -160,10 +160,10 @@ void main() {
         expect(SuperTextFieldInspector.findSelection()!.extent.offset, 0);
       });
 
-      testWidgetsOnMobile("tap up shows the keyboard if the field has focus", (tester) async {     
+      testWidgetsOnMobile("tap up shows the keyboard if the field already has focus", (tester) async {     
         await _pumpTestApp(tester);
 
-        bool isShowKeyboarCalled = false;
+        bool isShowKeyboardCalled = false;
 
         // Tap down and up so the field is focused.
         await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
@@ -173,7 +173,7 @@ void main() {
         tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) {
           final methodCall = const JSONMethodCodec().decodeMethodCall(message);
           if (methodCall.method == "TextInput.show") {
-            isShowKeyboarCalled = true;
+            isShowKeyboardCalled = true;
           }
         });
 
@@ -185,7 +185,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Ensure we requested the keyboard to the platform
-        expect(isShowKeyboarCalled, true);
+        expect(isShowKeyboardCalled, true);
       });
     });
   });


### PR DESCRIPTION
Force `SuperTextField` to show keyboard on tap. Resolves https://github.com/superlistapp/super_editor/issues/673

After tapping the field and closing the keyboard, tapping at the field again was not opening the keyboard.

I modified it to call `show()` on `TextInputConnection` if it's already focused and attached to ime.