### PR TITLE
Added support for custom Markdown block syntaxes (Resolves #829)

### DIFF
--- a/super_editor/example/macos/Podfile.lock
+++ b/super_editor/example/macos/Podfile.lock
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c

--- a/super_editor/example/pubspec.lock
+++ b/super_editor/example/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   attributed_text:
     dependency: transitive
     description:
       name: attributed_text
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -156,6 +156,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_test_robots:
+    dependency: transitive
+    description:
+      name: flutter_test_robots
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.17"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -251,21 +258,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -293,7 +300,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -431,7 +438,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -452,56 +459,56 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   super_editor:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.2.2"
   super_editor_markdown:
     dependency: "direct main"
     description:
       path: "../../super_editor_markdown"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.3"
   super_text_layout:
     dependency: "direct main"
     description:
       path: "../../super_text_layout"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.4"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: transitive
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.1"
+    version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
@@ -573,5 +580,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.10.0-0"

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -1,0 +1,249 @@
+import 'package:super_editor/super_editor.dart';
+
+import 'super_editor_syntax.dart';
+
+/// The given [syntax] controls how the [doc] is serialized, e.g., [MarkdownSyntax.normal] for standard
+/// Markdown syntax, or [MarkdownSyntax.superEditor] to use Super Editor's extended syntax.
+String serializeDocumentToMarkdown(
+  Document doc, {
+  MarkdownSyntax syntax = MarkdownSyntax.superEditor,
+}) {
+  StringBuffer buffer = StringBuffer();
+
+  bool isFirstLine = true;
+  for (int i = 0; i < doc.nodes.length; ++i) {
+    final node = doc.nodes[i];
+
+    if (!isFirstLine) {
+      // Create a new line to encode the given node.
+      buffer.writeln("");
+    } else {
+      isFirstLine = false;
+    }
+
+    if (node is ImageNode) {
+      buffer.write('![${node.altText}](${node.imageUrl})');
+    } else if (node is HorizontalRuleNode) {
+      buffer.write('---');
+    } else if (node is ListItemNode) {
+      final indent = List.generate(node.indent + 1, (index) => '  ').join('');
+      final symbol = node.type == ListItemType.unordered ? '*' : '1.';
+
+      buffer.write('$indent$symbol ${node.text.toMarkdown()}');
+
+      final nodeBelow = i < doc.nodes.length - 1 ? doc.nodes[i + 1] : null;
+      if (nodeBelow != null && (nodeBelow is! ListItemNode || nodeBelow.type != node.type)) {
+        // This list item is the last item in the list. Add an extra
+        // blank line after it.
+        buffer.writeln('');
+      }
+    } else if (node is ParagraphNode) {
+      final Attribution? blockType = node.getMetadataValue('blockType');
+
+      if (blockType == header1Attribution) {
+        buffer.write('# ${node.text.toMarkdown()}');
+      } else if (blockType == header2Attribution) {
+        buffer.write('## ${node.text.toMarkdown()}');
+      } else if (blockType == header3Attribution) {
+        buffer.write('### ${node.text.toMarkdown()}');
+      } else if (blockType == header4Attribution) {
+        buffer.write('#### ${node.text.toMarkdown()}');
+      } else if (blockType == header5Attribution) {
+        buffer.write('##### ${node.text.toMarkdown()}');
+      } else if (blockType == header6Attribution) {
+        buffer.write('###### ${node.text.toMarkdown()}');
+      } else if (blockType == blockquoteAttribution) {
+        // TODO: handle multiline
+        buffer.write('> ${node.text.toMarkdown()}');
+      } else if (blockType == codeAttribution) {
+        buffer //
+          ..writeln('```') //
+          ..writeln(node.text.toMarkdown()) //
+          ..write('```');
+      } else {
+        final String? textAlign = node.getMetadataValue('textAlign');
+        // Left alignment is the default, so there is no need to add the alignment token.
+        if (syntax == MarkdownSyntax.superEditor && textAlign != null && textAlign != 'left') {
+          final alignmentToken = _convertAlignmentToMarkdown(textAlign);
+          if (alignmentToken != null) {
+            buffer.writeln(alignmentToken);
+          }
+        }
+        buffer.write(node.text.toMarkdown());
+      }
+
+      // We're not at the end of the document yet. Add a blank line after the
+      // paragraph so that we can tell the difference between separate
+      // paragraphs vs. newlines within a single paragraph.
+      if (i != doc.nodes.length - 1) {
+        buffer.writeln();
+      }
+    }
+  }
+
+  return buffer.toString();
+}
+
+String? _convertAlignmentToMarkdown(String alignment) {
+  switch (alignment) {
+    case 'left':
+      return ':---';
+    case 'center':
+      return ':---:';
+    case 'right':
+      return '---:';
+    default:
+      return null;
+  }
+}
+
+extension Markdown on AttributedText {
+  String toMarkdown() {
+    final serializer = AttributedTextMarkdownSerializer();
+    return serializer.serialize(this);
+  }
+}
+
+/// Serializes an [AttributedText] into markdown format
+class AttributedTextMarkdownSerializer extends AttributionVisitor {
+  late String _fullText;
+  late StringBuffer _buffer;
+  late int _bufferCursor;
+
+  String serialize(AttributedText attributedText) {
+    _fullText = attributedText.text;
+    _buffer = StringBuffer();
+    _bufferCursor = 0;
+    attributedText.visitAttributions(this);
+    return _buffer.toString();
+  }
+
+  @override
+  void visitAttributions(
+    AttributedText fullText,
+    int index,
+    Set<Attribution> startingAttributions,
+    Set<Attribution> endingAttributions,
+  ) {
+    // Write out the text between the end of the last markers, and these new markers.
+    _writeTextToBuffer(
+      fullText.text.substring(_bufferCursor, index),
+    );
+
+    // Add start markers.
+    if (startingAttributions.isNotEmpty) {
+      final markdownStyles = _sortAndSerializeAttributions(startingAttributions, AttributionVisitEvent.start);
+      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
+      // can't be checked using equality comparison) and asymmetrical in markdown.
+      final linkMarker = _encodeLinkMarker(startingAttributions, AttributionVisitEvent.start);
+
+      _buffer
+        ..write(linkMarker)
+        ..write(markdownStyles);
+    }
+
+    // Write out the character at this index.
+    _writeTextToBuffer(_fullText[index]);
+    _bufferCursor = index + 1;
+
+    // Add end markers.
+    if (endingAttributions.isNotEmpty) {
+      final markdownStyles = _sortAndSerializeAttributions(endingAttributions, AttributionVisitEvent.end);
+      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
+      // can't be checked using equality comparison) and asymmetrical in markdown.
+      final linkMarker = _encodeLinkMarker(endingAttributions, AttributionVisitEvent.end);
+
+      // +1 on end index because this visitor has inclusive indices
+      // whereas substring() expects an exclusive ending index.
+      _buffer
+        ..write(markdownStyles)
+        ..write(linkMarker);
+    }
+  }
+
+  @override
+  void onVisitEnd() {
+    // When the last span has no attributions, we still have text that wasn't added to the buffer yet.
+    if (_bufferCursor <= _fullText.length - 1) {
+      _writeTextToBuffer(_fullText.substring(_bufferCursor));
+    }
+  }
+
+  /// Writes the given [text] to [_buffer].
+  ///
+  /// Separates multiple lines in a single paragraph using two spaces before each line break.
+  ///
+  /// A line ending with two or more spaces represents a hard line break,
+  /// as defined in the Markdown spec.
+  void _writeTextToBuffer(String text) {
+    final lines = text.split('\n');
+    for (int i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        // Adds two spaces before line breaks.
+        // The Markdown spec defines that a line ending with two or more spaces
+        // represents a hard line break, which causes the next line to be part of
+        // the previous paragraph during deserialization.
+        _buffer.write('  ');
+        _buffer.write('\n');
+      }
+
+      _buffer.write(lines[i]);
+    }
+  }
+
+  /// Serializes style attributions into markdown syntax in a repeatable
+  /// order such that opening and closing styles match each other on
+  /// the opening and closing ends of a span.
+  static String _sortAndSerializeAttributions(Set<Attribution> attributions, AttributionVisitEvent event) {
+    const startOrder = [
+      codeAttribution,
+      boldAttribution,
+      italicsAttribution,
+      strikethroughAttribution,
+      underlineAttribution,
+    ];
+
+    final buffer = StringBuffer();
+    final encodingOrder = event == AttributionVisitEvent.start ? startOrder : startOrder.reversed;
+
+    for (final markdownStyleAttribution in encodingOrder) {
+      if (attributions.contains(markdownStyleAttribution)) {
+        buffer.write(_encodeMarkdownStyle(markdownStyleAttribution));
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  static String _encodeMarkdownStyle(Attribution attribution) {
+    if (attribution == codeAttribution) {
+      return '`';
+    } else if (attribution == boldAttribution) {
+      return '**';
+    } else if (attribution == italicsAttribution) {
+      return '*';
+    } else if (attribution == strikethroughAttribution) {
+      return '~';
+    } else if (attribution == underlineAttribution) {
+      return '¬';
+    } else {
+      return '';
+    }
+  }
+
+  /// Checks for the presence of a link in the attributions and returns the characters necessary to represent it
+  /// at the open or closing boundary of the attribution, depending on the event.
+  static String _encodeLinkMarker(Set<Attribution> attributions, AttributionVisitEvent event) {
+    final linkAttributions = attributions.where((element) => element is LinkAttribution?);
+    if (linkAttributions.isNotEmpty) {
+      final linkAttribution = linkAttributions.first as LinkAttribution;
+
+      if (event == AttributionVisitEvent.start) {
+        return '[';
+      } else {
+        return '](${linkAttribution.url.toString()})';
+      }
+    }
+    return "";
+  }
+}

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -254,8 +254,6 @@ class AttributedTextMarkdownSerializer extends AttributionVisitor {
       // can't be checked using equality comparison) and asymmetrical in markdown.
       final linkMarker = _encodeLinkMarker(endingAttributions, AttributionVisitEvent.end);
 
-      // +1 on end index because this visitor has inclusive indices
-      // whereas substring() expects an exclusive ending index.
       _buffer
         ..write(markdownStyles)
         ..write(linkMarker);

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -1,24 +1,30 @@
 import 'dart:convert';
 
-import 'package:flutter/widgets.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:super_editor/super_editor.dart';
 
-// TODO: return a regular Document instead of a MutableDocument.
-//       For now, we return MutableDocument because DocumentEditor
-//       requires one. When the editing system matures, there should
-//       be a way to return something here that is not concrete.
+import 'super_editor_syntax.dart';
 
-/// The given [syntax] controls how the [markdown] is parsed, e.g., [MarkdownSyntax.normal] for strict
-/// Markdown parsing, or [MarkdownSyntax.superEditor] to use Super Editor's extended syntax.
+/// Parses the given [markdown] and deserializes it into a [MutableDocument].
+///
+/// The given [syntax] controls how the [markdown] is parsed, e.g., [MarkdownSyntax.normal]
+/// for strict Markdown parsing, or [MarkdownSyntax.superEditor] to use Super Editor's
+/// extended syntax.
+///
+/// To add support for parsing non-standard Markdown blocks, provide [customBlockSyntax]s
+/// that parse Markdown text into [md.Element]s, and provide [customElementToNodeConverters] that
+/// turn those [md.Element]s into [DocumentNode]s.
 MutableDocument deserializeMarkdownToDocument(
   String markdown, {
   MarkdownSyntax syntax = MarkdownSyntax.superEditor,
+  List<md.BlockSyntax> customBlockSyntax = const [],
+  List<ElementToNodeConverter> customElementToNodeConverters = const [],
 }) {
   final markdownLines = const LineSplitter().convert(markdown);
 
   final markdownDoc = md.Document(
     blockSyntaxes: [
+      ...customBlockSyntax,
       if (syntax == MarkdownSyntax.superEditor) //
         _ParagraphWithAlignmentSyntax(),
       _EmptyLinePreservingParagraphSyntax(),
@@ -30,7 +36,7 @@ MutableDocument deserializeMarkdownToDocument(
   final markdownNodes = blockParser.parseLines();
 
   // Convert structured markdown to a Document.
-  final nodeVisitor = _MarkdownToDocument();
+  final nodeVisitor = _MarkdownToDocument(customElementToNodeConverters);
   for (final node in markdownNodes) {
     node.accept(nodeVisitor);
   }
@@ -49,101 +55,6 @@ MutableDocument deserializeMarkdownToDocument(
   return MutableDocument(nodes: documentNodes);
 }
 
-/// The given [syntax] controls how the [doc] is serialized, e.g., [MarkdownSyntax.normal] for standard
-/// Markdown syntax, or [MarkdownSyntax.superEditor] to use Super Editor's extended syntax.
-String serializeDocumentToMarkdown(
-  Document doc, {
-  MarkdownSyntax syntax = MarkdownSyntax.superEditor,
-}) {
-  StringBuffer buffer = StringBuffer();
-
-  bool isFirstLine = true;
-  for (int i = 0; i < doc.nodes.length; ++i) {
-    final node = doc.nodes[i];
-
-    if (!isFirstLine) {
-      // Create a new line to encode the given node.
-      buffer.writeln("");
-    } else {
-      isFirstLine = false;
-    }
-
-    if (node is ImageNode) {
-      buffer.write('![${node.altText}](${node.imageUrl})');
-    } else if (node is HorizontalRuleNode) {
-      buffer.write('---');
-    } else if (node is ListItemNode) {
-      final indent = List.generate(node.indent + 1, (index) => '  ').join('');
-      final symbol = node.type == ListItemType.unordered ? '*' : '1.';
-
-      buffer.write('$indent$symbol ${node.text.toMarkdown()}');
-
-      final nodeBelow = i < doc.nodes.length - 1 ? doc.nodes[i + 1] : null;
-      if (nodeBelow != null && (nodeBelow is! ListItemNode || nodeBelow.type != node.type)) {
-        // This list item is the last item in the list. Add an extra
-        // blank line after it.
-        buffer.writeln('');
-      }
-    } else if (node is ParagraphNode) {
-      final Attribution? blockType = node.getMetadataValue('blockType');
-
-      if (blockType == header1Attribution) {
-        buffer.write('# ${node.text.toMarkdown()}');
-      } else if (blockType == header2Attribution) {
-        buffer.write('## ${node.text.toMarkdown()}');
-      } else if (blockType == header3Attribution) {
-        buffer.write('### ${node.text.toMarkdown()}');
-      } else if (blockType == header4Attribution) {
-        buffer.write('#### ${node.text.toMarkdown()}');
-      } else if (blockType == header5Attribution) {
-        buffer.write('##### ${node.text.toMarkdown()}');
-      } else if (blockType == header6Attribution) {
-        buffer.write('###### ${node.text.toMarkdown()}');
-      } else if (blockType == blockquoteAttribution) {
-        // TODO: handle multiline
-        buffer.write('> ${node.text.toMarkdown()}');
-      } else if (blockType == codeAttribution) {
-        buffer //
-          ..writeln('```') //
-          ..writeln(node.text.toMarkdown()) //
-          ..write('```');
-      } else {
-        final String? textAlign = node.getMetadataValue('textAlign');
-        // Left alignment is the default, so there is no need to add the alignment token.
-        if (syntax == MarkdownSyntax.superEditor && textAlign != null && textAlign != 'left') {
-          final alignmentToken = _convertAlignmentToMarkdown(textAlign);
-          if (alignmentToken != null) {
-            buffer.writeln(alignmentToken);
-          }
-        }
-        buffer.write(node.text.toMarkdown());
-      }
-
-      // We're not at the end of the document yet. Add a blank line after the
-      // paragraph so that we can tell the difference between separate
-      // paragraphs vs. newlines within a single paragraph.
-      if (i != doc.nodes.length - 1) {
-        buffer.writeln();
-      }
-    }
-  }
-
-  return buffer.toString();
-}
-
-String? _convertAlignmentToMarkdown(String alignment) {
-  switch (alignment) {
-    case 'left':
-      return ':---';
-    case 'center':
-      return ':---:';
-    case 'right':
-      return '---:';
-    default:
-      return null;
-  }
-}
-
 /// Converts structured markdown to a list of [DocumentNode]s.
 ///
 /// To use [_MarkdownToDocument], obtain a series of markdown
@@ -153,7 +64,9 @@ String? _convertAlignmentToMarkdown(String alignment) {
 /// contains [DocumentNode]s that correspond to the visited
 /// markdown content.
 class _MarkdownToDocument implements md.NodeVisitor {
-  _MarkdownToDocument();
+  _MarkdownToDocument([this._elementToNodeConverters = const []]);
+
+  final List<ElementToNodeConverter> _elementToNodeConverters;
 
   final _content = <DocumentNode>[];
   List<DocumentNode> get content => _content;
@@ -162,6 +75,14 @@ class _MarkdownToDocument implements md.NodeVisitor {
 
   @override
   bool visitElementBefore(md.Element element) {
+    for (final converter in _elementToNodeConverters) {
+      final node = converter.handleElement(element);
+      if (node != null) {
+        _content.add(node);
+        return true;
+      }
+    }
+
     // TODO: re-organize parsing such that visitElementBefore collects
     //       the block type info and then visitText and visitElementAfter
     //       take the action to create the node (#153)
@@ -497,154 +418,27 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
   }
 }
 
-extension Markdown on AttributedText {
-  String toMarkdown() {
-    final serializer = AttributedTextMarkdownSerializer();
-    return serializer.serialize(this);
-  }
+/// Converts a deserialized Markdown element into a [DocumentNode].
+///
+/// For example, the Markdown parser might identify an element called
+/// "blockquote". A corresponding [ElementToNodeConverter] would receive
+/// the "blockquote" element and create an appropriate [ParagraphNode] to
+/// represent that blockquote in the deserialized [Document].
+abstract class ElementToNodeConverter {
+  DocumentNode? handleElement(md.Element element);
 }
 
-/// Serializes an [AttributedText] into markdown format
-class AttributedTextMarkdownSerializer extends AttributionVisitor {
-  late String _fullText;
-  late StringBuffer _buffer;
-  late int _bufferCursor;
-
-  String serialize(AttributedText attributedText) {
-    _fullText = attributedText.text;
-    _buffer = StringBuffer();
-    _bufferCursor = 0;
-    attributedText.visitAttributions(this);
-    return _buffer.toString();
-  }
+/// A Markdown [TagSyntax] that matches underline spans of text, which are represented in
+/// Markdown with surrounding `¬` tags, e.g., "this is ¬underline¬ text".
+///
+/// This [TagSyntax] produces `Element`s with a `u` tag.
+class UnderlineSyntax extends md.TagSyntax {
+  UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true);
 
   @override
-  void visitAttributions(
-    AttributedText fullText,
-    int index,
-    Set<Attribution> startingAttributions,
-    Set<Attribution> endingAttributions,
-  ) {
-    // Write out the text between the end of the last markers, and these new markers.
-    _writeTextToBuffer(
-      fullText.text.substring(_bufferCursor, index),
-    );
-
-    // Add start markers.
-    if (startingAttributions.isNotEmpty) {
-      final markdownStyles = _sortAndSerializeAttributions(startingAttributions, AttributionVisitEvent.start);
-      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
-      // can't be checked using equality comparison) and asymmetrical in markdown.
-      final linkMarker = _encodeLinkMarker(startingAttributions, AttributionVisitEvent.start);
-
-      _buffer
-        ..write(linkMarker)
-        ..write(markdownStyles);
-    }
-
-    // Write out the character at this index.
-    _writeTextToBuffer(_fullText[index]);
-    _bufferCursor = index + 1;
-
-    // Add end markers.
-    if (endingAttributions.isNotEmpty) {
-      final markdownStyles = _sortAndSerializeAttributions(endingAttributions, AttributionVisitEvent.end);
-      // Links are different from the plain styles since they are both not NamedAttributions (and therefore
-      // can't be checked using equality comparison) and asymmetrical in markdown.
-      final linkMarker = _encodeLinkMarker(endingAttributions, AttributionVisitEvent.end);
-
-      // +1 on end index because this visitor has inclusive indices
-      // whereas substring() expects an exclusive ending index.
-      _buffer
-        ..write(markdownStyles)
-        ..write(linkMarker);
-    }
-  }
-
-  @override
-  void onVisitEnd() {
-    // When the last span has no attributions, we still have text that wasn't added to the buffer yet.
-    if (_bufferCursor <= _fullText.length - 1) {
-      _writeTextToBuffer(_fullText.substring(_bufferCursor));
-    }
-  }
-
-  /// Writes the given [text] to [_buffer].
-  ///
-  /// Separates multiple lines in a single paragraph using two spaces before each line break.
-  /// 
-  /// A line ending with two or more spaces represents a hard line break,
-  /// as defined in the Markdown spec.
-  void _writeTextToBuffer(String text) {
-    final lines = text.split('\n');
-    for (int i = 0; i < lines.length; i++) {
-      if (i > 0) {
-        // Adds two spaces before line breaks.
-        // The Markdown spec defines that a line ending with two or more spaces
-        // represents a hard line break, which causes the next line to be part of
-        // the previous paragraph during deserialization.
-        _buffer.write('  ');
-        _buffer.write('\n');
-      }
-
-      _buffer.write(lines[i]);
-    }
-  }
-
-  /// Serializes style attributions into markdown syntax in a repeatable
-  /// order such that opening and closing styles match each other on
-  /// the opening and closing ends of a span.
-  static String _sortAndSerializeAttributions(Set<Attribution> attributions, AttributionVisitEvent event) {
-    const startOrder = [
-      codeAttribution,
-      boldAttribution,
-      italicsAttribution,
-      strikethroughAttribution,
-      underlineAttribution,
-    ];
-
-    final buffer = StringBuffer();
-    final encodingOrder = event == AttributionVisitEvent.start ? startOrder : startOrder.reversed;
-
-    for (final markdownStyleAttribution in encodingOrder) {
-      if (attributions.contains(markdownStyleAttribution)) {
-        buffer.write(_encodeMarkdownStyle(markdownStyleAttribution));
-      }
-    }
-
-    return buffer.toString();
-  }
-
-  static String _encodeMarkdownStyle(Attribution attribution) {
-    if (attribution == codeAttribution) {
-      return '`';
-    } else if (attribution == boldAttribution) {
-      return '**';
-    } else if (attribution == italicsAttribution) {
-      return '*';
-    } else if (attribution == strikethroughAttribution) {
-      return '~';
-    } else if (attribution == underlineAttribution) {
-      return '¬';
-    } else {
-      return '';
-    }
-  }
-
-  /// Checks for the presence of a link in the attributions and returns the characters necessary to represent it
-  /// at the open or closing boundary of the attribution, depending on the event.
-  static String _encodeLinkMarker(Set<Attribution> attributions, AttributionVisitEvent event) {
-    final linkAttributions = attributions.where((element) => element is LinkAttribution?);
-    if (linkAttributions.isNotEmpty) {
-      final linkAttribution = linkAttributions.first as LinkAttribution;
-
-      if (event == AttributionVisitEvent.start) {
-        return '[';
-      } else {
-        return '](${linkAttribution.url.toString()})';
-      }
-    }
-    return "";
+  md.Node close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
+      {required List<md.Node> Function() getChildren}) {
+    return md.Element('u', getChildren());
   }
 }
 
@@ -753,7 +547,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
       if (parser.isDone) {
         // The document ended with a single empty line, so we just ignore it.
         // To be considered as a paragraph starting with an empty line
-        // we need at least two empty lines: 
+        // we need at least two empty lines:
         // one to separate the paragraph from the previous block
         // and another one to be the content of the paragraph.
         return null;
@@ -761,7 +555,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
 
       if (!_blankLinePattern.hasMatch(parser.current)) {
         // We found an empty line, but the following line isn't blank.
-        // As there is no hard line break, the first line is consumed 
+        // As there is no hard line break, the first line is consumed
         // as a separator between blocks.
         // Therefore, we aren't looking at a paragraph with blank lines.
         return null;
@@ -828,7 +622,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
   ///
   /// As per the Markdown spec, a line ending with two or more spaces
   /// represents a hard line break.
-  /// 
+  ///
   /// A hard line break causes the next line to be part of the
   /// same paragraph, except if it's the beginning of another block element.
   bool _endsWithHardLineBreak(String line) {
@@ -846,39 +640,6 @@ class _LineBreakSeparatedElement extends md.Element {
   String get textContent {
     return (children ?? []).map((md.Node? child) => child!.textContent).join('\n');
   }
-}
-
-/// A Markdown [TagSyntax] that matches underline spans of text, which are represented in
-/// Markdown with surrounding `¬` tags, e.g., "this is ¬underline¬ text".
-///
-/// This [TagSyntax] produces `Element`s with a `u` tag.
-class UnderlineSyntax extends md.TagSyntax {
-  UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true);
-
-  @override
-  md.Node close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
-      {required List<md.Node> Function() getChildren}) {
-    return md.Element('u', getChildren());
-  }
-}
-
-enum MarkdownSyntax {
-  /// Standard markdown syntax.
-  normal,
-
-  /// Extended syntax which supports serialization of text alignment, strikethrough and underline.
-  ///
-  /// Underline text is serialized between a pair of `¬`.
-  ///
-  /// Text alignment is serialized using an alignment notation at the
-  /// line preceding the paragraph:
-  ///
-  /// `:---` represents left alignment. (The default)
-  ///
-  /// `:---:` represents center alignment.
-  ///
-  /// `---:` represents right alignment.
-  superEditor,
 }
 
 /// Matches empty lines or lines containing only whitespace.

--- a/super_editor_markdown/lib/src/super_editor_syntax.dart
+++ b/super_editor_markdown/lib/src/super_editor_syntax.dart
@@ -1,0 +1,18 @@
+enum MarkdownSyntax {
+  /// Standard markdown syntax.
+  normal,
+
+  /// Extended syntax which supports serialization of text alignment, strikethrough and underline.
+  ///
+  /// Underline text is serialized between a pair of `¬`.
+  ///
+  /// Text alignment is serialized using an alignment notation at the
+  /// line preceding the paragraph:
+  ///
+  /// `:---` represents left alignment. (The default)
+  ///
+  /// `:---:` represents center alignment.
+  ///
+  /// `---:` represents right alignment.
+  superEditor,
+}

--- a/super_editor_markdown/lib/super_editor_markdown.dart
+++ b/super_editor_markdown/lib/super_editor_markdown.dart
@@ -1,1 +1,3 @@
-export 'src/markdown.dart';
+export 'src/document_to_markdown_serializer.dart';
+export 'src/markdown_to_document_parsing.dart';
+export 'src/super_editor_syntax.dart';

--- a/super_editor_markdown/test/attributed_text_markdown_test.dart
+++ b/super_editor_markdown/test/attributed_text_markdown_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
-import 'package:super_editor_markdown/src/markdown.dart';
+import 'package:super_editor_markdown/src/document_to_markdown_serializer.dart';
 
 void main() {
   group("AttributedText markdown serializes", () {

--- a/super_editor_markdown/test/custom_block_parser_test.dart
+++ b/super_editor_markdown/test/custom_block_parser_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+import 'custom_parsers/callout_block.dart';
+import 'custom_parsers/upsell_block.dart';
+
+void main() {
+  group("Markdown deserialization", () {
+    test("handles custom placeholder block syntax", () {
+      final document = deserializeMarkdownToDocument(
+        '''# Header 1
+This is a normal paragraph.
+
+@@@ upsell
+  
+This is another normal paragraph.''',
+        customBlockSyntax: [UpsellBlockSyntax()],
+        customElementToNodeConverters: [UpsellElementToNodeConverter()],
+      );
+
+      expect(document.nodes.length, 4);
+      expect(
+        document.nodes[0],
+        isA<ParagraphNode>(),
+      );
+      expect(
+        document.nodes[1],
+        isA<ParagraphNode>(),
+      );
+      expect(
+        document.nodes[2],
+        isA<UpsellNode>(),
+      );
+      expect(
+        document.nodes[3],
+        isA<ParagraphNode>(),
+      );
+    });
+
+    test("handles custom text block syntax", () {
+      final document = deserializeMarkdownToDocument(
+        '''# Header 1
+This is a normal paragraph.
+
+@@@ callout
+This is a **callout**!
+@@@
+  
+This is another normal paragraph.''',
+        customBlockSyntax: [CalloutBlockSyntax()],
+        customElementToNodeConverters: [CalloutElementToNodeConverter()],
+      );
+
+      expect(document.nodes.length, 4);
+      expect(
+        document.nodes[0],
+        isA<ParagraphNode>(),
+      );
+      expect(
+        document.nodes[1],
+        isA<ParagraphNode>(),
+      );
+      expect(
+        document.nodes[2],
+        isA<ParagraphNode>(),
+      );
+      expect(
+        (document.nodes[2] as ParagraphNode).metadata["blockType"],
+        const NamedAttribution("callout"),
+      );
+      expect(
+        document.nodes[3],
+        isA<ParagraphNode>(),
+      );
+    });
+  });
+}

--- a/super_editor_markdown/test/custom_block_serializer_test.dart
+++ b/super_editor_markdown/test/custom_block_serializer_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+import 'custom_parsers/callout_block.dart';
+import 'custom_parsers/upsell_block.dart';
+
+void main() {
+  group("Markdown serialization", () {
+    test("handles custom placeholder block node", () {
+      final markdown = serializeDocumentToMarkdown(
+        MutableDocument(
+          nodes: [
+            ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText(text: "Paragraph 1")),
+            UpsellNode(DocumentEditor.createNodeId()),
+            ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText(text: "Paragraph 2")),
+          ],
+        ),
+        customNodeSerializers: [UpsellSerializer()],
+      );
+
+      expect(
+        markdown,
+        '''Paragraph 1
+
+@@@ upsell
+
+Paragraph 2''',
+      );
+    });
+
+    test("handles custom text node", () {
+      final markdown = serializeDocumentToMarkdown(
+        MutableDocument(
+          nodes: [
+            ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText(text: "Paragraph 1")),
+            ParagraphNode(
+              id: DocumentEditor.createNodeId(),
+              text: AttributedText(
+                text: "This is a callout!",
+                spans: AttributedSpans(
+                  attributions: [
+                    SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
+                    SpanMarker(attribution: boldAttribution, offset: 17, markerType: SpanMarkerType.end),
+                  ],
+                ),
+              ),
+              metadata: {"blockType": const NamedAttribution("callout")},
+            ),
+            ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText(text: "Paragraph 2")),
+          ],
+        ),
+        customNodeSerializers: [CalloutSerializer()],
+      );
+
+      expect(
+        markdown,
+        '''Paragraph 1
+
+@@@ callout
+This is a **callout!**
+@@@
+
+Paragraph 2''',
+      );
+    });
+  });
+}

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -203,3 +203,21 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
     }
   }
 }
+
+class CalloutSerializer implements DocumentNodeMarkdownSerializer {
+  @override
+  String? serialize(DocumentNode node) {
+    if (node is! ParagraphNode) {
+      return null;
+    }
+    if (node.metadata["blockType"] != const NamedAttribution("callout")) {
+      return null;
+    }
+
+    final buffer = StringBuffer();
+    buffer.writeln("@@@ callout");
+    buffer.writeln(node.text.toMarkdown());
+    buffer.write("@@@");
+    return buffer.toString();
+  }
+}

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -1,0 +1,205 @@
+import 'package:markdown/markdown.dart' as md;
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+/// Markdown block-parser for callouts.
+///
+/// This [BlockSyntax] produces an [md.Element] with the name "callout".
+///
+/// Consider a blog post that mentions a detail in passing. The author might
+/// like to introduce a standalone block of content that explains that detail
+/// for readers who may be interested. That content should be visually separated
+/// from the main content in the blog post, so that readers can skip the aside,
+/// if desired.
+class CalloutBlockSyntax extends md.BlockSyntax {
+  static final _endLinePattern = RegExp(r'^@@@\s*$');
+
+  @override
+  RegExp get pattern => RegExp(r'^@@@\s*callout\s*$');
+
+  const CalloutBlockSyntax();
+
+  // This method was adapted from the standard Blockquote parser, and
+  // the standard code fence block parser.
+  @override
+  List<String> parseChildLines(md.BlockParser parser) {
+    // Grab all of the lines that form the custom block, stripping off the
+    // first line, e.g., "@@@ customBlock", and the last line, e.g., "@@@".
+    var childLines = <String>[];
+
+    while (!parser.isDone) {
+      final openingLine = pattern.firstMatch(parser.current);
+      if (openingLine != null) {
+        // This is the first line. Ignore it.
+        parser.advance();
+        continue;
+      }
+      final closingLine = _endLinePattern.firstMatch(parser.current);
+      if (closingLine != null) {
+        // This is the closing line. Ignore it.
+        parser.advance();
+
+        // If we're followed by a blank line, skip it, so that we don't end
+        // up with an extra paragraph for that blank line.
+        if (parser.current.trim().isEmpty) {
+          parser.advance();
+        }
+
+        // We're done.
+        break;
+      }
+
+      childLines.add(parser.current);
+      parser.advance();
+    }
+
+    return childLines;
+  }
+
+  // This method was adapted from the standard Blockquote parser, and
+  // the standard code fence block parser.
+  @override
+  md.Node parse(md.BlockParser parser) {
+    final childLines = parseChildLines(parser);
+
+    return md.Element('callout', [md.Text(childLines.join("\n"))]);
+  }
+}
+
+/// An [ElementToNodeConverter] that converts a "callout" Markdown [md.Element]
+/// to a [ParagraphNode].
+class CalloutElementToNodeConverter implements ElementToNodeConverter {
+  @override
+  DocumentNode? handleElement(md.Element element) {
+    if (element.tag != "callout") {
+      return null;
+    }
+
+    return ParagraphNode(
+      id: DocumentEditor.createNodeId(),
+      text: _parseInlineText(element),
+      metadata: {
+        'blockType': const NamedAttribution("callout"),
+      },
+    );
+  }
+}
+
+AttributedText _parseInlineText(md.Element element) {
+  final inlineVisitor = _parseInline(element);
+  return inlineVisitor.attributedText;
+}
+
+_InlineMarkdownToDocument _parseInline(md.Element element) {
+  final inlineParser = md.InlineParser(
+    element.textContent,
+    md.Document(
+      inlineSyntaxes: [
+        md.StrikethroughSyntax(),
+        UnderlineSyntax(),
+      ],
+    ),
+  );
+  final inlineVisitor = _InlineMarkdownToDocument();
+  final inlineNodes = inlineParser.parse();
+  for (final inlineNode in inlineNodes) {
+    inlineNode.accept(inlineVisitor);
+  }
+  return inlineVisitor;
+}
+
+class _InlineMarkdownToDocument implements md.NodeVisitor {
+  _InlineMarkdownToDocument();
+
+  // For our purposes, we only support block-level images. Therefore,
+  // if we find an image without any text, we're parsing an image.
+  // Otherwise, if there is any text, then we're parsing a paragraph
+  // and we ignore the image.
+  bool get isImage => _imageUrl != null && attributedText.text.isEmpty;
+
+  String? _imageUrl;
+  String? get imageUrl => _imageUrl;
+
+  String? _imageAltText;
+  String? get imageAltText => _imageAltText;
+
+  AttributedText get attributedText => _textStack.first;
+
+  final List<AttributedText> _textStack = [AttributedText()];
+
+  @override
+  bool visitElementBefore(md.Element element) {
+    if (element.tag == 'img') {
+      // TODO: handle missing "src" attribute
+      _imageUrl = element.attributes['src']!;
+      _imageAltText = element.attributes['alt'] ?? '';
+      return true;
+    }
+
+    _textStack.add(AttributedText());
+
+    return true;
+  }
+
+  @override
+  void visitText(md.Text text) {
+    final attributedText = _textStack.removeLast();
+    _textStack.add(attributedText.copyAndAppend(AttributedText(text: text.text)));
+  }
+
+  @override
+  void visitElementAfter(md.Element element) {
+    // Reset to normal text style because a plain text element does
+    // not receive a call to visitElementBefore().
+    final styledText = _textStack.removeLast();
+
+    if (element.tag == 'strong') {
+      styledText.addAttribution(
+        boldAttribution,
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    } else if (element.tag == 'em') {
+      styledText.addAttribution(
+        italicsAttribution,
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    } else if (element.tag == "del") {
+      styledText.addAttribution(
+        strikethroughAttribution,
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    } else if (element.tag == "u") {
+      styledText.addAttribution(
+        underlineAttribution,
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    } else if (element.tag == 'a') {
+      styledText.addAttribution(
+        LinkAttribution(url: Uri.parse(element.attributes['href']!)),
+        SpanRange(
+          start: 0,
+          end: styledText.text.length - 1,
+        ),
+      );
+    }
+
+    if (_textStack.isNotEmpty) {
+      final surroundingText = _textStack.removeLast();
+      _textStack.add(surroundingText.copyAndAppend(styledText));
+    } else {
+      _textStack.add(styledText);
+    }
+  }
+}

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -206,7 +206,7 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
 
 class CalloutSerializer implements DocumentNodeMarkdownSerializer {
   @override
-  String? serialize(DocumentNode node) {
+  String? serialize(Document document, DocumentNode node) {
     if (node is! ParagraphNode) {
       return null;
     }
@@ -217,7 +217,7 @@ class CalloutSerializer implements DocumentNodeMarkdownSerializer {
     final buffer = StringBuffer();
     buffer.writeln("@@@ callout");
     buffer.writeln(node.text.toMarkdown());
-    buffer.write("@@@");
+    buffer.writeln("@@@");
     return buffer.toString();
   }
 }

--- a/super_editor_markdown/test/custom_parsers/upsell_block.dart
+++ b/super_editor_markdown/test/custom_parsers/upsell_block.dart
@@ -54,13 +54,9 @@ class UpsellElementToNodeConverter implements ElementToNodeConverter {
   }
 }
 
-class UpsellSerializer implements DocumentNodeMarkdownSerializer {
+class UpsellSerializer extends NodeTypedDocumentNodeMarkdownSerializer<UpsellNode> {
   @override
-  String? serialize(DocumentNode node) {
-    if (node is! UpsellNode) {
-      return null;
-    }
-
-    return "@@@ upsell";
+  String doSerialization(Document document, UpsellNode node) {
+    return "@@@ upsell\n";
   }
 }

--- a/super_editor_markdown/test/custom_parsers/upsell_block.dart
+++ b/super_editor_markdown/test/custom_parsers/upsell_block.dart
@@ -53,3 +53,14 @@ class UpsellElementToNodeConverter implements ElementToNodeConverter {
     return UpsellNode(DocumentEditor.createNodeId());
   }
 }
+
+class UpsellSerializer implements DocumentNodeMarkdownSerializer {
+  @override
+  String? serialize(DocumentNode node) {
+    if (node is! UpsellNode) {
+      return null;
+    }
+
+    return "@@@ upsell";
+  }
+}

--- a/super_editor_markdown/test/custom_parsers/upsell_block.dart
+++ b/super_editor_markdown/test/custom_parsers/upsell_block.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+/// A [DocumentNode] that represents a placeholder for an "upsell message".
+///
+/// Consider a blog post. The author might like to display an advertisement,
+/// or an upsell message after the first paragraph. A developer could include
+/// an [UpsellNode] in the [Document] after the first paragraph, and then the
+/// corresponding [SuperReader] could render the desired upsell message. Perhaps
+/// the upsell widget is chosen by the server, so that the upsell message can
+/// change on all blog posts over time. As a result, this node, and its component
+/// in the [SuperReader] are just placeholders for content that will be chosen
+/// when rendered.
+class UpsellNode extends BlockNode with ChangeNotifier {
+  UpsellNode(this.id);
+
+  @override
+  final String id;
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    return null;
+  }
+}
+
+/// Markdown block-parser for upsell messages.
+///
+/// This [BlockSyntax] produces an [md.Element] with the name "upsell".
+class UpsellBlockSyntax extends md.BlockSyntax {
+  @override
+  RegExp get pattern => RegExp(r'^@@@\s*upsell\s*$');
+
+  const UpsellBlockSyntax();
+
+  @override
+  md.Node parse(md.BlockParser parser) {
+    parser.advance();
+    return md.Element('upsell', []);
+  }
+}
+
+/// An [ElementToNodeConverter] that converts an "upsell" Markdown [md.Element]
+/// to an [UpsellNode].
+class UpsellElementToNodeConverter implements ElementToNodeConverter {
+  @override
+  DocumentNode? handleElement(md.Element element) {
+    if (element.tag != "upsell") {
+      return null;
+    }
+
+    return UpsellNode(DocumentEditor.createNodeId());
+  }
+}


### PR DESCRIPTION
Added support for custom Markdown block syntaxes (Resolves #829)

I also refactored the source code to accomplish a couple things:

- Separated serialization and deserialization because they're mostly independent, and it's easier to read them when separated
- Converted serialization to use a list of serializer objects, instead of hard-coding all the supported nodes in the global serializer