### PR TITLE
[SuperEditor] Fix placement of caret for the second time

### DIFF
--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -48,8 +48,9 @@ class DocumentComposer with ChangeNotifier {
   final selectionNotifier = ValueNotifier<DocumentSelection?>(null);
 
   /// Clears the current [selection].
+  /// Previous extent position is set on base parameter to clear the selection
   void clearSelection() {
-    selection = null;
+    selection = _selection?.copyWith(base: _selection!.extent.copyWith());
   }
 
   final ValueNotifier<ImeConfiguration> imeConfiguration;

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -48,7 +48,6 @@ class DocumentComposer with ChangeNotifier {
   final selectionNotifier = ValueNotifier<DocumentSelection?>(null);
 
   /// Clears the current [selection].
-  /// Previous extent position is set on base parameter to clear the selection
   void clearSelection() {
     selection = null;
   }

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -50,7 +50,7 @@ class DocumentComposer with ChangeNotifier {
   /// Clears the current [selection].
   /// Previous extent position is set on base parameter to clear the selection
   void clearSelection() {
-    selection = _selection?.copyWith(base: _selection!.extent.copyWith());
+    selection = null;
   }
 
   final ValueNotifier<ImeConfiguration> imeConfiguration;

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -150,8 +150,11 @@ void main() {
       // Type some text by simulating hardware keyboard key presses.
       await tester.typeKeyboardText("Hello, world!");
 
+      //Simulate the delay between first tap and second tap
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
       // Tap to place the caret in the last position
-      await tester.placeCaretInParagraph("1", 12);
+      await tester.placeCaretInParagraph("1", 13);
 
       // Type some text by simulating hardware keyboard key presses.
       await tester.typeKeyboardText("ABC");

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -134,5 +134,30 @@ void main() {
       // Verify that SuperEditor displays the text we typed.
       expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!");
     });
+
+    testWidgetsOnDesktop("enters text by placing the carit for second time with hardware keyboard", (tester) async {
+      // Configure and render a document.
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .forDesktop()
+          .autoFocus(true)
+          .pump();
+
+      // Tap to place the caret in the first paragraph.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Type some text by simulating hardware keyboard key presses.
+      await tester.typeKeyboardText("Hello, world!");
+
+      // Tap to place the caret in the last position
+      await tester.placeCaretInParagraph("1", 12);
+
+      // Type some text by simulating hardware keyboard key presses.
+      await tester.typeKeyboardText("ABC");
+
+      // Verify that SuperEditor displays the text we typed.
+      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
+    });
   });
 }


### PR DESCRIPTION
It was found that clearSelection() method in document_composer.dart was assigning null to selection setter to clear selection which is needed to be non-null for text to get inserted in the paragraph field after placing caret for the second.

To clear selection, selection setter is assigned with a new object with base attribute same as extent attribute of the previous selection object.