### PR TITLE
[SuperTextField] [Desktop] Fix text behaving scrollable when maxLines is null (Resolves #566)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -248,6 +248,10 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   }
 
   double _getEstimatedLineHeight() {
+    final lineHeight = _textKey.currentState?.textLayout.getLineHeightAtPosition(const TextPosition(offset: 0)) ?? 0;
+    if (lineHeight > 0) {
+      return lineHeight;
+    }
     final defaultStyle = widget.textStyleBuilder({});
     return (defaultStyle.height ?? 1.0) * defaultStyle.fontSize!;
   }

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -206,7 +206,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   bool _updateViewportHeight() {
     final estimatedLineHeight = _getEstimatedLineHeight();
     final estimatedLinesOfText = _getEstimatedLinesOfText();
-    final estimatedContentHeight = estimatedLinesOfText * estimatedLineHeight;
+    final estimatedContentHeight = (estimatedLinesOfText * estimatedLineHeight) + widget.padding.vertical;
     final minHeight = widget.minLines != null ? widget.minLines! * estimatedLineHeight + widget.padding.vertical : null;
     final maxHeight = widget.maxLines != null ? widget.maxLines! * estimatedLineHeight + widget.padding.vertical : null;
     double? viewportHeight;

--- a/super_editor/test/super_textfield/super_texfield_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_texfield_scroll_test.dart
@@ -68,11 +68,12 @@ void main() {
       expect(textBottom, lessThanOrEqualTo(viewportBottom));
     });
 
-    testWidgetsOnDesktop("with unlimited lines doesn't scroll vertically", (tester) async {
+    testWidgetsOnDesktop("doesn't scroll vertically when maxLines is null", (tester) async {
       // With the Ahem font the estimated line height is equal to the true line height
       // so we need to use a custom font.
       await loadAppFonts();
 
+      // We use some padding because it affects the viewport height calculation.
       const verticalPadding = 6.0;
 
       await tester.pumpWidget(

--- a/super_editor/test/super_textfield/super_texfield_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_texfield_scroll_test.dart
@@ -100,6 +100,23 @@ void main() {
       );
       await tester.pump();
 
+      // The original issue was that the textfield was calculating a viewport height 
+      // that wasn't big enough to display the text, causing it to be scrollable.
+      // The textfield sizes it's viewport based on a estimated line height, so if the
+      // true line height differs from the estimated one, the issue happens.
+      //
+      // Ideally we should test if the textfield's ScrollController has a zero maxScrollExtent,
+      // to prove that it's not scrollable.
+      // However, I couldn't reproduce a failing test with this expectation.
+      // For example: when running the app, the SuperText inside the textfield with a 
+      // fontSize of 14 is 19 pixels tall.
+      // Running the test it is 14 pixels tall, even loading the app fonts.
+      // Because of this, SuperText fits inside the textfield's Scrollview and the scrolling
+      // issue doesn't happen.
+      //
+      // This test only ensures that the viewport height isn't too small, checking if a
+      // calculated line height plus padding fits inside the viewport.
+
       final viewportHeight = tester.getRect(find.byType(SuperTextFieldScrollview)).height;
 
       final layoutState = (find.byType(SuperDesktopTextField).evaluate().single as StatefulElement).state as SuperDesktopTextFieldState;

--- a/super_editor/test/super_textfield/super_texfield_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_texfield_scroll_test.dart
@@ -100,22 +100,11 @@ void main() {
       );
       await tester.pump();
 
-      // The original issue was that the textfield was calculating a viewport height 
-      // that wasn't big enough to display the text, causing it to be scrollable.
-      // The textfield sizes it's viewport based on a estimated line height, so if the
-      // true line height differs from the estimated one, the issue happens.
-      //
-      // Ideally we should test if the textfield's ScrollController has a zero maxScrollExtent,
-      // to prove that it's not scrollable.
-      // However, I couldn't reproduce a failing test with this expectation.
-      // For example: when running the app, the SuperText inside the textfield with a 
-      // fontSize of 14 is 19 pixels tall.
-      // Running the test it is 14 pixels tall, even loading the app fonts.
-      // Because of this, SuperText fits inside the textfield's Scrollview and the scrolling
-      // issue doesn't happen.
-      //
-      // This test only ensures that the viewport height isn't too small, checking if a
-      // calculated line height plus padding fits inside the viewport.
+      // In the running app, the estimated line height and actual line height differ. 
+      // This test ensures that we account for that. Ideally, this test would check that the scrollview doesn't scroll. 
+      // However, in test suites, the estimated and actual line heights are always identical.
+      // Therefore, this test ensures that we add up the appropriate dimensions, 
+      // rather than verify the scrollview's max scroll extent.
 
       final viewportHeight = tester.getRect(find.byType(SuperTextFieldScrollview)).height;
 

--- a/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:super_editor/super_editor.dart';
 
 import '../test_tools.dart';
@@ -8,452 +9,500 @@ import 'super_textfield_inspector.dart';
 import 'super_textfield_robot.dart';
 
 void main() {
-  group('SuperTextField with keyboard', () {
-    group('containing only one emoji', (){
-      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢',
-        );
+  group('SuperTextField', () {
+    group('with keyboard', () {
+      group('containing only one emoji', () {
+        testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢',
+          );
 
-        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
-        // Place caret at the beginning of the text
-        await tester.placeCaretInSuperTextField(0);
-        // Move caret to the right   
-        await tester.pressRightArrow();
+          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+          // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+          // Move caret to the right
+          await tester.pressRightArrow();
 
-        // Ensure we are at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 2),
-        );   
+          // Ensure we are at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 2),
+          );
 
-        // Press left arrow key to move the selection to the beginning of the text
-        await tester.pressLeftArrow();      
+          // Press left arrow key to move the selection to the beginning of the text
+          await tester.pressLeftArrow();
 
-        // Ensure caret is at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0)
-        );         
+          // Ensure caret is at the beginning of the text
+          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
+        });
+
+        testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢',
+          );
+
+          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+          // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+          // Move caret to the right
+          await tester.pressRightArrow();
+
+          // Ensure we are at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 2),
+          );
+
+          // Press shift + left arrow key to expand the selection to the left
+          await tester.pressShiftLeftArrow();
+
+          // Ensure that the emoji is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 2,
+              extentOffset: 0,
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢',
+          );
+
+          // Place caret before the emoji
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press right arrow key to move the selection to the right
+          await tester.pressRightArrow();
+
+          // Ensure caret is at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 2),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢',
+          );
+
+          // Place caret before the emoji
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press shift + right arrow key to expand the selection to the right
+          await tester.pressShiftRightArrow();
+
+          // Ensure that the emoji is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 2,
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("selects the emoji on double tap", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢',
+          );
+
+          await tester.doubleTapAtSuperTextField(0);
+
+          // Ensure that the emoji is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 2,
+            ),
+          );
+        });
       });
 
