### PR TITLE
[SuperEditor] [iOS] Fix list indentation using TAB key (Resolves #745)

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -875,6 +875,12 @@ class SoftwareKeyboardHandler {
       return;
     }
 
+    if (delta.textInserted == "\t" && (defaultTargetPlatform == TargetPlatform.iOS)) {
+      // On iOS, tabs pressed at the the software keyboard are reported here.
+      commonOps.indentListItem();
+      return;
+    }
+
     editorImeLog.fine(
         "Inserting text: ${delta.textInserted}, insertion offset: ${delta.insertionOffset}, ime selection: ${delta.selection}");
 
@@ -902,6 +908,12 @@ class SoftwareKeyboardHandler {
       } else {
         editorImeLog.fine("Skipping replacement delta because its a newline");
       }
+      return;
+    }
+
+    if (delta.replacementText == "\t" && (defaultTargetPlatform == TargetPlatform.iOS)) {
+      // On iOS, tabs pressed at the the software keyboard are reported here.
+      commonOps.indentListItem();
       return;
     }
 

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -131,6 +131,31 @@ class SuperEditorInspector {
     return superTextWithSelection.richText.style;
   }
 
+  /// Returns the [DocumentNode] at given the [index].
+  /// 
+  /// The given [index] must be a valid node index inside the [Document].The node at [index] 
+  /// must be of type [NodeType].
+  /// 
+  /// {@macro supereditor_finder}
+  static NodeType getNodeAt<NodeType extends DocumentNode>(int index, [Finder? superEditorFinder]) {
+    final doc = findDocument(superEditorFinder); 
+       
+    if (doc == null) {
+      throw Exception('SuperEditor not found');
+    }
+
+    if (index >= doc.nodes.length) {
+      throw Exception('Tried to access index $index in a document where the max index is ${doc.nodes.length - 1}');
+    }
+
+    final node = doc.nodes[index];
+    if (node is! NodeType) {
+      throw Exception('Tried to access a ${node.runtimeType} as $NodeType');
+    }
+
+    return node;
+  }
+
   /// Finds the [DocumentLayout] that backs a [SuperEditor] in the widget tree.
   ///
   /// {@macro supereditor_finder}

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -285,29 +285,34 @@ void main() {
 
   group('SuperEditor software keyboard', () {
     testWidgetsOnIos('pressing tab indent list', (tester) async {
-      final testContext = await _pumpUnorderedList(tester);
-      final doc = testContext.editContext.editor.document;
-      final nodeId = doc.nodes.first.id;
+      await _pumpUnorderedList(tester);
+
+      final node = SuperEditorInspector.getNodeAt<ListItemNode>(0);
 
       // Ensure we started with indentation level 0.
-      expect((doc.nodes.first as ListItemNode).indent, 0);
+      expect(node.indent, 0);
 
-      await tester.placeCaretInParagraph(nodeId, 0);
-
-      final selectionBeforeTab = SuperEditorInspector.findDocumentSelection();
-      final textBeforeTab = SuperEditorInspector.findTextInParagraph(nodeId);
+      await tester.placeCaretInParagraph(node.id, 0);
 
       // Simulate the user pressing TAB on the software keyboard.
       await tester.typeImeText("\t");
 
       // Ensure we indented the list item.
-      expect((doc.nodes.first as ListItemNode).indent, 1);
+      expect(node.indent, 1);
 
       // Ensure the selection didn't change.
-      expect(SuperEditorInspector.findDocumentSelection(), selectionBeforeTab);
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: node.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
 
       // Ensure the content of the list item didn't change.
-      expect(SuperEditorInspector.findTextInParagraph(nodeId), textBeforeTab);
+      expect(node.text.text, 'list item 1');
     });
   });
 }


### PR DESCRIPTION
[SuperEditor] [iOS] Fix list indentation using TAB key. Resolves #745 

Pressing the TAB button on the iOS software keyboard isn't indenting list items. The tabs are reported as an insertion delta of `\t` and being inserted as text.

This PR changes the IME handler to trigger the list indentation command when a `\t` is received.

I tested some android tablet simulators and none of them have the tab key, so this command is only triggered on iOS.

