### PR TITLE
[SuperEditor] Fix serialization/deserialization of empty paragraphs (Resolves #710)

### DIFF
--- a/super_editor/test/super_editor/document_test_tools_test.dart
+++ b/super_editor/test/super_editor/document_test_tools_test.dart
@@ -37,7 +37,9 @@ void main() {
         await tester //
             .createDocument() //
             .fromMarkdown('''This is **paragraph 1**.
+
 This is *paragraph 2*.
+
 This is [paragraph 3](https://flutter.dev).''') //
             .forDesktop() //
             .pump();
@@ -45,7 +47,9 @@ This is [paragraph 3](https://flutter.dev).''') //
         expect(
           SuperEditorInspector.findDocument()!,
           equalsMarkdown('''This is **paragraph 1**.
+
 This is *paragraph 2*.
+
 This is [paragraph 3](https://flutter.dev).'''),
         );
       });

--- a/super_editor/test/super_editor/supereditor_component_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_component_selection_test.dart
@@ -312,7 +312,7 @@ void main() {
       expect(
         find.byType(SuperEditor),
         equalsMarkdown(
-          "This is the first node in a document.\n"
+          "This is the first node in a document.\n\n"
           "This is the third node in a document.",
         ),
       );
@@ -337,7 +337,7 @@ void main() {
       expect(
         find.byType(SuperEditor),
         equalsMarkdown(
-          "This is the first node in a document.\n"
+          "This is the first node in a document.\n\n"
           "This is the third node in a document.",
         ),
       );

--- a/super_editor_markdown/lib/src/markdown.dart
+++ b/super_editor_markdown/lib/src/markdown.dart
@@ -560,8 +560,10 @@ class AttributedTextMarkdownSerializer extends AttributionVisitor {
 
   /// Writes the given [text] to [_buffer].
   ///
-  /// Separates multiple lines in a single paragraph according to
-  /// the Markdown spec.
+  /// Separates multiple lines in a single paragraph using two spaces before each line break.
+  /// 
+  /// A line ending with two or more spaces represents a hard line break,
+  /// as defined in the Markdown spec.
   void _writeTextToBuffer(String text) {
     final lines = text.split('\n');
     for (int i = 0; i < lines.length; i++) {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -415,6 +415,70 @@ This is some code
         expect(serializeDocumentToMarkdown(doc, syntax: MarkdownSyntax.normal), 'Paragraph1');
       });
 
+      test('empty paragraph', () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
+            ParagraphNode(id: '2', text: AttributedText(text: '')),
+            ParagraphNode(id: '3', text: AttributedText(text: 'Paragraph3')),
+          ]),
+        );
+
+        expect(serialized, """Paragraph1
+
+
+
+Paragraph3""");
+      });
+
+      test('separates multiple paragraphs with blank lines', () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
+            ParagraphNode(id: '2', text: AttributedText(text: 'Paragraph2')),
+            ParagraphNode(id: '3', text: AttributedText(text: 'Paragraph3')),
+          ]),
+        );
+
+        expect(serialized, """Paragraph1
+
+Paragraph2
+
+Paragraph3""");
+      });
+
+      test('separates paragraph from other blocks with blank lines', () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'First Paragraph')),
+            HorizontalRuleNode(id: '2'),
+          ]),
+        );
+
+        expect(serialized, 'First Paragraph\n\n---');
+      });
+
+      test('preserves linebreaks at the end of a paragraph', () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1\n')),
+            ParagraphNode(id: '2', text: AttributedText(text: 'Paragraph2')),
+          ]),
+        );
+
+        expect(serialized, 'Paragraph1\n\n\nParagraph2');
+      });
+
+      test('preserves linebreaks within a paragraph', () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'Line1\n\nLine2')),
+          ]),
+        );
+
+        expect(serialized, 'Line1\n\nLine2');
+      });
+
       test('image', () {
         final doc = MutableDocument(nodes: [
           ImageNode(
@@ -627,6 +691,16 @@ This is some code
 
         // ignore: unused_local_variable
         final markdown = serializeDocumentToMarkdown(doc);
+      });
+
+      test("doesn't add empty lines at the end of the document", () {
+        final serialized = serializeDocumentToMarkdown(
+          MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
+          ]),
+        );
+
+        expect(serialized, 'Paragraph1');
       });
     });
 
@@ -936,6 +1010,20 @@ This is some code
         final paragraph = doc.nodes.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), isNull);
         expect(paragraph.text.text, ':---\nParagraph1');
+      });
+
+      test('empty paragraph', () {
+        final input = """Paragraph1
+
+
+
+Paragraph3""";
+        final doc = deserializeMarkdownToDocument(input);
+
+        expect(doc.nodes.length, 3);
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'Paragraph1');
+        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect((doc.nodes[2] as ParagraphNode).text.text, 'Paragraph3');
       });
     });
   });


### PR DESCRIPTION
[SuperEditor] Fix serialization/deserialization of empty paragraphs. Resolves #710

The markdown spec doesn't describe how to represent empty paragraphs, so multiple blank lines between paragraphs are ignored. However, we don't want to delete empty paragraphs when serializing/deserializing.

This PR changes the deserialization logic so that when we get two consecutive blank lines, the second one is considered an empty paragraph.

Also, SuperEditor doesn't add blank lines after paragraphs. This causes problems when deserializing some blocks.  For example:

A document containing one paragraph and one horizontal rule is serialized as
```
Paragraph
---
```

When this markdown is deserialized, it's interpreted as a setext-style header and we lose the horizontal rule.

This PR changes the paragraph serialization to add a blank line after a paragraph, except when it's the last node in the document.

The example above will now produce:

```
Paragraph

---
```

One thing that's still missing is the deserialization of paragraphs that aren't empty, but contain blank lines. The blank lines are serialized, but during serialization, they might be interpreted as empty paragraphs. 

One possible solution is to use hard line breaks as described in the markdown spec, where we would add two spaces before the line break. That way, the line break and the next line would be considered part of the previous paragraph.