-      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢',
-        );
+      group('containing only two consecutive emojis', () {
+        testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢🐢',
+          );
 
-        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
-        // Place caret at the beginning of the text
-        await tester.placeCaretInSuperTextField(0);
-        // Move caret to the right   
-        await tester.pressRightArrow(); 
+          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+          // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+          // Move caret to the right
+          await tester.pressRightArrow();
+          // Move caret to the right
+          await tester.pressRightArrow();
 
-        // Ensure we are at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 2),
-        );      
+          // Ensure we are at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 4),
+          );
 
-        // Press shift + left arrow key to expand the selection to the left
-        await tester.pressShiftLeftArrow();      
+          // Press left arrow key to move the selection to the left
+          await tester.pressLeftArrow();
 
-        // Ensure that the emoji is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 2,
-            extentOffset: 0,
-          ),
-        );         
+          // Ensure caret is between the two emojis
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 2),
+          );
+
+          // Press left arrow key to move the selection to the left
+          await tester.pressLeftArrow();
+
+          // Ensure caret is at the beginning of the text
+          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
+        });
+
+        testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢🐢',
+          );
+
+          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+          // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+          // Move caret to the right
+          await tester.pressRightArrow();
+          // Move caret to the right
+          await tester.pressRightArrow();
+
+          // Ensure we are at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 4),
+          );
+
+          // Press shift + left arrow key to expand the selection to the left
+          await tester.pressShiftLeftArrow();
+
+          // Ensure that the last emoji is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 4,
+              extentOffset: 2,
+            ),
+          );
+
+          // Press shift + left arrow key to expand the selection to the left
+          await tester.pressShiftLeftArrow();
+
+          // Ensure the whole text is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 4,
+              extentOffset: 0,
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢🐢',
+          );
+
+          // Place caret before the first emoji
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press right arrow key to move the selection to the right
+          await tester.pressRightArrow();
+
+          // Ensure caret is between the two emojis
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 2),
+          );
+
+          // Press right arrow key to move the selection to the right
+          await tester.pressRightArrow();
+
+          // Ensure caret is at the end of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 4),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: '🐢🐢',
+          );
+
+          // Place caret before the first emoji
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press shift + right arrow key to expand the selection to the right
+          await tester.pressShiftRightArrow();
+
+          // Ensure the first emoji is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 2,
+            ),
+          );
+
+          // Press shift + right arrow key to expand the selection to the right
+          await tester.pressShiftRightArrow();
+
+          // Ensure we selected the whole text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 4,
+            ),
+          );
+        });
       });
