### PR TITLE
Export infrastructure/platform_detector.dart

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -51,6 +51,7 @@ export 'src/infrastructure/focus.dart';
 export 'src/infrastructure/ime_input_owner.dart';
 export 'src/infrastructure/keyboard.dart';
 export 'src/infrastructure/multi_tap_gesture.dart';
+export 'src/infrastructure/platform_detector.dart';
 export 'src/infrastructure/platforms/android/android_document_controls.dart';
 export 'src/infrastructure/platforms/ios/ios_document_controls.dart';
 export 'src/infrastructure/platforms/mobile_documents.dart';


### PR DESCRIPTION
`Platform` class from `src/infrastructure/platform_detector.dart` needs to be exported so that the test client code can set the platform in widget tests.

This came up when client code relies on `PrimaryShortcutKey.isPrimaryShortcutKeyPressed` extension method.