### PR TITLE
[SuperTextField] Expose padding property (Resolves #588)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/_user_interaction.dart
@@ -361,7 +361,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
     final globalOffset = (context.findRenderObject() as RenderBox).localToGlobal(localOffset);
     final textOffset = (widget.textKey.currentContext!.findRenderObject() as RenderBox).globalToLocal(globalOffset);
-    return _textLayout.getPositionAtOffset(textOffset);
+    return _textLayout.getPositionNearestToOffset(textOffset);
   }
 
   /// Returns a [TextSelection] that selects the word surrounding the given

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -41,6 +41,7 @@ class SuperAndroidTextField extends StatefulWidget {
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
+    this.padding,
   }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
@@ -121,6 +122,9 @@ class SuperAndroidTextField extends StatefulWidget {
 
   /// Builder that creates the popover toolbar widget that appears when text is selected.
   final Widget Function(BuildContext, AndroidEditingOverlayController) popoverToolbarBuilder;
+
+  /// Padding placed around the text content of this text field.
+  final EdgeInsets? padding;
 
   @override
   State createState() => SuperAndroidTextFieldState();
@@ -479,6 +483,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             lineHeight: widget.lineHeight,
             perLineAutoScrollDuration: const Duration(milliseconds: 100),
             showDebugPaint: widget.showDebugPaint,
+            padding: widget.padding,
             child: ListenableBuilder(
               listenable: _textEditingController,
               builder: (context) {

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -123,7 +123,8 @@ class SuperAndroidTextField extends StatefulWidget {
   /// Builder that creates the popover toolbar widget that appears when text is selected.
   final Widget Function(BuildContext, AndroidEditingOverlayController) popoverToolbarBuilder;
 
-  /// Padding placed around the text content of this text field.
+  /// Padding placed around the text content of this text field, but within the
+  /// scrollable viewport.
   final EdgeInsets? padding;
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
@@ -354,19 +354,19 @@ class _TextScrollViewState extends State<TextScrollView>
     final estimatedContentHeight = (linesOfText * estimatedLineHeight) + totalVerticalPadding;
     _log.finer(' - estimated content height: $estimatedContentHeight');
 
-    final minContentHeight = (widget.minLines != null //
+    final minContentHeight = widget.minLines != null //
         ? widget.minLines! * estimatedLineHeight
-        : estimatedLineHeight); // Can't be shorter than 1 line.
+        : estimatedLineHeight; // Can't be shorter than 1 line.
 
     final minHeight = minContentHeight + totalVerticalPadding;
 
-    final maxContentHeight = (widget.maxLines != null //
+    final maxContentHeight = widget.maxLines != null //
         ? (widget.maxLines! * estimatedLineHeight) //
-        : null);
+        : null;
 
-    final maxHeight = (maxContentHeight != null //
+    final maxHeight = maxContentHeight != null //
         ? maxContentHeight + totalVerticalPadding
-        : null);
+        : null;
 
     _log.finer(' - minHeight: $minHeight, maxHeight: $maxHeight');
 

--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
@@ -94,7 +94,8 @@ class TextScrollView extends StatefulWidget {
   /// The text alignment within the scrollview.
   final TextAlign textAlign;
 
-  /// Padding placed around the text content of this text field.
+  /// Padding placed around the text content of this text field, but within the
+  /// scrollable viewport.
   final EdgeInsets? padding;
 
   /// The child widget.
@@ -348,18 +349,25 @@ class _TextScrollViewState extends State<TextScrollView>
       }
     }
 
-    final verticalPadding = widget.padding?.vertical ?? 0.0;
+    final totalVerticalPadding = widget.padding?.vertical ?? 0.0;
 
-    final estimatedContentHeight = (linesOfText * estimatedLineHeight) + verticalPadding;
+    final estimatedContentHeight = (linesOfText * estimatedLineHeight) + totalVerticalPadding;
     _log.finer(' - estimated content height: $estimatedContentHeight');
 
-    final minHeight = (widget.minLines != null //
-            ? widget.minLines! * estimatedLineHeight
-            : estimatedLineHeight) + // Can't be shorter than 1 line
-        verticalPadding;
-    final maxHeight = (widget.maxLines != null //
-        ? (widget.maxLines! * estimatedLineHeight) + verticalPadding //
+    final minContentHeight = (widget.minLines != null //
+        ? widget.minLines! * estimatedLineHeight
+        : estimatedLineHeight); // Can't be shorter than 1 line.
+
+    final minHeight = minContentHeight + totalVerticalPadding;
+
+    final maxContentHeight = (widget.maxLines != null //
+        ? (widget.maxLines! * estimatedLineHeight) //
         : null);
+
+    final maxHeight = (maxContentHeight != null //
+        ? maxContentHeight + totalVerticalPadding
+        : null);
+
     _log.finer(' - minHeight: $minHeight, maxHeight: $maxHeight');
 
     double? viewportHeight;
@@ -483,13 +491,13 @@ class _TextScrollViewState extends State<TextScrollView>
   }) {
     return Align(
       alignment: _getAlignment(),
-      child: Padding(
-        padding: widget.padding ?? EdgeInsets.zero,
-        child: SingleChildScrollView(
-          key: _textFieldViewportKey,
-          controller: _scrollController,
-          physics: const NeverScrollableScrollPhysics(),
-          scrollDirection: isMultiline ? Axis.vertical : Axis.horizontal,
+      child: SingleChildScrollView(
+        key: _textFieldViewportKey,
+        controller: _scrollController,
+        physics: const NeverScrollableScrollPhysics(),
+        scrollDirection: isMultiline ? Axis.vertical : Axis.horizontal,
+        child: Padding(
+          padding: widget.padding ?? EdgeInsets.zero,
           child: widget.child,
         ),
       ),

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_user_interaction.dart
@@ -330,7 +330,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     final globalOffset = (context.findRenderObject() as RenderBox).localToGlobal(localOffset);
     final textOffset =
         (widget.selectableTextKey.currentContext!.findRenderObject() as RenderBox).globalToLocal(globalOffset);
-    return _textLayout.getPositionAtOffset(textOffset);
+    return _textLayout.getPositionNearestToOffset(textOffset);
   }
 
   /// Returns a [TextSelection] that selects the word surrounding the given

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -127,7 +127,8 @@ class SuperIOSTextField extends StatefulWidget {
   /// Whether to paint debug guides.
   final bool showDebugPaint;
 
-  /// Padding placed around the text content of this text field.
+  /// Padding placed around the text content of this text field, but within the
+  /// scrollable viewport.
   final EdgeInsets? padding;
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -45,6 +45,7 @@ class SuperIOSTextField extends StatefulWidget {
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
+    this.padding,
   }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
@@ -125,6 +126,9 @@ class SuperIOSTextField extends StatefulWidget {
 
   /// Whether to paint debug guides.
   final bool showDebugPaint;
+
+  /// Padding placed around the text content of this text field.
+  final EdgeInsets? padding;
 
   @override
   State createState() => SuperIOSTextFieldState();
@@ -477,6 +481,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             lineHeight: widget.lineHeight,
             perLineAutoScrollDuration: const Duration(milliseconds: 100),
             showDebugPaint: widget.showDebugPaint,
+            padding: widget.padding,
             child: ListenableBuilder(
               listenable: _textEditingController,
               builder: (context) {

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -142,7 +142,8 @@ class SuperTextField extends StatefulWidget {
   /// Only used on desktop.
   final List<TextFieldKeyboardHandler> keyboardHandlers;
 
-  /// Padding placed around the text content of this text field.
+  /// Padding placed around the text content of this text field, but within the
+  /// scrollable viewport.
   final EdgeInsets? padding;
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -63,6 +63,7 @@ class SuperTextField extends StatefulWidget {
     this.maxLines = 1,
     this.lineHeight,
     this.keyboardHandlers = defaultTextFieldKeyboardHandlers,
+    this.padding,
   }) : super(key: key);
 
   final FocusNode? focusNode;
@@ -140,6 +141,9 @@ class SuperTextField extends StatefulWidget {
   ///
   /// Only used on desktop.
   final List<TextFieldKeyboardHandler> keyboardHandlers;
+
+  /// Padding placed around the text content of this text field.
+  final EdgeInsets? padding;
 
   @override
   State<SuperTextField> createState() => SuperTextFieldState();
@@ -238,6 +242,7 @@ class SuperTextFieldState extends State<SuperTextField> {
           minLines: widget.minLines,
           maxLines: widget.maxLines,
           keyboardHandlers: widget.keyboardHandlers,
+          padding: widget.padding ?? EdgeInsets.zero,
         );
       case SuperTextFieldPlatformConfiguration.android:
         return Shortcuts(
@@ -257,6 +262,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
             textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
+            padding: widget.padding,
           ),
         );
       case SuperTextFieldPlatformConfiguration.iOS:
@@ -277,6 +283,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
             textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
+            padding: widget.padding,
           ),
         );
     }

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -44,6 +44,80 @@ void main() {
       });
     });
 
+    group('tapping at padding', () {
+      testWidgetsOnAllPlatforms('at left places the caret', (tester) async {
+        await _pumpTestApp(
+          tester,
+          padding: const EdgeInsets.only(left: 20),
+          text: '',
+        );
+
+        // Tap in a place inside the padding.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)) + const Offset(18, 1));
+        await tester.pumpAndSettle();
+
+        // Ensure caret was placed.
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('at top places the caret', (tester) async {
+        await _pumpTestApp(
+          tester,
+          padding: const EdgeInsets.only(top: 20),
+          text: '',
+        );
+
+        // Tap in a place inside the padding.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)) + const Offset(2, 18));
+        await tester.pumpAndSettle();
+
+        // Ensure caret was placed.
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('at bottom places the caret', (tester) async {
+        await _pumpTestApp(
+          tester,
+          padding: const EdgeInsets.only(bottom: 20),
+          text: '',
+        );
+
+        // Tap in a place inside the padding.
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(2, 18));
+        await tester.pumpAndSettle();
+
+        // Ensure caret was placed.
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('at right places the caret', (tester) async {
+        await _pumpTestApp(
+          tester,
+          padding: const EdgeInsets.only(right: 20),
+          text: '',
+        );
+
+        // Tap in a place inside the padding.
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(18, 2));
+        await tester.pumpAndSettle();
+
+        // Ensure caret was placed.
+        expect(
+          SuperTextFieldInspector.findSelection(),
+          const TextSelection.collapsed(offset: 0),
+        );
+      });
+    });
+
     group('tapping in an area containing text places the caret at tap position', () {
       testWidgetsOnMobile("when the field does not have focus", (tester) async {
         await _pumpTestApp(tester);
@@ -226,14 +300,17 @@ void main() {
 Future<void> _pumpTestApp(
   WidgetTester tester, {
   AttributedTextEditingController? controller,
+  EdgeInsets? padding,
+  String text = 'abc',
 }) async {
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
         body: SuperTextField(
+          padding: padding,
           textController: controller ??
               AttributedTextEditingController(
-                text: AttributedText(text: "abc"),
+                text: AttributedText(text: text),
               ),
         ),
       ),

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -90,7 +90,8 @@ void main() {
 
         final finder = find.byType(SuperTextField);
         // Tap in a place inside the padding.
-        await tester.tapAt(tester.getBottomRight(finder) - Offset(tester.getSize(finder).width / 2, 1));
+        // On linux, tapping exactly at middle is placing caret at offset 1.
+        await tester.tapAt(tester.getBottomRight(finder) - Offset((tester.getSize(finder).width / 2) - 1, 1));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -44,16 +44,16 @@ void main() {
       });
     });
 
-    group('tapping at padding', () {
-      testWidgetsOnAllPlatforms('at left places the caret', (tester) async {
+    group('tapping on padding places caret', () {
+      testWidgetsOnAllPlatforms('on the left side', (tester) async {
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(left: 20),
-          text: '',
         );
 
+        final finder = find.byType(SuperTextField);
         // Tap in a place inside the padding.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)) + const Offset(18, 1));
+        await tester.tapAt(tester.getTopLeft(finder) + Offset(1, tester.getSize(finder).height / 2));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.
@@ -63,57 +63,57 @@ void main() {
         );
       });
 
-      testWidgetsOnAllPlatforms('at top places the caret', (tester) async {
+      testWidgetsOnAllPlatforms('on the top', (tester) async {
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(top: 20),
-          text: '',
         );
 
+        final finder = find.byType(SuperTextField);
         // Tap in a place inside the padding.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)) + const Offset(2, 18));
+        await tester.tapAt(tester.getTopLeft(finder) + Offset(tester.getSize(finder).width / 2, 1));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 0),
+          const TextSelection.collapsed(offset: 3),
         );
       });
 
-      testWidgetsOnAllPlatforms('at bottom places the caret', (tester) async {
+      testWidgetsOnAllPlatforms('on the bottom', (tester) async {
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(bottom: 20),
-          text: '',
         );
 
+        final finder = find.byType(SuperTextField);
         // Tap in a place inside the padding.
-        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(2, 18));
+        await tester.tapAt(tester.getBottomRight(finder) - Offset(tester.getSize(finder).width / 2, 1));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 0),
+          const TextSelection.collapsed(offset: 3),
         );
       });
 
-      testWidgetsOnAllPlatforms('at right places the caret', (tester) async {
+      testWidgetsOnAllPlatforms('on the right side', (tester) async {
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(right: 20),
-          text: '',
         );
 
+        final finder = find.byType(SuperTextField);
         // Tap in a place inside the padding.
-        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(18, 2));
+        await tester.tapAt(tester.getBottomRight(finder) - Offset(1, tester.getSize(finder).height / 2));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 0),
+          const TextSelection.collapsed(offset: 3),
         );
       });
     });
@@ -301,7 +301,6 @@ Future<void> _pumpTestApp(
   WidgetTester tester, {
   AttributedTextEditingController? controller,
   EdgeInsets? padding,
-  String text = 'abc',
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -310,7 +309,7 @@ Future<void> _pumpTestApp(
           padding: padding,
           textController: controller ??
               AttributedTextEditingController(
-                text: AttributedText(text: text),
+                text: AttributedText(text: 'abc'),
               ),
         ),
       ),

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -85,6 +85,7 @@ void main() {
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(bottom: 20),
+          textAlign: TextAlign.center,
         );
 
         final finder = find.byType(SuperTextField);
@@ -95,7 +96,7 @@ void main() {
         // Ensure caret was placed.
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 3),
+          const TextSelection.collapsed(offset: 2),
         );
       });
 
@@ -301,12 +302,14 @@ Future<void> _pumpTestApp(
   WidgetTester tester, {
   AttributedTextEditingController? controller,
   EdgeInsets? padding,
+  TextAlign? textAlign,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
         body: SuperTextField(
           padding: padding,
+          textAlign: textAlign ?? TextAlign.left,
           textController: controller ??
               AttributedTextEditingController(
                 text: AttributedText(text: 'abc'),

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -52,7 +52,7 @@ void main() {
         );
 
         final finder = find.byType(SuperTextField);
-        // Tap in a place inside the padding.
+        // Tap at the left side of the text field, at the vertical center.
         await tester.tapAt(tester.getTopLeft(finder) + Offset(1, tester.getSize(finder).height / 2));
         await tester.pumpAndSettle();
 
@@ -64,24 +64,28 @@ void main() {
       });
 
       testWidgetsOnAllPlatforms('on the top', (tester) async {
+        /// Pump a center-aligned text field so we can tap at the middle of the text.
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(top: 20),
+          textAlign: TextAlign.center,
         );
 
         final finder = find.byType(SuperTextField);
-        // Tap in a place inside the padding.
-        await tester.tapAt(tester.getTopLeft(finder) + Offset(tester.getSize(finder).width / 2, 1));
+        // Tap at the top of the text field, at the horizontal center.
+        // On linux, tapping exactly at middle is placing caret at offset 1.
+        await tester.tapAt(tester.getTopLeft(finder) + Offset((tester.getSize(finder).width / 2) + 1, 1));
         await tester.pumpAndSettle();
 
         // Ensure caret was placed.
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 3),
+          const TextSelection.collapsed(offset: 2),
         );
       });
 
       testWidgetsOnAllPlatforms('on the bottom', (tester) async {
+        /// Pump a center-aligned text field so we can tap at the middle of the text.
         await _pumpTestApp(
           tester,
           padding: const EdgeInsets.only(bottom: 20),
@@ -89,7 +93,7 @@ void main() {
         );
 
         final finder = find.byType(SuperTextField);
-        // Tap in a place inside the padding.
+        // Tap at the bottom of the text field, at the horizontal center.
         // On linux, tapping exactly at middle is placing caret at offset 1.
         await tester.tapAt(tester.getBottomRight(finder) - Offset((tester.getSize(finder).width / 2) - 1, 1));
         await tester.pumpAndSettle();
@@ -108,7 +112,7 @@ void main() {
         );
 
         final finder = find.byType(SuperTextField);
-        // Tap in a place inside the padding.
+        // Tap at the right side of the text field, at the vertical center.
         await tester.tapAt(tester.getBottomRight(finder) - Offset(1, tester.getSize(finder).height / 2));
         await tester.pumpAndSettle();
 

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -201,6 +201,31 @@ void main() {
         expect(_isCaretPresent(tester), isTrue);
       });
     });
+
+    group('padding', () {
+      testWidgetsOnAllPlatforms('is applied when configured', (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              padding: EdgeInsets.fromLTRB(5, 10, 15, 20),
+              minLines: 1,
+              maxLines: 2,
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final textFieldRect = tester.getRect(find.byType(SuperTextField));
+        final contentRect = tester.getRect(find.byType(SuperTextWithSelection));
+
+        // Ensure padding was applied.
+        expect(contentRect.left - textFieldRect.left, 5);
+        expect(contentRect.top - textFieldRect.top, 10);
+        expect(textFieldRect.right - contentRect.right, 15);
+        expect(textFieldRect.bottom - contentRect.bottom, 20);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
[SuperTextField] Expose padding property. Resolves #588 

Currently `SuperDesktopTextField` exposes a `padding` property, but `SuperTextField` don't.

This PR exposes the  `padding` property at `SuperTextField` public API and implements padding support in `SuperAndroidTextField` and `SuperIOSTextField`.