### PR TITLE
Removed the need to specify a lineHeight for multiline SuperTextField's (Resolves #622)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -37,9 +37,7 @@ class SuperAndroidTextField extends StatefulWidget {
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
-  })  : assert(minLines == null || minLines == 1 || lineHeight != null, 'minLines > 1 requires a non-null lineHeight'),
-        assert(maxLines == null || maxLines == 1 || lineHeight != null, 'maxLines > 1 requires a non-null lineHeight'),
-        super(key: key);
+  }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -104,12 +102,10 @@ class SuperAndroidTextField extends StatefulWidget {
   /// The height of a single line of text in this text scroll view, used
   /// with [minLines] and [maxLines] to size the text field.
   ///
-  /// An explicit [lineHeight] is required for multi-line text fields
-  /// because rich text in this text scroll view might have lines of
-  /// varying height, which would result in a constantly changing text
-  /// field height during scrolling. To avoid that situation, a single,
-  /// explicit [lineHeight] is provided and used for all text field height
-  /// calculations.
+  /// If a [lineHeight] is provided, the text field viewport is sized as a
+  /// multiple of that [lineHeight]. If no [lineHeight] is provided, the
+  /// text field viewport is sized as a multiple of the line-height of the
+  /// first line of text.
   final double? lineHeight;
 
   /// The type of action associated with the action button on the mobile

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -41,9 +41,7 @@ class SuperIOSTextField extends StatefulWidget {
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
-  })  : assert(minLines == null || minLines == 1 || lineHeight != null, 'minLines > 1 requires a non-null lineHeight'),
-        assert(maxLines == null || maxLines == 1 || lineHeight != null, 'maxLines > 1 requires a non-null lineHeight'),
-        super(key: key);
+  }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -108,12 +106,10 @@ class SuperIOSTextField extends StatefulWidget {
   /// The height of a single line of text in this text scroll view, used
   /// with [minLines] and [maxLines] to size the text field.
   ///
-  /// An explicit [lineHeight] is required for multi-line text fields
-  /// because rich text in this text scroll view might have lines of
-  /// varying height, which would result in a constantly changing text
-  /// field height during scrolling. To avoid that situation, a single,
-  /// explicit [lineHeight] is provided and used for all text field height
-  /// calculations.
+  /// If a [lineHeight] is provided, the text field viewport is sized as a
+  /// multiple of that [lineHeight]. If no [lineHeight] is provided, the
+  /// text field viewport is sized as a multiple of the line-height of the
+  /// first line of text.
   final double? lineHeight;
 
   /// The type of action associated with the action button on the mobile
@@ -200,7 +196,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       _textEditingController
         ..removeListener(_onTextOrSelectionChange)
         ..onIOSFloatingCursorChange = null;
-      if (_textEditingController.onPerformActionPressed == _onPerformActionPressed){
+      if (_textEditingController.onPerformActionPressed == _onPerformActionPressed) {
         _textEditingController.onPerformActionPressed = null;
       }
 
@@ -370,7 +366,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         break;
       default:
         _log.warning("User pressed unhandled action button: $action");
-    } 
+    }
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -63,9 +63,7 @@ class SuperTextField extends StatefulWidget {
     this.maxLines = 1,
     this.lineHeight,
     this.keyboardHandlers = defaultTextFieldKeyboardHandlers,
-  })  : assert(minLines == null || minLines == 1 || lineHeight != null, 'minLines > 1 requires a non-null lineHeight'),
-        assert(maxLines == null || maxLines == 1 || lineHeight != null, 'maxLines > 1 requires a non-null lineHeight'),
-        super(key: key);
+  }) : super(key: key);
 
   final FocusNode? focusNode;
 
@@ -202,11 +200,11 @@ class SuperTextFieldState extends State<SuperTextField> {
   }
 
   /// Shortcuts that should be ignored on web.
-  /// 
+  ///
   /// Without this we can't handle space and arrow keys inside [SuperTextField].
-  /// 
+  ///
   /// For exemple, when [SuperTextField] is inside a [ScrollView],
