### PR TITLE
Fixed desktop scroll momentum that was broken by Flutter 3.3.3 (Resolves #806)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -408,6 +408,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor>
     if (_panGestureDevice == PointerDeviceKind.trackpad) {
       // The user ended a pan gesture with two fingers on a trackpad.
       // We already scrolled the document.
+      widget.autoScroller.goBallistic(-details.velocity.pixelsPerSecond.dy);
       return;
     }
     _onDragEnd();
@@ -442,6 +443,13 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor>
     if (event is PointerScrollEvent) {
       _scrollVertically(event.scrollDelta.dy);
     }
+  }
+
+  /// Beginning with Flutter 3.3.3, we are responsible for starting and
+  /// stopping scroll momentum. This method cancels any scroll momentum
+  /// in our scroll controller.
+  void _cancelScrollMomentum() {
+    widget.autoScroller.goIdle();
   }
 
   void _updateDragSelection() {
@@ -577,6 +585,8 @@ Updating drag selection:
   Widget build(BuildContext context) {
     return Listener(
       onPointerSignal: _scrollOnMouseWheel,
+      onPointerHover: (event) => _cancelScrollMomentum(),
+      onPointerDown: (event) => _cancelScrollMomentum(),
       child: _buildCursorStyle(
         child: _buildGestureInput(
           child: _buildDocumentContainer(

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -6,11 +6,11 @@ import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
-import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/document_selection_on_focus_mixin.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
+import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 
@@ -587,6 +587,7 @@ Updating drag selection:
       onPointerSignal: _scrollOnMouseWheel,
       onPointerHover: (event) => _cancelScrollMomentum(),
       onPointerDown: (event) => _cancelScrollMomentum(),
+      onPointerPanZoomStart: (event) => _cancelScrollMomentum(),
       child: _buildCursorStyle(
         child: _buildGestureInput(
           child: _buildDocumentContainer(

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -360,6 +360,33 @@ class AutoScrollController with ChangeNotifier {
     );
   }
 
+  void goBallistic(double pixelsPerSecond) {
+    final pos = _getScrollPosition?.call();
+    if (pos == null) {
+      // We're not attached to a scroll position. We can't go ballistic.
+      return;
+    }
+
+    if (pos is ScrollPositionWithSingleContext) {
+      pos.goBallistic(pixelsPerSecond);
+      pos.context.setIgnorePointer(false);
+    }
+  }
+
+  void goIdle() {
+    final pos = _getScrollPosition?.call();
+    if (pos == null) {
+      // We're not attached to a scroll position. There's nothing to idle.
+      return;
+    }
+
+    if (pos is ScrollPositionWithSingleContext) {
+      if (pos.pixels > pos.minScrollExtent && pos.pixels < pos.maxScrollExtent) {
+        pos.goIdle();
+      }
+    }
+  }
+
   /// Immediately changes the attached [Scrollable]'s scroll offset so that all
   /// of the given [globalRegion] is visible.
   void ensureGlobalRectIsVisible(Rect globalRegion) {

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -360,6 +360,8 @@ class AutoScrollController with ChangeNotifier {
     );
   }
 
+  /// Animates the scroll position like a ballistic particle with friction, beginning
+  /// with the given [pixelsPerSecond] velocity.
   void goBallistic(double pixelsPerSecond) {
     final pos = _getScrollPosition?.call();
     if (pos == null) {
@@ -373,6 +375,7 @@ class AutoScrollController with ChangeNotifier {
     }
   }
 
+  /// Immediately stops scrolling animation/momentum.
   void goIdle() {
     final pos = _getScrollPosition?.call();
     if (pos == null) {


### PR DESCRIPTION
Flutter 3.3.3 broke desktop scrolling. The listener widget no longer includes scrolling momentum in the pointer signal. As a result, we now need to implement momentum, and cancel the momentum at the appropriate time.

This PR was guided by comments in https://github.com/flutter/flutter/issues/112880