### PR TITLE
[SuperEditor][DemoApp] Fix toolbar dismissal on copy (Resolves #818)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -38,7 +38,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
   OverlayEntry? _imageFormatBarOverlayEntry;
   final _imageSelectionAnchor = ValueNotifier<Offset?>(null);
 
-  final _toolbarController = MagnifierAndToolbarController();
+  final _overlayController = MagnifierAndToolbarController();
 
   @override
   void initState() {
@@ -221,17 +221,17 @@ class _ExampleEditorState extends State<ExampleEditor> {
 
   void _cut() {
     _docOps.cut();
-    _toolbarController.hideToolbar();
+    _overlayController.hideToolbar();
   }
 
   void _copy() {
     _docOps.copy();
-    _toolbarController.hideToolbar();
+    _overlayController.hideToolbar();
   }
 
   void _paste() {
     _docOps.paste();
-    _toolbarController.hideToolbar();
+    _overlayController.hideToolbar();
   }
 
   void _selectAll() => _docOps.selectAll();
@@ -385,7 +385,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
           onCopyPressed: _copy,
           onPastePressed: _paste,
         ),
-        toolbarController: _toolbarController,
+        overlayController: _overlayController,
       ),
     );
   }

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -38,6 +38,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
   OverlayEntry? _imageFormatBarOverlayEntry;
   final _imageSelectionAnchor = ValueNotifier<Offset?>(null);
 
+  final _toolbarController = MagnifierAndToolbarController();
+
   @override
   void initState() {
     super.initState();
@@ -217,9 +219,21 @@ class _ExampleEditorState extends State<ExampleEditor> {
     }
   }
 
-  void _cut() => _docOps.cut();
-  void _copy() => _docOps.copy();
-  void _paste() => _docOps.paste();
+  void _cut() {
+    _docOps.cut();
+    _toolbarController.hideToolbar();
+  }
+
+  void _copy() {
+    _docOps.copy();
+    _toolbarController.hideToolbar();
+  }
+
+  void _paste() {
+    _docOps.paste();
+    _toolbarController.hideToolbar();
+  }
+
   void _selectAll() => _docOps.selectAll();
 
   void _showImageToolbar() {
@@ -371,6 +385,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
           onCopyPressed: _copy,
           onPastePressed: _paste,
         ),
+        toolbarController: _toolbarController,
       ),
     );
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -39,6 +39,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
+    this.toolbarController,
     required this.child,
   }) : super(key: key);
 
@@ -50,6 +51,10 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
   final ValueNotifier<DocumentSelection?> selection;
 
   final ScrollController? scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  final MagnifierAndToolbarController? toolbarController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -86,6 +91,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   // The alternative case is the one in which this interactor defers to an
   // ancestor scrollable.
   late ScrollController _scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  late MagnifierAndToolbarController _toolbarController;
   // The ScrollPosition attached to the _ancestorScrollable, if there's an ancestor
   // Scrollable.
   ScrollPosition? _ancestorScrollPosition;
@@ -144,9 +153,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
+    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+
     _editingController = AndroidDocumentGestureEditingController(
       documentLayoutLink: _documentLayoutLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
+      toolbarController: _toolbarController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -211,6 +223,11 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     if (widget.getDocumentLayout != oldWidget.getDocumentLayout) {
       onDocumentLayoutResolverReplaced(widget.getDocumentLayout);
+    }
+
+    if (widget.toolbarController != oldWidget.toolbarController) {
+      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+      _editingController.toolbarController = _toolbarController;
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -39,7 +39,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
-    this.toolbarController,
+    this.overlayController,
     required this.child,
   }) : super(key: key);
 
@@ -52,9 +52,8 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
 
   final ScrollController? scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -92,9 +91,8 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   // ancestor scrollable.
   late ScrollController _scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  late MagnifierAndToolbarController _toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  late MagnifierAndToolbarController _overlayController;
   // The ScrollPosition attached to the _ancestorScrollable, if there's an ancestor
   // Scrollable.
   ScrollPosition? _ancestorScrollPosition;
@@ -153,12 +151,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
-    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+    _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
 
     _editingController = AndroidDocumentGestureEditingController(
       documentLayoutLink: _documentLayoutLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
-      toolbarController: _toolbarController,
+      overlayController: _overlayController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -225,9 +223,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       onDocumentLayoutResolverReplaced(widget.getDocumentLayout);
     }
 
-    if (widget.toolbarController != oldWidget.toolbarController) {
-      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
-      _editingController.toolbarController = _toolbarController;
+    if (widget.overlayController != oldWidget.overlayController) {
+      _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
+      _editingController.overlayController = _overlayController;
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -35,7 +35,7 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
     required this.floatingCursorController,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
-    this.toolbarController,
+    this.overlayController,
     required this.child,
   }) : super(key: key);
 
@@ -48,9 +48,8 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
 
   final ScrollController? scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -92,9 +91,8 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   // ancestor scrollable.
   late ScrollController _scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  late MagnifierAndToolbarController _toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  late MagnifierAndToolbarController _overlayController;
   // The ScrollPosition attached to the _ancestorScrollable.
   ScrollPosition? _ancestorScrollPosition;
   // The actual ScrollPosition that's used for the document layout, either
@@ -165,12 +163,12 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
-    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+    _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
 
     _editingController = IosDocumentGestureEditingController(
       documentLayoutLink: _documentLayerLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
-      toolbarController: _toolbarController,
+      overlayController: _overlayController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -240,9 +238,9 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       }
     }
 
-    if (widget.toolbarController != oldWidget.toolbarController) {
-      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
-      _editingController.toolbarController = _toolbarController;
+    if (widget.overlayController != oldWidget.overlayController) {
+      _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
+      _editingController.overlayController = _overlayController;
     }
 
     if (widget.getDocumentLayout != oldWidget.getDocumentLayout) {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -35,6 +35,7 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
     required this.floatingCursorController,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
+    this.toolbarController,
     required this.child,
   }) : super(key: key);
 
@@ -46,6 +47,10 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
   final ValueNotifier<DocumentSelection?> selection;
 
   final ScrollController? scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  final MagnifierAndToolbarController? toolbarController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -86,6 +91,10 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
   // The alternative case is the one in which this interactor defers to an
   // ancestor scrollable.
   late ScrollController _scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  late MagnifierAndToolbarController _toolbarController;
   // The ScrollPosition attached to the _ancestorScrollable.
   ScrollPosition? _ancestorScrollPosition;
   // The actual ScrollPosition that's used for the document layout, either