-    
-      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢',
-        );
 
-        // Place caret before the emoji      
-        await tester.placeCaretInSuperTextField(0);
+      group('containing emojis and non-emojis', () {
+        testWidgetsOnAllPlatforms("moves caret upstream around the text", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: 'a🐢b',
+          );
 
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );     
+          // Place caret at |b
+          await tester.placeCaretInSuperTextField(3);
 
-        // Press right arrow key to move the selection to the right
-        await tester.pressRightArrow();      
+          // Ensure we are after the emoji
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 3),
+          );
 
-        // Ensure caret is at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 2),
-        );         
-      });    
+          // Press left arrow key to move the selection to the left
+          await tester.pressLeftArrow();
 
-      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢',
-        );
+          // Ensure we are between the emoji and the 'a'
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 1),
+          );
 
-        // Place caret before the emoji
-        await tester.placeCaretInSuperTextField(0);    
+          // Press left arrow key to move the selection to the left
+          await tester.pressLeftArrow();
 
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );    
+          // Ensure caret is at the beginning of the text
+          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
+        });
 
-        // Press shift + right arrow key to expand the selection to the right
-        await tester.pressShiftRightArrow();      
+        testWidgetsOnAllPlatforms("expands selection upstream around the text", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: 'a🐢b',
+          );
 
-        // Ensure that the emoji is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 2,
-          ),
-        );         
-      });
+          // Place caret at |b
+          await tester.placeCaretInSuperTextField(3);
 
-      testWidgetsOnAllPlatforms("selects the emoji on double tap", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢',
-        );
+          // Ensure we are after the emoji
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 3),
+          );
 
-        await tester.doubleTapAtSuperTextField(0);             
+          // Press shift + left arrow key to expand the selection to the left
+          await tester.pressShiftLeftArrow();
 
-        // Ensure that the emoji is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 2,
-          ),
-        );         
+          // Ensure we selected the emoji
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 3,
+              extentOffset: 1,
+            ),
+          );
+
+          // Press shift + left arrow key to expand the selection to the left
+          await tester.pressShiftLeftArrow();
+
+          // Ensure "a🐢" is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 3,
+              extentOffset: 0,
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("moves caret downstream around the text", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: 'a🐢b',
+          );
+
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press right arrow key to move the selection to the right
+          await tester.pressRightArrow();
+
+          // Ensure we are at a|
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 1),
+          );
+
+          // Press right arrow key to move the selection to the right
+          await tester.pressRightArrow();
+
+          // Ensure caret is after the emoji
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 3),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("expands selection downstream around the text", (tester) async {
+          await _pumpSuperTextFieldEmojiTest(
+            tester,
+            text: 'a🐢b',
+          );
+
+          // Place caret at the beginning of the text
+          await tester.placeCaretInSuperTextField(0);
+
+          // Ensure we are at the beginning of the text
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection.collapsed(offset: 0),
+          );
+
+          // Press shift + right arrow key to expand the selection to the right
+          await tester.pressShiftRightArrow();
+
+          // Ensure 'a' is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 1,
+            ),
+          );
+
+          // Press shift + right arrow key to expand the selection to the right
+          await tester.pressShiftRightArrow();
+
+          // Ensure "a🐢" is selected
+          expect(
+            SuperTextFieldInspector.findSelection(),
+            const TextSelection(
+              baseOffset: 0,
+              extentOffset: 3,
+            ),
+          );
+        });
       });
     });
 
