### PR TITLE
[SuperEditor] Fix scrolling issue when the editor is inside a horizontal Scrollable (Resolves #501)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -521,6 +521,22 @@ Updating drag selection:
     widget.editContext.composer.clearSelection();
   }
 
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Listener(

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -520,23 +520,7 @@ Updating drag selection:
     editorGesturesLog.fine("Clearing document selection");
     widget.editContext.composer.clearSelection();
   }
-
-  ScrollableState? _findAncestorScrollable(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
-    if (ancestorScrollable == null) {
-      return null;
-    }
-
-    final direction = ancestorScrollable.axisDirection;
-    // If the direction is horizontal, then we are inside a widget like a TabBar 
-    // or a horizontal ListView, so we can't use the ancestor scrollable 
-    if (direction == AxisDirection.left || direction == AxisDirection.right) {
-      return null;
-    }
-
-    return ancestorScrollable;
-  }
-
+  
   @override
   Widget build(BuildContext context) {
     return Listener(

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -520,7 +520,7 @@ Updating drag selection:
     editorGesturesLog.fine("Clearing document selection");
     widget.editContext.composer.clearSelection();
   }
-  
+
   @override
   Widget build(BuildContext context) {
     return Listener(

--- a/super_editor/lib/src/default_editor/document_gestures_touch.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch.dart
@@ -48,9 +48,25 @@ class ScrollableDocument extends StatelessWidget {
   /// The document layout widget.
   final Widget child;
 
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = _findAncestorScrollable(context);
     final _ancestorScrollPosition = ancestorScrollable?.position;
     final addScrollView = _ancestorScrollPosition == null;
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -153,7 +153,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    _ancestorScrollPosition = Scrollable.of(context)?.position;
+    _ancestorScrollPosition = _findAncestorScrollable(context)?.position;
 
     // On the next frame, check if our active scroll position changed to a
     // different instance. If it did, move our listener to the new one.
@@ -370,7 +370,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   /// widget includes a `ScrollView` and this `State`'s render object
   /// is the viewport `RenderBox`.
   RenderBox get viewportBox =>
-      (Scrollable.of(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
+      (_findAncestorScrollable(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
 
   /// Converts the given [offset] from the [DocumentInteractor]'s coordinate
   /// space to the [DocumentLayout]'s coordinate space.
@@ -838,6 +838,22 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void _clearSelection() {
     editorGesturesLog.fine("Clearing document selection");
     widget.composer.clearSelection();
+  }
+
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -169,7 +169,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    _ancestorScrollPosition = Scrollable.of(context)?.position;
+    _ancestorScrollPosition = _findAncestorScrollable(context)?.position;
 
     // On the next frame, check if our active scroll position changed to a
     // different instance. If it did, move our listener to the new one.
@@ -373,7 +373,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   /// widget includes a `ScrollView` and this `State`'s render object
   /// is the viewport `RenderBox`.
   RenderBox get viewportBox =>
-      (Scrollable.of(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
+      (_findAncestorScrollable(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
 
   RenderBox get interactorBox => context.findRenderObject() as RenderBox;
 
@@ -1012,6 +1012,22 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     widget.composer.selection = DocumentSelection.collapsed(
       position: position,
     );
+  }
+
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -44,6 +44,9 @@ class DocumentScrollable extends StatefulWidget {
 
   /// The [ScrollController] that governs this [DocumentScrollable]'s scroll
   /// offset.
+  ///
+  /// `scrollController` is not used if this `SuperEditor` has an ancestor
+  /// `Scrollable`.
   final ScrollController? scrollController;
 
   /// This widget's child, which should include a document.
@@ -99,7 +102,7 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
       if (oldWidget.scrollController == null) {
         _scrollController.dispose();
       }
-      _scrollController = widget.scrollController ?? ScrollController();           
+      _scrollController = widget.scrollController ?? ScrollController();
     }
 
     if (widget.autoScroller != oldWidget.autoScroller) {
@@ -120,8 +123,8 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
     // if (widget.scrollingMinimapId == null) {
     //   ScrollingMinimaps.of(context)?.put(widget.scrollingMinimapId!, null);
     // }
-    
-    if (widget.scrollController == null){
+
+    if (widget.scrollController == null) {
       _scrollController.dispose();
     }
 
@@ -137,8 +140,7 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
   /// If this widget doesn't have an ancestor `Scrollable`, then this
   /// widget includes a `ScrollView` and this `State`'s render object
   /// is the viewport `RenderBox`.
-  RenderBox get _viewport =>
-      (_findAncestorScrollable(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
+  RenderBox get _viewport => (_findAncestorScrollable(context)?.context.findRenderObject() ?? context.findRenderObject()) as RenderBox;
 
   /// Returns the `ScrollPosition` that controls the scroll offset of
   /// this widget.
@@ -159,8 +161,8 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
     }
 
     final direction = ancestorScrollable.axisDirection;
-    // If the direction is horizontal, then we are inside a widget like a TabBar 
-    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    // If the direction is horizontal, then we are inside a widget like a TabBar
+    // or a horizontal ListView, so we can't use the ancestor scrollable
     if (direction == AxisDirection.left || direction == AxisDirection.right) {
       return null;
     }

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -42,10 +42,12 @@ class DocumentScrollable extends StatefulWidget {
   /// debugging, when `true`.
   final bool showDebugPaint;
 
+  /// The [ScrollController] that governs this [DocumentScrollable]'s scroll
+  /// offset.
+  final ScrollController? scrollController;
+
   /// This widget's child, which should include a document.
   final Widget child;
-
-  final ScrollController? scrollController;
 
   @override
   State<DocumentScrollable> createState() => _DocumentScrollableState();

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -567,6 +567,7 @@ class SuperEditorState extends State<SuperEditor> {
     return LayoutBuilder(builder: (context, viewportConstraints) {
       return DocumentScrollable(
         autoScroller: _autoScrollController,
+        scrollController: widget.scrollController,
         scrollingMinimapId: widget.debugPaint.scrollingMinimapId,
         showDebugPaint: widget.debugPaint.scrolling,
         child: ConstrainedBox(

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -397,7 +397,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField> with Ticke
   /// is visible on the viewport when it's focused
   void _autoScrollToKeepTextFieldVisible() {
     // If we are not inside a [Scrollable] we don't autoscroll
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = _findAncestorScrollable(context);
     if (ancestorScrollable == null) {
       return;
     }
@@ -428,6 +428,22 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField> with Ticke
       duration: _autoScrollAnimationDuration,
       curve: _autoScrollAnimationCurve,
     );
+  }
+
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -393,7 +393,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
   /// is visible on the viewport when it's focused
   void _autoScrollToKeepTextFieldVisible() {
     // If we are not inside a [Scrollable] we don't autoscroll
-    final ancestorScrollable = Scrollable.of(context);
+    final ancestorScrollable = _findAncestorScrollable(context);
     if (ancestorScrollable == null) {
       return;
     }
@@ -424,6 +424,22 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField> with TickerProvide
       duration: _autoScrollAnimationDuration,
       curve: _autoScrollAnimationCurve,
     );
+  }
+
+  ScrollableState? _findAncestorScrollable(BuildContext context) {
+    final ancestorScrollable = Scrollable.of(context);
+    if (ancestorScrollable == null) {
+      return null;
+    }
+
+    final direction = ancestorScrollable.axisDirection;
+    // If the direction is horizontal, then we are inside a widget like a TabBar 
+    // or a horizontal ListView, so we can't use the ancestor scrollable 
+    if (direction == AxisDirection.left || direction == AxisDirection.right) {
+      return null;
+    }
+
+    return ancestorScrollable;
   }
 
   @override

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -99,7 +99,8 @@ class TestDocumentConfigurator {
   bool _autoFocus = false;
   ui.Size? _editorSize;
   List<ComponentBuilder>? _componentBuilders;
-  SubtreeBuilder? _subtreeBuilder;
+  WidgetTreeBuilder? _widgetTreeBuilder;
+  ScrollController? _scrollController;
 
   /// Configures the [SuperEditor] for standard desktop interactions,
   /// e.g., mouse and keyboard input.
@@ -151,11 +152,15 @@ class TestDocumentConfigurator {
     return this;
   }
 
-  /// Configures the [SuperEditor] to use a custom subtree between [MaterialApp] and [SuperEditor].
-  ///
-  /// By default, [SuperEditor] is displayed inside a [Scaffold].
-  TestDocumentConfigurator withCustomSubtree(SubtreeBuilder? builder) {
-    _subtreeBuilder = builder;
+  /// Configures the [SuperEditor] to use a custom widget tree above [SuperEditor].
+  TestDocumentConfigurator withCustomWidgetTreeBuilder(WidgetTreeBuilder? builder) {
+    _widgetTreeBuilder = builder;
+    return this;
+  }
+
+  /// Configures the [SuperEditor] to use the given [scrollController]
+  TestDocumentConfigurator withScrollController(ScrollController? scrollController) {
+    _scrollController = scrollController;
     return this;
   }
 
@@ -265,14 +270,12 @@ class TestDocumentConfigurator {
           ...(_componentBuilders ?? defaultComponentBuilders),
         ],
         autofocus: _autoFocus,
+        scrollController: _scrollController,
       ),
     );
 
     await _widgetTester.pumpWidget(
-      MaterialApp(
-        theme: _appTheme,
-        home: _buildSubtree(superEditor),
-      ),
+      _buildWidgetTree(superEditor),
     );
 
     return testDocumentContext;
@@ -291,18 +294,21 @@ class TestDocumentConfigurator {
     return superEditor;
   }
 
-  Widget _buildSubtree(Widget superEditor) {
-    if (_subtreeBuilder != null) {
-      return _subtreeBuilder!(superEditor);
+  Widget _buildWidgetTree(Widget superEditor) {
+    if (_widgetTreeBuilder != null) {
+      return _widgetTreeBuilder!(superEditor);
     }
-    return Scaffold(
-      body: superEditor,
+    return MaterialApp(
+      theme: _appTheme,
+      home: Scaffold(
+        body: superEditor,
+      ),
     );
   }
 }
 
-/// Must return a widget subtree containing the given [superEditor]
-typedef SubtreeBuilder = Widget Function(Widget superEditor);
+/// Must return a widget tree containing the given [superEditor]
+typedef WidgetTreeBuilder = Widget Function(Widget superEditor);
 
 class TestDocumentContext {
   const TestDocumentContext._({

--- a/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
+++ b/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../test_tools.dart';
+import 'document_test_tools.dart';
+import 'supereditor_robot.dart';
+
+void main() {
+  group('SuperEditor', () {
+    group('inside a TabBar', () {
+      testWidgetsOnAllPlatforms("doesn't change TabBar index", (tester) async {
+        final tabController = TabController(length: 2, vsync: tester);
+
+        await tester
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(DocumentInputSource.ime)
+            .withCustomSubtree(
+              (superEditor) => ConstrainedBox(
+                constraints: const BoxConstraints(
+                  minWidth: 300,
+                  maxHeight: 100,
+                ),
+                child: Scaffold(
+                  appBar: AppBar(
+                    bottom: TabBar(
+                      controller: tabController,
+                      tabs: const [
+                        Tab(text: 'Tab 1'),
+                        Tab(text: 'Tab 2'),
+                      ],
+                    ),
+                  ),
+                  body: TabBarView(
+                    controller: tabController,
+                    children: [
+                      superEditor,
+                      const SizedBox(),
+                    ],
+                  ),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure SuperEditor added its own Scrollview.
+        // If the Scrollview wasn't added, the content will overflow
+        // the editor bounds.
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+
+        // Select the editor.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Add new lines so the content will cause editor to scroll
+        await _addNewLines(tester, count: 20);
+
+        // Ensure that scrolling didn't cause a tab change
+        expect(tabController.index, equals(0));
+      });
+    });
+
+    group('inside a horizontal ListView', () {
+      testWidgetsOnAllPlatforms("doesn't scroll the ListView", (tester) async {
+        final scrollController = ScrollController();
+
+        await tester
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(DocumentInputSource.ime)
+            .withCustomSubtree(
+              (superEditor) => Scaffold(
+                body: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minWidth: 300,
+                    maxHeight: 100,
+                    maxWidth: 300,
+                  ),
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    controller: scrollController,
+                    children: [
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 100),
+                        child: superEditor,
+                      ),
+                      ...List.generate(20, (index) => Text('Text $index')),
+                    ],
+                  ),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure SuperEditor added its own Scrollview.
+        // If the Scrollview wasn't added, the content will overflow
+        // the editor bounds.
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+
+        // Select the editor.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Add new lines so the content will cause editor to scroll
+        await _addNewLines(tester, count: 20);
+
+        // Ensure that scrolling didn't scroll the ListView
+        expect(scrollController.position.pixels, equals(0));
+      });
+    });
+  });
+}
+
+/// Adds [count] new lines using IME actions
+Future<void> _addNewLines(
+  WidgetTester tester, {
+  required int count,
+}) async {
+  for (int i = 0; i < count; i++) {
+    await tester.testTextInput.receiveAction(TextInputAction.newline);
+    await tester.pump();
+  }
+}

--- a/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
+++ b/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
@@ -56,7 +56,7 @@ void main() {
       await tester.placeCaretInParagraph('1', 0);
 
       // Add new lines so the content will cause editor to scroll
-      await _addNewLines(tester, count: 20);
+      await _addNewLines(tester, count: 40);
       await tester.pumpAndSettle();
 
       // Ensure SuperEditor has scrolled
@@ -110,7 +110,7 @@ void main() {
       await tester.placeCaretInParagraph('1', 0);
 
       // Add new lines so the content will cause editor to scroll
-      await _addNewLines(tester, count: 20);
+      await _addNewLines(tester, count: 40);
       await tester.pumpAndSettle();
 
       // Ensure SuperEditor has scrolled

--- a/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
+++ b/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
@@ -47,11 +47,6 @@ void main() {
           )
           .pump();
 
-      // Ensure SuperEditor added its own Scrollview.
-      // If the Scrollview wasn't added, the content will overflow
-      // the editor bounds.
-      expect(find.byType(SingleChildScrollView), findsOneWidget);
-
       // Select the editor.
       await tester.placeCaretInParagraph('1', 0);
 
@@ -100,11 +95,6 @@ void main() {
             ),
           )
           .pump();
-
-      // Ensure SuperEditor added its own Scrollview.
-      // If the Scrollview wasn't added, the content will overflow
-      // the editor bounds.
-      expect(find.byType(SingleChildScrollView), findsOneWidget);
 
       // Select the editor.
       await tester.placeCaretInParagraph('1', 0);

--- a/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
+++ b/super_editor/test/super_editor/supereditor_ancestor_scrollable_test.dart
@@ -12,6 +12,8 @@ void main() {
       final tabController = TabController(length: 2, vsync: tester);
       final scrollController = ScrollController();
 
+      // Pump a SuperEditor with a small maxHeight, so adding lines
+      // will cause the editor to scroll.
       await tester
           .createDocument()
           .withSingleEmptyParagraph()
@@ -65,6 +67,8 @@ void main() {
       final listScrollController = ScrollController();
       final editorScrollController = ScrollController();
 
+      // Pump a SuperEditor with a small maxHeight, so adding lines
+      // will cause the editor to scroll.
       await tester
           .createDocument()
           .withSingleEmptyParagraph()


### PR DESCRIPTION
[SuperEditor] Fix scrolling issue when the editor is inside a horizontal `Scrollable`. Resolves #501

When adding the editor to a `TabBarView`, once the screen is filled with text, the `TabBarView` automatically changes to the next tab rather than scroll down in the editor.

A similar issue happens when adding the editor inside a horizontal `ListView`, where adding text causes the `ListView` to scroll.

The problem is that when `SuperEditor` has an ancestor `Scrollable`, it doesn't create its own `SingleChildScrollView` and scrolls the ancestor `Scrollable` instead. Because of that, widgets that use a horizontal `Scrollable` are affected.

I changed it to ignore the ancestor `Scrollable` if it has a horizontal `AxisDirection`.

I also added an option in `TestDocumentConfigurator` to configure the subtree between `MaterialApp` and `SuperEditor`.
