### PR TITLE
[super_editor_markdown] Add header alignment

### DIFF
--- a/super_editor_markdown/CHANGELOG.md
+++ b/super_editor_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.4+2] - Nov, 2022
+ * Added support for header alignment.
+ * Updated `markdown` to ^6.0.1.
+
 ## [0.1.4+1] - Nov, 2022
  * Added support for custom Markdown block syntax.
  * Fix: parsing empty markdown into a document.

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -140,6 +140,20 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
 
     final Attribution? blockType = node.getMetadataValue('blockType');
 
+    final String? textAlign = node.getMetadataValue('textAlign');
+    // Left alignment is the default, so there is no need to add the alignment token.
+    // The alignment markdown excluded for BLock Quote and Block Code
+    if (markdownSyntax == MarkdownSyntax.superEditor &&
+        textAlign != null &&
+        textAlign != 'left' &&
+        blockType != blockquoteAttribution &&
+        blockType != codeAttribution) {
+      final alignmentToken = _convertAlignmentToMarkdown(textAlign);
+      if (alignmentToken != null) {
+        buffer.writeln(alignmentToken);
+      }
+    }
+
     if (blockType == header1Attribution) {
       buffer.write('# ${node.text.toMarkdown()}');
     } else if (blockType == header2Attribution) {
@@ -161,14 +175,6 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
         ..writeln(node.text.toMarkdown()) //
         ..write('```');
     } else {
-      final String? textAlign = node.getMetadataValue('textAlign');
-      // Left alignment is the default, so there is no need to add the alignment token.
-      if (markdownSyntax == MarkdownSyntax.superEditor && textAlign != null && textAlign != 'left') {
-        final alignmentToken = _convertAlignmentToMarkdown(textAlign);
-        if (alignmentToken != null) {
-          buffer.writeln(alignmentToken);
-        }
-      }
       buffer.write(node.text.toMarkdown());
     }
 

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -434,12 +434,12 @@ abstract class ElementToNodeConverter {
 /// Markdown with surrounding `¬` tags, e.g., "this is ¬underline¬ text".
 ///
 /// This [TagSyntax] produces `Element`s with a `u` tag.
-class UnderlineSyntax extends md.DelimiterSyntax {
+class UnderlineSyntax extends md.TagSyntax {
   UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true);
 
   @override
-  md.Node? close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
-      {required String tag, required List<md.Node> Function() getChildren}) {
+  md.Node close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
+      {required List<md.Node> Function() getChildren}) {
     return md.Element('u', getChildren());
   }
 }

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -446,11 +446,6 @@ class UnderlineSyntax extends md.DelimiterSyntax {
 
 /// Parses a header preceded by an alignment token.
 class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
-  /// This pattern matches the text aligment notation.
-  ///
-  /// Possible values are `:---`, `:---:` and `---:`
-  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:$');
-
   /// Use internal HeaderSyntax
   final _headerSyntax = const md.HeaderSyntax();
 
@@ -460,7 +455,7 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
   @override
   bool canParse(md.BlockParser parser) {
     //
-    if (!_alignmentNotationPattern.hasMatch(parser.current)) {
+    if (!_ParagraphWithAlignmentSyntax._alignmentNotationPattern.hasMatch(parser.current)) {
       return false;
     }
 
@@ -481,7 +476,7 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
 
   @override
   md.Node? parse(md.BlockParser parser) {
-    final match = _alignmentNotationPattern.firstMatch(parser.current);
+    final match = _ParagraphWithAlignmentSyntax._alignmentNotationPattern.firstMatch(parser.current);
 
     // Move to the next line because the current line is alignment patterm
     parser.advance();

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -478,15 +478,18 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
   md.Node? parse(md.BlockParser parser) {
     final match = _ParagraphWithAlignmentSyntax._alignmentNotationPattern.firstMatch(parser.current);
 
-    // Move to the next line because the current line is alignment patterm
+    // We've parsed the alignment token on the current line. We know a paragraph starts on the
+    // next line. Move the parser to the next line so that we can parse the paragraph.
     parser.advance();
 
-    final headerNode = _headerSyntax.parse(parser) as md.Element;
+    final headerNode = _headerSyntax.parse(parser);
 
     // Use markdown alignment converter from [_ParagraphWithAlignmentSyntax]
-    headerNode.attributes.addAll({
-      'textAlign': _ParagraphWithAlignmentSyntax._convertMarkdownAlignmentTokenToSuperEditorAlignment(match!.input)
-    });
+    if (headerNode is md.Element) {
+      headerNode.attributes.addAll({
+        'textAlign': _ParagraphWithAlignmentSyntax._convertMarkdownAlignmentTokenToSuperEditorAlignment(match!.input)
+      });
+    }
 
     return headerNode;
   }

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -434,12 +434,12 @@ abstract class ElementToNodeConverter {
 /// Markdown with surrounding `¬` tags, e.g., "this is ¬underline¬ text".
 ///
 /// This [TagSyntax] produces `Element`s with a `u` tag.
-class UnderlineSyntax extends md.TagSyntax {
+class UnderlineSyntax extends md.DelimiterSyntax {
   UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true);
 
   @override
-  md.Node close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
-      {required List<md.Node> Function() getChildren}) {
+  md.Node? close(md.InlineParser parser, md.Delimiter opener, md.Delimiter closer,
+      {required String tag, required List<md.Node> Function() getChildren}) {
     return md.Element('u', getChildren());
   }
 }

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor_markdown
 description: Markdown (de)serialization for super_editor documents.
-version: 0.1.4+1
+version: 0.1.4+2
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
 
   super_editor: ^0.2.3
   logging: ^1.0.1
-  markdown: ^4.0.0
+  markdown: ^6.0.1
 
 dependency_overrides:
   # Override to local mono-repo path so devs can test this repo

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor_markdown
 description: Markdown (de)serialization for super_editor documents.
-version: 0.1.4+2
+version: 0.1.4+1
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
 
   super_editor: ^0.2.3
   logging: ^1.0.1
-  markdown: ^6.0.1
+  markdown: ^4.0.0
 
 dependency_overrides:
   # Override to local mono-repo path so devs can test this repo

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -32,6 +32,56 @@ void main() {
         expect(serializeDocumentToMarkdown(doc), '###### My Header');
       });
 
+      test('header with left alignment', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(text: 'Header1'),
+            metadata: {
+              'textAlign': 'left',
+              'blockType': header1Attribution,
+            },
+          ),
+        ]);
+
+        // Even when using superEditor markdown syntax, which has support
+        // for text alignment, we don't add an alignment token when
+        // the paragraph is left-aligned.
+        // Paragraphs are left-aligned by default, so it isn't necessary
+        // to serialize the alignment token.
+        expect(serializeDocumentToMarkdown(doc), '# Header1');
+      });
+
+      test('header with center alignment', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(text: 'Header1'),
+            metadata: {
+              'textAlign': 'center',
+              'blockType': header1Attribution,
+            },
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), ':---:\n# Header1');
+      });
+
+      test('header with right alignment', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(text: 'Header1'),
+            metadata: {
+              'textAlign': 'right',
+              'blockType': header1Attribution,
+            },
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '---:\n# Header1');
+      });
+
       test('header with styles', () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -341,10 +391,22 @@ This is some code
               text: 'First LinkSecond Link',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 0, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 9, markerType: SpanMarkerType.end),
