### PR TITLE
[SuperTextField] - fix word jumping for expanded selection, and add tests (Resolves #560)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -764,7 +764,7 @@ class AttributedTextEditingController with ChangeNotifier {
     if (!selection.isCollapsed && !expandSelection) {
       // The selection isn't collapsed and the user doesn't
       // want to continue expanding the selection. Move the
-      // extent to the left side of the selection.
+      // extent to the right side of the selection.
       selection = TextSelection.collapsed(offset: selection.end);
       return;
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -691,79 +691,137 @@ class AttributedTextEditingController with ChangeNotifier {
     required bool moveLeft,
     required MovementModifier? movementModifier,
   }) {
-    int newExtent;
-
     if (moveLeft) {
-      if (selection.extentOffset <= 0 && selection.isCollapsed) {
-        // Can't move further left.
-        return;
-      }
-
-      if (!selection.isCollapsed && !expandSelection) {
-        // The selection isn't collapsed and the user doesn't
-        // want to continue expanding the selection. Move the
-        // extent to the left side of the selection.
-        newExtent = selection.start;
-      } else if (movementModifier != null && movementModifier == MovementModifier.line) {
-        newExtent = textLayout.getPositionAtStartOfLine(TextPosition(offset: selection.extentOffset)).offset;
-      } else if (movementModifier != null && movementModifier == MovementModifier.word) {
-        final plainText = text.text;
-
-        newExtent = selection.extentOffset;
-        newExtent -= 1; // we always want to jump at least 1 character.
-        while (newExtent > 0 && plainText[newExtent - 1] != ' ' && plainText[newExtent - 1] != '\n') {
-          newExtent -= 1;
-        }
-      } else {
-        newExtent = text.text.moveOffsetUpstreamByCharacter(selection.extentOffset) ?? 0;
-      }
+      _moveCaretUpstream(
+        textLayout: textLayout,
+        expandSelection: expandSelection,
+        movementModifier: movementModifier,
+      );
     } else {
-      if (selection.extentOffset >= text.text.length && selection.isCollapsed) {
-        // Can't move further right.
-        return;
-      }
+      _moveCaretDownstream(
+        textLayout: textLayout,
+        expandSelection: expandSelection,
+        movementModifier: movementModifier,
+      );
+    }
+  }
 
-      if (!selection.isCollapsed && !expandSelection) {
-        // The selection isn't collapsed and the user doesn't
-        // want to continue expanding the selection. Move the
-        // extent to the left side of the selection.
-        newExtent = selection.end;
-      } else if (movementModifier != null && movementModifier == MovementModifier.line) {
-        final endOfLine = textLayout.getPositionAtEndOfLine(TextPosition(offset: selection.extentOffset));
-
-        final endPosition = TextPosition(offset: text.text.length);
-        final plainText = text.text;
-
-        // Note: we compare offset values because we don't care if the affinitys are equal
-        final isAutoWrapLine = endOfLine.offset != endPosition.offset && (plainText[endOfLine.offset] != '\n');
-
-        // Note: For lines that auto-wrap, moving the cursor to `offset` causes the
-        //       cursor to jump to the next line because the cursor is placed after
-        //       the final selected character. We don't want this, so in this case
-        //       we `-1`.
-        //
-        //       However, if the line that is selected ends with an explicit `\n`,
-        //       or if the line is the terminal line for the paragraph then we don't
-        //       want to `-1` because that would leave a dangling character after the
-        //       selection.
-        // TODO: this is the concept of text affinity. Implement support for affinity.
-        // TODO: with affinity, ensure it works as expected for right-aligned text
-        // TODO: this logic fails for justified text - find a solution for that (#55)
-        newExtent = isAutoWrapLine ? endOfLine.offset - 1 : endOfLine.offset;
-      } else if (movementModifier != null && movementModifier == MovementModifier.word) {
-        final extentPosition = selection.extent;
-        final plainText = text.text;
-
-        newExtent = extentPosition.offset;
-        newExtent += 1; // we always want to jump at least 1 character.
-        while (newExtent < plainText.length && plainText[newExtent] != ' ' && plainText[newExtent] != '\n') {
-          newExtent += 1;
-        }
-      } else {
-        newExtent = text.text.moveOffsetDownstreamByCharacter(selection.extentOffset) ?? text.text.length;
-      }
+  void _moveCaretUpstream({
+    required ProseTextLayout textLayout,
+    required bool expandSelection,
+    required MovementModifier? movementModifier,
+  }) {
+    if (!selection.isCollapsed && !expandSelection) {
+      // The selection isn't collapsed and the user doesn't
+      // want to continue expanding the selection. Move the
+      // extent to the left side of the selection.
+      selection = TextSelection.collapsed(offset: selection.start);
+      return;
     }
 
+    if (selection.extentOffset <= 0) {
+      // Can't move further left.
+      return;
+    }
+
+    if (movementModifier == MovementModifier.line) {
+      final newExtent = textLayout.getPositionAtStartOfLine(TextPosition(offset: selection.extentOffset)).offset;
+      selection = TextSelection(
+        baseOffset: expandSelection ? selection.baseOffset : newExtent,
+        extentOffset: newExtent,
+      );
+      return;
+    }
+
+    if (movementModifier == MovementModifier.word) {
+      final plainText = text.text;
+
+      int newExtent = selection.extentOffset;
+      newExtent -= 1; // we always want to jump at least 1 character.
+      while (newExtent > 0 && plainText[newExtent - 1] != ' ' && plainText[newExtent - 1] != '\n') {
+        newExtent -= 1;
+      }
+
+      selection = TextSelection(
+        baseOffset: expandSelection ? selection.baseOffset : newExtent,
+        extentOffset: newExtent,
+      );
+      return;
+    }
+
+    final newExtent = text.text.moveOffsetUpstreamByCharacter(selection.extentOffset) ?? 0;
+    selection = TextSelection(
+      baseOffset: expandSelection ? selection.baseOffset : newExtent,
+      extentOffset: newExtent,
+    );
+  }
+
+  void _moveCaretDownstream({
+    required ProseTextLayout textLayout,
+    required bool expandSelection,
+    required MovementModifier? movementModifier,
+  }) {
+    if (!selection.isCollapsed && !expandSelection) {
+      // The selection isn't collapsed and the user doesn't
+      // want to continue expanding the selection. Move the
+      // extent to the left side of the selection.
+      selection = TextSelection.collapsed(offset: selection.end);
+      return;
+    }
+
+    if (selection.extentOffset >= text.text.length) {
+      // Can't move further right.
+      return;
+    }
+
+    if (movementModifier == MovementModifier.line) {
+      final endOfLine = textLayout.getPositionAtEndOfLine(TextPosition(offset: selection.extentOffset));
+
+      final endPosition = TextPosition(offset: text.text.length);
+      final plainText = text.text;
+
+      // Note: we compare offset values because we don't care if the affinitys are equal
+      final isAutoWrapLine = endOfLine.offset != endPosition.offset && (plainText[endOfLine.offset] != '\n');
+
+      // Note: For lines that auto-wrap, moving the cursor to `offset` causes the
+      //       cursor to jump to the next line because the cursor is placed after
+      //       the final selected character. We don't want this, so in this case
+      //       we `-1`.
+      //
+      //       However, if the line that is selected ends with an explicit `\n`,
+      //       or if the line is the terminal line for the paragraph then we don't
+      //       want to `-1` because that would leave a dangling character after the
+      //       selection.
+      // TODO: this is the concept of text affinity. Implement support for affinity.
+      // TODO: with affinity, ensure it works as expected for right-aligned text
+      // TODO: this logic fails for justified text - find a solution for that (#55)
+      final newExtent = isAutoWrapLine ? endOfLine.offset - 1 : endOfLine.offset;
+
+      selection = TextSelection(
+        baseOffset: expandSelection ? selection.baseOffset : newExtent,
+        extentOffset: newExtent,
+      );
+      return;
+    }
+
+    if (movementModifier == MovementModifier.word) {
+      final extentPosition = selection.extent;
+      final plainText = text.text;
+
+      int newExtent = extentPosition.offset;
+      newExtent += 1; // we always want to jump at least 1 character.
+      while (newExtent < plainText.length && plainText[newExtent] != ' ' && plainText[newExtent] != '\n') {
+        newExtent += 1;
+      }
+
+      selection = TextSelection(
+        baseOffset: expandSelection ? selection.baseOffset : newExtent,
+        extentOffset: newExtent,
+      );
+      return;
+    }
+
+    final newExtent = text.text.moveOffsetDownstreamByCharacter(selection.extentOffset) ?? text.text.length;
     selection = TextSelection(
       baseOffset: expandSelection ? selection.baseOffset : newExtent,
       extentOffset: newExtent,

--- a/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
@@ -102,7 +102,7 @@ void main() {
           movementModifier: MovementModifier.word,
         );
 
-        // Ensure that the selection didn't change.
+        // Ensure that the selection moved upstream by one word.
         expect(controller.selection, const TextSelection.collapsed(offset: 4));
       });
 
@@ -121,7 +121,7 @@ void main() {
           movementModifier: MovementModifier.word,
         );
 
-        // Ensure that the selection didn't change.
+        // Ensure that the selection moved downstream by one word.
         expect(controller.selection, const TextSelection.collapsed(offset: 7));
       });
     });

