### PR TITLE
[super_editor_markdown] Fix deserialization of empty markdown (Resolves #779)

### DIFF
--- a/super_editor_markdown/lib/src/markdown.dart
+++ b/super_editor_markdown/lib/src/markdown.dart
@@ -35,7 +35,18 @@ MutableDocument deserializeMarkdownToDocument(
     node.accept(nodeVisitor);
   }
 
-  return MutableDocument(nodes: nodeVisitor.content);
+  final documentNodes = nodeVisitor.content;
+
+  if (documentNodes.isEmpty) {
+    // An empty markdown was parsed.
+    // For the user to be able to interact with the editor, at least one
+    // node is required, so we add an empty paragraph.
+    documentNodes.add(
+      ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText(text: '')),
+    );
+  }
+
+  return MutableDocument(nodes: documentNodes);
 }
 
 /// The given [syntax] controls how the [doc] is serialized, e.g., [MarkdownSyntax.normal] for standard

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1129,6 +1129,15 @@ First Paragraph.
         expect(doc.nodes.last, isA<ParagraphNode>());
         expect((doc.nodes.last as ParagraphNode).text.text, '');
       });
+
+      test('empty markdown produces an empty paragraph', () {
+        final doc = deserializeMarkdownToDocument('');
+
+        expect(doc.nodes.length, 1);
+
+        expect(doc.nodes.first, isA<ParagraphNode>());
+        expect((doc.nodes.first as ParagraphNode).text.text, '');
+      });
     });
   });
 }


### PR DESCRIPTION
[super_editor_markdown] Fix deserialization of empty markdown. Resolves #779

Parsing empty markdown results in a document with an empty list of nodes. For the user to be able to interact with the editor, at least one node is required. So, after parsing the empty markdown, the user can't tap the editor and start typing.

This PR changes the markdown parsing to return a document containing an empty paragraph if no nodes were parsed.