-                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 10, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 20, markerType: SpanMarkerType.end),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 0,
+                      markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                      offset: 9,
+                      markerType: SpanMarkerType.end),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
+                      offset: 10,
+                      markerType: SpanMarkerType.start),
+                  SpanMarker(
+                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
+                      offset: 20,
+                      markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -1102,8 +1164,7 @@ Paragraph4""";
       });
 
       test('paragraph beginning with multiple blank lines', () {
-        final doc =
-            deserializeMarkdownToDocument('  \n  \nFirst Paragraph.\n\nSecond Paragraph');
+        final doc = deserializeMarkdownToDocument('  \n  \nFirst Paragraph.\n\nSecond Paragraph');
 
         expect(doc.nodes.length, 2);
 
@@ -1113,7 +1174,7 @@ Paragraph4""";
         expect(doc.nodes.last, isA<ParagraphNode>());
         expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
       });
-    
+
       test('document ending with an empty paragraph', () {
         final doc = deserializeMarkdownToDocument("""
 First Paragraph.

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -391,22 +391,10 @@ This is some code
               text: 'First LinkSecond Link',
               spans: AttributedSpans(
                 attributions: [
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 0,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 9,
-                      markerType: SpanMarkerType.end),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
-                      offset: 10,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
-                      offset: 20,
-                      markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 0, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('example.org', '')), offset: 9, markerType: SpanMarkerType.end),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 10, markerType: SpanMarkerType.start),
+                  SpanMarker(attribution: LinkAttribution(url: Uri.https('github.com', '')), offset: 20, markerType: SpanMarkerType.end),
                 ],
               ),
             ),
@@ -1164,7 +1152,8 @@ Paragraph4""";
       });
 
       test('paragraph beginning with multiple blank lines', () {
-        final doc = deserializeMarkdownToDocument('  \n  \nFirst Paragraph.\n\nSecond Paragraph');
+        final doc =
+            deserializeMarkdownToDocument('  \n  \nFirst Paragraph.\n\nSecond Paragraph');
 
         expect(doc.nodes.length, 2);
 
@@ -1174,7 +1163,7 @@ Paragraph4""";
         expect(doc.nodes.last, isA<ParagraphNode>());
         expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
       });
-
+  
       test('document ending with an empty paragraph', () {
         final doc = deserializeMarkdownToDocument("""
 First Paragraph.


### PR DESCRIPTION
I know the plugin supports custom parsers but I think the header alignment should be added by default to be compatible with the super_editor, so I made this PR. 