-    group('containing only two consecutive emojis', (){
-      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢🐢',
-        );
+    group('with unlimited lines', () {
+      testWidgetsOnDesktop("doesn't scroll vertically", (tester) async {
+        // With the Ahem font the estimated line height is equal to the true line height
+        // so we need to use a custom font.
+        await loadAppFonts();
 
-        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
-        // Place caret at the beginning of the text
-        await tester.placeCaretInSuperTextField(0);
-        // Move caret to the right   
-        await tester.pressRightArrow();
-        // Move caret to the right   
-        await tester.pressRightArrow();
+        const verticalPadding = 6.0;
 
-        // Ensure we are at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 4),
-        );   
-
-        // Press left arrow key to move the selection to the left
-        await tester.pressLeftArrow();   
-
-        // Ensure caret is between the two emojis
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 2),
-        );    
-
-        // Press left arrow key to move the selection to the left
-        await tester.pressLeftArrow();   
-
-        // Ensure caret is at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0)
-        );         
-      });
-
-      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢🐢',
-        );
-
-        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
-        // Place caret at the beginning of the text
-        await tester.placeCaretInSuperTextField(0);
-        // Move caret to the right   
-        await tester.pressRightArrow();
-        // Move caret to the right   
-        await tester.pressRightArrow();
-
-        // Ensure we are at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 4),
-        );      
-
-        // Press shift + left arrow key to expand the selection to the left
-        await tester.pressShiftLeftArrow();   
-
-        // Ensure that the last emoji is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 4,
-            extentOffset: 2,
-          ),
-        );    
-
-        // Press shift + left arrow key to expand the selection to the left
-        await tester.pressShiftLeftArrow(); 
-
-        // Ensure the whole text is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 4,
-            extentOffset: 0,
-          ),
-        );         
-      });    
-    
-      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢🐢',
-        );
-
-        // Place caret before the first emoji  
-        await tester.placeCaretInSuperTextField(0);
-
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );     
-
-        // Press right arrow key to move the selection to the right
-        await tester.pressRightArrow();      
-
-        // Ensure caret is between the two emojis
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 2),
-        ); 
-
-        // Press right arrow key to move the selection to the right
-        await tester.pressRightArrow();  
-
-        // Ensure caret is at the end of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 4),
-        );         
-      });    
-    
-      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: '🐢🐢',
-        );
-
-        // Place caret before the first emoji
-        await tester.placeCaretInSuperTextField(0);    
-
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );    
-
-        // Press shift + right arrow key to expand the selection to the right
-        await tester.pressShiftRightArrow();      
-
-        // Ensure the first emoji is selected
-         expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 2,
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 300),
+                child: SuperDesktopTextField(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: verticalPadding),
+                  minLines: 1,
+                  maxLines: null,
+                  textController: AttributedTextEditingController(
+                    text: AttributedText(text: "SuperTextField"),
+                  ),
+                  textStyleBuilder: (_) => const TextStyle(
+                    fontSize: 14,
+                    height: 1,
+                    fontFamily: 'Roboto',
+                  ),
+                ),
+              ),
+            ),
           ),
         );
+        await tester.pump();
 
-        // Press shift + right arrow key to expand the selection to the right
-        await tester.pressShiftRightArrow(); 
+        final viewportHeight = tester.getRect(find.byType(SuperTextFieldScrollview)).height;
 
-        // Ensure we selected the whole text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 4,
-          ),
-        );         
-      });    
-    });  
+        final layoutState = (find.byType(SuperDesktopTextField).evaluate().single as StatefulElement).state as SuperDesktopTextFieldState;
+        final contentHeight = layoutState.textLayout.getLineHeightAtPosition(const TextPosition(offset: 0));
 
