### PR TITLE
[SuperEditor] Fix caret display on focus (Resolves #722)

### DIFF
--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -36,6 +36,11 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
     super.initState();
     widget.composer.selectionNotifier.addListener(_onSelectionChange);
     _blinkController = BlinkController(tickerProvider: this)..startBlinking();
+
+    // If we already have a selection, we need to display the caret.
+    if (widget.composer.selection != null) {
+      _onSelectionChange();
+    }
   }
 
   @override
@@ -45,6 +50,11 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
     if (widget.composer != oldWidget.composer) {
       oldWidget.composer.selectionNotifier.removeListener(_onSelectionChange);
       widget.composer.selectionNotifier.addListener(_onSelectionChange);
+
+      // Selection has changed, we need to update the caret.
+      if (widget.composer.selection != oldWidget.composer.selection) {
+        _onSelectionChange();
+      }
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -156,6 +156,11 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       getDocumentLayout: widget.getDocumentLayout,
     );
 
+    // If we already have a selection, we need to display the caret.
+    if (widget.composer.selection != null) {
+      _onSelectionChange();
+    }
+
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -195,6 +200,11 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       oldWidget.composer.removeListener(_onSelectionChange);
       widget.composer.addListener(_onSelectionChange);
       onDocumentComposerReplaced(widget.composer);
+
+      // Selection has changed, we need to update the caret.
+      if (widget.composer.selection != oldWidget.composer.selection) {
+        _onSelectionChange();
+      }
     }
 
     if (widget.getDocumentLayout != oldWidget.getDocumentLayout) {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -172,6 +172,11 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       getDocumentLayout: widget.getDocumentLayout,
     );
 
+    // If we already have a selection, we need to display the caret.
+    if (widget.composer.selection != null) {
+      _onSelectionChange();
+    }
+
     WidgetsBinding.instance.addObserver(this);
   }
 
@@ -218,6 +223,11 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       oldWidget.composer.removeListener(_onSelectionChange);
       widget.composer.addListener(_onSelectionChange);
       onDocumentComposerReplaced(widget.composer);
