### PR TITLE
SuperTextField: Initialize controller selection if focused during initState

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -120,10 +120,12 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     super.initState();
 
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
-    _hasFocus = _focusNode.hasFocus;
 
     _controller = (widget.textController ?? AttributedTextEditingController())
       ..addListener(_onSelectionOrContentChange);
+
+    _onFocusChange();
+
     _scrollController = ScrollController();
   }
 

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -182,6 +182,30 @@ void main() {
         expect(_isCaretPresent(tester), isTrue);
       });
 
+      // TODO: Enable this test on mobile once text fields are fixed
+      testWidgetsOnDesktop("is inserted automatically when the field is initialized with focused node", (tester) async {
+        final node = FocusNode()..requestFocus();
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: Focus.withExternalFocusNode(
+              focusNode: node,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        );
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              focusNode: node,
+            ),
+          ),
+        );
+        await tester.pump();
+        node.dispose();
+
+        expect(_isCaretPresent(tester), isTrue);
+      });
+
       testWidgetsOnAllPlatforms("is inserted automatically when the field is given focus", (tester) async {
         final focusNode = FocusNode();
         await tester.pumpWidget(


### PR DESCRIPTION
Partially fixes https://github.com/superlistapp/super_editor/issues/842 (for desktop platforms)