### PR TITLE
[SuperEditor] Fix crash after changing the gesture mode (Resolves #742)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -145,7 +145,13 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
 
     widget.focusNode.addListener(_onFocusChange);
     if (widget.focusNode.hasFocus) {
-      _showEditingControlsOverlay();
+      // During Hot Reload, the gesture mode could be changed.
+      // If that's the case, initState is called while the Overlay is being
+      // built. This could crash the app. Because of that, we show the editing
+      // controls overlay in the next frame.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _showEditingControlsOverlay();
+      });
     }
 
     _scrollController = _scrollController = (widget.scrollController ?? ScrollController());
@@ -249,7 +255,12 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       _removeEditingOverlayControls();
 
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        _showEditingControlsOverlay();
+        // During Hot Reload, the gesture mode could be changed,
+        // so it's possible that we are no longer mounted after
+        // the post frame callback.
+        if (mounted) {
+          _showEditingControlsOverlay();
+        }
       });
     }
   }
@@ -1086,9 +1097,18 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   @override
   Widget build(BuildContext context) {
     if (_scrollController.hasClients) {
-      if (scrollPosition != _activeScrollPosition) {
-        _activeScrollPosition = scrollPosition;
-        _activeScrollPosition?.addListener(_onScrollChange);
+      if (_scrollController.positions.length > 1) {
+        // During Hot Reload, if the gesture mode was changed,
+        // the widget might be built while the old gesture interactor
+        // scroller is still attached to the _scrollController.
+        //
+        // Defer adding the listener to the next frame.
+        setState(() {});
+      } else {
+        if (scrollPosition != _activeScrollPosition) {
+          _activeScrollPosition = scrollPosition;
+          _activeScrollPosition?.addListener(_onScrollChange);
+        }
       }
     }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1103,7 +1103,9 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
         // scroller is still attached to the _scrollController.
         //
         // Defer adding the listener to the next frame.
-        setState(() {});
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          setState(() {});
+        });
       } else {
         if (scrollPosition != _activeScrollPosition) {
           _activeScrollPosition = scrollPosition;


### PR DESCRIPTION
[SuperEditor] Fix crash after changing the gesture mode. Resolves #742

When `SuperEditor` has focus, if we change the gesture mode and hot reload it crashes the app.

The crash is happening because, when we change the gesture mode and hot reload, the `initState` of the new gesture interactor is called while the app `Overlay` is being built, so we can't show the editing controls overlay in the same frame.

This PR changes the mobile interactors to show the editing controls overlay in a post frame callback.

Also, the iOS interactor is adding a listener to the scroll position during the `build` method. In the first build of the interactor after the gesture mode change, the `ScrollController` seems to be also attached to the old interactor, which also crashes the app.  I'm not sure why we are doing that, as in the android interactor we aren't doing that.

https://github.com/superlistapp/super_editor/blob/d5e7460956fc6d60abd65991d48ca2c073c1da38/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart#L1087-L1094

This PR changes the build to defer adding the listener to the next frame.

I'm not sure how to write a test for this.