### PR TITLE
Added dart_test.yaml to silence meaningless test warnings about golden tags (#854)

### DIFF
--- a/super_editor/dart_test.yaml
+++ b/super_editor/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:


### PR DESCRIPTION
Cherry-picked from `main`.