### PR TITLE
Fixed mobile handle dragging with ancestor Scrollables (Resolves #525)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -557,7 +557,12 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     widget.focusNode.requestFocus();
   }
 
+  void _onPanDown(DragDownDetails details) {
+    print("ON PAN DOWN");
+  }
+
   void _onPanStart(DragStartDetails details) {
+    print("ON PAN START");
     // TODO: to help the user drag handles instead of scrolling, try checking touch
     //       placement during onTapDown, and then pick that up here. I think the little
     //       bit of slop might be the problem.
@@ -1032,7 +1037,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     required Widget child,
   }) {
     return RawGestureDetector(
-      behavior: HitTestBehavior.translucent,
+      behavior: HitTestBehavior.opaque,
       gestures: <Type, GestureRecognizerFactory>{
         TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
           () => TapSequenceGestureRecognizer(),
@@ -1044,10 +1049,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
               ..onTimeout = _onTapTimeout;
           },
         ),
-        PanGestureRecognizer: GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-          () => PanGestureRecognizer(),
-          (PanGestureRecognizer recognizer) {
-            recognizer
+        // We use a VerticalDragGestureRecognizer instead of a PanGestureRecognizer
+        // because `Scrollable` also uses a VerticalDragGestureRecognizer and we
+        // need to beat out any ancestor `Scrollable` in the gesture arena.
+        VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+          () => VerticalDragGestureRecognizer(),
+          (VerticalDragGestureRecognizer instance) {
+            instance
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onDown = _onPanDown
               ..onStart = _onPanStart
               ..onUpdate = _onPanUpdate
               ..onEnd = _onPanEnd

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -558,11 +558,11 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   }
 
   void _onPanDown(DragDownDetails details) {
-    print("ON PAN DOWN");
+    // No-op: this method is only here to beat out any ancestor
+    // Scrollable that's also trying to drag.
   }
 
   void _onPanStart(DragStartDetails details) {
-    print("ON PAN START");
     // TODO: to help the user drag handles instead of scrolling, try checking touch
     //       placement during onTapDown, and then pick that up here. I think the little
     //       bit of slop might be the problem.


### PR DESCRIPTION
Fixed mobile handle dragging with ancestor Scrollables (Resolves #525)

The root problem seems to be that we were using a `PanGestureRecognizer` but `Scrollable` uses a `VerticalDragGestureRecognizer`. I thought maybe our `PanGestureRecognizer`was losing out in the gesture arena. So I changed our recognizer to also be a `VerticalDragGestureRecognizer` and it now seems to beat out the ancestor `Scrollable`.

This ancestor gesture behavior is unintuitive. I would consider this to be a bug in Flutter. Nonetheless, I'm now able to easy drag the iOS caret around in the sliver demo.