### PR TITLE
[Example App] Fix toolbar hiding the alignment menu (Resolves #670)

### DIFF
--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -115,6 +115,13 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // We need our own [Overlay] instead of the one created by the navigator
+    // because overlay entries added to navigator's [Overlay] are always
+    // displayed above all routes.
+    //    
+    // We display the editor's toolbar in an [OverlayEntry], so inserting it
+    // at the navigator's [Overlay] causes widgets that are displayed in routes, 
+    // e.g. [DropdownButton] items, to be displayed beneath the toolbar.    
     return Overlay(
       initialEntries: [
         OverlayEntry(builder: (context) {

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -115,12 +115,18 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      key: _scaffoldKey,
-      appBar: _buildAppBar(context),
-      extendBodyBehindAppBar: true,
-      body: _selectedMenuItem!.pageBuilder(context),
-      drawer: _buildDrawer(),
+    return Overlay(
+      initialEntries: [
+        OverlayEntry(builder: (context) {
+          return Scaffold(
+            key: _scaffoldKey,
+            appBar: _buildAppBar(context),
+            extendBodyBehindAppBar: true,
+            body: _selectedMenuItem!.pageBuilder(context),
+            drawer: _buildDrawer(),
+          );
+        })
+      ],
     );
   }
 

--- a/super_text_layout/lib/src/super_text_layout_with_selection.dart
+++ b/super_text_layout/lib/src/super_text_layout_with_selection.dart
@@ -144,6 +144,13 @@ class _RebuildOptimizedSuperTextWithSelectionState extends State<_RebuildOptimiz
       // the cache so that the full SuperText widget subtree is rebuilt.
       _cachedSubtree = null;
     }
+    if (widget.textAlign != oldWidget.textAlign) {
+      buildsLog.fine("Text align changed. Invalidating the cached SuperText widget.");
+
+      // The text align changed, which means the text layout changed. Invalidate
+      // the cache so that the full SuperText widget subtree is rebuilt.
+      _cachedSubtree = null;
+    }
   }
 
   // The current length of the text displayed by this widget. The value

--- a/super_text_layout/lib/src/super_text_layout_with_selection.dart
+++ b/super_text_layout/lib/src/super_text_layout_with_selection.dart
@@ -144,13 +144,6 @@ class _RebuildOptimizedSuperTextWithSelectionState extends State<_RebuildOptimiz
       // the cache so that the full SuperText widget subtree is rebuilt.
       _cachedSubtree = null;
     }
-    if (widget.textAlign != oldWidget.textAlign) {
-      buildsLog.fine("Text align changed. Invalidating the cached SuperText widget.");
-
-      // The text align changed, which means the text layout changed. Invalidate
-      // the cache so that the full SuperText widget subtree is rebuilt.
-      _cachedSubtree = null;
-    }
   }
 
   // The current length of the text displayed by this widget. The value


### PR DESCRIPTION
Fix toolbar hiding the alignment menu. Resolves https://github.com/superlistapp/super_editor/issues/670

Currently we use an `Overlay` to display the toolbar. This is causing the dropdown items to be displayed behind the toolbar.

After some research I found that `DropdownButton` displays its items in another route and that the overlay is always displayed above this route. Based on https://github.com/flutter/flutter/issues/22917#issuecomment-431457670 it seems that this is the expected behaviour.

I changed the example editor to display the toolbar in the stack.

Checking this ticket I've found another issue:

Clicking to change the text alignment is not applying the new alignment until an attribution is toggled. The reason is that `_RebuildOptimizedSuperTextWithSelectionState` is not invalidating the cached `SuperText` when the text alignment changes.
