### PR TITLE
[SuperTextField] Fix selection and input when initializing with a focused FocusNode (Resolves #843)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -177,6 +177,13 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     );
 
     WidgetsBinding.instance.addObserver(this);
+
+    if (_focusNode.hasFocus) {
+      // The given FocusNode already has focus, we need to update selection and attach to IME.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _onFocusChange();
+      });
+    }
   }
 
   @override
@@ -186,6 +193,13 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     if (widget.focusNode != oldWidget.focusNode) {
       _focusNode.removeListener(_onFocusChange);
       _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+
+      if ((widget.focusNode?.hasFocus ?? false) != (oldWidget.focusNode?.hasFocus ?? false)) {
+        // Focus changed, check in the next frame if we need to update selection and attach/detach to IME.
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          _onFocusChange();
+        });
+      }
     }
 
     if (widget.textInputAction != oldWidget.textInputAction && _textEditingController.isAttachedToIme) {

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -193,13 +193,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     if (widget.focusNode != oldWidget.focusNode) {
       _focusNode.removeListener(_onFocusChange);
       _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
-
-      if ((widget.focusNode?.hasFocus ?? false) != (oldWidget.focusNode?.hasFocus ?? false)) {
-        // Focus changed, check in the next frame if we need to update selection and attach/detach to IME.
-        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-          _onFocusChange();
-        });
-      }
     }
 
     if (widget.textInputAction != oldWidget.textInputAction && _textEditingController.isAttachedToIme) {

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -160,7 +160,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   @override
   void initState() {
     super.initState();
-    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange)
@@ -181,7 +181,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     if (_focusNode.hasFocus) {
       // The given FocusNode already has focus, we need to update selection and attach to IME.
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        _onFocusChange();
+        _updateSelectionAndImeConnectionOnFocusChange();
       });
     }
   }
@@ -191,8 +191,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     super.didUpdateWidget(oldWidget);
 
     if (widget.focusNode != oldWidget.focusNode) {
-      _focusNode.removeListener(_onFocusChange);
-      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+      _focusNode.removeListener(_updateSelectionAndImeConnectionOnFocusChange);
+      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
     }
 
     if (widget.textInputAction != oldWidget.textInputAction && _textEditingController.isAttachedToIme) {
@@ -258,7 +258,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       });
     }
 
-    _focusNode.removeListener(_onFocusChange);
+    _focusNode.removeListener(_updateSelectionAndImeConnectionOnFocusChange);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -291,7 +291,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   bool get _isMultiline => (widget.minLines ?? 1) != 1 || widget.maxLines != 1;
 
-  void _onFocusChange() {
+  void _updateSelectionAndImeConnectionOnFocusChange() {
     if (_focusNode.hasFocus) {
       if (!_textEditingController.isAttachedToIme) {
         _log.info('Attaching TextInputClient to TextInput');

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -120,11 +120,13 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     super.initState();
 
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
-    _hasFocus = _focusNode.hasFocus;
 
     _controller = (widget.textController ?? AttributedTextEditingController())
       ..addListener(_onSelectionOrContentChange);
     _scrollController = ScrollController();
+
+    // Check if we need to update the selection.
+    _onFocusChange();
   }
 
   @override
@@ -137,7 +139,9 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
         _focusNode.dispose();
       }
       _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
-      _hasFocus = _focusNode.hasFocus;
+
+      // Check if we need to update the selection.
+      _onFocusChange();
     }
 
     if (widget.textController != oldWidget.textController) {

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -119,14 +119,14 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   void initState() {
     super.initState();
 
-    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionOnFocusChange);
 
     _controller = (widget.textController ?? AttributedTextEditingController())
       ..addListener(_onSelectionOrContentChange);
     _scrollController = ScrollController();
 
     // Check if we need to update the selection.
-    _onFocusChange();
+    _updateSelectionOnFocusChange();
   }
 
   @override
@@ -134,14 +134,14 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     super.didUpdateWidget(oldWidget);
 
     if (widget.focusNode != oldWidget.focusNode) {
-      _focusNode.removeListener(_onFocusChange);
+      _focusNode.removeListener(_updateSelectionOnFocusChange);
       if (oldWidget.focusNode == null) {
         _focusNode.dispose();
       }
-      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionOnFocusChange);
 
       // Check if we need to update the selection.
-      _onFocusChange();
+      _updateSelectionOnFocusChange();
     }
 
     if (widget.textController != oldWidget.textController) {
@@ -163,7 +163,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   @override
   void dispose() {
     _scrollController.dispose();
-    _focusNode.removeListener(_onFocusChange);
+    _focusNode.removeListener(_updateSelectionOnFocusChange);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -184,7 +184,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     _focusNode.requestFocus();
   }
 
-  void _onFocusChange() {
+  void _updateSelectionOnFocusChange() {
     // If our FocusNode just received focus, automatically set our
     // controller's text position to the end of the available content.
     //

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -165,7 +165,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   @override
   void initState() {
     super.initState();
-    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange)
@@ -191,7 +191,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     if (_focusNode.hasFocus) {
       // The given FocusNode already has focus, we need to update selection and attach to IME.
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        _onFocusChange();
+        _updateSelectionAndImeConnectionOnFocusChange();
       });
     }
   }
