### PR TITLE
[SuperEditor] Fix caret misplaced when indenting a list item (Resolves #777)

### DIFF
--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -3,6 +3,8 @@ import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import '../../super_editor.dart';
+
 /// Document overlay that paints a caret with the given [caretStyle].
 class CaretDocumentOverlay extends StatefulWidget {
   const CaretDocumentOverlay({
@@ -10,6 +12,7 @@ class CaretDocumentOverlay extends StatefulWidget {
     required this.composer,
     required this.documentLayoutResolver,
     required this.caretStyle,
+    required this.document,
   }) : super(key: key);
 
   /// The editor's [DocumentComposer], which reports the current selection.
@@ -18,6 +21,9 @@ class CaretDocumentOverlay extends StatefulWidget {
   /// Delegate that returns a reference to the editor's [DocumentLayout], so
   /// that the current selection can be mapped to an (x,y) offset and a height.
   final DocumentLayout Function() documentLayoutResolver;
+
+  /// The editor's [Document].
+  final Document document;
 
   /// The visual style of the caret that this overlay paints.
   final CaretStyle caretStyle;
@@ -35,6 +41,7 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
   void initState() {
     super.initState();
     widget.composer.selectionNotifier.addListener(_onSelectionChange);
+    widget.document.addListener(_onSelectionChange);
     _blinkController = BlinkController(tickerProvider: this)..startBlinking();
 
     // If we already have a selection, we need to display the caret.
@@ -46,6 +53,11 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
   @override
   void didUpdateWidget(CaretDocumentOverlay oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (widget.document != oldWidget.document) {
+      oldWidget.document.removeListener(_onSelectionChange);
+      widget.document.addListener(_onSelectionChange);
+    }
 
     if (widget.composer != oldWidget.composer) {
       oldWidget.composer.selectionNotifier.removeListener(_onSelectionChange);
@@ -61,6 +73,7 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
   @override
   void dispose() {
     widget.composer.selectionNotifier.removeListener(_onSelectionChange);
+    widget.document.removeListener(_onSelectionChange);
     _blinkController.dispose();
     super.dispose();
   }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -693,6 +693,7 @@ class DefaultCaretOverlayBuilder implements DocumentLayerBuilder {
       composer: editContext.composer,
       documentLayoutResolver: () => editContext.documentLayout,
       caretStyle: caretStyle,
+      document: editContext.editor.document,
     );
   }
 }

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
 
+import '../../super_editor/document_test_tools.dart';
+import '../../test_tools.dart';
 import '../_document_test_tools.dart';
 import '../_text_entry_test_tools.dart';
 import '../infrastructure/_platform_test_tools.dart';
@@ -233,6 +237,142 @@ void main() {
         Platform.setTestInstance(null);
       });
     });
+
+    group('unordered list', () {
+      testWidgetsOnArbitraryDesktop('updates caret position when indenting', (tester) async {
+        await _pumpUnorderedList(tester);
+
+        final doc = SuperEditorInspector.findDocument()!;
+        final listItemId = doc.nodes.first.id;
+
+        // Place caret at the first list item, which has one level of indentation.
+        await tester.placeCaretInParagraph(listItemId, 0);
+
+        final caretOffsetBeforeIndent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Press tab to trigger the list indent command.
+        await tester.pressTab();
+
+        // Compute the offset at which the caret should be displayed.
+        final computedOffsetAfterIndent = SuperEditorInspector.calculateOffsetForCaret(
+          DocumentPosition(
+            nodeId: listItemId,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Ensure the list indentation was actually performed.
+        expect(computedOffsetAfterIndent.dx, greaterThan(caretOffsetBeforeIndent.dx));
+
+        // Find the offset at which the caret is currently being displayed.
+        final caretOffsetAfterIndent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Ensure the caret is being displayed at the correct position.
+        expect(caretOffsetAfterIndent, offsetMoreOrLessEquals(computedOffsetAfterIndent));
+      });
+
+      testWidgetsOnArbitraryDesktop('updates caret position when unindenting', (tester) async {
+        await _pumpUnorderedList(tester);
+
+        final doc = SuperEditorInspector.findDocument()!;
+        final listItemId = doc.nodes.last.id;
+
+        // Place caret at the last list item, which has two levels of indentation.
+        // For some reason, taping at the first character isn't displaying any caret,
+        // so we put the caret at the second character and then go back one position.
+        await tester.placeCaretInParagraph(listItemId, 1);
+        await tester.pressLeftArrow();
+
+        final caretOffsetBeforeUnindent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Press backspace to trigger the list unindent command.
+        await tester.pressBackspace();
+
+        // Compute the offset at which the caret should be displayed.
+        final computedOffsetAfterUnindent = SuperEditorInspector.calculateOffsetForCaret(
+          DocumentPosition(
+            nodeId: listItemId,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Ensure the list indentation was actually performed.
+        expect(computedOffsetAfterUnindent.dx, lessThan(caretOffsetBeforeUnindent.dx));
+
+        // Find the offset at which the caret is currently being displayed.
+        final caretOffsetAfterUnindent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Ensure the caret is being displayed at the correct position.
+        expect(caretOffsetAfterUnindent, offsetMoreOrLessEquals(computedOffsetAfterUnindent));
+      });
+    });
+
+    group('ordered list', () {
+      testWidgetsOnArbitraryDesktop('updates caret position when indenting', (tester) async {
+        await _pumpOrderedList(tester);
+
+        final doc = SuperEditorInspector.findDocument()!;
+        final listItemId = doc.nodes.first.id;
+
+        // Place caret at the first list item, which has one level of indentation.
+        await tester.placeCaretInParagraph(listItemId, 0);
+
+        final caretOffsetBeforeIndent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Press tab to trigger the list indent command.
+        await tester.pressTab();
+
+        // Compute the offset at which the caret should be displayed.
+        final computedOffsetAfterIndent = SuperEditorInspector.calculateOffsetForCaret(
+          DocumentPosition(
+            nodeId: listItemId,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Find the offset at which the caret is currently being displayed.
+        final caretOffsetAfterIndent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Ensure the list indentation was actually performed.
+        expect(computedOffsetAfterIndent.dx, greaterThan(caretOffsetBeforeIndent.dx));
+
+        // Ensure the caret is being displayed at the correct position.
+        expect(caretOffsetAfterIndent, offsetMoreOrLessEquals(computedOffsetAfterIndent));
+      });
+
+      testWidgetsOnArbitraryDesktop('updates caret position when unindenting', (tester) async {
+        await _pumpOrderedList(tester);
+
+        final doc = SuperEditorInspector.findDocument()!;
+        final listItemId = doc.nodes.last.id;
+
+        // Place caret at the last list item, which has two levels of indentation.
+        // For some reason, taping at the first character isn't displaying any caret,
+        // so we put the caret at the second character and then go back one position.
+        await tester.placeCaretInParagraph(listItemId, 1);
+        await tester.pressLeftArrow();
+
+        final caretOffsetBeforeUnindent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Press backspace to trigger the list unindent command.
+        await tester.pressBackspace();
+
+        // Compute the offset at which the caret should be displayed.
+        final computedOffsetAfterUnindent = SuperEditorInspector.calculateOffsetForCaret(DocumentPosition(
+          nodeId: listItemId,
+          nodePosition: const TextNodePosition(offset: 0),
+        ));
+
+        // Find the offset at which the caret is currently being displayed.
+        final caretOffsetAfterUnindent = SuperEditorInspector.findCaretOffsetInDocument();
+
+        // Ensure the list indentation was actually performed.
+        expect(computedOffsetAfterUnindent.dx, lessThan(caretOffsetBeforeUnindent.dx));
+
+        // Ensure the caret is being displayed at the correct position.
+        expect(caretOffsetAfterUnindent, offsetMoreOrLessEquals(computedOffsetAfterUnindent));
+      });
+    });
   });
 }
 
@@ -264,4 +404,40 @@ void _typeKeys(EditContext editContext, List<FakeRawKeyEvent> keys) {
       keyEvent: key,
     );
   }
+}
+
+/// Pumps a [SuperEditor] containing 3 unordered list items.
+///
+/// The first two items have one level of indentation.
+///
+/// The last two items have two levels of indentation.
+Future<void> _pumpUnorderedList(WidgetTester tester) async {
+  const markdown = '''
+ * list item 1
+ * list item 2
+   * list item 2.1
+   * list item 2.2''';
+
+  await tester //
+      .createDocument()
+      .fromMarkdown(markdown)
+      .pump();
+}
+
+/// Pumps a [SuperEditor] containing 4 ordered list items.
+///
+/// The first two items have one level of indentation.
+///
+/// The last two items have two levels of indentation.
+Future<void> _pumpOrderedList(WidgetTester tester) async {
+  const markdown = '''
+ 1. list item 1
+ 1. list item 2
+    1. list item 2.1
+    1. list item 2.2''';
+
+  await tester //
+      .createDocument()
+      .fromMarkdown(markdown)
+      .pump();
 }

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -264,11 +264,8 @@ void main() {
         // Ensure the list indentation was actually performed.
         expect(computedOffsetAfterIndent.dx, greaterThan(caretOffsetBeforeIndent.dx));
 
-        // Find the offset at which the caret is currently being displayed.
-        final caretOffsetAfterIndent = SuperEditorInspector.findCaretOffsetInDocument();
-
         // Ensure the caret is being displayed at the correct position.
-        expect(caretOffsetAfterIndent, offsetMoreOrLessEquals(computedOffsetAfterIndent));
+        expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterIndent));
       });
 
       testWidgetsOnArbitraryDesktop('updates caret position when unindenting', (tester) async {
@@ -299,11 +296,8 @@ void main() {
         // Ensure the list indentation was actually performed.
         expect(computedOffsetAfterUnindent.dx, lessThan(caretOffsetBeforeUnindent.dx));
 
-        // Find the offset at which the caret is currently being displayed.
-        final caretOffsetAfterUnindent = SuperEditorInspector.findCaretOffsetInDocument();
-
         // Ensure the caret is being displayed at the correct position.
-        expect(caretOffsetAfterUnindent, offsetMoreOrLessEquals(computedOffsetAfterUnindent));
+        expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
       });
     });
 
