### PR TITLE
Fix issues found when auditing example app with Flutter 3.3.x

### DIFF
--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -4,7 +4,6 @@ import 'package:super_editor/super_editor.dart';
 /// Demo of an [SuperEditor] widget that can lose focus to a nearby
 /// [TextField] to ensure that the [SuperEditor] correctly removes
 /// its caret.
-// TODO: Add widget tests for focus interaction verifications
 class LoseFocusDemo extends StatefulWidget {
   @override
   _LoseFocusDemoState createState() => _LoseFocusDemoState();
@@ -31,7 +30,7 @@ class _LoseFocusDemoState extends State<LoseFocusDemo> {
     return SafeArea(
       child: Column(
         children: [
-          _buildDocSelector(),
+          _buildTextField(),
           Expanded(
             child: SuperEditor(
               editor: _docEditor,
@@ -45,7 +44,7 @@ class _LoseFocusDemoState extends State<LoseFocusDemo> {
     );
   }
 
-  Widget _buildDocSelector() {
+  Widget _buildTextField() {
     return const Padding(
       padding: EdgeInsets.symmetric(horizontal: 48.0),
       child: TextField(

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
@@ -158,7 +158,7 @@ class _MobileEditingAndroidDemoState extends State<MobileEditingAndroidDemo> {
   }) {
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(56),
+        padding: const EdgeInsets.only(left: 56, right: 56, bottom: 24),
         child: AspectRatio(
           aspectRatio: 9 / 19.5,
           child: Container(

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -124,7 +124,7 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> {
   }) {
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(56),
+        padding: const EdgeInsets.only(left: 56, right: 56, bottom: 24),
         child: AspectRatio(
           aspectRatio: 9 / 19.5,
           child: Container(

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -43,7 +43,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
     super.initState();
     _doc = createInitialDocument()..addListener(_hideOrShowToolbar);
     _docEditor = DocumentEditor(document: _doc as MutableDocument);
-    _composer = DocumentComposer()..addListener(_hideOrShowToolbar);
+    _composer = DocumentComposer();
+    _composer.selectionNotifier.addListener(_hideOrShowToolbar);
     _docOps = CommonEditorOperations(
       editor: _docEditor,
       composer: _composer,

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -43,7 +43,7 @@ Future<void> main() async {
     // editorOpsLog,
     // editorLayoutLog,
     // editorDocLog,
-    // editorStyleLog,
+    editorStyleLog,
     // textFieldLog,
     appLog,
   });

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -31,7 +31,6 @@ import 'demos/demo_document_loses_focus.dart';
 import 'demos/demo_switch_document_content.dart';
 import 'demos/super_document/demo_read_only_scrolling_document.dart';
 import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
-import 'logging.dart';
 
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
@@ -303,7 +302,7 @@ final _menu = <_MenuGroup>[
   ),
   _MenuGroup(
     title: 'SCROLLING',
-    items: [      
+    items: [
       _MenuItem(
         icon: Icons.task,
         title: 'Task and Chat Demo - Slivers',

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -43,7 +43,7 @@ Future<void> main() async {
     // editorOpsLog,
     // editorLayoutLog,
     // editorDocLog,
-    editorStyleLog,
+    // editorStyleLog,
     // textFieldLog,
     appLog,
   });

--- a/super_editor/lib/src/default_editor/document_selection_on_focus_mixin.dart
+++ b/super_editor/lib/src/default_editor/document_selection_on_focus_mixin.dart
@@ -76,6 +76,7 @@ mixin DocumentSelectionOnFocusMixin<T extends StatefulWidget> on State<T> {
 
   void _onFocusChange() {
     if (!_focusNode!.hasFocus) {
+      _selection?.value = null;
       return;
     }
 

--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_per_component.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_per_component.dart
@@ -33,17 +33,15 @@ class SingleColumnLayoutCustomComponentStyler extends SingleColumnLayoutStylePha
   }
 
   SingleColumnLayoutComponentViewModel _applyLayoutStyles(
-      DocumentNode node,
-      SingleColumnLayoutComponentViewModel viewModel,
-      ) {
+    DocumentNode node,
+    SingleColumnLayoutComponentViewModel viewModel,
+  ) {
     final componentStyles = SingleColumnLayoutComponentStyles.fromMetadata(node);
 
     viewModel
       ..maxWidth = componentStyles.width ?? viewModel.maxWidth
       ..padding = componentStyles.padding ?? viewModel.padding;
 
-    editorStyleLog
-        .warning("Tried to apply custom component styles to unknown layout component view model: $viewModel");
     return viewModel;
   }
 }
@@ -76,11 +74,11 @@ class SingleColumnLayoutComponentStyles {
   }
 
   Map<String, dynamic> toMetadata() => {
-    _metadataKey: {
-      _widthKey: width,
-      _paddingKey: padding,
-    },
-  };
+        _metadataKey: {
+          _widthKey: width,
+          _paddingKey: padding,
+        },
+      };
 
   SingleColumnLayoutComponentStyles copyWith({
     double? width,
@@ -95,10 +93,10 @@ class SingleColumnLayoutComponentStyles {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is SingleColumnLayoutComponentStyles &&
-              runtimeType == other.runtimeType &&
-              width == other.width &&
-              padding == other.padding;
+      other is SingleColumnLayoutComponentStyles &&
+          runtimeType == other.runtimeType &&
+          width == other.width &&
+          padding == other.padding;
 
   @override
   int get hashCode => width.hashCode ^ padding.hashCode;

--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -106,6 +106,7 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
             'ERROR: Building a paragraph component but the selection is not a TextSelection. Node: ${node.id}, Selection: ${nodeSelection.nodeSelection}');
       }
       final showCaret = _shouldDocumentShowCaret && nodeSelection != null ? nodeSelection.isExtent : false;
+      editorStyleLog.fine("Showing caret? $showCaret");
       final highlightWhenEmpty =
           nodeSelection == null ? false : nodeSelection.highlightWhenEmpty && _selectionStyles.highlightEmptyTextBlocks;
 

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -259,6 +259,37 @@ void main() {
       );
     });
 
+    testWidgetsOnAllPlatforms("removes caret when it loses focus", (tester) async {
+      await tester
+          .createDocument()
+          .withLongTextContent()
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    const TextField(),
+                    Expanded(child: superEditor),
+                  ],
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      // Place the caret in the document.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Focus the textfield.
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+
+      // Ensure that the document doesn't have focus, and isn't displaying a caret.
+      expect(SuperEditorInspector.hasFocus(), isFalse);
+      expect(SuperEditorInspector.findDocumentSelection(), isNull);
+      expect(_caretFinder(), findsNothing); // TODO: move caret finding into inspector
+    });
+
     testWidgetsOnAllPlatforms("places caret at end of document upon first editor focus with tab", (tester) async {
       await tester
           .createDocument()
@@ -657,7 +688,7 @@ Second Paragraph
 
       // Ensure caret is displayed.
       expect(_caretFinder(), findsOneWidget);
-    });  
+    });
   });
 }
 


### PR DESCRIPTION
I audited the example app looking for issues after upgrading to Flutter 3.3.x.

I found some scrolling issues that seem to be caused by Flutter 3.3.x and I filed an issue or two with Flutter. I don't think there's anything we can do until Flutter addresses those issues.

I found that https://github.com/flutter/flutter/issues/111425 seems to be impacting our I-beam text cursor throughout SuperEditor. That's also outside our control.

There didn't seem to be any Flutter changes in 3.3.x that caused problems in SuperEditor that we can fix, but I did find and fix some pre-existing issues. Those fixes are in this PR.