### PR TITLE
[AttributedText] Add method to get the attributed range for a set of attributions. (Resolves #590)

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -232,9 +232,7 @@ class AttributedSpans {
         throw Exception(
             'Tried to get the attributed range of ($attribution) at offset "$offset" but the given attribution does not exist at that offset.');
       }
-      // The following methods should be guaranteed to produce non-null
-      // values because we already verified that the attribution
-      // exists at the given offset.
+
       int startMarkerOffset = _getStartingMarkerAtOrBefore(offset, attribution: attribution)!.offset;
       int endMarkerOffset = _getEndingMarkerAtOrAfter(offset, attribution: attribution)!.offset;
 
@@ -247,9 +245,8 @@ class AttributedSpans {
       }
     }
 
-    // Both offsets should be guaranteed to be non-null
-    // because we verify that all attributions are present at 
-    // the given offset.
+    // Note: maxStartMarkerOffset and minEndMarkerOffset are non-null because we verified
+    // that all desired attributions are present at the given offset.
     return SpanRange(
       start: maxStartMarkerOffset!,
       end: minEndMarkerOffset!,

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -216,9 +216,9 @@ class AttributedSpans {
     return matchingAttributionSpans;
   }
 
-  /// Returns the range that's attributed around [offset]. [attributions] must not be empty.
+  /// Returns the range about [offset], which is attributed with all given [attributions].
   ///
-  /// It will return only the portion in which all attributions are present.
+  /// [attributions] must not be empty.
   SpanRange getAttributedRange(Set<Attribution> attributions, int offset) {
     if (attributions.isEmpty) {
       throw Exception('getAttributedRange requires a non empty set of attributions');
@@ -229,8 +229,12 @@ class AttributedSpans {
 
     for (final attribution in attributions) {
       if (!hasAttributionAt(offset, attribution: attribution)) {
-        throw Exception('Tried to get the attributed range of ($attribution) at offset "$offset" but the given attribution does not exist at that offset.');
+        throw Exception(
+            'Tried to get the attributed range of ($attribution) at offset "$offset" but the given attribution does not exist at that offset.');
       }
+      // The following methods should be guaranteed to produce non-null
+      // values because we already verified that the attribution
+      // exists at the given offset.
       int startMarkerOffset = _getStartingMarkerAtOrBefore(offset, attribution: attribution)!.offset;
       int endMarkerOffset = _getEndingMarkerAtOrAfter(offset, attribution: attribution)!.offset;
 
@@ -243,6 +247,9 @@ class AttributedSpans {
       }
     }
 
+    // Both offsets should be guaranteed to be non-null
+    // because we verify that all attributions are present at 
+    // the given offset.
     return SpanRange(
       start: maxStartMarkerOffset!,
       end: minEndMarkerOffset!,

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -109,11 +109,11 @@ class AttributedSpans {
     int offset, {
     Attribution? attribution,
   }) {
-    SpanMarker? markerBefore = _getStartingMarkerAtOrBefore(offset, attribution: attribution);
+    SpanMarker? markerBefore = getStartingMarkerAtOrBefore(offset, attribution: attribution);
     if (markerBefore == null) {
       return false;
     }
-    SpanMarker? markerAfter = _getEndingMarkerAtOrAfter(markerBefore.offset, attribution: attribution);
+    SpanMarker? markerAfter = getEndingMarkerAtOrAfter(markerBefore.offset, attribution: attribution);
     if (markerAfter == null) {
       throw Exception('Found an open-ended attribution. It starts with: $markerBefore');
     }
@@ -140,8 +140,8 @@ class AttributedSpans {
     // The following methods should be guaranteed to produce non-null
     // values because we already verified that the given attribution
     // exists at the given offset.
-    SpanMarker markerBefore = _getStartingMarkerAtOrBefore(offset, attribution: attribution)!;
-    SpanMarker markerAfter = _getEndingMarkerAtOrAfter(markerBefore.offset, attribution: attribution)!;
+    SpanMarker markerBefore = getStartingMarkerAtOrBefore(offset, attribution: attribution)!;
+    SpanMarker markerAfter = getEndingMarkerAtOrAfter(markerBefore.offset, attribution: attribution)!;
 
     return AttributionSpan(
       attribution: attribution,
@@ -218,7 +218,7 @@ class AttributedSpans {
   /// Finds and returns the nearest [start] marker that appears at or before the
   /// given [offset], optionally looking specifically for a marker with
   /// the given [attribution].
-  SpanMarker? _getStartingMarkerAtOrBefore(int offset, {Attribution? attribution}) {
+  SpanMarker? getStartingMarkerAtOrBefore(int offset, {Attribution? attribution}) {
     return markers //
         .reversed // search from the end so its the nearest start marker
         .where((marker) {
@@ -232,7 +232,7 @@ class AttributedSpans {
   /// Finds and returns the nearest [end] marker that appears at or after the
   /// given [offset], optionally looking specifically for a marker with
   /// the given [attribution].
-  SpanMarker? _getEndingMarkerAtOrAfter(int offset, {Attribution? attribution}) {
+  SpanMarker? getEndingMarkerAtOrAfter(int offset, {Attribution? attribution}) {
     return markers
         .where((marker) =>
             attribution == null ||

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -142,6 +142,39 @@ class AttributedText {
     );
   }
 
+  /// Returns the range that's attributed around [offset]. [attributions] must not be empty.
+  ///
+  /// It will return only the portion in which all attributions are present.
+  SpanRange getAttributedRange(Set<Attribution> attributions, int offset) {
+    if (attributions.isEmpty) {
+      throw Exception('getAttributedRange requires a non empty set of attributions');
+    }
+
+    int? maxStartMarkerOffset;
+    int? minEndMarkerOffset;
+
+    for (final attribution in attributions) {
+      if (!hasAttributionAt(offset, attribution: attribution)) {
+        throw Exception('Tried to get the attributed range of ($attribution) at offset "$offset" but the given attribution does not exist at that offset.');
+      }
+      int startMarkerOffset = spans.getStartingMarkerAtOrBefore(offset, attribution: attribution)!.offset;
+      int endMarkerOffset = spans.getEndingMarkerAtOrAfter(offset, attribution: attribution)!.offset;
+
+      if (maxStartMarkerOffset == null || startMarkerOffset > maxStartMarkerOffset) {
+        maxStartMarkerOffset = startMarkerOffset;
+      }
+
+      if (minEndMarkerOffset == null || endMarkerOffset < minEndMarkerOffset) {
+        minEndMarkerOffset = endMarkerOffset;
+      }
+    }
+
+    return SpanRange(
+      start: maxStartMarkerOffset!,
+      end: minEndMarkerOffset!,
+    );
+  }
+
   /// Adds the given [attribution] to all characters within the given
   /// [range], inclusive.
   void addAttribution(Attribution attribution, SpanRange range) {

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -142,9 +142,9 @@ class AttributedText {
     );
   }
 
-  /// Returns the range that's attributed around [offset]. [attributions] must not be empty.
+  /// Returns the range about [offset], which is attributed with all given [attributions].
   ///
-  /// It will return only the portion in which all attributions are present.
+  /// [attributions] must not be empty.
   SpanRange getAttributedRange(Set<Attribution> attributions, int offset) {
     return spans.getAttributedRange(attributions, offset);
   }

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -146,33 +146,7 @@ class AttributedText {
   ///
   /// It will return only the portion in which all attributions are present.
   SpanRange getAttributedRange(Set<Attribution> attributions, int offset) {
-    if (attributions.isEmpty) {
-      throw Exception('getAttributedRange requires a non empty set of attributions');
-    }
-
-    int? maxStartMarkerOffset;
-    int? minEndMarkerOffset;
-
-    for (final attribution in attributions) {
-      if (!hasAttributionAt(offset, attribution: attribution)) {
-        throw Exception('Tried to get the attributed range of ($attribution) at offset "$offset" but the given attribution does not exist at that offset.');
-      }
-      int startMarkerOffset = spans.getStartingMarkerAtOrBefore(offset, attribution: attribution)!.offset;
-      int endMarkerOffset = spans.getEndingMarkerAtOrAfter(offset, attribution: attribution)!.offset;
-
-      if (maxStartMarkerOffset == null || startMarkerOffset > maxStartMarkerOffset) {
-        maxStartMarkerOffset = startMarkerOffset;
-      }
-
-      if (minEndMarkerOffset == null || endMarkerOffset < minEndMarkerOffset) {
-        minEndMarkerOffset = endMarkerOffset;
-      }
-    }
-
-    return SpanRange(
-      start: maxStartMarkerOffset!,
-      end: minEndMarkerOffset!,
-    );
+    return spans.getAttributedRange(attributions, offset);
   }
 
   /// Adds the given [attribution] to all characters within the given

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -156,6 +156,115 @@ void main() {
           ),
         );
       });
+
+      group('getAttributedRange', () {
+        test('returns the range of a single attribution for an offset in the middle of a span', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold}, 5);
+          expect(range, SpanRange(start: 4, end: 9));
+        });
+
+        test('returns the range of a single attribution for an offset at the beginning of a span', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold}, 4);
+          expect(range, SpanRange(start: 4, end: 9));
+        });
+
+        test('returns the range of a single attribution for an offset at the end of a span', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold}, 9);
+          expect(range, SpanRange(start: 4, end: 9));
+        });
+
+        test('returns the range for multiple attributions for an offset in the middle of the overlapping range', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 5);
+          expect(range, SpanRange(start: 4, end: 7));
+        });
+
+        test('returns the range for multiple attributions for an offset at the beginning of the overlapping range', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 4);
+          expect(range, SpanRange(start: 4, end: 7));
+        });
+
+        test('returns the range for multiple attributions for an offset at the end of the overlapping range', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 7);
+          expect(range, SpanRange(start: 4, end: 7));
+        });
+
+        test('throws when given an empty attribution set', () {
+          final spans = AttributedSpans();
+
+          expect(() => spans.getAttributedRange({}, 0), throwsException);
+        });
+
+        test('throws when any attribution is not present at the given offset', () {
+          final spans = AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          );
+
+          expect(() => spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 7), throwsException);
+        });
+      });
     });
 
     group('single attribution', () {
@@ -651,8 +760,7 @@ class _LinkAttribution implements Attribution {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is _LinkAttribution && runtimeType == other.runtimeType && url == other.url;
+  bool operator ==(Object other) => identical(this, other) || other is _LinkAttribution && runtimeType == other.runtimeType && url == other.url;
 
   @override
   int get hashCode => url.hashCode;

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -178,5 +178,98 @@ void main() {
         );
       });
     });
