### PR TITLE
[SuperEditor] Fix list item style when converting to paragraph and back again (Resolves #795)

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -8,7 +8,6 @@ import 'package:super_editor/src/infrastructure/keyboard.dart';
 
 import '../core/document.dart';
 import '../core/document_editor.dart';
-import 'document_input_keyboard.dart';
 import 'layout_single_column/layout_single_column.dart';
 import 'paragraph.dart';
 import 'text.dart';
@@ -57,8 +56,12 @@ class ListItemNode extends TextNode {
         super(
           id: id,
           text: text,
-          metadata: metadata,
-        );
+          metadata: metadata ?? {},
+        ) {
+    if (!hasMetadataValue("blockType")) {
+      putMetadataValue("blockType", const NamedAttribution("listItem"));
+    }
+  }
 
   final ListItemType type;
 

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -239,8 +239,7 @@ void main() {
         Platform.setTestInstance(null);
       });
 
-      testWidgetsOnArbitraryDesktop(
-          "respects stylesheet when converting unordered list item to paragraph and back again",
+      testWidgetsOnArbitraryDesktop("applies styles when unordered list item is converted to and from a paragraph",
           (WidgetTester tester) async {
         final testContext = await _pumpUnorderedList(
           tester,
@@ -284,7 +283,7 @@ void main() {
         expect(richText.text.style!.color, Colors.blue);
       });
 
-      testWidgetsOnArbitraryDesktop("respects stylesheet when converting ordered list item to paragraph and back again",
+      testWidgetsOnArbitraryDesktop("applies styles when ordered list item is converted to and from a paragraph",
           (WidgetTester tester) async {
         final testContext = await _pumpOrderedList(
           tester,

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:super_editor/src/infrastructure/platform_detector.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../../super_editor/document_test_tools.dart';
 import '../../test_tools.dart';
@@ -236,6 +238,95 @@ void main() {
 
         Platform.setTestInstance(null);
       });
+
+      testWidgetsOnArbitraryDesktop(
+          "respects stylesheet when converting unordered list item to paragraph and back again",
+          (WidgetTester tester) async {
+        final testContext = await _pumpUnorderedList(
+          tester,
+          styleSheet: _styleSheet,
+        );
+        final doc = SuperEditorInspector.findDocument()!;
+
+        LayoutAwareRichText richText;
+
+        // Ensure that the textStyle for a list item was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.blue);
+
+        // Tap to place caret.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Convert the list item to a paragraph.
+        testContext.editContext.commonOps.convertToParagraph(
+          newMetadata: {
+            'blockType': const NamedAttribution("paragraph"),
+          },
+        );
+        await tester.pumpAndSettle();
+
+        // Ensure that the textStyle for a paragraph was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.red);
+
+        // Convert the paragraph back to an unordered list item.
+        testContext.editContext.commonOps.convertToListItem(
+          ListItemType.unordered,
+          (doc.nodes.first as ParagraphNode).text,
+        );
+        await tester.pumpAndSettle();
+
+        // Ensure that the textStyle for a list item was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.blue);
+      });
+
+      testWidgetsOnArbitraryDesktop("respects stylesheet when converting ordered list item to paragraph and back again",
+          (WidgetTester tester) async {
+        final testContext = await _pumpOrderedList(
+          tester,
+          styleSheet: _styleSheet,
+        );
+        final doc = SuperEditorInspector.findDocument()!;
+
+        LayoutAwareRichText richText;
+
+        // Ensure that the textStyle for a list item was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.blue);
+
+        // Tap to place caret.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Convert the list item to a paragraph.
+        testContext.editContext.commonOps.convertToParagraph(
+          newMetadata: {
+            'blockType': const NamedAttribution("paragraph"),
+          },
+        );
+        await tester.pumpAndSettle();
+
+        // Ensure that the textStyle for a paragraph was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.red);
+
+        // Convert the paragraph back to an ordered list item.
+        testContext.editContext.commonOps.convertToListItem(
+          ListItemType.ordered,
+          (doc.nodes.first as ParagraphNode).text,
+        );
+        await tester.pumpAndSettle();
+
+        // Ensure that the textStyle for a list item was applied.
+        expect(find.byType(LayoutAwareRichText), findsWidgets);
+        richText = (find.byType(LayoutAwareRichText).evaluate().first.widget) as LayoutAwareRichText;
+        expect(richText.text.style!.color, Colors.blue);
+      });
     });
 
     group('unordered list', () {
@@ -399,16 +490,20 @@ void _typeKeys(EditContext editContext, List<FakeRawKeyEvent> keys) {
 /// The first two items have one level of indentation.
 ///
 /// The last two items have two levels of indentation.
-Future<void> _pumpUnorderedList(WidgetTester tester) async {
+Future<TestDocumentContext> _pumpUnorderedList(
+  WidgetTester tester, {
+  Stylesheet? styleSheet,
+}) async {
   const markdown = '''
  * list item 1
  * list item 2
    * list item 2.1
    * list item 2.2''';
 
-  await tester //
+  return await tester //
       .createDocument()
       .fromMarkdown(markdown)
+      .useStylesheet(styleSheet)
       .pump();
 }
 
@@ -417,15 +512,49 @@ Future<void> _pumpUnorderedList(WidgetTester tester) async {
 /// The first two items have one level of indentation.
 ///
 /// The last two items have two levels of indentation.
-Future<void> _pumpOrderedList(WidgetTester tester) async {
+Future<TestDocumentContext> _pumpOrderedList(
+  WidgetTester tester, {
+  Stylesheet? styleSheet,
+}) async {
   const markdown = '''
  1. list item 1
  1. list item 2
     1. list item 2.1
     1. list item 2.2''';
 
-  await tester //
+  return await tester //
       .createDocument()
       .fromMarkdown(markdown)
+      .useStylesheet(styleSheet)
       .pump();
 }
+
+TextStyle _inlineTextStyler(Set<Attribution> attributions, TextStyle base) => base;
+
+final _styleSheet = Stylesheet(
+  inlineTextStyler: _inlineTextStyler,
+  rules: [
+    StyleRule(
+      const BlockSelector("paragraph"),
+      (doc, docNode) {
+        return {
+          "textStyle": const TextStyle(
+            color: Colors.red,
+            fontSize: 16,
+          ),
+        };
+      },
+    ),
+    StyleRule(
+      const BlockSelector("listItem"),
+      (doc, docNode) {
+        return {
+          "textStyle": const TextStyle(
+            color: Colors.blue,
+            fontSize: 16,
+          ),
+        };
+      },
+    ),
+  ],
+);

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -217,7 +217,7 @@ class TestDocumentConfigurator {
   }
 
   /// Configures the [SuperEditor] to use the given [stylesheet].
-  TestDocumentConfigurator useStylesheet(Stylesheet stylesheet) {
+  TestDocumentConfigurator useStylesheet(Stylesheet? stylesheet) {
     _stylesheet = stylesheet;
     return this;
   }


### PR DESCRIPTION
[SuperEditor] Fix list item style when converting to paragraph and back again. Resolves #795 

Converting a list item to a paragraph and back again wasn't respecting the styles for a list item.

The cause is that only the `ListItemNode` named constructors are setting the `blockType` metadata to `listItem`, and `ConvertParagraphToListItemCommand` uses the unnamed constructor. 

As the `StyleRule` for the list items uses a `listItem` block selector, this rule isn't picked.

Deserializing from markdown might also be affected, as it also uses the unnamed constructor.

This PR changes `ListItemNode` unnamed constructor to set the `blockType` if it isn't set.