@@ -330,14 +324,11 @@ void main() {
           ),
         );
 
-        // Find the offset at which the caret is currently being displayed.
-        final caretOffsetAfterIndent = SuperEditorInspector.findCaretOffsetInDocument();
-
         // Ensure the list indentation was actually performed.
         expect(computedOffsetAfterIndent.dx, greaterThan(caretOffsetBeforeIndent.dx));
 
         // Ensure the caret is being displayed at the correct position.
-        expect(caretOffsetAfterIndent, offsetMoreOrLessEquals(computedOffsetAfterIndent));
+        expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterIndent));
       });
 
       testWidgetsOnArbitraryDesktop('updates caret position when unindenting', (tester) async {
@@ -363,14 +354,11 @@ void main() {
           nodePosition: const TextNodePosition(offset: 0),
         ));
 
-        // Find the offset at which the caret is currently being displayed.
-        final caretOffsetAfterUnindent = SuperEditorInspector.findCaretOffsetInDocument();
-
         // Ensure the list indentation was actually performed.
         expect(computedOffsetAfterUnindent.dx, lessThan(caretOffsetBeforeUnindent.dx));
 
         // Ensure the caret is being displayed at the correct position.
-        expect(caretOffsetAfterUnindent, offsetMoreOrLessEquals(computedOffsetAfterUnindent));
+        expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
       });
     });
   });


### PR DESCRIPTION
[SuperEditor] Fix caret misplaced when indenting a list item. Resolves #777

When indenting or unindenting a list item via keyboard (pressing tab/backspace) the node gets indented but the caret remains in the old position, as seen in the video: 

https://user-images.githubusercontent.com/31278849/189396028-a9233274-6be3-47a5-ad53-4bd587d3768e.mov

The issue happens because `CaretDocumentOverlay` isn't being notified that something changed, as it only listens for selection changes.

This PR changes `CaretDocumentOverlay` to update the caret on all document changes.
