### PR TITLE
Allow blockquote mouse gestures by ignoring pointer events on container

### DIFF
--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -198,21 +198,23 @@ class BlockquoteComponent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-      decoration: BoxDecoration(
-        borderRadius: borderRadius,
-        color: backgroundColor,
-      ),
-      child: TextComponent(
-        key: textKey,
-        text: text,
-        textStyleBuilder: styleBuilder,
-        textSelection: textSelection,
-        selectionColor: selectionColor,
-        highlightWhenEmpty: highlightWhenEmpty,
-        showDebugPaint: showDebugPaint,
-      ),
+    return IgnorePointer(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          color: backgroundColor,
+        ),
+        child: TextComponent(
+          key: textKey,
+          text: text,
+          textStyleBuilder: styleBuilder,
+          textSelection: textSelection,
+          selectionColor: selectionColor,
+          highlightWhenEmpty: highlightWhenEmpty,
+          showDebugPaint: showDebugPaint,
+        ),
+      )
     );
   }
 }


### PR DESCRIPTION
Fixes #769

I just started to dabble into Flutter and the gesture stuff is a little over my head, but I think if I understand correctly, to fix this issue we just need to ignore the pointer events here