--- a/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
@@ -1,15 +1,133 @@
+import 'dart:ui';
+
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 void main() {
-  // TODO: handle selection changes.
+  group("AttributedTextEditingController", () {
+    group("word jumping", () {
+      test("does nothing at beginning of text when collapsed", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection.collapsed(offset: 0);
 
-  group('AttributedTextEditingController', () {
-    group('user', () {
-      test('types hello **world** into empty field', () {
+        // Move upstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: false,
+          moveLeft: true,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      });
+
+      test("does nothing at beginning of text when expanded", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection(extentOffset: 0, baseOffset: 3);
+
+        // Move upstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: true,
+          moveLeft: true,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection(extentOffset: 0, baseOffset: 3));
+      });
+
+      test("does nothing at end of text when collapsed", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection.collapsed(offset: 13); // at the end of the text.
+
+        // Move downstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: false,
+          moveLeft: false,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection.collapsed(offset: 13));
+      });
+
+      test("does nothing at end of text when expanded", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection(extentOffset: 13, baseOffset: 8);
+
+        // Move upstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: true,
+          moveLeft: false,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection(extentOffset: 13, baseOffset: 8));
+      });
+
+      test("jumps word upstream", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection.collapsed(offset: 7);
+
+        // Move upstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: false,
+          moveLeft: true,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection.collapsed(offset: 4));
+      });
+
+      test("jumps word downstream", () {
+        final controller = AttributedTextEditingController(
+          text: AttributedText(
+            text: 'one two three',
+          ),
+        )..selection = const TextSelection.collapsed(offset: 4);
+
+        // Move downstream by word.
+        controller.moveCaretHorizontally(
+          textLayout: _NoOpTextLayout(),
+          expandSelection: false,
+          moveLeft: false,
+          movementModifier: MovementModifier.word,
+        );
+
+        // Ensure that the selection didn't change.
+        expect(controller.selection, const TextSelection.collapsed(offset: 7));
+      });
+    });
+
+    group("user", () {
+      test("types hello **world** into empty field", () {
         final controller = AttributedTextEditingController(
           selection: const TextSelection.collapsed(offset: 0),
         )
@@ -711,16 +829,13 @@ void main() {
           );
           expect(controller.composingAttributions.length, 3);
 
-          controller.removeComposingAttributions(
-              {boldAttribution, underlineAttribution});
-              
+          controller.removeComposingAttributions({boldAttribution, underlineAttribution});
+
           expect(controller.composingAttributions.length, 1);
-          expect(controller.composingAttributions.contains(italicsAttribution), true);          
+          expect(controller.composingAttributions.contains(italicsAttribution), true);
         });
-       
-        test(
-            "does nothing when it doesn't have the given composing attributions",
-            () {
+
+        test("does nothing when it doesn't have the given composing attributions", () {
           final controller = AttributedTextEditingController(
             text: AttributedText(text: 'my text'),
           );
@@ -738,4 +853,109 @@ void main() {
       });
     });
   });
+}
+
+/// A [ProseTextLayout] that throws an error if anything is called.
+///
+/// A [_NoOpTextLayout] can be used when a [ProseTextLayout] is needed by
+/// the interface, the specific operation doesn't expect to call anything
+/// on the [ProseTextLayout].
+class _NoOpTextLayout implements ProseTextLayout {
+  @override
+  double get estimatedLineHeight => throw UnimplementedError();
+
+  @override
+  TextSelection expandSelection(TextPosition startingPosition, TextExpansion expansion, TextAffinity affinity) {
+    throw UnimplementedError();
+  }
+
+  @override
+  List<TextBox> getBoxesForSelection(TextSelection selection) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextBox? getCharacterBox(TextPosition position) {
+    throw UnimplementedError();
+  }
+
+  @override
+  double? getHeightForCaret(TextPosition position) {
+    throw UnimplementedError();
+  }
+
+  @override
+  int getLineCount() {
+    throw UnimplementedError();
+  }
+
+  @override
+  double getLineHeightAtPosition(TextPosition position) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Offset getOffsetAtPosition(TextPosition position) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Offset getOffsetForCaret(TextPosition position) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition getPositionAtEndOfLine(TextPosition textPosition) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition? getPositionAtOffset(Offset localOffset) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition getPositionAtStartOfLine(TextPosition textPosition) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition getPositionInFirstLineAtX(double x) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition getPositionInLastLineAtX(double x) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition getPositionNearestToOffset(Offset localOffset) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition? getPositionOneLineDown(TextPosition textPosition) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextPosition? getPositionOneLineUp(TextPosition textPosition) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextSelection getSelectionInRect(Offset baseOffset, Offset extentOffset) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool isTextAtOffset(Offset localOffset) {
+    throw UnimplementedError();
+  }
+
+  @override
+  TextSelection getWordSelectionAt(TextPosition position) {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
[SuperTextField] - fix word jumping for expanded selection, and add tests (Resolves #560)

- Fixed a word-jumping bug when selection is expanded
- Decomposed horizontal caret movement method to improve readability
- Added tests for word-jumping under various conditions.