### PR TITLE
[SuperEditor] Change TextInputClient implementations to use it as a mixin (Resolves #840)

### DIFF
--- a/super_editor/example/lib/demos/debugging/simple_deltas_input.dart
+++ b/super_editor/example/lib/demos/debugging/simple_deltas_input.dart
@@ -12,7 +12,7 @@ class SimpleDeltasInputDemo extends StatefulWidget {
   _SimpleDeltasInputState createState() => _SimpleDeltasInputState();
 }
 
-class _SimpleDeltasInputState extends State<SimpleDeltasInputDemo> implements DeltaTextInputClient {
+class _SimpleDeltasInputState extends State<SimpleDeltasInputDemo> with TextInputClient, DeltaTextInputClient {
   final _textGlobalKey = GlobalKey(debugLabel: "text_input");
   AttributedText _text = AttributedText(text: "Hello, world!");
 
@@ -166,21 +166,6 @@ class _SimpleDeltasInputState extends State<SimpleDeltasInputDemo> implements De
   @override
   void updateFloatingCursor(RawFloatingCursorPoint point) {
     // no-op
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    // TODO: implement insertTextPlaceholder
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    // TODO: implement removeTextPlaceholder
-  }
-
-  @override
-  void showToolbar() {
-    // TODO: implement showToolbar
   }
 
   @override

--- a/super_editor/example/lib/demos/flutter_features/textinputclient/barebones_ios_text_input_client.dart
+++ b/super_editor/example/lib/demos/flutter_features/textinputclient/barebones_ios_text_input_client.dart
@@ -36,8 +36,7 @@ class _BareBonesTextFieldWithInputClient extends StatefulWidget {
   _BareBonesTextFieldWithInputClientState createState() => _BareBonesTextFieldWithInputClientState();
 }
 
-class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldWithInputClient>
-    implements TextInputClient {
+class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldWithInputClient> with TextInputClient {
   final _textKey = GlobalKey<ProseTextState>();
 
   late FocusNode _focusNode;
@@ -223,21 +222,6 @@ class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldW
         _floatingCursorCurrentOffset = null;
         break;
     }
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void showToolbar() {
-    // No-op: this is for scribble
   }
 
   @override

--- a/super_editor/example/lib/demos/flutter_features/textinputclient/basic_text_input_client.dart
+++ b/super_editor/example/lib/demos/flutter_features/textinputclient/basic_text_input_client.dart
@@ -36,8 +36,7 @@ class _BareBonesTextFieldWithInputClient extends StatefulWidget {
   _BareBonesTextFieldWithInputClientState createState() => _BareBonesTextFieldWithInputClientState();
 }
 
-class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldWithInputClient>
-    implements TextInputClient {
+class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldWithInputClient> with TextInputClient {
   final _textKey = GlobalKey<ProseTextState>();
 
   late FocusNode _focusNode;
@@ -223,21 +222,6 @@ class _BareBonesTextFieldWithInputClientState extends State<_BareBonesTextFieldW
         _floatingCursorCurrentOffset = null;
         break;
     }
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void showToolbar() {
-    // No-op: this is for scribble
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -72,7 +72,9 @@ class DocumentImeInteractor extends StatefulWidget {
   State createState() => _DocumentImeInteractorState();
 }
 
-class _DocumentImeInteractorState extends State<DocumentImeInteractor> implements DeltaTextInputClient, ImeInputOwner {
+class _DocumentImeInteractorState extends State<DocumentImeInteractor>
+    with TextInputClient, DeltaTextInputClient
+    implements ImeInputOwner {
   late FocusNode _focusNode;
 
   TextInputConnection? _inputConnection;
@@ -361,21 +363,6 @@ class _DocumentImeInteractorState extends State<DocumentImeInteractor> implement
         widget.floatingCursorController?.offset = null;
         break;
     }
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void showToolbar() {
-    // No-op: this is for scribble
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -26,7 +26,8 @@ final _log = imeTextFieldLog;
 /// By default, an [ImeAttributedTextEditingController] is not connected to the platform
 /// IME. To connect to the IME, call `attachToIme`. To detach from the IME, call
 /// `detachFromIme`.
-class ImeAttributedTextEditingController extends AttributedTextEditingController implements DeltaTextInputClient {
+class ImeAttributedTextEditingController extends AttributedTextEditingController
+    with TextInputClient, DeltaTextInputClient {
   ImeAttributedTextEditingController({
     AttributedTextEditingController? controller,
     bool disposeClientController = true,
@@ -311,21 +312,6 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     _log.info('TextInputClient: connectionClosed()');
     _inputConnection = null;
     _latestPlatformTextEditingValue = null;
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    // No-op: this is for scribble
-  }
-
-  @override
-  void showToolbar() {
-    // No-op: this is for scribble
   }
 
   @override


### PR DESCRIPTION
[SuperEditor] Change `TextInputClient` implementations to use it as a mixin. Resolves #840

`TextInputClient` was changed to be a mixin. That way, we can use it with the `with` keyword to inherit the default implementations and avoid breaking the build when new methods with default implementations are added.

This PR changes the places where we implemented `DeltaTextInputClient` and `TextInputClient` to use them with the `with` keyword.