### PR TITLE
Fixed getRangeBetween() in MutableDocument, and added tests for getDocumentSelectionInRegion in SingleColumnDocumentLayout (Resolves #48, Resolves #50)

### DIFF
--- a/super_editor/lib/src/core/document_editor.dart
+++ b/super_editor/lib/src/core/document_editor.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:uuid/uuid.dart';
 
@@ -187,21 +189,10 @@ class MutableDocument with ChangeNotifier implements Document {
 
   @override
   DocumentRange getRangeBetween(DocumentPosition position1, DocumentPosition position2) {
-    final node1 = getNode(position1);
-    if (node1 == null) {
-      throw Exception('No such position in document: $position1');
-    }
-    final index1 = _nodes.indexOf(node1);
-
-    final node2 = getNode(position2);
-    if (node2 == null) {
-      throw Exception('No such position in document: $position2');
-    }
-    final index2 = _nodes.indexOf(node2);
-
+    late TextAffinity affinity = getAffinityBetween(base: position1, extent: position2);
     return DocumentRange(
-      start: index1 < index2 ? position1 : position2,
-      end: index1 < index2 ? position2 : position1,
+      start: affinity == TextAffinity.downstream ? position1 : position2,
+      end: affinity == TextAffinity.downstream ? position2 : position1,
     );
   }
 

--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -219,8 +219,16 @@ extension InspectDocumentAffinity on Document {
     required DocumentPosition base,
     required DocumentPosition extent,
   }) {
+    final baseNode = getNode(base);
+    if (baseNode == null) {
+      throw Exception('No such position in document: $base');
+    }
     final baseIndex = getNodeIndex(getNode(base)!);
-    final extentNode = getNode(extent)!;
+
+    final extentNode = getNode(extent);
+    if (extentNode == null) {
+      throw Exception('No such position in document: $extent');
+    }
     final extentIndex = getNodeIndex(extentNode);
 
     late TextAffinity affinity;

--- a/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
@@ -48,7 +48,7 @@ class SingleColumnDocumentLayout extends StatefulWidget {
   final bool showDebugPaint;
 
   @override
-  _SingleColumnDocumentLayoutState createState() => _SingleColumnDocumentLayoutState();
+  State createState() => _SingleColumnDocumentLayoutState();
 }
 
 class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout> implements DocumentLayout {
@@ -264,11 +264,6 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
   @override
   DocumentSelection? getDocumentSelectionInRegion(Offset baseOffset, Offset extentOffset) {
     editorLayoutLog.info('getDocumentSelectionInRegion() - from: $baseOffset, to: $extentOffset');
-    // Drag direction determines whether the extent offset is at the
-    // top or bottom of the drag rect.
-    // TODO: this condition is wrong when the user is dragging within a single line of text (#50)
-    final isDraggingDown = baseOffset.dy < extentOffset.dy;
-
     final region = Rect.fromPoints(baseOffset, extentOffset);
 
     String? topNodeId;
@@ -339,6 +334,11 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
       );
     } else {
       // Region covers multiple components.
+
+      // Drag direction determines whether the extent offset is at the
+      // top or bottom of the drag rect.
+      final isDraggingDown = baseOffset.dy < extentOffset.dy;
+
       return DocumentSelection(
         base: DocumentPosition(
           nodeId: isDraggingDown ? topNodeId : bottomNodeId,

--- a/super_editor/test/super_editor/mutable_document_test.dart
+++ b/super_editor/test/super_editor/mutable_document_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+void main() {
+  group("MutableDocument", () {
+    test("calculates a range from an upstream selection within a single node", () {
+      final document = MutableDocument(
+        nodes: [
+          ParagraphNode(
+            id: "1",
+            text: AttributedText(text: "This is a paragraph of text."),
+          ),
+        ],
+      );
+
+      // Try to get an upstream range.
+      final range = document.getRangeBetween(
+        const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 20)),
+        const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 10)),
+      );
+
+      // Ensure the range is upstream.
+      expect(
+        range.start,
+        const DocumentPosition(
+          nodeId: "1",
+          nodePosition: TextNodePosition(offset: 10),
+        ),
+      );
+      expect(
+        range.end,
+        const DocumentPosition(
+          nodeId: "1",
+          nodePosition: TextNodePosition(offset: 20),
+        ),
+      );
+    });
+
+    test("calculates a range from an downstream selection within a single node", () {
+      final document = MutableDocument(
+        nodes: [
+          ParagraphNode(
+            id: "1",
+            text: AttributedText(text: "This is a paragraph of text."),
+          ),
+        ],
+      );
+
+      // Try to get an upstream range.
+      final range = document.getRangeBetween(
+        const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 10)),
+        const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 20)),
+      );
+
+      // Ensure the range is upstream.
+      expect(
+        range.start,
+        const DocumentPosition(
+          nodeId: "1",
+          nodePosition: TextNodePosition(offset: 10),
+        ),
+      );
+      expect(
+        range.end,
+        const DocumentPosition(
+          nodeId: "1",
+          nodePosition: TextNodePosition(offset: 20),
+        ),
+      );
+    });
+  });
+}

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -59,7 +59,7 @@ void main() {
           const Offset(150, 60) + globalLayoutOrigin, const Offset(200, 40) + globalLayoutOrigin);
       expect(selection, isNotNull);
 
