### PR TITLE
[SuperTextField] [Desktop] Fix exception when hot reloading (Resolves #763)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -251,9 +251,13 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   }
 
   double _getEstimatedLineHeight() {
-    final lineHeight = _controller.text.text.isEmpty //
+    // After hot reloading, the text layout might be null, so we can't
+    // directly use _textKey.currentState!.textLayout because using it 
+    // we can't check for null.
+    final textLayout = RenderSuperTextLayout.textLayoutFrom(_textKey);
+    final lineHeight = _controller.text.text.isEmpty || textLayout == null
         ? 0.0
-        : _textKey.currentState?.textLayout.getLineHeightAtPosition(const TextPosition(offset: 0)) ?? 0;
+        : textLayout.getLineHeightAtPosition(const TextPosition(offset: 0));
     if (lineHeight > 0) {
       return lineHeight;
     }

--- a/super_text_layout/lib/src/super_text.dart
+++ b/super_text_layout/lib/src/super_text.dart
@@ -176,8 +176,8 @@ class RenderSuperTextLayout extends RenderBox
   /// Returns the [ProseTextLayout] within a [SuperText] that's connected
   /// to the given [key].
   static ProseTextLayout? textLayoutFrom(GlobalKey key) {
-    final renderTextLayout = key.currentContext?.findRenderObject() as RenderSuperTextLayout;
-    if (renderTextLayout.state._paragraph == null) {
+    final renderTextLayout = key.currentContext?.findRenderObject() as RenderSuperTextLayout?;
+    if (renderTextLayout == null || renderTextLayout.state._paragraph == null) {
       return null;
     }
 


### PR DESCRIPTION
[SuperTextField] [Desktop] Fix exception when hot reloading. Resolves #763

When there's a `SuperDesktopTexField ` being rendered and the developer hot reloads the app, an exception is thrown.

This was caused by https://github.com/superlistapp/super_editor/pull/707. 

That PR changed `SuperDesktopTexField` to measure the text using its `textLayout`. However, after hot reloading, the text layout might be null.

This PR changes how text layout is being accessed in `_getEstimatedLineHeight` to a way in which we can check for null.