+
+    group('getAttributedRange', () {
+      test('returns the range of a single attribution for an offset in the middle of a span', () {
+        final attributedText = AttributedText(
+          text: 'Hello world',
+          spans: AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          ),
+        );
+
+        final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 5);
+        expect(range, SpanRange(start: 4, end: 9));
+      });
+
+      test('returns the range of a single attribution for an offset at the beginning of a span', () {
+        final attributedText = AttributedText(
+          text: 'Hello world',
+          spans: AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          ),
+        );
+
+        final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 4);
+        expect(range, SpanRange(start: 4, end: 9));
+      });
+
+      test('returns the range of a single attribution for an offset at the end of a span', () {
+        final attributedText = AttributedText(
+          text: 'Hello world',
+          spans: AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          ),
+        );
+
+        final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 9);
+        expect(range, SpanRange(start: 4, end: 9));
+      });
+
+      test('returns the range for multiple attributions', () {
+        final attributedText = AttributedText(
+          text: 'Hello world',
+          spans: AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+            ],
+          ),
+        );
+
+        final range = attributedText.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 5);
+        expect(range, SpanRange(start: 4, end: 7));
+      });
+
+      test('throws when given an empty attribution set', () {
+        final attributedText = AttributedText(text: 'Hello world');
+
+        expect(() => attributedText.getAttributedRange({}, 0), throwsException);
+      });
+
+      test('throws when any attribution is not present at the given offset', () {
+        final attributedText = AttributedText(
+          text: 'Hello world',
+          spans: AttributedSpans(
+            attributions: [
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+              
+            ],
+          ),
+        );
+
+        expect(() => attributedText.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 7), throwsException);
+      });
+    });
   });
 }

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -179,16 +179,14 @@ void main() {
       });
     });
 