-  /// pressing [LogicalKeyboardKey.space] scrolls the scrollview. 
+  /// pressing [LogicalKeyboardKey.space] scrolls the scrollview.
   final Map<LogicalKeySet, Intent> _scrollShortcutOverrides = kIsWeb
       ? {
           LogicalKeySet(LogicalKeyboardKey.space): DoNothingAndStopPropagationIntent(),

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -21,7 +21,6 @@ void main() {
         _buildScaffold(
           child: SuperTextField(
             textStyleBuilder: (_) => const TextStyle(fontSize: 16),
-            lineHeight: 16,
           ),
         ),
       );
@@ -59,7 +58,6 @@ void main() {
         _buildScaffold(
           child: SuperTextField(
             textStyleBuilder: (_) => const TextStyle(fontSize: 16),
-            lineHeight: 16,
           ),
         ),
       );
@@ -96,9 +94,7 @@ void main() {
     testWidgetsOnAllPlatforms("is NOT displayed without a text selection", (tester) async {
       await tester.pumpWidget(
         _buildScaffold(
-          child: const SuperTextField(
-            lineHeight: 16,
-          ),
+          child: const SuperTextField(),
         ),
       );
       await tester.pump();
@@ -116,7 +112,6 @@ void main() {
           child: SuperTextField(
             focusNode: FocusNode()..requestFocus(),
             textController: controller,
-            lineHeight: 16,
           ),
         ),
       );

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -160,7 +160,7 @@ void main() {
         expect(SuperTextFieldInspector.findSelection()!.extent.offset, 0);
       });
 
-      testWidgetsOnMobile("tap up shows the keyboard if the field already has focus", (tester) async {     
+      testWidgetsOnMobile("tap up shows the keyboard if the field already has focus", (tester) async {
         await _pumpTestApp(tester);
 
         bool isShowKeyboardCalled = false;
@@ -170,11 +170,12 @@ void main() {
         await tester.pumpAndSettle();
 
         // Intercept messages sent to the platform.
-        tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) {
+        tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) async {
           final methodCall = const JSONMethodCodec().decodeMethodCall(message);
           if (methodCall.method == "TextInput.show") {
             isShowKeyboardCalled = true;
           }
+          return null;
         });
 
         // Avoid a double tap.
@@ -196,7 +197,6 @@ Future<void> _pumpTestApp(WidgetTester tester) async {
     MaterialApp(
       home: Scaffold(
         body: SuperTextField(
-          lineHeight: 16,
           textController: AttributedTextEditingController(
             text: AttributedText(text: "abc"),
           ),

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -5,7 +5,6 @@ import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../test_tools.dart';
-import 'super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField", () {
@@ -16,9 +15,7 @@ void main() {
 
           await tester.pumpWidget(
             _buildScaffold(
-              child: const SuperTextField(
-                lineHeight: 16,
-              ),
+              child: const SuperTextField(),
             ),
           );
 
@@ -32,7 +29,6 @@ void main() {
             _buildScaffold(
               child: const SuperTextField(
                 configuration: SuperTextFieldPlatformConfiguration.desktop,
-                lineHeight: 16,
               ),
             ),
           );
@@ -47,9 +43,7 @@ void main() {
 
           await tester.pumpWidget(
             _buildScaffold(
-              child: const SuperTextField(
-                lineHeight: 16,
-              ),
+              child: const SuperTextField(),
             ),
           );
 
@@ -63,7 +57,6 @@ void main() {
             _buildScaffold(
               child: const SuperTextField(
                 configuration: SuperTextFieldPlatformConfiguration.android,
-                lineHeight: 16,
               ),
             ),
           );
@@ -78,9 +71,7 @@ void main() {
 
           await tester.pumpWidget(
             _buildScaffold(
-              child: const SuperTextField(
-                lineHeight: 16,
-              ),
+              child: const SuperTextField(),
             ),
           );
 
@@ -94,7 +85,6 @@ void main() {
             _buildScaffold(
               child: const SuperTextField(
                 configuration: SuperTextFieldPlatformConfiguration.iOS,
-                lineHeight: 16,
               ),
             ),
           );
@@ -105,14 +95,13 @@ void main() {
     });
 
     group("on mobile", () {
-      group("configures inner textfield textInputAction for newline when it's multiline", () {        
+      group("configures inner textfield textInputAction for newline when it's multiline", () {
         testWidgetsOnAndroid('(on Android)', (tester) async {
           await tester.pumpWidget(
             _buildScaffold(
               child: const SuperTextField(
                 minLines: 10,
                 maxLines: 10,
-                lineHeight: 16,
               ),
             ),
           );
@@ -130,7 +119,6 @@ void main() {
               child: const SuperTextField(
                 minLines: 10,
                 maxLines: 10,
-                lineHeight: 16,
               ),
             ),
           );
@@ -142,7 +130,7 @@ void main() {
           expect(innerTextField.textInputAction, TextInputAction.newline);
         });
       });
-      
+
       group("configures inner textfield textInputAction for done when it's singleline", () {
         testWidgetsOnAndroid('(on Android)', (tester) async {
           await tester.pumpWidget(
@@ -150,7 +138,6 @@ void main() {
               child: const SuperTextField(
                 minLines: 1,
                 maxLines: 1,
-                lineHeight: 16,
               ),
             ),
           );
@@ -168,7 +155,6 @@ void main() {
               child: const SuperTextField(
                 minLines: 1,
                 maxLines: 1,
-                lineHeight: 16,
               ),
             ),
           );
@@ -179,7 +165,7 @@ void main() {
           // because we should NOT receive new lines
           expect(innerTextField.textInputAction, TextInputAction.done);
         });
-      });    
+      });
     });
 
     group("selection", () {
@@ -188,7 +174,6 @@ void main() {
           _buildScaffold(
             child: SuperTextField(
               focusNode: FocusNode()..requestFocus(),
-              lineHeight: 16,
             ),
           ),
         );
@@ -203,7 +188,6 @@ void main() {
           _buildScaffold(
             child: SuperTextField(
               focusNode: focusNode,
-              lineHeight: 16,
             ),
           ),
         );


### PR DESCRIPTION
Removed the need to specify a lineHeight for multiline SuperTextField's (Resolves #622)

Historically, we've required that any multi-line `SuperTextField` provide an explicit line height in pixels. This is because styled text can produce varying line heights, and text scrolling currently scrolls by line, not by pixel. So how tall should a `SuperTextField` be if, for example, we have a 5 line field with different font sizes inside of it? Our answer was to make the developer choose a line height and then `SuperTextField` would multiply that value by the number of lines.

This is an annoying requirement. Even with an explicit line height, the result can be poor. The eventual answer is to offer pixel-based scrolling, when desired. But for now, this PR removes the need to pass a line height to `SuperTextField`. Instead, if a `lineHeight` isn't provided, `SuperTextField` will calculate a reasonable estimate internally.