### PR TITLE
[SuperEditor] Fix bad state when pasting content (Resolves #841)

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -948,7 +948,7 @@ class AttributedSpans {
       }
     }
 
-    if (collapsedSpans.last.end < contentLength - 1) {
+    if (collapsedSpans.isNotEmpty && collapsedSpans.last.end < contentLength - 1) {
       // The last span committed during the loop does not reach the end of the requested content range. We either ran
       // out of markers or the remaining markers are outside the content range. In both cases the value in currentSpan
       // should already have the correct start, end, and attributions values to cover the remaining content.


### PR DESCRIPTION
[SuperEditor] Fix bad state when pasting content. Resolves #841

In the example app, adding some new lines and then copying and pasting throws the exception: `Bad state: No element`

This was caused because in the `collapseSpans` we got a span end marker with an offset greater than the content length.

This is caused because when looking for links on the pasted text we are always checking the first line. I'm not sure why we are doing this.

https://github.com/superlistapp/super_editor/blob/47d2b4a492aca04b69274871a8880394821b18e8/super_editor/lib/src/default_editor/common_editor_operations.dart#L2349-L2357