### PR TITLE
[SuperTextField] Auto-scroll when field is focused (Resolves #663)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -13,6 +13,7 @@ import 'package:super_editor/src/infrastructure/super_textfield/input_method_eng
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../../_logging.dart';
+import '../metrics.dart';
 import '../styles.dart';
 import 'android_textfield.dart';
 
@@ -416,8 +417,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField> with Ticke
       TextPosition(offset: _textEditingController.selection.extentOffset),
     );
     final fieldBox = context.findRenderObject() as RenderBox;
-
-    const gapBetweenCaretAndKeyboard = 30;
 
     // The area of the text field that should be revealed.
     // We add a small margin to leave some space between the text field and the keyboard.    

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -417,13 +417,15 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField> with Ticke
     );
     final fieldBox = context.findRenderObject() as RenderBox;
 
+    const gapBetweenCaretAndKeyboard = 30;
+
     // The area of the text field that should be revealed.
     // We add a small margin to leave some space between the text field and the keyboard.    
     final textFieldFocalRect = Rect.fromLTWH(
       textFieldFocalPoint.dx,
       textFieldFocalPoint.dy,
       fieldBox.size.width,
-      lineHeight + 30,
+      lineHeight + gapBetweenCaretAndKeyboard,
     );
 
     fieldBox.showOnScreen(

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -11,6 +11,7 @@ import 'package:super_editor/src/infrastructure/super_textfield/ios/_editing_con
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../../platforms/ios/toolbar.dart';
+import '../metrics.dart';
 import '../styles.dart';
 import '_floating_cursor.dart';
 import '_user_interaction.dart';
@@ -407,8 +408,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
       TextPosition(offset: _textEditingController.selection.extentOffset),
     );
     final fieldBox = context.findRenderObject() as RenderBox;
-
-    const gapBetweenCaretAndKeyboard = 30;
 
     // The area of the text field that should be revealed.
     // We add a small margin to leave some space between the text field and the keyboard.    

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -129,6 +129,9 @@ class SuperIOSTextField extends StatefulWidget {
 }
 
 class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProviderStateMixin, WidgetsBindingObserver implements ProseTextBlock {
+  static const Duration _autoScrollAnimationDuration = Duration(milliseconds: 100);
+  static const Curve _autoScrollAnimationCurve = Curves.fastOutSlowIn;
+
   final _textFieldKey = GlobalKey();
   final _textFieldLayerLink = LayerLink();
   final _textContentLayerLink = LayerLink();
@@ -149,9 +152,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
   // positions the invisible touch targets for base/extent
   // dragging.
   OverlayEntry? _controlsOverlayEntry;
-
-  static const Duration _autoScrollAnimationDuration = Duration(milliseconds: 100);
-  static const Curve _autoScrollAnimationCurve = Curves.fastOutSlowIn;
 
   @override
   void initState() {
@@ -280,7 +280,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
     // appearance/disappearance.
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       if (mounted && _focusNode.hasFocus) {
-        _ensureIsVisible();
+        _autoScrollToKeepTextFieldVisible();
       }
     });
   }
@@ -304,7 +304,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
             textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
           );
 
-          _ensureIsVisible();
+          _autoScrollToKeepTextFieldVisible();
           _showHandles();
         });
       }
@@ -391,35 +391,36 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
 
   /// Scrolls the ancestor [Scrollable], if any, so [SuperTextField]
   /// is visible on the viewport when it's focused