-    group('containing emojis and non-emojis', (){
-      testWidgetsOnAllPlatforms("moves caret upstream around the text", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: 'a🐢b',
-        );
+        // Vertical padding is added to both top and bottom
+        final totalHeight = contentHeight + (verticalPadding * 2);
 
-        // Place caret at |b   
-        await tester.placeCaretInSuperTextField(3);   
-
-        // Ensure we are after the emoji
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 3),
-        );   
-
-        // Press left arrow key to move the selection to the left
-        await tester.pressLeftArrow();   
-
-        // Ensure we are between the emoji and the 'a'
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 1),
-        );    
-
-        // Press left arrow key to move the selection to the left
-        await tester.pressLeftArrow();   
-
-        // Ensure caret is at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0)
-        );         
-      });
-    
-      testWidgetsOnAllPlatforms("expands selection upstream around the text", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: 'a🐢b',
-        );
-
-        // Place caret at |b
-        await tester.placeCaretInSuperTextField(3); 
-
-        // Ensure we are after the emoji
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 3),
-        );      
-
-        // Press shift + left arrow key to expand the selection to the left
-        await tester.pressShiftLeftArrow();   
-
-        // Ensure we selected the emoji
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 3,
-            extentOffset: 1,
-          ),
-        );    
-
-        // Press shift + left arrow key to expand the selection to the left
-        await tester.pressShiftLeftArrow(); 
-
-        // Ensure "a🐢" is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 3,
-            extentOffset: 0,
-          ),
-        );         
-      });    
-    
-      testWidgetsOnAllPlatforms("moves caret downstream around the text", (tester) async {      
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: 'a🐢b',
-        );
-
-        // Place caret at the beginning of the text    
-        await tester.placeCaretInSuperTextField(0);
-
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );     
-
-        // Press right arrow key to move the selection to the right
-        await tester.pressRightArrow();      
-
-        // Ensure we are at a|
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 1),
-        ); 
-
-        // Press right arrow key to move the selection to the right
-        await tester.pressRightArrow();  
-
-        // Ensure caret is after the emoji
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 3),
-        );         
-      });    
-    
-      testWidgetsOnAllPlatforms("expands selection downstream around the text", (tester) async {           
-        await _pumpSuperTextFieldEmojiTest(tester, 
-          text: 'a🐢b',
-        );
-
-        // Place caret at the beginning of the text
-        await tester.placeCaretInSuperTextField(0);    
-
-        // Ensure we are at the beginning of the text
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection.collapsed(offset: 0),
-        );    
-
-        // Press shift + right arrow key to expand the selection to the right
-        await tester.pressShiftRightArrow();      
-
-        // Ensure 'a' is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 1,
-          ),
-        );
-
-        // Press shift + right arrow key to expand the selection to the right
-        await tester.pressShiftRightArrow(); 
-
-        // Ensure "a🐢" is selected
-        expect(
-          SuperTextFieldInspector.findSelection(), 
-          const TextSelection(
-            baseOffset: 0,
-            extentOffset: 3,
-          ),
-        );         
+        // Ensure the viewport is big enough so the text doesn't scroll vertically
+        expect(viewportHeight, greaterThanOrEqualTo(totalHeight));
       });
     });
   });
 }
 
-Future<void> _pumpSuperTextFieldEmojiTest(
-  WidgetTester tester, {
-  required String text
-}) async {
+Future<void> _pumpSuperTextFieldEmojiTest(WidgetTester tester, {required String text}) async {
   final controller = AttributedTextEditingController(
     text: AttributedText(text: text),
   );
   await tester.pumpWidget(
     MaterialApp(
-      home: Scaffold(            
+      home: Scaffold(
         body: SuperTextField(
           configuration: SuperTextFieldPlatformConfiguration.desktop,
           textController: controller,

--- a/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_text_layout_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
-import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:super_editor/super_editor.dart';
 
 import '../test_tools.dart';
@@ -9,500 +8,452 @@ import 'super_textfield_inspector.dart';
 import 'super_textfield_robot.dart';
 
 void main() {
-  group('SuperTextField', () {
-    group('with keyboard', () {
-      group('containing only one emoji', () {
-        testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢',
-          );
+  group('SuperTextField with keyboard', () {
+    group('containing only one emoji', (){
+      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
 
-          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-          // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-          // Move caret to the right
-          await tester.pressRightArrow();
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
 
-          // Ensure we are at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 2),
-          );
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );   
 
-          // Press left arrow key to move the selection to the beginning of the text
-          await tester.pressLeftArrow();
+        // Press left arrow key to move the selection to the beginning of the text
+        await tester.pressLeftArrow();      
 
-          // Ensure caret is at the beginning of the text
-          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
-        });
-
-        testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢',
-          );
-
-          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-          // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-          // Move caret to the right
-          await tester.pressRightArrow();
-
-          // Ensure we are at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 2),
-          );
-
-          // Press shift + left arrow key to expand the selection to the left
-          await tester.pressShiftLeftArrow();
-
-          // Ensure that the emoji is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 2,
-              extentOffset: 0,
-            ),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢',
-          );
-
-          // Place caret before the emoji
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press right arrow key to move the selection to the right
-          await tester.pressRightArrow();
-
-          // Ensure caret is at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 2),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢',
-          );
-
-          // Place caret before the emoji
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press shift + right arrow key to expand the selection to the right
-          await tester.pressShiftRightArrow();
-
-          // Ensure that the emoji is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 2,
-            ),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("selects the emoji on double tap", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢',
-          );
-
-          await tester.doubleTapAtSuperTextField(0);
-
-          // Ensure that the emoji is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 2,
-            ),
-          );
-        });
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
       });
 
-      group('containing only two consecutive emojis', () {
-        testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢🐢',
-          );
+      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
 
-          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-          // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-          // Move caret to the right
-          await tester.pressRightArrow();
-          // Move caret to the right
-          await tester.pressRightArrow();
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the call to pressRightArrow when that bug is fixed.
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow(); 
 
-          // Ensure we are at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 4),
-          );
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );      
 
