### PR TITLE
[SuperEditor] Fix selection when tapping beyond end of content (Resolves #744)

### DIFF
--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -154,6 +154,31 @@ void main() {
       );
     });
 
+    testWidgetsOnAllPlatforms('places the caret at the end when tapping beyond the end of the document',
+        (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .fromMarkdown("This is a text")
+          .withEditorSize(const Size(300, 300))
+          .pump();
+
+      // Tap beyond the end of document with a small margin.
+      // As the document has only one line, this offset is after all the content.
+      await tester.tapAt(tester.getBottomLeft(find.byType(SuperEditor)) - const Offset(0, 10));
+      await tester.pump(kTapMinTime);
+
+      // Ensure selection is at the end of the document.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: testContext.editContext.editor.document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 14),
+          ),
+        ),
+      );
+    });
+
     testWidgetsOnDesktop(
         "dragging a single component selection above a component selects to the beginning of the component",
         (tester) async {

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -179,6 +179,30 @@ void main() {
       );
     });
 
+    testWidgetsOnAllPlatforms('places the caret at the beginning when tapping above the start of the content',
+        (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .withSingleParagraph()
+          .withEditorSize(const Size(300, 300))
+          .pump();
+
+      // Tap above the start of the content a small margin.
+      await tester.tapAt(tester.getTopRight(find.byType(SuperEditor)) - const Offset(10, 0));
+      await tester.pump(kTapMinTime);
+
+      // Ensure selection is at the beginning of the document.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: testContext.editContext.editor.document.nodes.first.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
     testWidgetsOnDesktop(
         "dragging a single component selection above a component selects to the beginning of the component",
         (tester) async {


### PR DESCRIPTION
[SuperEditor] Fix selection when tapping beyond end of content. Resolves #744

Tapping at the empty space after the content in `SuperEditor` is placing the caret at the horizontal position where the tap happened.

This PR changes `SuperEditor` to place the caret at the end of the document when a tap happens beyond the end of the content.
