### PR TITLE
Fix serialization of spans with intersecting attributions (Resolves #526)

### DIFF
--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -309,9 +309,27 @@ class AttributedText {
 
   void visitAttributions(AttributionVisitor visitor) {
     final collapsedSpans = spans.collapseSpans(contentLength: text.length);
-    for (final span in collapsedSpans) {
-      visitor(this, span.start, span.attributions, AttributionVisitEvent.start);
-      visitor(this, span.end, span.attributions, AttributionVisitEvent.end);
+    for (int i = 0; i < collapsedSpans.length; i++) {
+      final currentSpan = collapsedSpans[i];
+      final previousSpan = i > 0 ? collapsedSpans[i - 1] : null;
+      final nextSpan = i < collapsedSpans.length - 1 ? collapsedSpans[i + 1] : null;
+
+      // When the previous span ends right before the current one
+      // whe only add start markers for the attributions that weren't present
+      // in the previous span.
+      final startAtributions = previousSpan == null || previousSpan.end != currentSpan.start - 1 //
+          ? currentSpan.attributions
+          : currentSpan.attributions.where((e) => !previousSpan.attributions.contains(e)).toSet();
+
+      // When the next span starts right after the current one
+      // whe only add end markers for the attributions that won't be present
+      // in the next span.
+      final endAtributions = nextSpan == null || nextSpan.start != currentSpan.end + 1 //
+          ? currentSpan.attributions
+          : currentSpan.attributions.where((e) => !nextSpan.attributions.contains(e)).toSet();
+
+      visitor(this, currentSpan.start, startAtributions, AttributionVisitEvent.start);
+      visitor(this, currentSpan.end, endAtributions, AttributionVisitEvent.end);
     }
   }
 

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -314,17 +314,15 @@ class AttributedText {
       final previousSpan = i > 0 ? collapsedSpans[i - 1] : null;
       final nextSpan = i < collapsedSpans.length - 1 ? collapsedSpans[i + 1] : null;
 
-      // When the previous span ends right before the current one
-      // whe only add start markers for the attributions that weren't present
+      // Whe only add start markers for attributions that weren't present
       // in the previous span.
-      final startAtributions = previousSpan == null || previousSpan.end != currentSpan.start - 1 //
+      final startAtributions = previousSpan == null //
           ? currentSpan.attributions
           : currentSpan.attributions.where((e) => !previousSpan.attributions.contains(e)).toSet();
 
-      // When the next span starts right after the current one
-      // whe only add end markers for the attributions that won't be present
+      // Whe only add end markers for attributions that won't be present
       // in the next span.
-      final endAtributions = nextSpan == null || nextSpan.start != currentSpan.end + 1 //
+      final endAtributions = nextSpan == null //
           ? currentSpan.attributions
           : currentSpan.attributions.where((e) => !nextSpan.attributions.contains(e)).toSet();
 

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -22,6 +22,8 @@ dependency_overrides:
     path: ../super_editor
   super_text_layout:
     path: ../super_text_layout
+  attributed_text:
+    path: ../attributed_text
 
 dev_dependencies:
   # TODO: upgrade lints to 2.0.1 when we release super_editor 0.2.1

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -153,6 +153,27 @@ This is some code
         expect(serializeDocumentToMarkdown(doc), 'This ***is a*** paragraph.');
       });
 
+      test('paragraph with non-overlapping bold and italics', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
+                  const SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.start),
+                  const SpanMarker(attribution: italicsAttribution, offset: 19, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '**This is** *a paragraph.*');
+      });
+
       test('paragraph with intersecting bold and italics', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -172,9 +193,27 @@ This is some code
         ]);
 
         expect(serializeDocumentToMarkdown(doc), 'This ***is a** paragraph*.');
-      }, skip: '''Markdown serialization is currently broken for intersecting styles.
-                  See https://github.com/superlistapp/super_editor/issues/526''');
+      });
 
+      test('paragraph with intersecting bold and strikethrough', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'Bold and Strike Bold',
+              spans: AttributedSpans(attributions: [
+                const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+                const SpanMarker(attribution: boldAttribution, offset: 19, markerType: SpanMarkerType.end),
+                const SpanMarker(attribution: strikethroughAttribution, offset: 0, markerType: SpanMarkerType.start),
+                const SpanMarker(attribution: strikethroughAttribution, offset: 14, markerType: SpanMarkerType.end),
+              ]),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '**~Bold and Strike~ Bold**');
+      });
+    
       test('paragraph with overlapping code and bold', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -273,8 +312,28 @@ This is some code
         ]);
 
         expect(serializeDocumentToMarkdown(doc), '[This **is a** paragraph](https://example.org).');
-      }, skip: '''Markdown serialization is currently broken for intersecting styles.
-                  See https://github.com/superlistapp/super_editor/issues/526''');
+      });
+
+      test('paragraph with consecutive links', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'First LinkSecond Link',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 0, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 9, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 10, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 20, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '[First Link](https://example.org)[Second Link](https://github.com)');
+      });
 
       test('image', () {
         final doc = MutableDocument(nodes: [


### PR DESCRIPTION
Fix serialization of spans with intersecting attributions. Resolves https://github.com/superlistapp/super_editor/issues/526

Markdown serialization was not working properly for attributions which share a starting index but end in different places. 

For example:
**~Bold and Strike~ Bold** was being serialized as `**~Bold and Strike~**** Bold**`

I changed the serialization logic to don't add start/end markers for attributions that are present in the previous/next span.
