### PR TITLE
[SuperTextField] [Mobile] Fix viewport height when text changes (Resolves #794)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/text_scrollview.dart
@@ -392,25 +392,15 @@ class _TextScrollViewState extends State<TextScrollView>
       return false;
     }
 
-    if (viewportHeight == null && isMultiline && !isBounded) {
-      // We don't have a viewport height, but we're multiline and
-      // unbounded so a null viewport height is fine. We'll wrap
-      // the intrinsic height of the text.
-      _log.finer(' - viewport height is null, but TextScrollView is unbounded so that is OK');
-      final didChange = viewportHeight != _viewportHeight;
-      if (mounted) {
-        setState(() {
-          _needViewportHeight = false;
-          _viewportHeight = null;
-        });
-      }
-      return didChange;
-    }
+    final wantsUnboundedIntrinsicHeight = viewportHeight == null && isMultiline && !isBounded;
+    final multilineContentFitsMaxHeight =
+        viewportHeight == null && isMultiline && isBounded && estimatedContentHeight <= maxHeight!;
 
-    if (viewportHeight == null && isMultiline && maxHeight != null && estimatedContentHeight <= maxHeight) {
-      // We don't have a viewport height, but we're multiline and
-      // our estimated content height fits inside our max height.
+    if (wantsUnboundedIntrinsicHeight || multilineContentFitsMaxHeight) {
+      // We have either an unbounded height or our estimated content height fits inside our max height.
       // The viewport should expand to fit its content.
+      _log.finer(
+          ' - viewport height is null, but TextScrollView is unbounded or the content fits max height, so that is OK');
       final didChange = viewportHeight != _viewportHeight;
       if (mounted) {
         setState(() {

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -226,6 +226,72 @@ void main() {
         expect(textFieldRect.bottom - contentRect.bottom, 20);
       });
     });
+
+    testWidgetsOnAllPlatforms('recalculates its viewport height when text changes for text smaller than maxLines',
+        (tester) async {
+      final controller = AttributedTextEditingController();
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            minLines: 1,
+            maxLines: 10,
+            textController: controller,
+          ),
+        ),
+      );
+
+      // Change the text so the content height is greater
+      // than the initial content height.
+      controller.text = AttributedText(
+        text: """
+This is
+a
+multi-line
+SuperTextField
+""",
+      );
+      await tester.pumpAndSettle();
+
+      final textSize = tester.getSize(find.byType(SuperTextWithSelection));
+      final textFieldSize = tester.getSize(find.byType(SuperTextField));
+
+      // Ensure the text field height is big enough to display the whole content.
+      expect(textFieldSize.height, greaterThanOrEqualTo(textSize.height));
+    });
+
+    testWidgetsOnAllPlatforms('recalculates its viewport height when text changes for text bigger than maxLines',
+        (tester) async {
+      final controller = AttributedTextEditingController();
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            minLines: 1,
+            maxLines: 2,
+            textController: controller,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final textFieldSizeBefore = tester.getSize(find.byType(SuperTextField));
+
+      // Change the text, so the content height is greater
+      // than the initial content height.
+      controller.text = AttributedText(
+        text: """
+This is
+a
+multi-line
+SuperTextField
+""",
+      );
+      await tester.pumpAndSettle();
+
+      // Ensure the text field height has increased.
+      expect(tester.getSize(find.byType(SuperTextField)).height, greaterThan(textFieldSizeBefore.height));
+    });
   });
 }
 


### PR DESCRIPTION
[SuperTextField] [Mobile] Fix viewport height when text changes. Resolves #794 

On mobile, changing the text isn't causing the text field to recalculate its viewport height. 

For example:  when adding new lines in a multi-line text field with `maxLines != null`,  the text field maintains the same height calculated for its initial text.

This PR changes the `TextScrollView` used by the mobile text fields to recalculate its viewport height when text changes.

