### PR TITLE
[ExampleApp] Fix AppBar gestures (Resolves #811)

### DIFF
--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -132,9 +132,12 @@ class _HomeScreenState extends State<HomeScreen> {
           OverlayEntry(builder: (context) {
             return Scaffold(
               key: _scaffoldKey,
-              appBar: _buildAppBar(context),
-              extendBodyBehindAppBar: true,
-              body: _selectedMenuItem!.pageBuilder(context),
+              body: Stack(
+                children: [
+                  _selectedMenuItem!.pageBuilder(context),
+                  _buildDrawerButton(),
+                ],
+              ),
               drawer: _buildDrawer(),
             );
           })
@@ -143,15 +146,18 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  PreferredSizeWidget _buildAppBar(BuildContext context) {
-    return AppBar(
-      backgroundColor: Colors.transparent,
-      elevation: 0,
-      leading: IconButton(
-        icon: const Icon(Icons.menu),
-        color: Theme.of(context).colorScheme.onSurface,
-        splashRadius: 24,
-        onPressed: _toggleDrawer,
+  Widget _buildDrawerButton() {
+    return Material(
+      color: Colors.transparent,
+      child: SizedBox(
+        height: 56,
+        width: 56,
+        child: IconButton(
+          icon: const Icon(Icons.menu),
+          color: Theme.of(context).colorScheme.onSurface,
+          splashRadius: 24,
+          onPressed: _toggleDrawer,
+        ),
       ),
     );
   }

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -147,16 +147,18 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildDrawerButton() {
-    return Material(
-      color: Colors.transparent,
-      child: SizedBox(
-        height: 56,
-        width: 56,
-        child: IconButton(
-          icon: const Icon(Icons.menu),
-          color: Theme.of(context).colorScheme.onSurface,
-          splashRadius: 24,
-          onPressed: _toggleDrawer,
+    return SafeArea(
+      child: Material(
+        color: Colors.transparent,
+        child: SizedBox(
+          height: 56,
+          width: 56,
+          child: IconButton(
+            icon: const Icon(Icons.menu),
+            color: Theme.of(context).colorScheme.onSurface,
+            splashRadius: 24,
+            onPressed: _toggleDrawer,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
[ExampleApp] Fix AppBar gestures. Resolves #811

In the demo app, there is a transparent `AppBar` and the editor is displayed behind it. This blocks gestures at the `AppBar`'s area.  For example: double-clicking at the top of the image doesn't select it. Also when deleting all the content and typing a paragraph, it isn't possible to select the first line.

This PR removes the `AppBar` and adds the `IconButton` directly on a `Stack`.

Before:

https://user-images.githubusercontent.com/7597082/195227076-c1ff86a5-7f87-428f-afae-d7d602ce7870.mp4

After:

https://user-images.githubusercontent.com/7597082/195227132-d85aa30d-994e-4df1-8863-64d53507aa98.mp4