-    group('getAttributedRange', () {
-      test('returns the range of a single attribution for an offset in the middle of a span', () {
+    group('attribution queries', () {
+      test('finds all bold text around a character', () {
         final attributedText = AttributedText(
           text: 'Hello world',
           spans: AttributedSpans(
             attributions: [
               SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
               SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -197,41 +195,7 @@ void main() {
         expect(range, SpanRange(start: 4, end: 9));
       });
 
-      test('returns the range of a single attribution for an offset at the beginning of a span', () {
-        final attributedText = AttributedText(
-          text: 'Hello world',
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
-            ],
-          ),
-        );
-
-        final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 4);
-        expect(range, SpanRange(start: 4, end: 9));
-      });
-
-      test('returns the range of a single attribution for an offset at the end of a span', () {
-        final attributedText = AttributedText(
-          text: 'Hello world',
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
-            ],
-          ),
-        );
-
-        final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 9);
-        expect(range, SpanRange(start: 4, end: 9));
-      });
-
-      test('returns the range for multiple attributions', () {
+      test('finds all bold and italics text around a character', () {
         final attributedText = AttributedText(
           text: 'Hello world',
           spans: AttributedSpans(
@@ -250,25 +214,23 @@ void main() {
         expect(range, SpanRange(start: 4, end: 7));
       });
 
-      test('throws when given an empty attribution set', () {
-        final attributedText = AttributedText(text: 'Hello world');
-
-        expect(() => attributedText.getAttributedRange({}, 0), throwsException);
-      });
-
-      test('throws when any attribution is not present at the given offset', () {
+      test('finds all bold, italic and strikethrough text within a word that also includes a span with only bold and italics', () {
         final attributedText = AttributedText(
           text: 'Hello world',
           spans: AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
-              
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.end),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 1, markerType: SpanMarkerType.start),
+              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 3, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
-        expect(() => attributedText.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 7), throwsException);
+        final range = attributedText.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics, ExpectedSpans.strikethrough}, 2);
+        expect(range, SpanRange(start: 1, end: 3));
       });
     });
   });


### PR DESCRIPTION
[AttributedText] Add method to get the attributed range for a set of attributions. Resolves https://github.com/superlistapp/super_editor/issues/590

This PR adds a method to return the span range that's attributed around an offset.

For example:

`He**ll~o Wor**ld~` 

Calling this method with the offset of "W" and the attributions `bold` and `strikethrough` will return the range of "o Wor".

I made `getStartingMarkerAtOrBefore` and `getEndingMarkerAtOrAfter` public to avoid duplicating the code.