### PR TITLE
[SuperTextField] [Android] Fix backspace not working on Android (Resolves #506)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:attributed_text/attributed_text.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -369,24 +369,11 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       return KeyEventResult.ignored;
     }
 
-    int deleteEndIndex = -1;
-    int deleteStartIndex = -1;
     if (_textEditingController.selection.isCollapsed) {
-      deleteEndIndex = _textEditingController.selection.extentOffset;
-      deleteStartIndex = getCharacterStartBounds(_textEditingController.text.text, deleteEndIndex);
+      _textEditingController.deletePreviousCharacter();
     } else {
-      deleteEndIndex = max(_textEditingController.selection.baseOffset, _textEditingController.selection.extentOffset);
-      deleteStartIndex = min(_textEditingController.selection.baseOffset, _textEditingController.selection.extentOffset);
+      _textEditingController.deleteSelection();
     }
-
-    // We call updateTextAndSelection directly because, when deleting the last character
-    // using delete on the controller, an exception is thrown due to the fact that
-    // the selection is in an invalid position
-    final updatedText = _textEditingController.text.removeRegion(startOffset: deleteStartIndex, endOffset: deleteEndIndex);
-    _textEditingController.updateTextAndSelection(
-      text: updatedText,
-      selection: TextSelection.collapsed(offset: deleteStartIndex),
-    );
 
     return KeyEventResult.handled;
   }

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -579,8 +579,11 @@ class AttributedTextEditingController with ChangeNotifier {
     final updatedSelection =
         newSelection ?? _moveSelectionForDeletion(selection: _selection, deleteFrom: from, deleteTo: to);
 
-    text = updatedText;
-    selection = updatedSelection;
+    updateTextAndSelection(
+      text: updatedText,
+      selection: updatedSelection,
+    );
+    
     _updateComposingAttributions();
     // TODO: do we need to implement composing region update behavior like selections?
     composingRegion = newComposingRegion ?? TextRange.empty;

--- a/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
@@ -1,18 +1,18 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
 
 import '../test_tools.dart';
 
 void main() {
-  group('SuperTextField', () {
-    testWidgetsOnAndroid('BACKSPACE deletes previous character when selection is collapsed (on Android)', (tester) async {
+  group('SuperTextField on some bad Android software keyboards', () {
+    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a collapsed selection (on Android)', (tester) async {
       final controller = AttributedTextEditingController(
         text: AttributedText(text: 'This is a text'),
       );
-      await _pumpTestApp(tester, controller: controller);
+      await _pumpScaffold(tester, controller: controller);
 
       // Focus the text field
       await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
@@ -23,19 +23,17 @@ void main() {
       controller.selection = const TextSelection.collapsed(offset: 4);
       await tester.pump();
 
-      // Press backspace
-      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
-      await tester.pumpAndSettle();
+      await tester.pressBackspace();      
 
       // Ensure text is deleted
       expect(controller.text.text, 'Thi is a text');
     });
 
-    testWidgetsOnAndroid('BACKSPACE deletes selection when selection is expanded (on Android)', (tester) async {
+    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a expanded selection (on Android)', (tester) async {
       final controller = AttributedTextEditingController(
         text: AttributedText(text: 'This is a text'),
       );
-      await _pumpTestApp(tester, controller: controller);
+      await _pumpScaffold(tester, controller: controller);
 
       // Focus the text field
       await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
@@ -48,9 +46,7 @@ void main() {
       );
       await tester.pump();
 
-      // Press backspace
-      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
-      await tester.pumpAndSettle();
+      await tester.pressBackspace();
 
       // Ensure text is deleted
       expect(controller.text.text, 'This is a');
@@ -58,15 +54,18 @@ void main() {
   });
 }
 
-Future<void> _pumpTestApp(
+Future<void> _pumpScaffold(
   WidgetTester tester, {
   required AttributedTextEditingController controller,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
-        body: SuperTextField(
-          textController: controller,
+        body: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 300),
+          child: SuperTextField(
+            textController: controller,
+          ),
         ),
       ),
     ),

--- a/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
@@ -15,6 +15,7 @@ void main() {
       await _pumpScaffold(tester, controller: controller);
 
       // Focus the text field
+      // TODO: change to use the robot when mobile is supported
       await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
       await tester.pump();
 
@@ -36,6 +37,7 @@ void main() {
       await _pumpScaffold(tester, controller: controller);
 
       // Focus the text field
+      // TODO: change to use the robot when mobile is supported
       await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
       await tester.pump();
 

--- a/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_mobile_keyboard_test.dart
@@ -1,0 +1,74 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group('SuperTextField', () {
+    testWidgetsOnAndroid('BACKSPACE deletes previous character when selection is collapsed (on Android)', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText(text: 'This is a text'),
+      );
+      await _pumpTestApp(tester, controller: controller);
+
+      // Focus the text field
+      await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
+      await tester.pump();
+
+      // Place caret at This|. We don't put caret at the end of the text
+      // to ensure we are not deleting always the last character
+      controller.selection = const TextSelection.collapsed(offset: 4);
+      await tester.pump();
+
+      // Press backspace
+      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+      await tester.pumpAndSettle();
+
+      // Ensure text is deleted
+      expect(controller.text.text, 'Thi is a text');
+    });
+
+    testWidgetsOnAndroid('BACKSPACE deletes selection when selection is expanded (on Android)', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText(text: 'This is a text'),
+      );
+      await _pumpTestApp(tester, controller: controller);
+
+      // Focus the text field
+      await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
+      await tester.pump();
+
+      // Selects ' text'
+      controller.selection = const TextSelection(
+        baseOffset: 9,
+        extentOffset: 14,
+      );
+      await tester.pump();
+
+      // Press backspace
+      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+      await tester.pumpAndSettle();
+
+      // Ensure text is deleted
+      expect(controller.text.text, 'This is a');
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required AttributedTextEditingController controller,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperTextField(
+          textController: controller,
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Fix backspace not working on Android. Resolves https://github.com/superlistapp/super_editor/issues/506

Some third party keyboards report `backspace` as a key press rather than a deletion delta, so we need to handle this in `onKey`.

I handled `backspace` directly in `_onKeyPressed` because I was not sure if we need to handle multiple keyboard actions like in `SuperDesktopField`