### PR TITLE
[SuperTextField] [Desktop] Fix line height estimation on macOS (Resolves #764)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -1696,7 +1696,7 @@ class _EstimatedLineHeight {
   /// Computes the estimated line height for the given [style].
   ///
   /// The height is computed by laying out a [Paragraph] with an arbitrary
-  /// character and inspecting it's line metrics.
+  /// character and inspecting it's height.
   ///
   /// The result is cached for the last [style] used, so it's not computed
   /// at each call.
@@ -1712,8 +1712,7 @@ class _EstimatedLineHeight {
     final paragraph = builder.build();
     paragraph.layout(const ui.ParagraphConstraints(width: double.infinity));
 
-    final lineMetrics = paragraph.computeLineMetrics();
-    _lastLineHeight = lineMetrics.first.height;
+    _lastLineHeight = paragraph.height;
     _lastComputedStyle = style;
     return _lastLineHeight!;
   }


### PR DESCRIPTION
[SuperTextField] [Desktop] Fix line height estimation on macOS.  Resolves #764 

In macOS, estimating the line height when the font height is different from 1.0 using `computeLineMetrics` returns a value that doesn't seem to include the `descent`. As a result, letters like `p` and `g` are cut on the hint text.

This PR changes the line height estimation to use the `paragraph` height as the estimated line height.