### PR TITLE
[SuperEditor] Fix drag selection of non-selectable components (Resolves #363)

### DIFF
--- a/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
@@ -283,6 +283,12 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
 
       final component = componentKey.currentState as DocumentComponent;
 
+      // Unselectable components should be avoided at base or extent.
+      // They should only be selected when the surrounding components are selected.
+      if (!component.isVisualSelectionSupported()) {
+        continue;
+      }
+
       final componentOverlap = _getLocalOverlapWithComponent(region, component);
 
       if (componentOverlap != null) {

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -90,6 +90,7 @@ class TestDocumentConfigurator {
   Stylesheet? _stylesheet;
   bool _autoFocus = false;
   ui.Size? _editorSize;
+  List<ComponentBuilder>? _componentBuilders;
 
   /// Configures the [SuperEditor] for standard desktop interactions,
   /// e.g., mouse and keyboard input.
@@ -132,6 +133,12 @@ class TestDocumentConfigurator {
   /// Configures the [SuperEditor] to constrain its maxHeight and maxWidth using the given [size].
   TestDocumentConfigurator withEditorSize(ui.Size? size) {
     _editorSize = size;
+    return this;
+  }
+
+  /// Configures the [SuperEditor] to use only the given [componentBuilders]
+  TestDocumentConfigurator withComponentBuilders(List<ComponentBuilder>? componentBuilders) {
+    _componentBuilders = componentBuilders;
     return this;
   }
 
@@ -234,6 +241,7 @@ class TestDocumentConfigurator {
               gestureMode: _gestureMode ?? _defaultGestureMode,
               stylesheet: _stylesheet,
               autofocus: _autoFocus,
+              componentBuilders: _componentBuilders ?? defaultComponentBuilders,
             ),
           ),
         ),

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -97,7 +97,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (upstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (dragging upstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
@@ -123,7 +123,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (upstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (dragging upstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
@@ -149,7 +149,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (downstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (dragging downstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
@@ -175,7 +175,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (downstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (dragging downstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
@@ -201,7 +201,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (upstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (dragging upstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
@@ -228,7 +228,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (downstream)", (tester) async {
+    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (dragging downstream)", (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
       final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/core/document.dart';
-import 'package:super_editor/src/core/document_layout.dart';
-import 'package:super_editor/src/core/document_selection.dart';
-import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
-import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/super_editor.dart';
 
 import '../test_tools.dart';
 import 'document_test_tools.dart';
@@ -100,5 +96,226 @@ void main() {
         ),
       );
     });
+
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (upstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from the horizontal rule to the beginning of the first paragraph
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getBottomRight(find.byType(Divider)),
+        tester.getTopLeft(find.text('First Paragraph', findRichText: true)),
+      );
+
+      // Ensure we don't select the horizontal rule
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 15)),
+          extent: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+        ),
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (upstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from the end of the second paragraph to the horizontal rule
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getBottomRight(find.text('Second Paragraph', findRichText: true)),
+        tester.getTopLeft(find.byType(Divider)),
+      );
+
+      // Ensure we don't select the horizontal rule
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 16)),
+          extent: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+        ),
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at base (downstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from the horizontal rule to the end of the second paragraph
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getTopLeft(find.byType(Divider)),
+        tester.getBottomRight(find.text('Second Paragraph', findRichText: true)),
+      );
+
+      // Ensure we don't select the horizontal rule
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+          extent: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 16)),
+        ),
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("doesn't select an unselectable component at extent (downstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from first paragraph to the horizontal rule
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getTopLeft(find.text('First Paragraph', findRichText: true)),
+        tester.getBottomRight(find.byType(Divider)),
+      );
+
+      // Ensure we don't select the horizontal rule
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+          extent: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 15)),
+        ),
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (upstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
+      final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from the end of the second paragraph to the beginning of the first paragraph
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getBottomRight(find.text('Second Paragraph', findRichText: true)),
+        tester.getTopLeft(find.text('First Paragraph', findRichText: true)),
+      );
+
+      // Ensure we select the whole document
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 16)),
+          extent: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+        ),
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("selects paragraphs surrounding an unselectable component (downstream)", (tester) async {
+      final testContext = await _pumpUnselectableComponentTestApp(tester);
+
+      final firstParagraphId = testContext.editContext.editor.document.nodes.first.id;
+      final secondParagraphId = testContext.editContext.editor.document.nodes.last.id;
+
+      // TODO: replace the following direct layout access with a simulated user
+      // drag, once we've merged some new dragging tools in #645.
+      final layoutState = (find.byType(SingleColumnDocumentLayout).evaluate().single as StatefulElement).state;
+      final layout = layoutState as DocumentLayout;
+
+      // Attempt to select from the beginning of the first paragraph to the end of the second paragraph
+      final selection = layout.getDocumentSelectionInRegion(
+        tester.getTopLeft(find.text('First Paragraph', findRichText: true)),
+        tester.getBottomRight(find.text('Second Paragraph', findRichText: true)),
+      );
+
+      // Ensure we select the whole document
+      expect(
+        selection,
+        DocumentSelection(
+          base: DocumentPosition(nodeId: firstParagraphId, nodePosition: const TextNodePosition(offset: 0)),
+          extent: DocumentPosition(nodeId: secondParagraphId, nodePosition: const TextNodePosition(offset: 16)),
+        ),
+      );
+    });
   });
+}
+
+Future<TestDocumentContext> _pumpUnselectableComponentTestApp(WidgetTester tester) async {
+  return await tester //
+      .createDocument() //
+      .fromMarkdown("""
+First Paragraph
+
+---
+
+Second Paragraph
+""")
+      .withComponentBuilders([
+        const _UnselectableHrComponentBuilder(),
+        ...defaultComponentBuilders,
+      ])
+      .withEditorSize(const Size(300, 300))
+      .pump();
+}
+
+/// SuperEditor [ComponentBuilder] that builds a horizontal rule that is
+/// not selectable.
+class _UnselectableHrComponentBuilder implements ComponentBuilder {
+  const _UnselectableHrComponentBuilder();
+
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    // This builder can work with the standard horizontal rule view model, so
+    // we'll defer to the standard horizontal rule builder.
+    return null;
+  }
+
+  @override
+  Widget? createComponent(SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! HorizontalRuleComponentViewModel) {
+      return null;
+    }
+
+    return _UnselectableHorizontalRuleComponent(
+      componentKey: componentContext.componentKey,
+    );
+  }
+}
+
+class _UnselectableHorizontalRuleComponent extends StatelessWidget {
+  const _UnselectableHorizontalRuleComponent({
+    Key? key,
+    required this.componentKey,
+  }) : super(key: key);
+
+  final GlobalKey componentKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return BoxComponent(
+      key: componentKey,
+      isVisuallySelectable: false,
+      child: const Divider(
+        color: Color(0xFF000000),
+        thickness: 1.0,
+      ),
+    );
+  }
 }


### PR DESCRIPTION
[SuperEditor]  Fix drag selection of non-selectable components. Resolves https://github.com/superlistapp/super_editor/issues/363

Dragging a selection that ends on a non-selectable component was causing the component to be selected.

I modified `getDocumentSelectionInRegion` to ignore components that are marked with `isVisuallySelectable` equal to `false`. That way, a non-selectable component can't be at the `base` or `extent` of a `DocumentSelection`.

However, we still can select the surrounding components, causing the non-selectable component to be present in the selected region.

I also added an option to configure the `componentBuilders` in the `TestDocumentConfigurator`.
