### PR TITLE
Allow image mouse gestures by ignoring pointer events

### DIFF
--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -159,15 +159,17 @@ class ImageComponent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: SelectableBox(
-        selection: selection,
-        selectionColor: selectionColor,
-        child: BoxComponent(
-          key: componentKey,
-          child: Image.network(
-            imageUrl,
-            fit: BoxFit.contain,
+    return IgnorePointer(
+      child: Center(
+        child: SelectableBox(
+          selection: selection,
+          selectionColor: selectionColor,
+          child: BoxComponent(
+            key: componentKey,
+            child: Image.network(
+              imageUrl,
+              fit: BoxFit.contain,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Similar to #769, image components seem to block gestures (most noticeably here scrolling). The solution is also the same as #770 to just ignore the pointer events