-          // Press left arrow key to move the selection to the left
-          await tester.pressLeftArrow();
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();      
 
-          // Ensure caret is between the two emojis
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 2),
-          );
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 2,
+            extentOffset: 0,
+          ),
+        );         
+      });
+    
+      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
 
-          // Press left arrow key to move the selection to the left
-          await tester.pressLeftArrow();
+        // Place caret before the emoji      
+        await tester.placeCaretInSuperTextField(0);
 
-          // Ensure caret is at the beginning of the text
-          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
-        });
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
 
-        testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢🐢',
-          );
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
 
-          // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
-          // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-          // Move caret to the right
-          await tester.pressRightArrow();
-          // Move caret to the right
-          await tester.pressRightArrow();
+        // Ensure caret is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );         
+      });    
 
-          // Ensure we are at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 4),
-          );
+      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
 
-          // Press shift + left arrow key to expand the selection to the left
-          await tester.pressShiftLeftArrow();
+        // Place caret before the emoji
+        await tester.placeCaretInSuperTextField(0);    
 
-          // Ensure that the last emoji is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 4,
-              extentOffset: 2,
-            ),
-          );
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
 
-          // Press shift + left arrow key to expand the selection to the left
-          await tester.pressShiftLeftArrow();
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
 
-          // Ensure the whole text is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 4,
-              extentOffset: 0,
-            ),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢🐢',
-          );
-
-          // Place caret before the first emoji
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press right arrow key to move the selection to the right
-          await tester.pressRightArrow();
-
-          // Ensure caret is between the two emojis
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 2),
-          );
-
-          // Press right arrow key to move the selection to the right
-          await tester.pressRightArrow();
-
-          // Ensure caret is at the end of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 4),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: '🐢🐢',
-          );
-
-          // Place caret before the first emoji
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press shift + right arrow key to expand the selection to the right
-          await tester.pressShiftRightArrow();
-
-          // Ensure the first emoji is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 2,
-            ),
-          );
-
-          // Press shift + right arrow key to expand the selection to the right
-          await tester.pressShiftRightArrow();
-
-          // Ensure we selected the whole text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 4,
-            ),
-          );
-        });
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
+          ),
+        );         
       });
 