-  void _ensureIsVisible() {
+  void _autoScrollToKeepTextFieldVisible() {
     // If we are not inside a [Scrollable] we don't autoscroll
     final ancestorScrollable = Scrollable.of(context);
     if (ancestorScrollable == null) {
       return;
     }
 
-    // The [RenderBox] is needed so we can calculate the final [Offset]
-    final fieldBox = context.findRenderObject() as RenderBox?;
-    if (fieldBox == null) {
-      return;
-    }
-
-    final viewportBox = ancestorScrollable.context.findRenderObject() as RenderBox;
-
-    // We get the selection offset so the autoscroll also supports
-    // multi-line textfields with unbounded lines
-    final offsetInsideTextField = widget.maxLines == null && _textEditingController.selection.isValid
+    // Compute the text field offset that should be visible to the user
+    final textFieldFocalPoint = widget.maxLines == null && _textEditingController.selection.isValid
         ? _textContentKey.currentState!.textLayout.getOffsetAtPosition(
             TextPosition(offset: _textEditingController.selection.extentOffset),
           )
         : Offset.zero;
 
-    final offsetInsideViewport = viewportBox.globalToLocal(
-      fieldBox.localToGlobal(offsetInsideTextField),
+    final lineHeight = _textContentKey.currentState!.textLayout.getLineHeightAtPosition(
+      TextPosition(offset: _textEditingController.selection.extentOffset),
+    );
+    final fieldBox = context.findRenderObject() as RenderBox;
+
+    // The area of the text field that should be revealed.
+    // We add a small margin to leave some space between the text field and the keyboard.    
+    final textFieldFocalRect = Rect.fromLTWH(
+      textFieldFocalPoint.dx,
+      textFieldFocalPoint.dy,
+      fieldBox.size.width,
+      lineHeight + 30,
     );
 
     fieldBox.showOnScreen(
-      rect: Rect.fromLTWH(offsetInsideViewport.dx, offsetInsideViewport.dy, fieldBox.size.width, fieldBox.size.height),
+      rect: textFieldFocalRect,
       duration: _autoScrollAnimationDuration,
       curve: _autoScrollAnimationCurve,
     );

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -10,8 +10,6 @@ import 'package:super_editor/src/infrastructure/super_textfield/input_method_eng
 import 'package:super_editor/src/infrastructure/super_textfield/ios/_editing_controls.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
-import '../../../default_editor/document_gestures.dart';
-import '../../../default_editor/document_gestures_touch.dart';
 import '../../platforms/ios/toolbar.dart';
 import '../styles.dart';
 import '_floating_cursor.dart';
@@ -410,13 +408,15 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
     );
     final fieldBox = context.findRenderObject() as RenderBox;
 
+    const gapBetweenCaretAndKeyboard = 30;
+
     // The area of the text field that should be revealed.
     // We add a small margin to leave some space between the text field and the keyboard.    
     final textFieldFocalRect = Rect.fromLTWH(
       textFieldFocalPoint.dx,
       textFieldFocalPoint.dy,
       fieldBox.size.width,
-      lineHeight + 30,
+      lineHeight + gapBetweenCaretAndKeyboard,
     );
 
     fieldBox.showOnScreen(

--- a/super_editor/lib/src/infrastructure/super_textfield/metrics.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/metrics.dart
@@ -1,0 +1,1 @@
+const gapBetweenCaretAndKeyboard = 30;

--- a/super_editor/lib/src/infrastructure/super_textfield/metrics.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/metrics.dart
@@ -1,1 +1,3 @@
+/// Minimum distance that should be maintained between the bottom of the caret
+/// and the software keyboard when editing a `SuperTextField`.
 const gapBetweenCaretAndKeyboard = 30;

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/super_textfield/metrics.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
@@ -11,9 +12,6 @@ const screenSizeWithKeyboard = Size(400, 300);
 void main() {
   group('SuperTextField on mobile', () {
     group('with an ancestor Scrollable', () {
-      // Default gap between the caret and the keyboard.
-      const gapBetweenCaretAndKeyboard = 30;
-
       testWidgetsOnMobileWithKeyboard('auto scrolls when focused in single-line', (tester, keyboardToggle) async {
         await _pumpTestApp(
           tester,

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -11,6 +11,9 @@ void main() {
       const screenSizeWithoutKeyboard = Size(400, 800);
       const screenSizeWithKeyboard = Size(400, 300);
 
+      // Space between the caret and the keyboard.
+      const gap = 30;
+
       testWidgetsOnMobile('auto scrolls when focused in single-line', (tester) async {
         tester.binding.window
           ..physicalSizeTestValue = screenSizeWithoutKeyboard
@@ -41,6 +44,9 @@ void main() {
 
         // Ensure selection is visible in the viewport
         expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
+
+        // Ensure we scroll only the necessary to reveal the selection, plus a small gap
+        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gap));
 
         // Ensure selection doesn't scroll beyond the top
         expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
@@ -76,6 +82,9 @@ void main() {
 
         // Ensure selected line is visible on viewport
         expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
+
+        // Ensure we scroll only the necessary to reveal the selection, plus a small gap
+        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gap));
 
         // Ensure selection doesn't scroll beyond the top
         expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -146,7 +146,7 @@ Future<void> _pumpTestApp(
 
 void testWidgetsOnMobileWithKeyboard(
   String description,
-  Future<void> Function(WidgetTester tester, KeyboardToggle keyboardToggle) test,
+  Future<void> Function(WidgetTester tester, _KeyboardToggle keyboardToggle) test,
 ) {
   testWidgetsOnMobile(description, (tester) async {
     tester.binding.window
@@ -155,7 +155,7 @@ void testWidgetsOnMobileWithKeyboard(
       ..devicePixelRatioTestValue = 1.0;
     addTearDown(() => tester.binding.window.clearAllTestValues());
 
-    final keyboardToggle = KeyboardToggle(
+    final keyboardToggle = _KeyboardToggle(
       tester: tester,
       sizeWithoutKeyboard: screenSizeWithoutKeyboard,
       sizeWithKeyboard: screenSizeWithKeyboard,
@@ -165,8 +165,8 @@ void testWidgetsOnMobileWithKeyboard(
   });
 }
 
-class KeyboardToggle {
-  KeyboardToggle({
+class _KeyboardToggle {
+  _KeyboardToggle({
     required this.tester,
     required this.sizeWithoutKeyboard,
     required this.sizeWithKeyboard,

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group('SuperTextField on mobile', () {
+    group('with an ancestor Scrollable', () {
+      const screenSizeWithoutKeyboard = Size(400, 800);
+      const screenSizeWithKeyboard = Size(400, 300);
+
+      testWidgetsOnMobile('auto scrolls when focused in single-line', (tester) async {
+        tester.binding.window
+          ..physicalSizeTestValue = screenSizeWithoutKeyboard
+          ..platformDispatcher.textScaleFactorTestValue = 1.0
+          ..devicePixelRatioTestValue = 1.0;
+        addTearDown(() => tester.binding.window.clearAllTestValues());
+
+        await _pumpTestApp(
+          tester,
+          text: 'Single line SuperTextField',
+          lineCount: 1,
+        );
+
+        // Tap to focus the text field
+        await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Shrink the screen height, as if the keyboard appeared.
+        await _resizeWindow(
+          tester: tester,
+          frameCount: 60,
+          initialScreenSize: screenSizeWithoutKeyboard,
+          finalScreenSize: screenSizeWithKeyboard,
+        );
+
+        // Find the global offset where the selection is
+        final selectionOffset = _findGlobalCaretOffset(tester);
+
+        // Ensure selection is visible in the viewport
+        expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
+
+        // Ensure selection doesn't scroll beyond the top
+        expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
+      });
+
+      testWidgetsOnMobile('auto scrolls when focused in multi-line', (tester) async {
+        tester.binding.window
+          ..physicalSizeTestValue = screenSizeWithoutKeyboard
+          ..platformDispatcher.textScaleFactorTestValue = 1.0
+          ..devicePixelRatioTestValue = 1.0;
+        addTearDown(() => tester.binding.window.clearAllTestValues());
+
+        await _pumpTestApp(
+          tester,
+          text: 'This is\na multiline\nSuperTextField',
+          lineCount: 3,
+        );
+
+        // Tap to focus to the text field
+        await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Shrink the screen height, as if the keyboard appeared.
+        await _resizeWindow(
+          tester: tester,
+          frameCount: 60,
+          initialScreenSize: screenSizeWithoutKeyboard,
+          finalScreenSize: screenSizeWithKeyboard,
+        );
+
+        // Find the offset of the selected line
+        final selectionOffset = _findGlobalCaretOffset(tester);
+
+        // Ensure selected line is visible on viewport
+        expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
+
+        // Ensure selection doesn't scroll beyond the top
+        expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
+      });
+    
+      testWidgetsOnMobile('doest not auto scroll when not focused', (tester) async {
+        tester.binding.window
+          ..physicalSizeTestValue = screenSizeWithoutKeyboard
+          ..platformDispatcher.textScaleFactorTestValue = 1.0
+          ..devicePixelRatioTestValue = 1.0;
+        addTearDown(() => tester.binding.window.clearAllTestValues());
+
+        await _pumpTestApp(
+          tester,
+          text: 'Single line SuperTextField',
+          lineCount: 1,
+        );
+      
+        // Position of the text field before resizing        
+        final initialTopLeft = tester.getTopLeft(find.byType(SuperTextField));
+
+        // Shrink the screen height, as if the keyboard appeared.
+        await _resizeWindow(
+          tester: tester,
+          frameCount: 60,
+          initialScreenSize: screenSizeWithoutKeyboard,
+          finalScreenSize: screenSizeWithKeyboard,
+        );
+
+        // Position of the text field after resizing
+        final finalTopLeft = tester.getTopLeft(find.byType(SuperTextField, skipOffstage: false));
+
+        // Ensure the text field does not cause autoscroll 
+        expect(finalTopLeft, initialTopLeft);              
+      });
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required String text,
+  required int lineCount,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: [
+            ...List.generate(8, (index) => const ListTile(title: Text("BEFORE"))),
+            SuperTextField(
+              minLines: lineCount,
+              maxLines: lineCount,
+              lineHeight: 24,
+              textController: AttributedTextEditingController(
+                text: AttributedText(text: text),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _resizeWindow({
+  required WidgetTester tester,
+  required Size initialScreenSize,
+  required Size finalScreenSize,
+  required int frameCount,
+}) async {
+  double resizedWidth = 0.0;
+  double resizedHeight = 0.0;
+  double totalWidthResize = initialScreenSize.width - finalScreenSize.width;
+  double totalHeightResize = initialScreenSize.height - finalScreenSize.height;
+  double widthShrinkPerFrame = totalWidthResize / frameCount;
+  double heightShrinkPerFrame = totalHeightResize / frameCount;
+  for (var i = 0; i < frameCount; i++) {
+    resizedWidth += widthShrinkPerFrame;
+    resizedHeight += heightShrinkPerFrame;
+    final currentScreenSize = (initialScreenSize - Offset(resizedWidth, resizedHeight)) as Size;
+    tester.binding.window.physicalSizeTestValue = currentScreenSize;
+    await tester.pumpAndSettle();
+  }
+}
+
+Offset _findGlobalCaretOffset(WidgetTester tester) {
+  final customPaint = find.byWidgetPredicate((widget) => widget is CustomPaint && widget.painter is CaretPainter);
+  final caretPainter = tester.widget<CustomPaint>(customPaint.last).painter as CaretPainter;
+  return tester.getTopLeft(customPaint) + caretPainter.offset!;
+}

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -5,22 +5,16 @@ import 'package:super_text_layout/super_text_layout.dart';
 
 import '../test_tools.dart';
 
+const screenSizeWithoutKeyboard = Size(400, 800);
+const screenSizeWithKeyboard = Size(400, 300);
+
 void main() {
   group('SuperTextField on mobile', () {
     group('with an ancestor Scrollable', () {
-      const screenSizeWithoutKeyboard = Size(400, 800);
-      const screenSizeWithKeyboard = Size(400, 300);
+      // Default gap between the caret and the keyboard.
+      const gapBetweenCaretAndKeyboard = 30;
 
-      // Space between the caret and the keyboard.
-      const gap = 30;
-
-      testWidgetsOnMobile('auto scrolls when focused in single-line', (tester) async {
-        tester.binding.window
-          ..physicalSizeTestValue = screenSizeWithoutKeyboard
-          ..platformDispatcher.textScaleFactorTestValue = 1.0
-          ..devicePixelRatioTestValue = 1.0;
-        addTearDown(() => tester.binding.window.clearAllTestValues());
-
+      testWidgetsOnMobileWithKeyboard('auto scrolls when focused in single-line', (tester, keyboardToggle) async {
         await _pumpTestApp(
           tester,
           text: 'Single line SuperTextField',
@@ -31,13 +25,8 @@ void main() {
         await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
         await tester.pumpAndSettle();
 
-        // Shrink the screen height, as if the keyboard appeared.
-        await _resizeWindow(
-          tester: tester,
-          frameCount: 60,
-          initialScreenSize: screenSizeWithoutKeyboard,
-          finalScreenSize: screenSizeWithKeyboard,
-        );
+        // Simulate a keyboard opening, which reduces available screen height.
+        await keyboardToggle.open();
 
         // Find the global offset where the selection is
         final selectionOffset = _findGlobalCaretOffset(tester);
@@ -46,19 +35,40 @@ void main() {
         expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
 
         // Ensure we scroll only the necessary to reveal the selection, plus a small gap
-        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gap));
+        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gapBetweenCaretAndKeyboard));
 
         // Ensure selection doesn't scroll beyond the top
         expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
       });
 
-      testWidgetsOnMobile('auto scrolls when focused in multi-line', (tester) async {
-        tester.binding.window
-          ..physicalSizeTestValue = screenSizeWithoutKeyboard
-          ..platformDispatcher.textScaleFactorTestValue = 1.0
-          ..devicePixelRatioTestValue = 1.0;
-        addTearDown(() => tester.binding.window.clearAllTestValues());
+      testWidgetsOnMobileWithKeyboard('auto scrolls when focused in single-line', (tester, keyboardToggle) async {
+        await _pumpTestApp(
+          tester,
+          text: 'Single line SuperTextField',
+          lineCount: 1,
+        );
 
+        // Tap to focus the text field
+        await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Simulate a keyboard opening, which reduces available screen height.
+        await keyboardToggle.open();
+
+        // Find the global offset where the selection is
+        final selectionOffset = _findGlobalCaretOffset(tester);
+
+        // Ensure selection is visible in the viewport
+        expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
+
+        // Ensure we scroll only the necessary to reveal the selection, plus a small gap
+        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gapBetweenCaretAndKeyboard));
+
+        // Ensure selection doesn't scroll beyond the top
+        expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
+      });
+
+      testWidgetsOnMobileWithKeyboard('auto scrolls when focused in multi-line', (tester, keyboardToggle) async {
         await _pumpTestApp(
           tester,
           text: 'This is\na multiline\nSuperTextField',
@@ -69,13 +79,8 @@ void main() {
         await tester.tapAt(tester.getCenter(find.byType(SuperTextField)));
         await tester.pumpAndSettle();
 
-        // Shrink the screen height, as if the keyboard appeared.
-        await _resizeWindow(
-          tester: tester,
-          frameCount: 60,
-          initialScreenSize: screenSizeWithoutKeyboard,
-          finalScreenSize: screenSizeWithKeyboard,
-        );
+        // Simulate a keyboard opening, which reduces available screen height.
+        await keyboardToggle.open();
 
         // Find the offset of the selected line
         final selectionOffset = _findGlobalCaretOffset(tester);
@@ -84,41 +89,30 @@ void main() {
         expect(selectionOffset.dy.floor(), lessThanOrEqualTo(screenSizeWithKeyboard.height));
 
         // Ensure we scroll only the necessary to reveal the selection, plus a small gap
-        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gap));
+        expect(screenSizeWithKeyboard.height - selectionOffset.dy.floor(), lessThanOrEqualTo(gapBetweenCaretAndKeyboard));
 
         // Ensure selection doesn't scroll beyond the top
         expect(selectionOffset.dy.floor(), greaterThanOrEqualTo(0));
       });
-    
-      testWidgetsOnMobile('doest not auto scroll when not focused', (tester) async {
-        tester.binding.window
-          ..physicalSizeTestValue = screenSizeWithoutKeyboard
-          ..platformDispatcher.textScaleFactorTestValue = 1.0
-          ..devicePixelRatioTestValue = 1.0;
-        addTearDown(() => tester.binding.window.clearAllTestValues());
 
+      testWidgetsOnMobileWithKeyboard('doest not auto scroll when not focused', (tester, keyboardToggle) async {
         await _pumpTestApp(
           tester,
           text: 'Single line SuperTextField',
           lineCount: 1,
         );
-      
-        // Position of the text field before resizing        
+
+        // Position of the text field before resizing
         final initialTopLeft = tester.getTopLeft(find.byType(SuperTextField));
 
-        // Shrink the screen height, as if the keyboard appeared.
-        await _resizeWindow(
-          tester: tester,
-          frameCount: 60,
-          initialScreenSize: screenSizeWithoutKeyboard,
-          finalScreenSize: screenSizeWithKeyboard,
-        );
+        // Simulate a keyboard opening, which reduces available screen height.
+        await keyboardToggle.open();
 
         // Position of the text field after resizing
         final finalTopLeft = tester.getTopLeft(find.byType(SuperTextField, skipOffstage: false));
 
-        // Ensure the text field does not cause autoscroll 
-        expect(finalTopLeft, initialTopLeft);              
+        // Ensure the text field does not cause autoscroll
+        expect(finalTopLeft, initialTopLeft);
       });
     });
   });
@@ -150,24 +144,54 @@ Future<void> _pumpTestApp(
   );
 }
 
-Future<void> _resizeWindow({
-  required WidgetTester tester,
-  required Size initialScreenSize,
-  required Size finalScreenSize,
-  required int frameCount,
-}) async {
-  double resizedWidth = 0.0;
-  double resizedHeight = 0.0;
-  double totalWidthResize = initialScreenSize.width - finalScreenSize.width;
-  double totalHeightResize = initialScreenSize.height - finalScreenSize.height;
-  double widthShrinkPerFrame = totalWidthResize / frameCount;
-  double heightShrinkPerFrame = totalHeightResize / frameCount;
-  for (var i = 0; i < frameCount; i++) {
-    resizedWidth += widthShrinkPerFrame;
-    resizedHeight += heightShrinkPerFrame;
-    final currentScreenSize = (initialScreenSize - Offset(resizedWidth, resizedHeight)) as Size;
-    tester.binding.window.physicalSizeTestValue = currentScreenSize;
-    await tester.pumpAndSettle();
+void testWidgetsOnMobileWithKeyboard(
+  String description,
+  Future<void> Function(WidgetTester tester, KeyboardToggle keyboardToggle) test,
+) {
+  testWidgetsOnMobile(description, (tester) async {
+    tester.binding.window
+      ..physicalSizeTestValue = screenSizeWithoutKeyboard
+      ..platformDispatcher.textScaleFactorTestValue = 1.0
+      ..devicePixelRatioTestValue = 1.0;
+    addTearDown(() => tester.binding.window.clearAllTestValues());
+
+    final keyboardToggle = KeyboardToggle(
+      tester: tester,
+      sizeWithoutKeyboard: screenSizeWithoutKeyboard,
+      sizeWithKeyboard: screenSizeWithKeyboard,
+    );
+
+    await test(tester, keyboardToggle);
+  });
+}
+
+class KeyboardToggle {
+  KeyboardToggle({
+    required this.tester,
+    required this.sizeWithoutKeyboard,
+    required this.sizeWithKeyboard,
+    this.frameCount = 60,
+  });
+
+  final WidgetTester tester;
+  final Size sizeWithoutKeyboard;
+  final Size sizeWithKeyboard;
+  final int frameCount;
+
+  Future<void> open() async {
+    double resizedWidth = 0.0;
+    double resizedHeight = 0.0;
+    double totalWidthResize = sizeWithoutKeyboard.width - sizeWithKeyboard.width;
+    double totalHeightResize = sizeWithoutKeyboard.height - sizeWithKeyboard.height;
+    double widthShrinkPerFrame = totalWidthResize / frameCount;
+    double heightShrinkPerFrame = totalHeightResize / frameCount;
+    for (var i = 0; i < frameCount; i++) {
+      resizedWidth += widthShrinkPerFrame;
+      resizedHeight += heightShrinkPerFrame;
+      final currentScreenSize = (sizeWithoutKeyboard - Offset(resizedWidth, resizedHeight)) as Size;
+      tester.binding.window.physicalSizeTestValue = currentScreenSize;
+      await tester.pumpAndSettle();
+    }
   }
 }
 


### PR DESCRIPTION
Auto-scroll when field is focused. Resolves #663

Giving focus to a `SuperTextField` inside a `Scrollable` was not causing it to auto-scroll. Because of this, the text field could be hidden by the keyboard.

I used the same approach that `SuperEditor` uses to auto-scroll its contents.