### PR TITLE
[SuperTextField] [Desktop] Fix hint text cutting off (Resolves #565)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -114,7 +114,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
 
   double? _viewportHeight;
 
-  final _textMetrics = _TextMetrics();
+  final _estimatedLineHeight = _EstimatedLineHeight();
 
   @override
   void initState() {
@@ -258,7 +258,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
       return lineHeight;
     }
     final defaultStyle = widget.textStyleBuilder({});
-    return _textMetrics.estimateLineHeight(defaultStyle);
+    return _estimatedLineHeight.calculate(defaultStyle);
   }
 
   @override
@@ -1682,7 +1682,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
 }
 
 /// Computes the estimated line height of a [TextStyle].
-class _TextMetrics {
+class _EstimatedLineHeight {
   /// Last computed line height.
   double? _lastLineHeight;
 
@@ -1696,7 +1696,7 @@ class _TextMetrics {
   ///
   /// The result is cached for the last [style] used, so it's not computed
   /// at each call.
-  double estimateLineHeight(TextStyle style) {
+  double calculate(TextStyle style) {
     if (_lastComputedStyle == style && _lastLineHeight != null) {
       return _lastLineHeight!;
     }

--- a/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
@@ -12,13 +12,13 @@ void main() {
       // is always equal to the true line height.
       await loadAppFonts();
 
-      // Pump an empty SuperTextField.
+      // Pump an empty SuperTextField containing a hint text.
       final controller = AttributedTextEditingController();
       await _pumpScaffold(tester, controller: controller);
       await tester.pumpAndSettle();
 
-      // When the text field is empty the line height is estimated.
-      final heightWithEmptyText = tester.getSize(find.byType(SuperTextField)).height;
+      // When the text field is displaying only the hint, the line height is estimated.
+      final heightWithHintText = tester.getSize(find.byType(SuperTextField)).height;
 
       // Change the text, this should recompute viewport height.
       controller.text = AttributedText(text: 'Leave a message');
@@ -28,7 +28,7 @@ void main() {
       final heightWithText = tester.getSize(find.byType(SuperTextField)).height;
 
       // Ensure the text field has ~ the same height when it's empty and when it has content
-      expect(heightWithEmptyText.truncate(), equals(heightWithText.truncate()));
+      expect((heightWithHintText - heightWithText).abs(), lessThanOrEqualTo(3e-1));
     });
   });
 }

--- a/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
@@ -18,17 +18,17 @@ void main() {
       await tester.pumpAndSettle();
 
       // When the text field is empty the line height is estimated.
-      final lineHeightWithEmptyText = tester.getSize(find.byType(SingleChildScrollView)).height;
+      final heightWithEmptyText = tester.getSize(find.byType(SuperTextField)).height;
 
       // Change the text, this should recompute viewport height.
       controller.text = AttributedText(text: 'Leave a message');
       await tester.pumpAndSettle();
 
       // When the text field has content the line height should be the true line height.
-      final lineHeightWithText = tester.getSize(find.byType(SingleChildScrollView)).height;
+      final heightWithText = tester.getSize(find.byType(SuperTextField)).height;
 
       // Ensure the text field has ~ the same height when it's empty and when it has content
-      expect(lineHeightWithEmptyText.truncate(), equals(lineHeightWithText.truncate()));
+      expect(heightWithEmptyText.truncate(), equals(heightWithText.truncate()));
     });
   });
 }

--- a/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../test_tools.dart';
+
+void main() {
+  group('SuperTextField', () {
+    testWidgetsOnArbitraryDesktop('computes line height for empty field', (tester) async {
+      // We need to load the app fonts, because using Ahem the estimated line height
+      // is always equal to the true line height.
+      await loadAppFonts();
+
+      // Pump an empty SuperTextField.
+      final controller = AttributedTextEditingController();
+      await _pumpScaffold(tester, controller: controller);
+      await tester.pumpAndSettle();
+
+      // When the text field is empty the line height is estimated.
+      final lineHeightWithEmptyText = tester.getSize(find.byType(SingleChildScrollView)).height;
+
+      // Change the text, this should recompute viewport height.
+      controller.text = AttributedText(text: 'Leave a message');
+      await tester.pumpAndSettle();
+
+      // When the text field has content the line height should be the true line height.
+      final lineHeightWithText = tester.getSize(find.byType(SingleChildScrollView)).height;
+
+      // Ensure the text field has ~ the same height when it's empty and when it has content
+      expect(lineHeightWithEmptyText.truncate(), equals(lineHeightWithText.truncate()));
+    });
+  });
+}
+
+Future<void> _pumpScaffold(WidgetTester tester, {required AttributedTextEditingController controller}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperTextField(
+          textController: controller,
+          hintBuilder: (context) {
+            return const Text(
+              'Leave a message',
+              style: TextStyle(
+                color: Colors.grey,
+                fontSize: 16,
+                fontFamily: 'Roboto',
+              ),
+            );
+          },
+          hintBehavior: HintBehavior.displayHintUntilTextEntered,
+          minLines: 1,
+          maxLines: null,
+          textStyleBuilder: (_) => const TextStyle(
+            fontSize: 16,
+            fontFamily: 'Roboto',
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
[SuperTextField] [Desktop] Fix hint text cutting off. Resolves #565

SuperTextField calculates its viewport height based on an estimated line height. This estimation may differ from the true line height. This difference can cause the hint text to be cut off, because the text field may not have enough room to display it.

The line height is calculated using the text layout `getLineHeightAtPosition` when it's available, so when there is text the field should have the correct height.

This PR changes the line height estimation to be calculated by laying out a `Paragraph` with a single arbitrary character and inspecting its line metrics.