### PR TITLE
Hide Flutter's ListenableBuilder temporarily

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
@@ -1147,7 +1147,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: widget.editingController,
-      builder: (context) {
+      builder: (context, _) {
         return Padding(
           // Remove the keyboard from the space that we occupy so that
           // clipping calculations apply to the expected visual borders,

--- a/super_editor/lib/src/default_editor/document_input_ime.dart
+++ b/super_editor/lib/src/default_editor/document_input_ime.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -1223,7 +1223,7 @@ class KeyboardEditingToolbar extends StatelessWidget {
                     scrollDirection: Axis.horizontal,
                     child: ListenableBuilder(
                         listenable: composer,
-                        builder: (context) {
+                        builder: (context, _) {
                           final selectedNode = document.getNodeById(selection.extent.nodeId);
                           final isSingleNodeSelected = selection.extent.nodeId == selection.base.nodeId;
 

--- a/super_editor/lib/src/infrastructure/_listenable_builder.dart
+++ b/super_editor/lib/src/infrastructure/_listenable_builder.dart
@@ -77,13 +77,13 @@ class ListenableBuilder extends StatelessWidget {
   }) : super(key: key);
 
   final Listenable listenable;
-  final WidgetBuilder builder;
+  final TransitionBuilder builder;
 
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
       animation: listenable,
-      builder: (context, _) => builder(context),
+      builder: builder,
     );
   }
 }

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
@@ -230,7 +230,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
   Widget build(BuildContext context) {
     return ListenableBuilder(
         listenable: widget.editingController,
-        builder: (context) {
+        builder: (context, _) {
           return Padding(
             // Remove the keyboard from the space that we occupy so that
             // clipping calculations apply to the expected visual borders,

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
@@ -494,7 +494,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             padding: widget.padding,
             child: ListenableBuilder(
               listenable: _textEditingController,
-              builder: (context) {
+              builder: (context, _) {
                 final isTextEmpty = _textEditingController.text.text.isEmpty;
                 final showHint = widget.hintBuilder != null &&
                     ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/_floating_cursor.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
@@ -24,7 +24,7 @@ class IOSFloatingCursor extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: controller,
-      builder: (context) {
+      builder: (context, _) {
         return Stack(
           children: [
             if (controller.isShowingFloatingCursor)

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -1,5 +1,5 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ListenableBuilder;
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -489,7 +489,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             padding: widget.padding,
             child: ListenableBuilder(
               listenable: _textEditingController,
-              builder: (context) {
+              builder: (context, _) {
                 final isTextEmpty = _textEditingController.text.text.isEmpty;
                 final showHint = widget.hintBuilder != null &&
                     ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/pull/116543, the Flutter team is planning to add a new `ListenableBuilder` widget that has an identical implementation to `AnimatedBuilder`. Unfortunately, this conflicts with SuperEditor's widget of the same name.

They're virtually identical, but SuperEditor's uses a `WidgetBuilder` callback instead of a `TransitionBuilder`, which has an additional nullable `child` widget argument for performance reasons.

This PR converts SuperEditor's `ListenableBuilder` to use a `TransitionBuilder`, and updates all of the call sites where it is used. In addition, to avoid lint warnings, I added a `hide ListenableBuilder` to the Flutter material library import in each of the files that use it.

Once the Flutter change lands, SuperEditor's `ListenableBuilder` can be removed, along with the `hide` directives.

## Related Issues
 - https://github.com/flutter/flutter/issues/19255

cc @matthew-carroll 