### PR TITLE
Fixing super_editor/example compilation by adding missing import

### DIFF
--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:example/demos/sliver_example_editor.dart';
 import 'package:example/demos/styles/demo_doc_styles.dart';
 import 'package:example/demos/supertextfield/demo_textfield.dart';
 import 'package:example/demos/supertextfield/ios/demo_superiostextfield.dart';
+import 'package:example/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';


### PR DESCRIPTION
A missing import in `super_editor/example/lib/main.dart` is causing the example app to fail to compile. This PR just adds the import back in. It looks like the import was removed as part of [this commit][1].

[1]: https://github.com/superlistapp/super_editor/commit/574bc21770a50d41fb48788aa7ea2df995723d26#diff-87261c6ba97adf363861c4f7733e9ff6edbd7cf8732724357ec0e8a8dc22b1bfL21