### PR TITLE
[SuperEditor] Handle software keyboard gestures (Resolves #817)

### DIFF
--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -823,9 +823,6 @@ class ImeConfiguration {
       keyboardActionButton.hashCode;
 }
 
-/// A function that converts a [TextSelection] from the platform to a [DocumentSelection].
-typedef ImeSelectionConverter = DocumentSelection? Function(TextSelection selection);
-
 /// Applies software keyboard edits to a document.
 class SoftwareKeyboardHandler {
   const SoftwareKeyboardHandler({

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -42,6 +42,9 @@ dependency_overrides:
     path: ../attributed_text
   super_text_layout:
     path: ../super_text_layout
+  flutter_test_robots:
+    git: 
+      url: https://github.com/Flutter-Bounty-Hunters/flutter_test_robots
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
[SuperEditor] Handle software keyboard gestures. Resolves #817

Some Android software keyboards, like GBoard, have some gestures:

* Swiping over the spacebar to change the selection.
* Swiping from right to left over the backspace key to delete a word.

The spacebar gesture generates a non-text delta and the backspace gesture generates a non-text delta to select the word followed by a deletion delta.

Currently, we don't perform any action when we receive a `TextEditingDeltaNonTextUpdate`, so these gestures don't work.

This PR changes the delta handling to change the document selection when we receive a `TextEditingDeltaNonTextUpdate`. This change use a pre-existing method to convert the selection from the delta to a `DocumentSelection`.

After the changes:

https://user-images.githubusercontent.com/7597082/205769007-888ac8e0-5667-40a5-ad38-28d55eaacadb.mp4

On the Samsung keyboard, the spacebar gesture is already working, because it generates key events instead of deltas.

During manual tests I noticed some exceptions, but these exceptions already happen without this change. The exceptions are related to https://github.com/superlistapp/super_editor/issues/791