@@ -156,9 +165,12 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
+    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+
     _editingController = IosDocumentGestureEditingController(
       documentLayoutLink: _documentLayerLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
+      toolbarController: _toolbarController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -226,6 +238,11 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       if (widget.selection.value != oldWidget.selection.value) {
         _onSelectionChange();
       }
+    }
+
+    if (widget.toolbarController != oldWidget.toolbarController) {
+      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+      _editingController.toolbarController = _toolbarController;
     }
 
     if (widget.getDocumentLayout != oldWidget.getDocumentLayout) {

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -17,6 +17,7 @@ import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import '../infrastructure/platforms/mobile_documents.dart';
 import 'attributions.dart';
 import 'blockquote.dart';
 import 'document_caret_overlay.dart';
@@ -92,6 +93,7 @@ class SuperEditor extends StatefulWidget {
     this.createOverlayControlsClipper,
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
+    this.toolbarController,
   })  : componentBuilders = defaultComponentBuilders,
         keyboardActions = defaultKeyboardActions,
         softwareKeyboardHandler = null,
@@ -123,6 +125,7 @@ class SuperEditor extends StatefulWidget {
     this.createOverlayControlsClipper,
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
+    this.toolbarController,
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         keyboardActions = keyboardActions ?? defaultKeyboardActions,
@@ -157,6 +160,7 @@ class SuperEditor extends StatefulWidget {
     this.documentOverlayBuilders = const [DefaultCaretOverlayBuilder()],
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
+    this.toolbarController,
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         keyboardActions = keyboardActions ?? defaultKeyboardActions,
@@ -177,6 +181,10 @@ class SuperEditor extends StatefulWidget {
   /// `scrollController` is not used if this `SuperEditor` has an ancestor
   /// `Scrollable`.
   final ScrollController? scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar for Android and iOS.
+  final MagnifierAndToolbarController? toolbarController;
 
   /// [GlobalKey] that's bound to the [DocumentLayout] within
   /// this `SuperEditor`.
@@ -574,6 +582,7 @@ class SuperEditorState extends State<SuperEditor> {
           handleColor: widget.androidHandleColor ?? Theme.of(context).primaryColor,
           popoverToolbarBuilder: widget.androidToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
+          toolbarController: widget.toolbarController,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );
@@ -589,6 +598,7 @@ class SuperEditorState extends State<SuperEditor> {
           popoverToolbarBuilder: widget.iOSToolbarBuilder ?? (_) => const SizedBox(),
           floatingCursorController: _floatingCursorController,
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
+          toolbarController: widget.toolbarController,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -93,7 +93,7 @@ class SuperEditor extends StatefulWidget {
     this.createOverlayControlsClipper,
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
-    this.toolbarController,
+    this.overlayController,
   })  : componentBuilders = defaultComponentBuilders,
         keyboardActions = defaultKeyboardActions,
         softwareKeyboardHandler = null,
@@ -125,7 +125,7 @@ class SuperEditor extends StatefulWidget {
     this.createOverlayControlsClipper,
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
-    this.toolbarController,
+    this.overlayController,
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         keyboardActions = keyboardActions ?? defaultKeyboardActions,
@@ -160,7 +160,7 @@ class SuperEditor extends StatefulWidget {
     this.documentOverlayBuilders = const [DefaultCaretOverlayBuilder()],
     this.debugPaint = const DebugPaintConfig(),
     this.autofocus = false,
-    this.toolbarController,
+    this.overlayController,
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         keyboardActions = keyboardActions ?? defaultKeyboardActions,
@@ -182,9 +182,8 @@ class SuperEditor extends StatefulWidget {
   /// `Scrollable`.
   final ScrollController? scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar for Android and iOS.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   /// [GlobalKey] that's bound to the [DocumentLayout] within
   /// this `SuperEditor`.
@@ -582,7 +581,7 @@ class SuperEditorState extends State<SuperEditor> {
           handleColor: widget.androidHandleColor ?? Theme.of(context).primaryColor,
           popoverToolbarBuilder: widget.androidToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
-          toolbarController: widget.toolbarController,
+          overlayController: widget.overlayController,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );
@@ -598,7 +597,7 @@ class SuperEditorState extends State<SuperEditor> {
           popoverToolbarBuilder: widget.iOSToolbarBuilder ?? (_) => const SizedBox(),
           floatingCursorController: _floatingCursorController,
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
-          toolbarController: widget.toolbarController,
+          overlayController: widget.overlayController,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -6,21 +6,20 @@ import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart'
 /// Controls the display of drag handles, a magnifier, and a
 /// floating toolbar, assuming Android-style behavior for the
 /// handles.
-class AndroidDocumentGestureEditingController with ChangeNotifier {
+class AndroidDocumentGestureEditingController extends GestureEditingController {
   AndroidDocumentGestureEditingController({
     required LayerLink documentLayoutLink,
     required LayerLink magnifierFocalPointLink,
     required MagnifierAndToolbarController overlayController,
   })  : _documentLayoutLink = documentLayoutLink,
-        _overlayController = overlayController,
-        _magnifierFocalPointLink = magnifierFocalPointLink {
-    _overlayController.addListener(_toolbarChanged);
-  }
+        super(
+          magnifierFocalPointLink: magnifierFocalPointLink,
+          overlayController: overlayController,
+        );
 
   @override
   void dispose() {
     _collapsedHandleAutoHideTimer?.cancel();
-    _overlayController.removeListener(_toolbarChanged);
     super.dispose();
   }
 
@@ -33,11 +32,6 @@ class AndroidDocumentGestureEditingController with ChangeNotifier {
   /// document layout.
   LayerLink get documentLayoutLink => _documentLayoutLink;
   final LayerLink _documentLayoutLink;
-
-  /// A `LayerLink` whose top-left corner sits at the location where the
-  /// magnifier should magnify.
-  LayerLink get magnifierFocalPointLink => _magnifierFocalPointLink;
-  final LayerLink _magnifierFocalPointLink;
 
   /// Whether or not a caret should be displayed.
   bool get hasCaret => caretTop != null;
@@ -135,43 +129,6 @@ class AndroidDocumentGestureEditingController with ChangeNotifier {
   bool get isCollapsedHandleAutoHidden => _isCollapsedHandleAutoHidden;
   bool _isCollapsedHandleAutoHidden = false;
 
-  /// Controls the magnifier and the toolbar.
-  MagnifierAndToolbarController get overlayController => _overlayController;
-  late MagnifierAndToolbarController _overlayController;
-  set overlayController(MagnifierAndToolbarController value) {
-    if (_overlayController != value) {
-      _overlayController.removeListener(_toolbarChanged);
-      _overlayController = value;
-      _overlayController.addListener(_toolbarChanged);
-    }
-  }
-
-  /// Whether the toolbar currently has a designated display position.
-  ///
-  /// The toolbar should not be displayed if this is `false`, even if
-  /// [shouldDisplayToolbar] is `true`.
-  bool get isToolbarPositioned => _overlayController.isToolbarPositioned;
-
-  /// Whether the toolbar should be displayed.
-  bool get shouldDisplayToolbar => _overlayController.shouldDisplayToolbar;
-
-  /// Whether the magnifier should be displayed.
-  bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
-
-  /// The point about which the floating toolbar should focus, when the toolbar
-  /// appears above the selected content.
-  ///
-  /// It's the clients responsibility to determine whether there's room for the
-  /// toolbar above this point. If not, use [toolbarBottomAnchor].
-  Offset? get toolbarTopAnchor => _overlayController.toolbarTopAnchor;
-
-  /// The point about which the floating toolbar should focus, when the toolbar
-  /// appears below the selected content.
-  ///
-  /// It's the clients responsibility to determine whether there's room for the
-  /// toolbar below this point. If not, use [toolbarTopAnchor].
-  Offset? get toolbarBottomAnchor => _overlayController.toolbarBottomAnchor;
-
   /// Starts a countdown that, if reached, fades out the collapsed drag handle.
   void startCollapsedHandleAutoHideCountdown() {
     _collapsedHandleAutoHideTimer?.cancel();
@@ -196,48 +153,5 @@ class AndroidDocumentGestureEditingController with ChangeNotifier {
       _isCollapsedHandleAutoHidden = false;
       notifyListeners();
     }
-  }
-
-  /// Shows the toolbar, and hides the magnifier.
-  void showToolbar() {
-    _overlayController.showToolbar();
-  }
-
-  /// Hides the toolbar.
-  void hideToolbar() {
-    _overlayController.hideToolbar();
-  }
-
-  /// Shows the magnify, and hides the toolbar.
-  void showMagnifier() {
-    _overlayController.showMagnifier();
-  }
-
-  /// Hides the magnifier.
-  void hideMagnifier() {
-    _overlayController.hideMagnifier();
-  }
-
-  /// Toggles the toolbar from visible to not visible, or vis-a-versa.
-  void toggleToolbar() {
-    _overlayController.toggleToolbar();
-  }
-
-  /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
-  ///
-  /// Setting the position will not cause the toolbar to be displayed on it's own.
-  /// To display the toolbar, call [showToolbar], too.
-  void positionToolbar({
-    required Offset topAnchor,
-    required Offset bottomAnchor,
-  }) {
-    _overlayController.positionToolbar(
-      topAnchor: topAnchor,
-      bottomAnchor: bottomAnchor,
-    );
-  }
-
-  void _toolbarChanged() {
-    notifyListeners();
   }
 }

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -6,22 +6,21 @@ import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart'
 /// Controls the display of drag handles, a magnifier, and a
 /// floating toolbar, assuming Android-style behavior for the
 /// handles.
-class AndroidDocumentGestureEditingController extends ChangeNotifier {
+class AndroidDocumentGestureEditingController with ChangeNotifier {
   AndroidDocumentGestureEditingController({
     required LayerLink documentLayoutLink,
     required LayerLink magnifierFocalPointLink,
-    required MagnifierAndToolbarController toolbarController,
+    required MagnifierAndToolbarController overlayController,
   })  : _documentLayoutLink = documentLayoutLink,
-        _toolbarController = toolbarController,
-        _magnifierFocalPointLink = magnifierFocalPointLink,
-        super() {
-    _toolbarController.addListener(_toolbarChanged);
+        _overlayController = overlayController,
+        _magnifierFocalPointLink = magnifierFocalPointLink {
+    _overlayController.addListener(_toolbarChanged);
   }
 
   @override
   void dispose() {
     _collapsedHandleAutoHideTimer?.cancel();
-    _toolbarController.removeListener(_toolbarChanged);
+    _overlayController.removeListener(_toolbarChanged);
     super.dispose();
   }
 
@@ -137,13 +136,13 @@ class AndroidDocumentGestureEditingController extends ChangeNotifier {
   bool _isCollapsedHandleAutoHidden = false;
 
   /// Controls the magnifier and the toolbar.
-  MagnifierAndToolbarController get toolbarController => _toolbarController;
-  late MagnifierAndToolbarController _toolbarController;
-  set toolbarController(MagnifierAndToolbarController value) {
-    if (_toolbarController != value) {
-      _toolbarController.removeListener(_toolbarChanged);
-      _toolbarController = value;
-      _toolbarController.addListener(_toolbarChanged);
+  MagnifierAndToolbarController get overlayController => _overlayController;
+  late MagnifierAndToolbarController _overlayController;
+  set overlayController(MagnifierAndToolbarController value) {
+    if (_overlayController != value) {
+      _overlayController.removeListener(_toolbarChanged);
+      _overlayController = value;
+      _overlayController.addListener(_toolbarChanged);
     }
   }
 
@@ -151,27 +150,27 @@ class AndroidDocumentGestureEditingController extends ChangeNotifier {
   ///
   /// The toolbar should not be displayed if this is `false`, even if
   /// [shouldDisplayToolbar] is `true`.
-  bool get isToolbarPositioned => _toolbarController.isToolbarPositioned;
+  bool get isToolbarPositioned => _overlayController.isToolbarPositioned;
 
   /// Whether the toolbar should be displayed.
-  bool get shouldDisplayToolbar => _toolbarController.shouldDisplayToolbar;
+  bool get shouldDisplayToolbar => _overlayController.shouldDisplayToolbar;
 
   /// Whether the magnifier should be displayed.
-  bool get shouldDisplayMagnifier => _toolbarController.shouldDisplayMagnifier;
+  bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
 
   /// The point about which the floating toolbar should focus, when the toolbar
   /// appears above the selected content.
   ///
   /// It's the clients responsibility to determine whether there's room for the
   /// toolbar above this point. If not, use [toolbarBottomAnchor].
-  Offset? get toolbarTopAnchor => _toolbarController.toolbarTopAnchor;
+  Offset? get toolbarTopAnchor => _overlayController.toolbarTopAnchor;
 
   /// The point about which the floating toolbar should focus, when the toolbar
   /// appears below the selected content.
   ///
   /// It's the clients responsibility to determine whether there's room for the
   /// toolbar below this point. If not, use [toolbarTopAnchor].
-  Offset? get toolbarBottomAnchor => _toolbarController.toolbarBottomAnchor;
+  Offset? get toolbarBottomAnchor => _overlayController.toolbarBottomAnchor;
 
   /// Starts a countdown that, if reached, fades out the collapsed drag handle.
   void startCollapsedHandleAutoHideCountdown() {
@@ -201,27 +200,27 @@ class AndroidDocumentGestureEditingController extends ChangeNotifier {
 
   /// Shows the toolbar, and hides the magnifier.
   void showToolbar() {
-    _toolbarController.showToolbar();
+    _overlayController.showToolbar();
   }
 
   /// Hides the toolbar.
   void hideToolbar() {
-    _toolbarController.hideToolbar();
+    _overlayController.hideToolbar();
   }
 
   /// Shows the magnify, and hides the toolbar.
   void showMagnifier() {
-    _toolbarController.showMagnifier();
+    _overlayController.showMagnifier();
   }
 
   /// Hides the magnifier.
   void hideMagnifier() {
-    _toolbarController.hideMagnifier();
+    _overlayController.hideMagnifier();
   }
 
   /// Toggles the toolbar from visible to not visible, or vis-a-versa.
   void toggleToolbar() {
-    _toolbarController.toggleToolbar();
+    _overlayController.toggleToolbar();
   }
 
   /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
@@ -232,7 +231,7 @@ class AndroidDocumentGestureEditingController extends ChangeNotifier {
     required Offset topAnchor,
     required Offset bottomAnchor,
   }) {
-    _toolbarController.positionToolbar(
+    _overlayController.positionToolbar(
       topAnchor: topAnchor,
       bottomAnchor: bottomAnchor,
     );

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -477,22 +477,16 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
 /// Controls the display of drag handles, a magnifier, and a
 /// floating toolbar, assuming iOS-style behavior for the
 /// handles.
-class IosDocumentGestureEditingController with ChangeNotifier {
+class IosDocumentGestureEditingController extends GestureEditingController {
   IosDocumentGestureEditingController({
     required LayerLink documentLayoutLink,
     required LayerLink magnifierFocalPointLink,
     required MagnifierAndToolbarController overlayController,
   })  : _documentLayoutLink = documentLayoutLink,
-        _magnifierFocalPointLink = magnifierFocalPointLink,
-        _overlayController = overlayController {
-    _overlayController.addListener(_toolbarChanged);
-  }
-
-  @override
-  void dispose() {
-    _overlayController.removeListener(_toolbarChanged);
-    super.dispose();
-  }
+        super(
+          magnifierFocalPointLink: magnifierFocalPointLink,
+          overlayController: overlayController,
+        );
 
   /// Layer link that's aligned to the top-left corner of the document layout.
   ///
@@ -503,11 +497,6 @@ class IosDocumentGestureEditingController with ChangeNotifier {
   /// document layout.
   LayerLink get documentLayoutLink => _documentLayoutLink;
   final LayerLink _documentLayoutLink;
-
-  /// A `LayerLink` whose top-left corner sits at the location where the
-  /// magnifier should magnify.
-  LayerLink get magnifierFocalPointLink => _magnifierFocalPointLink;
-  final LayerLink _magnifierFocalPointLink;
 
   /// Whether or not a caret should be displayed.
   bool get hasCaret => caretTop != null;
@@ -524,17 +513,6 @@ class IosDocumentGestureEditingController with ChangeNotifier {
   /// The height of the caret, or `null` if no caret should be displayed.
   double? get caretHeight => _caretHeight;
   double? _caretHeight;
-
-  /// Controls the magnifier and the toolbar.
-  MagnifierAndToolbarController get overlayController => _overlayController;
-  late MagnifierAndToolbarController _overlayController;
-  set overlayController(MagnifierAndToolbarController value) {
-    if (_overlayController != value) {
-      _overlayController.removeListener(_toolbarChanged);
-      _overlayController = value;
-      _overlayController.addListener(_toolbarChanged);
-    }
-  }
 
   /// Updates the caret's size and position.
   ///
@@ -624,75 +602,6 @@ class IosDocumentGestureEditingController with ChangeNotifier {
       _downstreamHandleOffset = offset;
       notifyListeners();
     }
-  }
-
-  /// Whether the toolbar currently has a designated display position.
-  ///
-  /// The toolbar should not be displayed if this is `false`, even if
-  /// [shouldDisplayToolbar] is `true`.
-  bool get isToolbarPositioned => _overlayController.isToolbarPositioned;
-
-  /// Whether the toolbar should be displayed.
-  bool get shouldDisplayToolbar => _overlayController.shouldDisplayToolbar;
-
-  /// Whether the magnifier should be displayed.
-  bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
-
-  /// The point about which the floating toolbar should focus, when the toolbar
-  /// appears above the selected content.
-  ///
-  /// It's the clients responsibility to determine whether there's room for the
-  /// toolbar above this point. If not, use [toolbarBottomAnchor].
-  Offset? get toolbarTopAnchor => _overlayController.toolbarTopAnchor;
-
-  /// The point about which the floating toolbar should focus, when the toolbar
-  /// appears below the selected content.
-  ///
-  /// It's the clients responsibility to determine whether there's room for the
-  /// toolbar below this point. If not, use [toolbarTopAnchor].
-  Offset? get toolbarBottomAnchor => _overlayController.toolbarBottomAnchor;
-
-  /// Shows the toolbar, and hides the magnifier.
-  void showToolbar() {
-    _overlayController.showToolbar();
-  }
-
-  /// Hides the toolbar.
-  void hideToolbar() {
-    _overlayController.hideToolbar();
-  }
-
-  /// Shows the magnify, and hides the toolbar.
-  void showMagnifier() {
-    _overlayController.showMagnifier();
-  }
-
-  /// Hides the magnifier.
-  void hideMagnifier() {
-    _overlayController.hideMagnifier();
-  }
-
-  /// Toggles the toolbar from visible to not visible, or vis-a-versa.
-  void toggleToolbar() {
-    _overlayController.toggleToolbar();
-  }
-
-  /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
-  ///
-  /// Setting the position will not cause the toolbar to be displayed on it's own.
-  /// To display the toolbar, call [showToolbar], too.
-  void positionToolbar({
-    required Offset topAnchor,
-    required Offset bottomAnchor,
-  }) {
-    _overlayController.positionToolbar(
-      topAnchor: topAnchor,
-      bottomAnchor: bottomAnchor,
-    );
-  }
-
-  void _toolbarChanged() {
-    notifyListeners();
   }
 }
 

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -477,12 +477,23 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
 /// Controls the display of drag handles, a magnifier, and a
 /// floating toolbar, assuming iOS-style behavior for the
 /// handles.
-class IosDocumentGestureEditingController extends MagnifierAndToolbarController {
+class IosDocumentGestureEditingController extends ChangeNotifier {
   IosDocumentGestureEditingController({
     required LayerLink documentLayoutLink,
     required LayerLink magnifierFocalPointLink,
+    required MagnifierAndToolbarController toolbarController,
   })  : _documentLayoutLink = documentLayoutLink,
-        super(magnifierFocalPointLink: magnifierFocalPointLink);
+        _magnifierFocalPointLink = magnifierFocalPointLink,
+        _toolbarController = toolbarController,
+        super() {
+    _toolbarController.addListener(_toolbarChanged);
+  }
+
+  @override
+  void dispose() {
+    _toolbarController.removeListener(_toolbarChanged);
+    super.dispose();
+  }
 
   /// Layer link that's aligned to the top-left corner of the document layout.
   ///
@@ -493,6 +504,11 @@ class IosDocumentGestureEditingController extends MagnifierAndToolbarController 
   /// document layout.
   LayerLink get documentLayoutLink => _documentLayoutLink;
   final LayerLink _documentLayoutLink;
+
+  /// A `LayerLink` whose top-left corner sits at the location where the
+  /// magnifier should magnify.
+  LayerLink get magnifierFocalPointLink => _magnifierFocalPointLink;
+  final LayerLink _magnifierFocalPointLink;
 
   /// Whether or not a caret should be displayed.
   bool get hasCaret => caretTop != null;
@@ -509,6 +525,17 @@ class IosDocumentGestureEditingController extends MagnifierAndToolbarController 
   /// The height of the caret, or `null` if no caret should be displayed.
   double? get caretHeight => _caretHeight;
   double? _caretHeight;
+
+  /// Controls the magnifier and the toolbar.
+  MagnifierAndToolbarController get toolbarController => _toolbarController;
+  late MagnifierAndToolbarController _toolbarController;
+  set toolbarController(MagnifierAndToolbarController value) {
+    if (_toolbarController != value) {
+      _toolbarController.removeListener(_toolbarChanged);
+      _toolbarController = value;
+      _toolbarController.addListener(_toolbarChanged);
+    }
+  }
 
   /// Updates the caret's size and position.
   ///
@@ -598,6 +625,75 @@ class IosDocumentGestureEditingController extends MagnifierAndToolbarController 
       _downstreamHandleOffset = offset;
       notifyListeners();
     }
+  }
+
+  /// Whether the toolbar currently has a designated display position.
+  ///
+  /// The toolbar should not be displayed if this is `false`, even if
+  /// [shouldDisplayToolbar] is `true`.
+  bool get isToolbarPositioned => _toolbarController.isToolbarPositioned;
+
+  /// Whether the toolbar should be displayed.
+  bool get shouldDisplayToolbar => _toolbarController.shouldDisplayToolbar;
+
+  /// Whether the magnifier should be displayed.
+  bool get shouldDisplayMagnifier => _toolbarController.shouldDisplayMagnifier;
+
+  /// The point about which the floating toolbar should focus, when the toolbar
+  /// appears above the selected content.
+  ///
+  /// It's the clients responsibility to determine whether there's room for the
+  /// toolbar above this point. If not, use [toolbarBottomAnchor].
+  Offset? get toolbarTopAnchor => _toolbarController.toolbarTopAnchor;
+
+  /// The point about which the floating toolbar should focus, when the toolbar
+  /// appears below the selected content.
+  ///
+  /// It's the clients responsibility to determine whether there's room for the
+  /// toolbar below this point. If not, use [toolbarTopAnchor].
+  Offset? get toolbarBottomAnchor => _toolbarController.toolbarBottomAnchor;
+
+  /// Shows the toolbar, and hides the magnifier.
+  void showToolbar() {
+    _toolbarController.showToolbar();
+  }
+
+  /// Hides the toolbar.
+  void hideToolbar() {
+    _toolbarController.hideToolbar();
+  }
+
+  /// Shows the magnify, and hides the toolbar.
+  void showMagnifier() {
+    _toolbarController.showMagnifier();
+  }
+
+  /// Hides the magnifier.
+  void hideMagnifier() {
+    _toolbarController.hideMagnifier();
+  }
+
+  /// Toggles the toolbar from visible to not visible, or vis-a-versa.
+  void toggleToolbar() {
+    _toolbarController.toggleToolbar();
+  }
+
+  /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
+  ///
+  /// Setting the position will not cause the toolbar to be displayed on it's own.
+  /// To display the toolbar, call [showToolbar], too.
+  void positionToolbar({
+    required Offset topAnchor,
+    required Offset bottomAnchor,
+  }) {
+    _toolbarController.positionToolbar(
+      topAnchor: topAnchor,
+      bottomAnchor: bottomAnchor,
+    );
+  }
+
+  void _toolbarChanged() {
+    notifyListeners();
   }
 }
 

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -477,21 +477,20 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
 /// Controls the display of drag handles, a magnifier, and a
 /// floating toolbar, assuming iOS-style behavior for the
 /// handles.
-class IosDocumentGestureEditingController extends ChangeNotifier {
+class IosDocumentGestureEditingController with ChangeNotifier {
   IosDocumentGestureEditingController({
     required LayerLink documentLayoutLink,
     required LayerLink magnifierFocalPointLink,
-    required MagnifierAndToolbarController toolbarController,
+    required MagnifierAndToolbarController overlayController,
   })  : _documentLayoutLink = documentLayoutLink,
         _magnifierFocalPointLink = magnifierFocalPointLink,
-        _toolbarController = toolbarController,
-        super() {
-    _toolbarController.addListener(_toolbarChanged);
+        _overlayController = overlayController {
+    _overlayController.addListener(_toolbarChanged);
   }
 
   @override
   void dispose() {
-    _toolbarController.removeListener(_toolbarChanged);
+    _overlayController.removeListener(_toolbarChanged);
     super.dispose();
   }
 
@@ -527,13 +526,13 @@ class IosDocumentGestureEditingController extends ChangeNotifier {
   double? _caretHeight;
 
   /// Controls the magnifier and the toolbar.
-  MagnifierAndToolbarController get toolbarController => _toolbarController;
-  late MagnifierAndToolbarController _toolbarController;
-  set toolbarController(MagnifierAndToolbarController value) {
-    if (_toolbarController != value) {
-      _toolbarController.removeListener(_toolbarChanged);
-      _toolbarController = value;
-      _toolbarController.addListener(_toolbarChanged);
+  MagnifierAndToolbarController get overlayController => _overlayController;
+  late MagnifierAndToolbarController _overlayController;
+  set overlayController(MagnifierAndToolbarController value) {
+    if (_overlayController != value) {
+      _overlayController.removeListener(_toolbarChanged);
+      _overlayController = value;
+      _overlayController.addListener(_toolbarChanged);
     }
   }
 
@@ -631,51 +630,51 @@ class IosDocumentGestureEditingController extends ChangeNotifier {
   ///
   /// The toolbar should not be displayed if this is `false`, even if
   /// [shouldDisplayToolbar] is `true`.
-  bool get isToolbarPositioned => _toolbarController.isToolbarPositioned;
+  bool get isToolbarPositioned => _overlayController.isToolbarPositioned;
 
   /// Whether the toolbar should be displayed.
-  bool get shouldDisplayToolbar => _toolbarController.shouldDisplayToolbar;
+  bool get shouldDisplayToolbar => _overlayController.shouldDisplayToolbar;
 
   /// Whether the magnifier should be displayed.
-  bool get shouldDisplayMagnifier => _toolbarController.shouldDisplayMagnifier;
+  bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
 
   /// The point about which the floating toolbar should focus, when the toolbar
   /// appears above the selected content.
   ///
   /// It's the clients responsibility to determine whether there's room for the
   /// toolbar above this point. If not, use [toolbarBottomAnchor].
-  Offset? get toolbarTopAnchor => _toolbarController.toolbarTopAnchor;
+  Offset? get toolbarTopAnchor => _overlayController.toolbarTopAnchor;
 
   /// The point about which the floating toolbar should focus, when the toolbar
   /// appears below the selected content.
   ///
   /// It's the clients responsibility to determine whether there's room for the
   /// toolbar below this point. If not, use [toolbarTopAnchor].
-  Offset? get toolbarBottomAnchor => _toolbarController.toolbarBottomAnchor;
+  Offset? get toolbarBottomAnchor => _overlayController.toolbarBottomAnchor;
 
   /// Shows the toolbar, and hides the magnifier.
   void showToolbar() {
-    _toolbarController.showToolbar();
+    _overlayController.showToolbar();
   }
 
   /// Hides the toolbar.
   void hideToolbar() {
-    _toolbarController.hideToolbar();
+    _overlayController.hideToolbar();
   }
 
   /// Shows the magnify, and hides the toolbar.
   void showMagnifier() {
-    _toolbarController.showMagnifier();
+    _overlayController.showMagnifier();
   }
 
   /// Hides the magnifier.
   void hideMagnifier() {
-    _toolbarController.hideMagnifier();
+    _overlayController.hideMagnifier();
   }
 
   /// Toggles the toolbar from visible to not visible, or vis-a-versa.
   void toggleToolbar() {
-    _toolbarController.toggleToolbar();
+    _overlayController.toggleToolbar();
   }
 
   /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
@@ -686,7 +685,7 @@ class IosDocumentGestureEditingController extends ChangeNotifier {
     required Offset topAnchor,
     required Offset bottomAnchor,
   }) {
-    _toolbarController.positionToolbar(
+    _overlayController.positionToolbar(
       topAnchor: topAnchor,
       bottomAnchor: bottomAnchor,
     );

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -98,6 +98,109 @@ class MagnifierAndToolbarController with ChangeNotifier {
   }
 }
 
+/// Controls the display and position of a magnifier and a floating toolbar
+/// using a [MagnifierAndToolbarController] as the source of truth.
+class GestureEditingController with ChangeNotifier {
+  GestureEditingController({
+    required MagnifierAndToolbarController overlayController,
+    required LayerLink magnifierFocalPointLink,
+  })  : _magnifierFocalPointLink = magnifierFocalPointLink,
+        _overlayController = overlayController {
+    _overlayController.addListener(_toolbarChanged);
+  }
+
+  @override
+  void dispose() {
+    _overlayController.removeListener(_toolbarChanged);
+    super.dispose();
+  }
+
+  /// A `LayerLink` whose top-left corner sits at the location where the
+  /// magnifier should magnify.
+  LayerLink get magnifierFocalPointLink => _magnifierFocalPointLink;
+  final LayerLink _magnifierFocalPointLink;
+
+  /// Controls the magnifier and the toolbar.
+  MagnifierAndToolbarController get overlayController => _overlayController;
+  late MagnifierAndToolbarController _overlayController;
+  set overlayController(MagnifierAndToolbarController value) {
+    if (_overlayController != value) {
+      _overlayController.removeListener(_toolbarChanged);
+      _overlayController = value;
+      _overlayController.addListener(_toolbarChanged);
+    }
+  }
+
+  /// Whether the toolbar currently has a designated display position.
+  ///
+  /// The toolbar should not be displayed if this is `false`, even if
+  /// [shouldDisplayToolbar] is `true`.
+  bool get isToolbarPositioned => _overlayController.isToolbarPositioned;
+
+  /// Whether the toolbar should be displayed.
+  bool get shouldDisplayToolbar => _overlayController.shouldDisplayToolbar;
+
+  /// Whether the magnifier should be displayed.
+  bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
+
+  /// The point about which the floating toolbar should focus, when the toolbar
+  /// appears above the selected content.
+  ///
+  /// It's the clients responsibility to determine whether there's room for the
+  /// toolbar above this point. If not, use [toolbarBottomAnchor].
+  Offset? get toolbarTopAnchor => _overlayController.toolbarTopAnchor;
+
+  /// The point about which the floating toolbar should focus, when the toolbar
+  /// appears below the selected content.
+  ///
+  /// It's the clients responsibility to determine whether there's room for the
+  /// toolbar below this point. If not, use [toolbarTopAnchor].
+  Offset? get toolbarBottomAnchor => _overlayController.toolbarBottomAnchor;
+
+  /// Shows the toolbar, and hides the magnifier.
+  void showToolbar() {
+    _overlayController.showToolbar();
+  }
+
+  /// Hides the toolbar.
+  void hideToolbar() {
+    _overlayController.hideToolbar();
+  }
+
+  /// Shows the magnify, and hides the toolbar.
+  void showMagnifier() {
+    _overlayController.showMagnifier();
+  }
+
+  /// Hides the magnifier.
+  void hideMagnifier() {
+    _overlayController.hideMagnifier();
+  }
+
+  /// Toggles the toolbar from visible to not visible, or vis-a-versa.
+  void toggleToolbar() {
+    _overlayController.toggleToolbar();
+  }
+
+  /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].
+  ///
+  /// Setting the position will not cause the toolbar to be displayed on it's own.
+  /// To display the toolbar, call [showToolbar], too.
+  void positionToolbar({
+    required Offset topAnchor,
+    required Offset bottomAnchor,
+  }) {
+    _overlayController.positionToolbar(
+      topAnchor: topAnchor,
+      bottomAnchor: bottomAnchor,
+    );
+  }
+
+  void _toolbarChanged() {
+    notifyListeners();
+  }
+}
+
 /// Auto-scrolls a given `ScrollPosition` based on the current position of
 /// a drag handle near the boundary of the scroll region.
 ///

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -5,14 +5,7 @@ import 'package:super_editor/src/infrastructure/document_gestures.dart';
 
 /// Controls the display and position of a magnifier and a floating toolbar.
 class MagnifierAndToolbarController with ChangeNotifier {
-  MagnifierAndToolbarController({
-    required LayerLink magnifierFocalPointLink,
-  }) : _magnifierFocalPointLink = magnifierFocalPointLink;
-
-  /// A `LayerLink` whose top-left corner sits at the location where the
-  /// magnifier should magnify.
-  LayerLink get magnifierFocalPointLink => _magnifierFocalPointLink;
-  final LayerLink _magnifierFocalPointLink;
+  MagnifierAndToolbarController();
 
   /// Whether the magnifier should be displayed.
   bool get shouldDisplayMagnifier => _isMagnifierVisible;

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -5,8 +5,6 @@ import 'package:super_editor/src/infrastructure/document_gestures.dart';
 
 /// Controls the display and position of a magnifier and a floating toolbar.
 class MagnifierAndToolbarController with ChangeNotifier {
-  MagnifierAndToolbarController();
-
   /// Whether the magnifier should be displayed.
   bool get shouldDisplayMagnifier => _isMagnifierVisible;
   bool _isMagnifierVisible = false;

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -36,6 +36,7 @@ class ReadOnlyAndroidDocumentTouchInteractor extends StatefulWidget {
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
+    this.toolbarController,
     required this.child,
   }) : super(key: key);
 
@@ -68,6 +69,10 @@ class ReadOnlyAndroidDocumentTouchInteractor extends StatefulWidget {
   /// will be allowed to appear anywhere in the overlay in which they sit
   /// (probably the entire screen).
   final CustomClipper<Rect> Function(BuildContext overlayContext)? createOverlayControlsClipper;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  final MagnifierAndToolbarController? toolbarController;
 
   final bool showDebugPaint;
 
@@ -106,6 +111,10 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   Offset? _dragEndInInteractor;
   SelectionHandleType? _handleType;
 
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  late MagnifierAndToolbarController _toolbarController;
+
   @override
   void initState() {
     super.initState();
@@ -136,9 +145,12 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
+    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+
     _editingController = AndroidDocumentGestureEditingController(
       documentLayoutLink: _documentLayoutLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
+      toolbarController: _toolbarController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -186,6 +198,11 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     if (widget.selection != oldWidget.selection) {
       oldWidget.selection.removeListener(_onSelectionChange);
       widget.selection.addListener(_onSelectionChange);
+    }
+
+    if (widget.toolbarController != oldWidget.toolbarController) {
+      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+      _editingController.toolbarController = _toolbarController;
     }
 
     // Selection has changed, we need to update the caret.

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -36,7 +36,7 @@ class ReadOnlyAndroidDocumentTouchInteractor extends StatefulWidget {
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
     this.showDebugPaint = false,
-    this.toolbarController,
+    this.overlayController,
     required this.child,
   }) : super(key: key);
 
@@ -70,9 +70,8 @@ class ReadOnlyAndroidDocumentTouchInteractor extends StatefulWidget {
   /// (probably the entire screen).
   final CustomClipper<Rect> Function(BuildContext overlayContext)? createOverlayControlsClipper;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   final bool showDebugPaint;
 
@@ -111,9 +110,8 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   Offset? _dragEndInInteractor;
   SelectionHandleType? _handleType;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  late MagnifierAndToolbarController _toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  late MagnifierAndToolbarController _overlayController;
 
   @override
   void initState() {
@@ -145,12 +143,12 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
-    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+    _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
 
     _editingController = AndroidDocumentGestureEditingController(
       documentLayoutLink: _documentLayoutLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
-      toolbarController: _toolbarController,
+      overlayController: _overlayController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -200,9 +198,9 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       widget.selection.addListener(_onSelectionChange);
     }
 
-    if (widget.toolbarController != oldWidget.toolbarController) {
-      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
-      _editingController.toolbarController = _toolbarController;
+    if (widget.overlayController != oldWidget.overlayController) {
+      _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
+      _editingController.overlayController = _overlayController;
     }
 
     // Selection has changed, we need to update the caret.

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -36,6 +36,7 @@ class ReadOnlyIOSDocumentTouchInteractor extends StatefulWidget {
     required this.handleColor,
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
+    this.toolbarController,
     this.showDebugPaint = false,
     required this.child,
   }) : super(key: key);
@@ -48,6 +49,10 @@ class ReadOnlyIOSDocumentTouchInteractor extends StatefulWidget {
   final ValueNotifier<DocumentSelection?> selection;
 
   final ScrollController? scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  final MagnifierAndToolbarController? toolbarController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -125,6 +130,10 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
   // avoid handling gestures while we are `_waitingForMoreTaps`.
   bool _waitingForMoreTaps = false;
 
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar.
+  late MagnifierAndToolbarController _toolbarController;
+
   @override
   void initState() {
     super.initState();
@@ -150,9 +159,12 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
+    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+
     _editingController = IosDocumentGestureEditingController(
       documentLayoutLink: _documentLayerLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
+      toolbarController: _toolbarController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -202,6 +214,11 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
     if (widget.document != oldWidget.document) {
       oldWidget.document.removeListener(_onDocumentChange);
       widget.document.addListener(_onDocumentChange);
+    }
+
+    if (widget.toolbarController != oldWidget.toolbarController) {
+      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+      _editingController.toolbarController = _toolbarController;
     }
 
     if (widget.selection != oldWidget.selection) {

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -36,7 +36,7 @@ class ReadOnlyIOSDocumentTouchInteractor extends StatefulWidget {
     required this.handleColor,
     required this.popoverToolbarBuilder,
     this.createOverlayControlsClipper,
-    this.toolbarController,
+    this.overlayController,
     this.showDebugPaint = false,
     required this.child,
   }) : super(key: key);
@@ -50,9 +50,8 @@ class ReadOnlyIOSDocumentTouchInteractor extends StatefulWidget {
 
   final ScrollController? scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   /// The closest that the user's selection drag gesture can get to the
   /// document boundary before auto-scrolling.
@@ -130,9 +129,8 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
   // avoid handling gestures while we are `_waitingForMoreTaps`.
   bool _waitingForMoreTaps = false;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar.
-  late MagnifierAndToolbarController _toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  late MagnifierAndToolbarController _overlayController;
 
   @override
   void initState() {
@@ -159,12 +157,12 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
     // TODO: rely solely on a ScrollPosition listener, not a ScrollController listener.
     _scrollController.addListener(_onScrollChange);
 
-    _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
+    _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
 
     _editingController = IosDocumentGestureEditingController(
       documentLayoutLink: _documentLayerLink,
       magnifierFocalPointLink: _magnifierFocalPointLink,
-      toolbarController: _toolbarController,
+      overlayController: _overlayController,
     );
 
     widget.document.addListener(_onDocumentChange);
@@ -216,9 +214,9 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
       widget.document.addListener(_onDocumentChange);
     }
 
-    if (widget.toolbarController != oldWidget.toolbarController) {
-      _toolbarController = widget.toolbarController ?? MagnifierAndToolbarController();
-      _editingController.toolbarController = _toolbarController;
+    if (widget.overlayController != oldWidget.overlayController) {
+      _overlayController = widget.overlayController ?? MagnifierAndToolbarController();
+      _editingController.overlayController = _overlayController;
     }
 
     if (widget.selection != oldWidget.selection) {

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -22,6 +22,7 @@ import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/unknown_component.dart';
 
+import '../infrastructure/platforms/mobile_documents.dart';
 import 'read_only_document_android_touch_interactor.dart';
 import 'read_only_document_ios_touch_interactor.dart';
 import 'read_only_document_keyboard_interactor.dart';
@@ -49,6 +50,7 @@ class SuperReader extends StatefulWidget {
     this.iOSToolbarBuilder,
     this.createOverlayControlsClipper,
     this.autofocus = false,
+    this.toolbarController,
     this.debugPaint = const DebugPaintConfig(),
   })  : stylesheet = stylesheet ?? readOnlyDefaultStylesheet,
         selectionStyles = selectionStyle ?? readOnlyDefaultSelectionStyle,
@@ -78,6 +80,10 @@ class SuperReader extends StatefulWidget {
   /// [scrollController] is not used if this [SuperReader] has an ancestor
   /// [Scrollable].
   final ScrollController? scrollController;
+
+  /// [MagnifierAndToolbarController] that governs the display and position of
+  /// the magnifier and the floating toolbar for Android and iOS.
+  final MagnifierAndToolbarController? toolbarController;
 
   /// Style rules applied through the document presentation.
   final Stylesheet stylesheet;
@@ -318,6 +324,7 @@ class SuperReaderState extends State<SuperReader> {
           popoverToolbarBuilder: widget.androidToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           showDebugPaint: widget.debugPaint.gestures,
+          toolbarController: widget.toolbarController,
           child: documentLayout,
         );
       case DocumentGestureMode.iOS:
@@ -332,6 +339,7 @@ class SuperReaderState extends State<SuperReader> {
           popoverToolbarBuilder: widget.iOSToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           showDebugPaint: widget.debugPaint.gestures,
+          toolbarController: widget.toolbarController,
           child: documentLayout,
         );
     }

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -50,7 +50,7 @@ class SuperReader extends StatefulWidget {
     this.iOSToolbarBuilder,
     this.createOverlayControlsClipper,
     this.autofocus = false,
-    this.toolbarController,
+    this.overlayController,
     this.debugPaint = const DebugPaintConfig(),
   })  : stylesheet = stylesheet ?? readOnlyDefaultStylesheet,
         selectionStyles = selectionStyle ?? readOnlyDefaultSelectionStyle,
@@ -81,9 +81,8 @@ class SuperReader extends StatefulWidget {
   /// [Scrollable].
   final ScrollController? scrollController;
 
-  /// [MagnifierAndToolbarController] that governs the display and position of
-  /// the magnifier and the floating toolbar for Android and iOS.
-  final MagnifierAndToolbarController? toolbarController;
+  /// Shows, hides, and positions a floating toolbar and magnifier.
+  final MagnifierAndToolbarController? overlayController;
 
   /// Style rules applied through the document presentation.
   final Stylesheet stylesheet;
@@ -324,7 +323,7 @@ class SuperReaderState extends State<SuperReader> {
           popoverToolbarBuilder: widget.androidToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           showDebugPaint: widget.debugPaint.gestures,
-          toolbarController: widget.toolbarController,
+          overlayController: widget.overlayController,
           child: documentLayout,
         );
       case DocumentGestureMode.iOS:
@@ -339,7 +338,7 @@ class SuperReaderState extends State<SuperReader> {
           popoverToolbarBuilder: widget.iOSToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           showDebugPaint: widget.debugPaint.gestures,
-          toolbarController: widget.toolbarController,
+          overlayController: widget.overlayController,
           child: documentLayout,
         );
     }


### PR DESCRIPTION
[SuperEditor][DemoApp] Fix toolbar dismissal on copy. Resolves #818 

Currently, tapping on the copy button doesn't close the toolbar. Tapping on cut or paste closes it, but this is incidental, the toolbar is closed because the document changes and the touch interactors hide the toolbar when this happens. 

It isn't possible for a package user to control the visibility of the toolbar. The toolbar is controlled by `AndroidDocumentGestureEditingController` and `IosDocumentGestureEditingController`, which aren't exposed in the public API. These controllers are created inside the touch interactors and can't be created elsewhere, as they hold `LayerLink's` to position the toolbar.

Both `AndroidDocumentGestureEditingController` and `IosDocumentGestureEditingController` extends `MagnifierAndToolbarController`, which is the class that actually controls the visibility of the toolbar and the magnifier.

This PR changes `AndroidDocumentGestureEditingController` and `IosDocumentGestureEditingController` to don't extend `MagnifierAndToolbarController` anymore. Instead, they will receive one in the constructor.

`SuperEditor` will expose the `MagnifierAndToolbarController` in its public API. That way, users can control the visibility of the toolbar.