+
+      // Selection has changed, we need to update the caret.
+      if (widget.composer.selection != oldWidget.composer.selection) {
+        _onSelectionChange();
+      }
     }
 
     if (widget.getDocumentLayout != oldWidget.getDocumentLayout) {

--- a/super_editor/lib/src/default_editor/document_selection_on_focus_mixin.dart
+++ b/super_editor/lib/src/default_editor/document_selection_on_focus_mixin.dart
@@ -41,6 +41,12 @@ mixin DocumentSelectionOnFocusMixin<T extends StatefulWidget> on State<T> {
     _composer = composer;
     _composer!.selectionNotifier.addListener(_onSelectionChange);
     _getDocumentLayout = getDocumentLayout;
+
+    // If we already start focused we need to check if the selection update is needed.
+    // This is happening on desktop when the editor uses autofocus.
+    if (focusNode.hasFocus) {
+      _onFocusChange();
+    }
   }
 
   // Stops watching and synchronizing focus with selection.

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -102,6 +102,7 @@ class TestDocumentConfigurator {
   WidgetTreeBuilder? _widgetTreeBuilder;
   ScrollController? _scrollController;
   FocusNode? _focusNode;
+  DocumentSelection? _selection;
 
   /// Configures the [SuperEditor] for standard desktop interactions,
   /// e.g., mouse and keyboard input.
@@ -168,6 +169,12 @@ class TestDocumentConfigurator {
   /// Configures the [SuperEditor] to use the given [focusNode]
   TestDocumentConfigurator withFocusNode(FocusNode? focusNode) {
     _focusNode = focusNode;
+    return this;
+  }
+
+  /// Configures the [SuperEditor] to use the given [selection] as its initial selection.
+  TestDocumentConfigurator withSelection(DocumentSelection? selection) {
+    _selection = selection;
     return this;
   }
 
@@ -239,7 +246,7 @@ class TestDocumentConfigurator {
       final layoutKey = GlobalKey();
       final focusNode = _focusNode ?? FocusNode();
       final editor = DocumentEditor(document: _document!);
-      final composer = DocumentComposer();
+      final composer = DocumentComposer(initialSelection: _selection);
       // ignore: prefer_function_declarations_over_variables
       final layoutResolver = () => layoutKey.currentState as DocumentLayout;
       final commonOps = CommonEditorOperations(

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/src/infrastructure/blinking_caret.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -295,6 +297,9 @@ void main() {
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
     testWidgetsOnAllPlatforms("places caret at end of document upon first editor focus with next", (tester) async {
@@ -336,9 +341,13 @@ void main() {
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
-    testWidgetsOnAllPlatforms("places caret at end of document upon first editor focus when requesting focus", (tester) async {
+    testWidgetsOnAllPlatforms("places caret at end of document upon first editor focus when requesting focus",
+        (tester) async {
       final focusNode = FocusNode();
 
       await tester //
@@ -366,6 +375,9 @@ void main() {
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
     testWidgetsOnAllPlatforms("places caret at end of document upon first editor focus on autofocus", (tester) async {
@@ -389,6 +401,9 @@ void main() {
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
     testWidgetsOnAllPlatforms("ignores unselectable components upon first editor focus", (tester) async {
@@ -436,6 +451,9 @@ Second Paragraph
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
     testWidgetsOnAllPlatforms("places caret at the previous selection when re-focusing by tab", (tester) async {
@@ -490,6 +508,9 @@ Second Paragraph
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
     testWidgetsOnAllPlatforms("places caret at the previous selection when re-focusing by next", (tester) async {
@@ -544,9 +565,13 @@ Second Paragraph
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
 
-    testWidgetsOnAllPlatforms("places caret at the previous selection when re-focusing by requesting focus", (tester) async {
+    testWidgetsOnAllPlatforms("places caret at the previous selection when re-focusing by requesting focus",
+        (tester) async {
       final focusNode = FocusNode();
 
       await tester
@@ -601,7 +626,38 @@ Second Paragraph
           ),
         ),
       );
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
     });
+
+    testWidgetsOnAllPlatforms('retains composer initial selection upon first editor focus', (tester) async {
+      final focusNode = FocusNode();
+
+      const initialSelection = DocumentSelection.collapsed(
+        position: DocumentPosition(
+          nodeId: '1',
+          nodePosition: TextNodePosition(offset: 6),
+        ),
+      );
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withFocusNode(focusNode)
+          .withSelection(initialSelection)
+          .pump();
+
+      focusNode.requestFocus();
+
+      await tester.pumpAndSettle();
+
+      // Ensure initial selection was retained.
+      expect(SuperEditorInspector.findDocumentSelection(), initialSelection);
+
+      // Ensure caret is displayed.
+      expect(_caretFinder(), findsOneWidget);
+    });  
   });
 }
 
@@ -667,4 +723,12 @@ class _UnselectableHorizontalRuleComponent extends StatelessWidget {
       ),
     );
   }
+}
+
+Finder _caretFinder() {
+  if (debugDefaultTargetPlatformOverride == TargetPlatform.iOS ||
+      debugDefaultTargetPlatformOverride == TargetPlatform.android) {
+    return find.byType(BlinkingCaret);
+  }
+  return find.byKey(primaryCaretKey);
 }


### PR DESCRIPTION
[SuperEditor] Fix caret display on focus. Resolves #722 

Creating a `SuperEditor` with autofocus set to `true` and with an initial selection wasn't displaying the caret, even though the document has a selection.

This PR changes the caret overlay and touch interactors to call `_onSelectionChange`, so the caret position is updated. It also updates the selection tests to ensure the caret is being displayed.

During manual tests I've found a situation happening only on desktop: when the editor has autofocus, by the time we get to `initState`, the focus node already has focus, so the `DocumentSelectionOnFocusMixin` isn't placing the selection at the end of the document. This PR adds a fix to this case by calling `_onFocusChange` in the mixin if we were given a focus node which already has focus. I couldn't reproduce this behavior during tests.