-      // Ensure that the document selection is upstream.
+      // Ensure that the document selection is downstream.
       final base = selection!.base.nodePosition as TextNodePosition;
       final extent = selection.extent.nodePosition as TextNodePosition;
       expect(base.offset < extent.offset, isTrue);

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -49,7 +49,7 @@ void main() {
       final layout = layoutState as DocumentLayout;
       final globalLayoutOrigin = (layoutState.context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
 
-      // Drag from lower-right to upper-left.
+      // Drag from lower-left to upper-right.
       //
       // By dragging in this exact direction, we're purposefully introducing contrary
       // directions: left-to-right is downstream for a single line, and down-to-up is

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document_layout.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+
+import '../test_tools.dart';
+import 'document_test_tools.dart';
+
+void main() {
+  group("SuperEditor selection", () {
+    testWidgetsOnArbitraryDesktop("calculates upstream document selection within a single node", (tester) async {
+      await tester //
+          .createDocument() //
+          .fromMarkdown("This all fits on one line.") //
+          .pump();
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+      final globalLayoutOrigin = (layoutState.context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
+
+      // Drag from upper-right to lower-left.
+      //
+      // By dragging in this exact direction, we're purposefully introducing contrary
+      // directions: right-to-left is upstream for a single line, and up-to-down is
+      // downstream for multi-node. This test ensures that the single-line direction is
+      // honored by the document layout, rather than the more common multi-node calculation.
+      final selection = layout.getDocumentSelectionInRegion(
+          const Offset(200, 40) + globalLayoutOrigin, const Offset(150, 60) + globalLayoutOrigin);
+      expect(selection, isNotNull);
+
+      // Ensure that the document selection is upstream.
+      final base = selection!.base.nodePosition as TextNodePosition;
+      final extent = selection.extent.nodePosition as TextNodePosition;
+      expect(base.offset > extent.offset, isTrue);
+    });
+
+    testWidgetsOnArbitraryDesktop("calculates downstream document selection within a single node", (tester) async {
+      await tester //
+          .createDocument() //
+          .fromMarkdown("This all fits on one line.") //
+          .pump();
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+      final globalLayoutOrigin = (layoutState.context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
+
+      // Drag from lower-right to upper-left.
+      //
+      // By dragging in this exact direction, we're purposefully introducing contrary
+      // directions: left-to-right is downstream for a single line, and down-to-up is
+      // upstream for multi-node. This test ensures that the single-line direction is
+      // honored by the document layout, rather than the more common multi-node calculation.
+      final selection = layout.getDocumentSelectionInRegion(
+          const Offset(150, 60) + globalLayoutOrigin, const Offset(200, 40) + globalLayoutOrigin);
+      expect(selection, isNotNull);
+
+      // Ensure that the document selection is upstream.
+      final base = selection!.base.nodePosition as TextNodePosition;
+      final extent = selection.extent.nodePosition as TextNodePosition;
+      expect(base.offset < extent.offset, isTrue);
+    });
+  });
+}

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -49,7 +49,7 @@ void testWidgetsOnAllPlatforms(
   testWidgetsOnWindows("$description (on Windows)", test, skip: skip);
   testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
   testWidgetsOnAndroid("$description (on Android)", test, skip: skip);
-  testWidgetsOnIos("$description (on iOS)", test, skip: skip);  
+  testWidgetsOnIos("$description (on iOS)", test, skip: skip);
 }
 
 /// A widget test that runs a variant for Windows and Linux.
@@ -65,6 +65,19 @@ void testWidgetsOnWindowsAndLinux(
 }) {
   testWidgetsOnWindows("$description (on Windows)", test, skip: skip);
   testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
+}
+
+/// A widget test that configures itself for an arbitrary desktop environment.
+///
+/// There's no guarantee which desktop environment is used. The purpose of this
+/// test method is to cause all relevant configurations to setup for desktop,
+/// without concern for any features that change between desktop platforms.
+void testWidgetsOnArbitraryDesktop(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgetsOnMac(description, test, skip: skip);
 }
 
 /// A widget test that configures itself as a Mac platform before executing the


### PR DESCRIPTION
Fixed getRangeBetween() in MutableDocument, and added tests for getDocumentSelectionInRegion in SingleColumnDocumentLayout (Resolves #48, Resolves #50)

#50 referenced a problem that seemed to get solved somewhere along the way. I added a couple tests to ensure that the problem doesn't return.

Fixed #48 by adjusting the implementation to use an existing calculation for document affinity, which solved that problem.