### PR TITLE
[SuperEditor] [DemoApp] Fix incorrect request focus (Resolves #775)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -177,14 +177,14 @@ class _ExampleEditorState extends State<ExampleEditor> {
       // and non-null implies the entry is in the overlay.
       _textFormatBarOverlayEntry!.remove();
       _textFormatBarOverlayEntry = null;
-    }
 
-    // Ensure that focus returns to the editor.
-    //
-    // I tried explicitly unfocus()'ing the URL textfield
-    // in the toolbar but it didn't return focus to the
-    // editor. I'm not sure why.
-    _editorFocusNode.requestFocus();
+      // Ensure that focus returns to the editor.
+      //
+      // I tried explicitly unfocus()'ing the URL textfield
+      // in the toolbar but it didn't return focus to the
+      // editor. I'm not sure why.
+      _editorFocusNode.requestFocus();
+    }
   }
 
   DocumentGestureMode get _gestureMode {
@@ -278,10 +278,10 @@ class _ExampleEditorState extends State<ExampleEditor> {
       // and non-null implies the entry is in the overlay.
       _imageFormatBarOverlayEntry!.remove();
       _imageFormatBarOverlayEntry = null;
-    }
 
-    // Ensure that focus returns to the editor.
-    _editorFocusNode.requestFocus();
+      // Ensure that focus returns to the editor.
+      _editorFocusNode.requestFocus();
+    }
   }
 
   @override


### PR DESCRIPTION
[SuperEditor] [DemoApp] Fix incorrect request focus. Resolves #775 

The demo app is always requesting focus to the editor when `_hideEditorToolbar` is called. This is done probably due to reasons explained in https://github.com/superlistapp/super_editor/issues/731

If another focusable widget is placed in the same widget tree, then the editor never releases focus. When taping another focusable widget the following happens:

1. Focus is removed from the editor, which closes the IME connection.
2. Closing the IME connection clears the selection.
3. Changing selection causes  `_hideEditorToolbar` to be called, which requests focus to the editor again.

c866122e52b22c995630d673c2af8258722e04ec changed `SuperEditor` to restore the selection when the editor receives focus, so we are in a loop of losing focus -> clearing selection -> requesting focus -> restoring selection.

Users following the demo app might run into this issue.

This PR changes the demo app to only request focus if a toolbar is present.