### PR TITLE
Ignore pointers in document overlay so that doc selection works (Resolves #756)

### DIFF
--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -30,6 +30,7 @@ import 'demos/demo_switch_document_content.dart';
 import 'demos/scrolling/demo_task_and_chat_with_renderobject.dart';
 import 'demos/super_document/demo_read_only_scrolling_document.dart';
 import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
+import 'logging.dart';
 
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -598,20 +598,24 @@ class SuperEditorState extends State<SuperEditor> {
                 ),
               ),
               // The document that the user is editing.
-              Align(
-                alignment: Alignment.topCenter,
-                child: Stack(
-                  children: [
-                    documentLayout,
-                    // We display overlay builders in this inner-Stack so that they
-                    // match the document size, rather than the viewport size.
-                    for (final overlayBuilder in widget.documentOverlayBuilders)
+              IgnorePointer(
+                ignoring: true,
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: Stack(
+                    children: [
                       IgnorePointer(
-                        child: Positioned.fill(
+                        ignoring: false,
+                        child: documentLayout,
+                      ),
+                      // We display overlay builders in this inner-Stack so that they
+                      // match the document size, rather than the viewport size.
+                      for (final overlayBuilder in widget.documentOverlayBuilders)
+                        Positioned.fill(
                           child: overlayBuilder.build(context, editContext),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -606,8 +606,10 @@ class SuperEditorState extends State<SuperEditor> {
                     // We display overlay builders in this inner-Stack so that they
                     // match the document size, rather than the viewport size.
                     for (final overlayBuilder in widget.documentOverlayBuilders)
-                      Positioned.fill(
-                        child: overlayBuilder.build(context, editContext),
+                      IgnorePointer(
+                        child: Positioned.fill(
+                          child: overlayBuilder.build(context, editContext),
+                        ),
                       ),
                   ],
                 ),


### PR DESCRIPTION
Ignore pointers in document overlay so that doc selection works (Resolves #756)

@miguelcmedeiros let me know if this PR works for you. I can't verify on my end, because the selection problem doesn't happen in the example app.