### PR TITLE
[SuperEditor] Annotate custom test methods

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -50,6 +50,7 @@ dev_dependencies:
   super_editor_markdown:
     path: ../super_editor_markdown
   text_table: ^4.0.1
+  meta: ^1.8.0
 
 flutter:
   # no Flutter configuration

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
 import 'package:logging/logging.dart' as logging;
+import 'package:meta/meta.dart';
 import 'package:super_editor/super_editor.dart';
 
+@isTestGroup
 void groupWithLogging(String description, Level logLevel, Set<logging.Logger> loggers, VoidCallback body) {
   initLoggers(logLevel, loggers);
 
@@ -14,6 +16,7 @@ void groupWithLogging(String description, Level logLevel, Set<logging.Logger> lo
 
 /// A widget test that runs a variant for every desktop platform, e.g.,
 /// Mac, Windows, Linux, and for all [DocumentInputSource]s.
+@isTestGroup
 void testAllInputsOnDesktop(
   String description,
   InputModeTesterCallback test, {
@@ -29,6 +32,7 @@ void testAllInputsOnDesktop(
 }
 
 /// A widget test that runs as a Mac, and for all [DocumentInputSource]s.
+@isTestGroup
 void testAllInputsOnMac(
   String description,
   InputModeTesterCallback test, {
@@ -44,6 +48,7 @@ void testAllInputsOnMac(
 }
 
 /// A widget test that runs a variant for Windows and Linux, and for all [DocumentInputSource]s.
+@isTestGroup
 void testAllInputsOnWindowsAndLinux(
   String description,
   InputModeTesterCallback test, {
@@ -65,6 +70,7 @@ typedef InputModeTesterCallback = Future<void> Function(
 
 /// A widget test that runs a variant for every desktop platform, e.g.,
 /// Mac, Windows, Linux.
+@isTestGroup
 void testWidgetsOnDesktop(
   String description,
   WidgetTesterCallback test, {
@@ -77,6 +83,7 @@ void testWidgetsOnDesktop(
 
 /// A widget test that runs a variant for every mobile platform, e.g.,
 /// Android and iOS
+@isTestGroup
 void testWidgetsOnMobile(
   String description,
   WidgetTesterCallback test, {
@@ -88,6 +95,7 @@ void testWidgetsOnMobile(
 
 /// A widget test that runs a variant for every platform, e.g.,
 /// Mac, Windows, Linux, Android and iOS.
+@isTestGroup
 void testWidgetsOnAllPlatforms(
   String description,
   WidgetTesterCallback test, {
@@ -106,6 +114,7 @@ void testWidgetsOnAllPlatforms(
 /// between Windows and Linux. It would be superfluous to replicate so
 /// many shortcut tests. Instead, this test method runs the given [test]
 /// with a simulated Windows and Linux platform.
+@isTestGroup
 void testWidgetsOnWindowsAndLinux(
   String description,
   WidgetTesterCallback test, {
@@ -120,6 +129,7 @@ void testWidgetsOnWindowsAndLinux(
 /// There's no guarantee which desktop environment is used. The purpose of this
 /// test method is to cause all relevant configurations to setup for desktop,
 /// without concern for any features that change between desktop platforms.
+@isTest
 void testWidgetsOnArbitraryDesktop(
   String description,
   WidgetTesterCallback test, {
@@ -130,6 +140,7 @@ void testWidgetsOnArbitraryDesktop(
 
 /// A widget test that configures itself as a Mac platform before executing the
 /// given [test], and nullifies the Mac configuration when the test is done.
+@isTest
 void testWidgetsOnMac(
   String description,
   WidgetTesterCallback test, {
@@ -158,6 +169,7 @@ void testWidgetsOnMac(
 /// the widget tree, which should be tested with [testWidgetsOnMac]. In the
 /// rare cases where a specific object, handler, or subsystem needs to be tested
 /// in isolation, and it cares about the platform, you can use this test method.
+@isTest
 void testOnMac(
   String description,
   VoidCallback realTest, {
@@ -175,6 +187,7 @@ void testOnMac(
 
 /// A widget test that configures itself as a Windows platform before executing the
 /// given [test], and nullifies the Windows configuration when the test is done.
+@isTest
 void testWidgetsOnWindows(
   String description,
   WidgetTesterCallback test, {
@@ -203,6 +216,7 @@ void testWidgetsOnWindows(
 /// the widget tree, which should be tested with [testWidgetsOnWindows]. In the
 /// rare cases where a specific object, handler, or subsystem needs to be tested
 /// in isolation, and it cares about the platform, you can use this test method.
+@isTest
 void testOnWindows(
   String description,
   VoidCallback realTest, {
@@ -220,6 +234,7 @@ void testOnWindows(
 
 /// A widget test that configures itself as a Linux platform before executing the
 /// given [test], and nullifies the Linux configuration when the test is done.
+@isTest
 void testWidgetsOnLinux(
   String description,
   WidgetTesterCallback test, {
@@ -248,6 +263,7 @@ void testWidgetsOnLinux(
 /// the widget tree, which should be tested with [testWidgetsOnLinux]. In the
 /// rare cases where a specific object, handler, or subsystem needs to be tested
 /// in isolation, and it cares about the platform, you can use this test method.
+@isTest
 void testOnLinux(
   String description,
   VoidCallback realTest, {
@@ -265,6 +281,7 @@ void testOnLinux(
 
 /// A widget test that configures itself as a Android platform before executing the
 /// given [test], and nullifies the Android configuration when the test is done.
+@isTest
 void testWidgetsOnAndroid(
   String description,
   WidgetTesterCallback test, {
@@ -282,6 +299,7 @@ void testWidgetsOnAndroid(
 
 /// A widget test that configures itself as a iOS platform before executing the
 /// given [test], and nullifies the iOS configuration when the test is done.
+@isTest
 void testWidgetsOnIos(
   String description,
   WidgetTesterCallback test, {


### PR DESCRIPTION
[SuperEditor] Annotate custom test methods

In VS Code, test methods and test groups are decorated with Run/Debug buttons, so users can easily run or debug a single test. Currently, for our custom test methods (`testWidgetsOnDesktop`, `testWidgetsOnMobile`, and others), these buttons are not displayed.

This PR annotates the custom test methods with `@isTestGroup` and `@isTest`, so VS Code displays the buttons as expected.