### PR TITLE
[SuperEditor] [SuperTextField] Change floating cursor color opacity (Resolves #753)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -403,7 +403,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
           handle: Container(
             width: 2,
             height: _floatingCursorHeight,
-            color: Colors.red,
+            color: Colors.red.withOpacity(0.75),
           ),
           debugColor: Colors.blue,
         );

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
@@ -34,7 +34,7 @@ class IOSFloatingCursor extends StatelessWidget {
                 child: Container(
                   width: 2,
                   height: controller.floatingCursorHeight,
-                  color: Colors.red,
+                  color: Colors.red.withOpacity(0.75),
                 ),
               ),
           ],


### PR DESCRIPTION
[SuperEditor] [SuperTextField] Change floating cursor color opacity. Resolves #753

Both `SuperEditor` and `SuperTextField` use `Colors.red` as the floating cursor color on iOS.

This PR changes them to use 75% opacity.