### PR TITLE
[super_editor_markdown] Fix serialization of text alignment, strikethrough and underline (Resolves #717)

### DIFF
--- a/super_editor_markdown/lib/src/markdown.dart
+++ b/super_editor_markdown/lib/src/markdown.dart
@@ -310,7 +310,12 @@ class _MarkdownToDocument implements md.NodeVisitor {
   }
 
   _InlineMarkdownToDocument _parseInline(md.Element element) {
-    final inlineParser = md.InlineParser(element.textContent, md.Document());
+    final inlineParser = md.InlineParser(
+      element.textContent,
+      md.Document(
+        inlineSyntaxes: [md.StrikethroughSyntax()],
+      ),
+    );
     final inlineVisitor = _InlineMarkdownToDocument();
     final inlineNodes = inlineParser.parse();
     for (final inlineNode in inlineNodes) {
@@ -388,6 +393,14 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
     } else if (element.tag == 'em') {
       styledText.addAttribution(
         italicsAttribution,
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    } else if (element.tag == "del") {
+      styledText.addAttribution(
+        strikethroughAttribution,
         SpanRange(
           start: 0,
           end: styledText.text.length - 1,

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -295,6 +295,24 @@ This is some code
         expect(serializeDocumentToMarkdown(doc), '[This **is a** paragraph](https://example.org).');
       });
 
+      test('paragraph with underline', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(attribution: underlineAttribution, offset: 10, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: underlineAttribution, offset: 18, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), 'This is a ¬paragraph¬.');
+      });
       test('paragraph with consecutive links', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -831,6 +849,18 @@ This is some code
 
         // Ensure text outside the range isn't attributed.
         expect(styledText.getAllAttributionsAt(7).contains(strikethroughAttribution), false);
+      });
+
+      test('paragraph with underline', () {
+        final doc = deserializeMarkdownToDocument('¬This is¬ a paragraph.');
+        final styledText = (doc.nodes[0] as ParagraphNode).text;
+
+        // Ensure text within the range is attributed.
+        expect(styledText.getAllAttributionsAt(0).contains(underlineAttribution), true);
+        expect(styledText.getAllAttributionsAt(6).contains(underlineAttribution), true);
+
+        // Ensure text outside the range isn't attributed.
+        expect(styledText.getAllAttributionsAt(7).contains(underlineAttribution), false);
       });
 
       test('paragraph with left alignment', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -763,6 +763,18 @@ This is some code
 
         expect(document.nodes[17], isA<ParagraphNode>());
       });
+
+      test('paragraph with strikethrough', () {
+        final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
+        final styledText = (doc.nodes[0] as ParagraphNode).text;
+
+        // Ensure text within the range is attributed.
+        expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), true);
+        expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), true);
+
+        // Ensure text outside the range isn't attributed.
+        expect(styledText.getAllAttributionsAt(7).contains(strikethroughAttribution), false);
+      });
     });
   });
 }

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -313,6 +313,26 @@ This is some code
 
         expect(serializeDocumentToMarkdown(doc), 'This is a ¬paragraph¬.');
       });
+
+      test('paragraph with strikethrough', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(
+              text: 'This is a paragraph.',
+              spans: AttributedSpans(
+                attributions: [
+                  SpanMarker(attribution: strikethroughAttribution, offset: 10, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: strikethroughAttribution, offset: 18, markerType: SpanMarkerType.end),
+                ],
+              ),
+            ),
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), 'This is a ~paragraph~.');
+      });
+
       test('paragraph with consecutive links', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -345,7 +365,11 @@ This is some code
           ),
         ]);
 
-        // Left alignment is the default, so it shouldn't be added.
+        // Even when using superEditor markdown syntax, which has support
+        // for text alignment, we don't add an alignment token when
+        // the paragraph is left-aligned.
+        // Paragraphs are left-aligned by default, so it isn't necessary
+        // to serialize the alignment token.
         expect(serializeDocumentToMarkdown(doc), 'Paragraph1');
       });
 
@@ -377,7 +401,7 @@ This is some code
         expect(serializeDocumentToMarkdown(doc), '---:\nParagraph1');
       });
 
-      test("doesn't serialize text alignment when not using extended syntax", () {
+      test("doesn't serialize text alignment when not using supereditor syntax", () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
@@ -388,7 +412,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc, extendedSyntax: false), 'Paragraph1');
+        expect(serializeDocumentToMarkdown(doc, syntax: MarkdownSyntax.normal), 'Paragraph1');
       });
 
       test('image', () {
@@ -887,7 +911,7 @@ This is some code
         expect(paragraph.text.text, 'Paragraph1');
       });
 
-      test('treats alignment notation as content at the end of the document', () {
+      test('treats alignment token as text at the end of the document', () {
         final doc = deserializeMarkdownToDocument('---:');
 
         final paragraph = doc.nodes.first as ParagraphNode;
@@ -895,7 +919,7 @@ This is some code
         expect(paragraph.text.text, '---:');
       });
 
-      test('treats alignment notation as content when not followed by a paragraph', () {
+      test('treats alignment token as text when not followed by a paragraph', () {
         final doc = deserializeMarkdownToDocument('---:\n - - -');
 
         final paragraph = doc.nodes.first as ParagraphNode;
@@ -906,8 +930,8 @@ This is some code
         expect(doc.nodes[1], isA<HorizontalRuleNode>());
       });
 
-      test('treats alignment notation as content when not using extended syntax', () {
-        final doc = deserializeMarkdownToDocument(':---\nParagraph1', extendedSyntax: false);
+      test('treats alignment token as text when not using supereditor syntax', () {
+        final doc = deserializeMarkdownToDocument(':---\nParagraph1', syntax: MarkdownSyntax.normal);
 
         final paragraph = doc.nodes.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), isNull);


### PR DESCRIPTION
[super_editor_markdown] Fix serialization of text alignment, strikethrough, and underline. Resolves #717

Strikethrough 
---
Strikethrough is being ignored during deserialization. The markdown package used for deserialization already supports the strikethrough syntax, however, it isn't enabled by default.

This PR enables the strikethrough syntax for deserialization.

Underline
---
Underline is being ignored in both serialization and deserialization. The markdown spec doesn't have a syntax for underline text. Some parsers allow the usage of a `ins` tag to specify the underline, however, we'd like to avoid using HTML, so a custom notation is needed.

This PR introduces a custom notation for underline:
```
This is ¬underline¬.
```

The `¬` character could be changed if a more appropriate one is suggested.

Text Alignment
---
Text alignment is being ignored in both serialization and deserialization. The markdown spec doesn't have a syntax for text alignment. Some parsers allow the usage of a `p` tag to specify the alignment, however, we'd like to avoid using HTML, so a custom notation is needed.

This PR introduces a custom notation for text alignment, similar to what is used to table alignment. An alignment indicator should precede the paragraph. For example:

```
:---
This is left-aligned. (Can be omitted, as it's the default)

:---:
This is center-aligned.

---:
This is right-aligned.
```

The usage of these custom notations is configurable.