### PR TITLE
[SuperEditor] [Desktop] Fix trackpad scrolling (Resolves #771)

### DIFF
--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -161,6 +161,7 @@ extension SuperEditorRobot on WidgetTester {
     required DocumentPosition from,
     Alignment startAlignmentWithinPosition = Alignment.center,
     Finder? superEditorFinder,
+    PointerDeviceKind deviceKind = PointerDeviceKind.mouse,
   }) async {
     final documentLayout = _findDocumentLayout(superEditorFinder);
 
@@ -171,7 +172,7 @@ extension SuperEditorRobot on WidgetTester {
     final dragStartOffset = startAlignmentWithinPosition.withinRect(dragStartRect);
 
     // Simulate the drag.
-    final gesture = await startGesture(dragStartOffset, kind: PointerDeviceKind.mouse);
+    final gesture = await startGesture(dragStartOffset, kind: deviceKind);
     await pump();
 
     // Move a tiny amount to start the pan gesture.


### PR DESCRIPTION
[SuperEditor] [Desktop] Fix trackpad scrolling. Partially resolves #771 

After Flutter 3.3, dragging with two fingers on a trackpad triggers a pan gesture with a `kind` of `PointerDeviceKind.trackpad`, as documented [in this design doc](https://flutter.dev/go/trackpad-gestures). 

This change causes the editor to expand the selection instead of scrolling the document with this gesture.

This PR changes `DocumentMouseInteractor` to scroll the document instead of expanding selection when the drag device is a `PointerDeviceKind.trackpad`.

This PR is based on https://github.com/superlistapp/super_editor/pull/772.

