### PR TITLE
[SuperEditor] Fix default input source (Resolves #740)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1,5 +1,5 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -145,7 +145,7 @@ class SuperEditor extends StatefulWidget {
     this.customStylePhases = const [],
     List<ComponentBuilder>? componentBuilders,
     SelectionStyles? selectionStyle,
-    this.inputSource = DocumentInputSource.keyboard,
+    this.inputSource,
     this.gestureMode,
     List<DocumentKeyboardAction>? keyboardActions,
     this.softwareKeyboardHandler,
@@ -210,7 +210,7 @@ class SuperEditor extends StatefulWidget {
   final List<SingleColumnLayoutStylePhase> customStylePhases;
 
   /// The `SuperEditor` input source, e.g., keyboard or Input Method Engine.
-  final DocumentInputSource inputSource;
+  final DocumentInputSource? inputSource;
 
   /// The `SuperEditor` gesture mode, e.g., mouse or touch.
   final DocumentGestureMode? gestureMode;
@@ -493,6 +493,26 @@ class SuperEditorState extends State<SuperEditor> {
     }
   }
 
+  /// Returns the [DocumentInputSource] which should be used.
+  ///
+  /// If the `inputSource` is configured, it is used. Otherwise,
+  /// the [DocumentInputSource] is chosen based on the platform.
+  DocumentInputSource get _inputSource {
+    if (widget.inputSource != null) {
+      return widget.inputSource!;
+    }
+    if (kIsWeb) {
+      return DocumentInputSource.keyboard;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        return DocumentInputSource.ime;
+      default:
+        return DocumentInputSource.keyboard;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return _buildInputSystem(
@@ -512,7 +532,7 @@ class SuperEditorState extends State<SuperEditor> {
   Widget _buildInputSystem({
     required Widget child,
   }) {
-    switch (widget.inputSource) {
+    switch (_inputSource) {
       case DocumentInputSource.keyboard:
         return DocumentKeyboardInteractor(
           focusNode: _focusNode,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -501,9 +501,6 @@ class SuperEditorState extends State<SuperEditor> {
     if (widget.inputSource != null) {
       return widget.inputSource!;
     }
-    if (kIsWeb) {
-      return DocumentInputSource.keyboard;
-    }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.iOS:

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -192,20 +192,6 @@ class TestDocumentConfigurator {
     return this;
   }
 
-  DocumentInputSource get _defaultInputSource {
-    switch (debugDefaultTargetPlatformOverride) {
-      case TargetPlatform.android:
-      case TargetPlatform.iOS:
-        return DocumentInputSource.ime;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        return DocumentInputSource.keyboard;
-      default:
-        return DocumentInputSource.keyboard;
-    }
-  }
 
   /// Configures the [ThemeData] used for the [MaterialApp] that wraps
   /// the [SuperEditor].
@@ -274,7 +260,7 @@ class TestDocumentConfigurator {
         editor: testDocumentContext.editContext.editor,
         composer: testDocumentContext.editContext.composer,
         focusNode: testDocumentContext.focusNode,
-        inputSource: _inputSource ?? _defaultInputSource,
+        inputSource: _inputSource,
         gestureMode: _gestureMode,
         androidToolbarBuilder: _androidToolbarBuilder,
         iOSToolbarBuilder: _iOSToolbarBuilder,

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -315,7 +315,7 @@ void main() {
   });
 
   group('SuperEditor inputSource', () {
-    testWidgetsOnMobile('configures for IME input', (tester) async {
+    testWidgetsOnMobile('configures for IME input by default', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()
@@ -338,7 +338,7 @@ void main() {
       expect(document.nodes.length, 2);
     });
 
-    testWidgetsOnDesktop('configures for keyboard input', (tester) async {
+    testWidgetsOnDesktop('configures for keyboard input by default', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -329,14 +329,9 @@ void main() {
       // Tap to give focus to the editor.
       await tester.placeCaretInParagraph(document.nodes.first.id, 0);
 
-      // Simulate a tap in the newline button, which will be handled
-      // by the IME interactor.
-      //
-      // When using a software keyboard, pressing the newline button
-      // will dispatch a TextInputAction to the connected TextInputClient.
-      // This action will cause the editor to add a new paragraph to the document.
-      //
-      // TextInputAction's can only be received in IME mode.
+      // Ensure that IME input is enabled. To check IME input, we arbitrarily simulate a newline action from
+      // the IME. If the editor responds to the newline, it means IME input is enabled.
+      // We expect the newline to insert a new paragraph node.
       await tester.testTextInput.receiveAction(TextInputAction.newline);
       await tester.pumpAndSettle();
 
@@ -358,9 +353,9 @@ void main() {
       // Tap to give focus to the editor.
       await tester.placeCaretInParagraph(document.nodes.first.id, 0);
 
-      // When we are in keyboard mode, we can't receive input actions.
-      // So, simulating an input action will have no effect.
-      // Therefore, this operation shouldn't change the document's content.
+      // Ensure that IME input is disabled. To check IME input, we arbitrarily simulate a newline action from
+      // the IME. If the editor doesn't respond to the newline, it means IME input is disabled.
+      // We expect that the document content remains unchanged.
       await tester.testTextInput.receiveAction(TextInputAction.newline);
       await tester.pumpAndSettle();
 

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -313,6 +313,62 @@ void main() {
       expect(node.text.text, 'list item 1');
     });
   });
+
+  group('SuperEditor inputSource', () {
+    testWidgetsOnMobile('configures for IME input', (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+
+      final document = SuperEditorInspector.findDocument()!;
+
+      // Ensure the document was created with one node.
+      expect(document.nodes.length, 1);
+
+      // Tap to give focus to the editor.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+
+      // Simulate a tap in the newline button, which will be handled
+      // by the IME interactor.
+      await tester.testTextInput.receiveAction(TextInputAction.newline);
+      await tester.pumpAndSettle();
+
+      // Ensure a new node was added.
+      expect(document.nodes.length, 2);
+    });
+
+    testWidgetsOnDesktop('configures for keyboard input', (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+
+      final document = SuperEditorInspector.findDocument()!;
+
+      // Ensure the document was created with one node.
+      expect(document.nodes.length, 1);
+
+      // Tap to give focus to the editor.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+
+      // Simulate a tap in the newline button, which is handled
+      // only by the IME interactor.
+      // As the editor should be configured for keyboard input,
+      // this shouldn't change the document.
+      await tester.testTextInput.receiveAction(TextInputAction.newline);
+      await tester.pumpAndSettle();
+
+      // Ensure no node was added.
+      expect(document.nodes.length, 1);
+
+      // Simulate typing on a keyboard.
+      await tester.typeKeyboardText('abc');
+
+      // Ensure text was added.
+      expect(SuperEditorInspector.findTextInParagraph(document.nodes.first.id).text, 'abc');
+    });
+  });
 }
 
 Future<String> _pumpSingleLineWithCaret(

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -315,7 +315,7 @@ void main() {
   });
 
   group('SuperEditor inputSource', () {
-    testWidgetsOnMobile('configures for IME input by default', (tester) async {
+    testWidgetsOnMobile('configures for IME input by default on mobile', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()
@@ -331,6 +331,12 @@ void main() {
 
       // Simulate a tap in the newline button, which will be handled
       // by the IME interactor.
+      //
+      // When using a software keyboard, pressing the newline button
+      // will dispatch a TextInputAction to the connected TextInputClient.
+      // This action will cause the editor to add a new paragraph to the document.
+      //
+      // TextInputAction's can only be received in IME mode.
       await tester.testTextInput.receiveAction(TextInputAction.newline);
       await tester.pumpAndSettle();
 
@@ -338,7 +344,7 @@ void main() {
       expect(document.nodes.length, 2);
     });
 
-    testWidgetsOnDesktop('configures for keyboard input by default', (tester) async {
+    testWidgetsOnDesktop('configures for keyboard input by default on desktop', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()
@@ -352,10 +358,9 @@ void main() {
       // Tap to give focus to the editor.
       await tester.placeCaretInParagraph(document.nodes.first.id, 0);
 
-      // Simulate a tap in the newline button, which is handled
-      // only by the IME interactor.
-      // As the editor should be configured for keyboard input,
-      // this shouldn't change the document.
+      // When we are in keyboard mode, we can't receive input actions.
+      // So, simulating an input action will have no effect.
+      // Therefore, this operation shouldn't change the document's content.
       await tester.testTextInput.receiveAction(TextInputAction.newline);
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
[SuperEditor] Fix default input source. Resolves #740

SuperEditor is using `keyboard` as its default `inputSource`.

This PR removes the default `inputSource` and changes the editor to choose the input source based on the platform if the editor's `inputSource` isn't configured.