-      group('containing emojis and non-emojis', () {
-        testWidgetsOnAllPlatforms("moves caret upstream around the text", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: 'a🐢b',
-          );
+      testWidgetsOnAllPlatforms("selects the emoji on double tap", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢',
+        );
 
-          // Place caret at |b
-          await tester.placeCaretInSuperTextField(3);
+        await tester.doubleTapAtSuperTextField(0);             
 
-          // Ensure we are after the emoji
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 3),
-          );
-
-          // Press left arrow key to move the selection to the left
-          await tester.pressLeftArrow();
-
-          // Ensure we are between the emoji and the 'a'
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 1),
-          );
-
-          // Press left arrow key to move the selection to the left
-          await tester.pressLeftArrow();
-
-          // Ensure caret is at the beginning of the text
-          expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 0));
-        });
-
-        testWidgetsOnAllPlatforms("expands selection upstream around the text", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: 'a🐢b',
-          );
-
-          // Place caret at |b
-          await tester.placeCaretInSuperTextField(3);
-
-          // Ensure we are after the emoji
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 3),
-          );
-
-          // Press shift + left arrow key to expand the selection to the left
-          await tester.pressShiftLeftArrow();
-
-          // Ensure we selected the emoji
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 3,
-              extentOffset: 1,
-            ),
-          );
-
-          // Press shift + left arrow key to expand the selection to the left
-          await tester.pressShiftLeftArrow();
-
-          // Ensure "a🐢" is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 3,
-              extentOffset: 0,
-            ),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("moves caret downstream around the text", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: 'a🐢b',
-          );
-
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press right arrow key to move the selection to the right
-          await tester.pressRightArrow();
-
-          // Ensure we are at a|
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 1),
-          );
-
-          // Press right arrow key to move the selection to the right
-          await tester.pressRightArrow();
-
-          // Ensure caret is after the emoji
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 3),
-          );
-        });
-
-        testWidgetsOnAllPlatforms("expands selection downstream around the text", (tester) async {
-          await _pumpSuperTextFieldEmojiTest(
-            tester,
-            text: 'a🐢b',
-          );
-
-          // Place caret at the beginning of the text
-          await tester.placeCaretInSuperTextField(0);
-
-          // Ensure we are at the beginning of the text
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection.collapsed(offset: 0),
-          );
-
-          // Press shift + right arrow key to expand the selection to the right
-          await tester.pressShiftRightArrow();
-
-          // Ensure 'a' is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 1,
-            ),
-          );
-
-          // Press shift + right arrow key to expand the selection to the right
-          await tester.pressShiftRightArrow();
-
-          // Ensure "a🐢" is selected
-          expect(
-            SuperTextFieldInspector.findSelection(),
-            const TextSelection(
-              baseOffset: 0,
-              extentOffset: 3,
-            ),
-          );
-        });
+        // Ensure that the emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
+          ),
+        );         
       });
     });
 
-    group('with unlimited lines', () {
-      testWidgetsOnDesktop("doesn't scroll vertically", (tester) async {
-        // With the Ahem font the estimated line height is equal to the true line height
-        // so we need to use a custom font.
-        await loadAppFonts();
+    group('containing only two consecutive emojis', (){
+      testWidgetsOnAllPlatforms("moves caret upstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
 
-        const verticalPadding = 6.0;
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
+        // Move caret to the right   
+        await tester.pressRightArrow();
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: ConstrainedBox(
-                constraints: const BoxConstraints(minWidth: 300),
-                child: SuperDesktopTextField(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: verticalPadding),
-                  minLines: 1,
-                  maxLines: null,
-                  textController: AttributedTextEditingController(
-                    text: AttributedText(text: "SuperTextField"),
-                  ),
-                  textStyleBuilder: (_) => const TextStyle(
-                    fontSize: 14,
-                    height: 1,
-                    fontFamily: 'Roboto',
-                  ),
-                ),
-              ),
-            ),
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );   
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is between the two emojis
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        );    
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
+      });
+
+      testWidgetsOnAllPlatforms("expands selection upstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // TODO: placing caret on the right side of the emoji at the end of the text isn't working correctly
+        // #549 - update to place caret at the end and remove the calls to pressRightArrow when that bug is fixed.
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);
+        // Move caret to the right   
+        await tester.pressRightArrow();
+        // Move caret to the right   
+        await tester.pressRightArrow();
+
+        // Ensure we are at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );      
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();   
+
+        // Ensure that the last emoji is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 4,
+            extentOffset: 2,
+          ),
+        );    
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow(); 
+
+        // Ensure the whole text is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 4,
+            extentOffset: 0,
+          ),
+        );         
+      });    
+    
+      testWidgetsOnAllPlatforms("moves caret downstream around the emoji", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret before the first emoji  
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
+
+        // Ensure caret is between the two emojis
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 2),
+        ); 
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();  
+
+        // Ensure caret is at the end of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 4),
+        );         
+      });    
+    
+      testWidgetsOnAllPlatforms("expands selection downstream around the emoji", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: '🐢🐢',
+        );
+
+        // Place caret before the first emoji
+        await tester.placeCaretInSuperTextField(0);    
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
+
+        // Ensure the first emoji is selected
+         expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 2,
           ),
         );