@@ -201,13 +201,13 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     super.didUpdateWidget(oldWidget);
 
     if (widget.focusNode != oldWidget.focusNode) {
-      _focusNode.removeListener(_onFocusChange);
+      _focusNode.removeListener(_updateSelectionAndImeConnectionOnFocusChange);
       if (widget.focusNode != null) {
         _focusNode = widget.focusNode!;
       } else {
         _focusNode = FocusNode();
       }
-      _focusNode.addListener(_onFocusChange);
+      _focusNode.addListener(_updateSelectionAndImeConnectionOnFocusChange);
     }
 
     if (widget.textController != oldWidget.textController) {
@@ -273,7 +273,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       });
     }
 
-    _focusNode.removeListener(_onFocusChange);
+    _focusNode.removeListener(_updateSelectionAndImeConnectionOnFocusChange);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -306,7 +306,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   @override
   DeltaTextInputClient get imeClient => _textEditingController;
 
-  void _onFocusChange() {
+  void _updateSelectionAndImeConnectionOnFocusChange() {
     if (_focusNode.hasFocus) {
       if (!_textEditingController.isAttachedToIme) {
         _log.info('Attaching TextInputClient to TextInput');

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -166,9 +166,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   void initState() {
     super.initState();
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
-    if (_focusNode.hasFocus) {
-      _showHandles();
-    }
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
       ..addListener(_onTextOrSelectionChange)
@@ -190,6 +187,13 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     );
 
     WidgetsBinding.instance.addObserver(this);
+
+    if (_focusNode.hasFocus) {
+      // The given FocusNode already has focus, we need to update selection and attach to IME.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _onFocusChange();
+      });
+    }
   }
 
   @override
@@ -204,6 +208,13 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         _focusNode = FocusNode();
       }
       _focusNode.addListener(_onFocusChange);
+
+      if ((widget.focusNode?.hasFocus ?? false) != (oldWidget.focusNode?.hasFocus ?? false)) {
+        // Focus changed, check in the next frame if we need to update selection and attach/detach to IME.
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          _onFocusChange();
+        });
+      }
     }
 
     if (widget.textController != oldWidget.textController) {

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -208,13 +208,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         _focusNode = FocusNode();
       }
       _focusNode.addListener(_onFocusChange);
-
-      if ((widget.focusNode?.hasFocus ?? false) != (oldWidget.focusNode?.hasFocus ?? false)) {
-        // Focus changed, check in the next frame if we need to update selection and attach/detach to IME.
-        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-          _onFocusChange();
-        });
-      }
     }
 
     if (widget.textController != oldWidget.textController) {

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -200,6 +200,34 @@ void main() {
 
         expect(_isCaretPresent(tester), isTrue);
       });
+
+      testWidgetsOnAllPlatforms(
+          "is inserted automatically when the field is initialized with a focused node used by another widget",
+          (tester) async {
+        final node = FocusNode()..requestFocus();
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: Focus(
+              focusNode: node,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        );
+
+        // Pumps a second widget tree, to simulate switching the FocusNode
+        // from one widget to another.
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              focusNode: node,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(_isCaretPresent(tester), isTrue);
+      });
     });
 
     group('padding', () {


### PR DESCRIPTION
[SuperTextField] Fix selection and input when initializing with a focused FocusNode. Resolves #843

When `SuperTextField` replaces another widget using an already focused `FocusNode` it doesn't show the caret and connect to IME.

This PR adds a post-frame callback to update selection/IME connection.

We already have a test which gives a focused `FocusNode` to the textfield  but, apparently, the issue only happens if the `FocusNode` was previously used.

https://github.com/superlistapp/super_editor/blob/47d2b4a492aca04b69274871a8880394821b18e8/super_editor/test/super_textfield/super_textfield_test.dart#L172-L183

This PR is based on https://github.com/superlistapp/super_editor/pull/843