### PR TITLE
Upgrade super_editor's super_text_layout dependency to v0.1.4

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http: ^0.13.1
   linkify: ^4.0.0
   logging: ^1.0.1
-  super_text_layout: ^0.1.3
+  super_text_layout: ^0.1.4
   uuid: ^3.0.3
 
   # Dependencies for testing tools that we ship with super_editor


### PR DESCRIPTION
Upgrade super_editor's super_text_layout dependency to v0.1.4

I released `super_text_layout` v0.1.4, which includes a fix to a null pointer exception.