-        await tester.pump();
 
-        final viewportHeight = tester.getRect(find.byType(SuperTextFieldScrollview)).height;
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow(); 
 
-        final layoutState = (find.byType(SuperDesktopTextField).evaluate().single as StatefulElement).state as SuperDesktopTextFieldState;
-        final contentHeight = layoutState.textLayout.getLineHeightAtPosition(const TextPosition(offset: 0));
+        // Ensure we selected the whole text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 4,
+          ),
+        );         
+      });    
+    });  
 
-        // Vertical padding is added to both top and bottom
-        final totalHeight = contentHeight + (verticalPadding * 2);
+    group('containing emojis and non-emojis', (){
+      testWidgetsOnAllPlatforms("moves caret upstream around the text", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
 
-        // Ensure the viewport is big enough so the text doesn't scroll vertically
-        expect(viewportHeight, greaterThanOrEqualTo(totalHeight));
+        // Place caret at |b   
+        await tester.placeCaretInSuperTextField(3);   
+
+        // Ensure we are after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );   
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure we are between the emoji and the 'a'
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 1),
+        );    
+
+        // Press left arrow key to move the selection to the left
+        await tester.pressLeftArrow();   
+
+        // Ensure caret is at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0)
+        );         
+      });
+    
+      testWidgetsOnAllPlatforms("expands selection upstream around the text", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at |b
+        await tester.placeCaretInSuperTextField(3); 
+
+        // Ensure we are after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );      
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow();   
+
+        // Ensure we selected the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 3,
+            extentOffset: 1,
+          ),
+        );    
+
+        // Press shift + left arrow key to expand the selection to the left
+        await tester.pressShiftLeftArrow(); 
+
+        // Ensure "a🐢" is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 3,
+            extentOffset: 0,
+          ),
+        );         
+      });    
+    
+      testWidgetsOnAllPlatforms("moves caret downstream around the text", (tester) async {      
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at the beginning of the text    
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );     
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();      
+
+        // Ensure we are at a|
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 1),
+        ); 
+
+        // Press right arrow key to move the selection to the right
+        await tester.pressRightArrow();  
+
+        // Ensure caret is after the emoji
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 3),
+        );         
+      });    
+    
+      testWidgetsOnAllPlatforms("expands selection downstream around the text", (tester) async {           
+        await _pumpSuperTextFieldEmojiTest(tester, 
+          text: 'a🐢b',
+        );
+
+        // Place caret at the beginning of the text
+        await tester.placeCaretInSuperTextField(0);    
+
+        // Ensure we are at the beginning of the text
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection.collapsed(offset: 0),
+        );    
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow();      
+
+        // Ensure 'a' is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 1,
+          ),
+        );
+
+        // Press shift + right arrow key to expand the selection to the right
+        await tester.pressShiftRightArrow(); 
+
+        // Ensure "a🐢" is selected
+        expect(
+          SuperTextFieldInspector.findSelection(), 
+          const TextSelection(
+            baseOffset: 0,
+            extentOffset: 3,
+          ),
+        );         
       });
     });
   });
 }
 
-Future<void> _pumpSuperTextFieldEmojiTest(WidgetTester tester, {required String text}) async {
+Future<void> _pumpSuperTextFieldEmojiTest(
+  WidgetTester tester, {
+  required String text
+}) async {
   final controller = AttributedTextEditingController(
     text: AttributedText(text: text),
   );
   await tester.pumpWidget(
     MaterialApp(
-      home: Scaffold(
+      home: Scaffold(            
         body: SuperTextField(
           configuration: SuperTextFieldPlatformConfiguration.desktop,
           textController: controller,


### PR DESCRIPTION
[SuperTextField] [Desktop] Fix text behaving scrollable when maxLines is null. Resolves #566 

We use an estimated line height to calculate the `SuperTextFieldScrollview` viewport height.  Because of this, when the true line height is bigger than the estimated line height, the text is bigger than the viewport, which causes the scrolling behavior.

The root cause of https://github.com/superlistapp/super_editor/issues/565 is the same: when the text is empty, the estimated line height differs from the true line height.

I changed to use the true line height when it's available. However, this might cause the text field to change its height when the user starts typing. If there's a better solution to this I will update the PR.

There's already an open issue to calculate true line height: https://github.com/superlistapp/super_editor/issues/46