### PR TITLE
Export touch_controls.dart

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -57,6 +57,7 @@ export 'src/infrastructure/platforms/mobile_documents.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';
 export 'src/infrastructure/strings.dart';
 export 'src/infrastructure/super_textfield/super_textfield.dart';
+export 'src/infrastructure/touch_controls.dart';
 
 // Super Reader
 export 'src/super_reader/read_only_document_android_touch_interactor.dart';


### PR DESCRIPTION
`super_editor` exports mobile handle widgets, but doesn't export the `HandleType`, which is required to use those handle widgets. This PR exports `HandleType`.