### PR TITLE
[SuperEditor] Avoid scrolling when dragging over an image (Resolves #812)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/document_selection_on_focus_mixin.dart';
+import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
@@ -150,24 +151,36 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor>
       _currentSelection != null;
 
   void _onSelectionChange(DocumentSelectionChange selectionChange) {
+    if (!mounted) {
+      return;
+    }
+
     if (selectionChange.reason != SelectionReason.userInteraction) {
       // The selection changed, but it isn't caused by an user interaction.
       // We don't want auto-scroll.
       return;
     }
-    if (mounted) {
-      // Use a post-frame callback to "ensure selection extent is visible"
-      // so that any pending visual document changes can happen before
-      // attempting to calculate the visual position of the selection extent.
-      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        editorGesturesLog.finer("Ensuring selection extent is visible because the doc selection changed");
 
-        final globalExtentRect = _getSelectionExtentAsGlobalRect();
-        if (globalExtentRect != null) {
-          widget.autoScroller.ensureGlobalRectIsVisible(globalExtentRect);
-        }
-      });
+    final selection = widget.selectionNotifier.value;
+    if (selection != null) {
+      final node = widget.document.getNodeById(selection.extent.nodeId);
+      if (node is ImageNode) {
+        // We don't want auto-scroll images.
+        return;
+      }
     }
+
+    // Use a post-frame callback to "ensure selection extent is visible"
+    // so that any pending visual document changes can happen before
+    // attempting to calculate the visual position of the selection extent.
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      editorGesturesLog.finer("Ensuring selection extent is visible because the doc selection changed");
+
+      final globalExtentRect = _getSelectionExtentAsGlobalRect();
+      if (globalExtentRect != null) {
+        widget.autoScroller.ensureGlobalRectIsVisible(globalExtentRect);
+      }
+    });
   }
 
   Rect? _getSelectionExtentAsGlobalRect() {

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -8,9 +8,9 @@ import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/box_component.dart';
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/document_selection_on_focus_mixin.dart';
-import 'package:super_editor/src/default_editor/image.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
@@ -164,8 +164,8 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor>
     final selection = widget.selectionNotifier.value;
     if (selection != null) {
       final node = widget.document.getNodeById(selection.extent.nodeId);
-      if (node is ImageNode) {
-        // We don't want auto-scroll images.
+      if (node is BlockNode) {
+        // We don't want auto-scroll block components.
         return;
       }
     }

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -484,3 +484,37 @@ class EquivalentDocumentMatcher extends Matcher {
     return null;
   }
 }
+
+/// A [ComponentBuilder] which builds an [ImageComponent] that always renders
+/// images as a [SizedBox] with the given [size].
+class FakeImageComponentBuilder implements ComponentBuilder {
+  const FakeImageComponentBuilder({
+    required this.size,
+  });
+
+  final ui.Size size;
+
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    return null;
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! ImageComponentViewModel) {
+      return null;
+    }
+
+    return ImageComponent(
+      componentKey: componentContext.componentKey,
+      imageUrl: componentViewModel.imageUrl,
+      selection: componentViewModel.selection,
+      selectionColor: componentViewModel.selectionColor,
+      imageBuilder: (context, imageUrl) => SizedBox(
+        height: size.height,
+        width: size.width,
+      ),
+    );
+  }
+}

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -280,7 +280,7 @@ void main() {
               ],
             ),
           )
-          .withAddedComponents([const _FakeImageComponentBuilder(size: editorSize)])
+          .withAddedComponents([const FakeImageComponentBuilder(size: editorSize)])
           .withEditorSize(editorSize)
           .pump();
 
@@ -306,38 +306,4 @@ void main() {
       );
     });
   });
-}
-
-/// A [ComponentBuilder] which builds an [ImageComponent] that always renders
-/// images as a [SizedBox] with the given [size].
-class _FakeImageComponentBuilder implements ComponentBuilder {
-  const _FakeImageComponentBuilder({
-    required this.size,
-  });
-
-  final Size size;
-
-  @override
-  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
-    return null;
-  }
-
-  @override
-  Widget? createComponent(
-      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
-    if (componentViewModel is! ImageComponentViewModel) {
-      return null;
-    }
-
-    return ImageComponent(
-      componentKey: componentContext.componentKey,
-      imageUrl: componentViewModel.imageUrl,
-      selection: componentViewModel.selection,
-      selectionColor: componentViewModel.selectionColor,
-      imageBuilder: (context, imageUrl) => SizedBox(
-        height: size.height,
-        width: size.width,
-      ),
-    );
-  }
 }


### PR DESCRIPTION
[SuperEditor] Avoid scrolling when dragging over an image (Resolves #812)

When dragging over an image, the editor scrolls to display the whole image.

This PR changes the mouse interactor to avoid scrolling when the selection extent is an `ImageNode`.

The downside is that when a user changes the selection manually, it won't scroll also.

We could also extract the `_FakeImageComponentBuilder` to a shared file where we could reuse it.