### PR TITLE
[SuperTextField] Expose caretStyle property (Resolves #884)

### DIFF
--- a/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
@@ -46,7 +46,7 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           }).build,
       selectionColor: Colors.blue.withOpacity(0.4),
-      caretColor: Colors.green,
+      caretStyle: CaretStyle(color: Colors.green),
       handlesColor: Colors.lightGreen,
       minLines: config.minLines,
       maxLines: config.maxLines,

--- a/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
@@ -47,7 +47,7 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           }).build,
       selectionColor: Colors.blue.withOpacity(0.4),
-      caretColor: Colors.blue,
+      caretStyle: CaretStyle(color: Colors.blue),
       handlesColor: Colors.blue,
       minLines: config.minLines,
       maxLines: config.maxLines,

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -35,14 +35,20 @@ class SuperAndroidTextField extends StatefulWidget {
     this.minLines,
     this.maxLines = 1,
     this.lineHeight,
-    required this.caretColor,
+    this.caretColor,
+    this.caretStyle,
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
-  }) : super(key: key);
+  })  : assert(caretStyle != null || caretColor != null, 'A caretStyle or a caretColor is required.'),
+        assert(
+            caretStyle == null || caretColor == null,
+            'Cannot provide both caretStyle and caretColor.\n'
+            'Use "caretStyle: CaretStyle(color: color)"'),
+        super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -67,7 +73,14 @@ class SuperAndroidTextField extends StatefulWidget {
   final WidgetBuilder? hintBuilder;
 
   /// Color of the caret.
-  final Color caretColor;
+  ///
+  /// If the [caretStyle] is used, this property must be null.
+  final Color? caretColor;
+
+  /// The visual representation of the caret.
+  ///
+  /// If the [caretColor] is used, this property must be null.
+  final CaretStyle? caretStyle;
 
   /// Color of the selection rectangle for selected text.
   final Color selectionColor;
@@ -533,9 +546,10 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           highlightStyle: SelectionHighlightStyle(
             color: widget.selectionColor,
           ),
-          caretStyle: CaretStyle(
-            color: widget.caretColor,
-          ),
+          caretStyle: widget.caretStyle ??
+              CaretStyle(
+                color: widget.caretColor!,
+              ),
           selection: _textEditingController.selection,
           hasCaret: _focusNode.hasFocus,
         ),

--- a/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/android/android_textfield.dart
@@ -35,20 +35,14 @@ class SuperAndroidTextField extends StatefulWidget {
     this.minLines,
     this.maxLines = 1,
     this.lineHeight,
-    this.caretColor,
-    this.caretStyle,
+    required this.caretStyle,
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
-  })  : assert(caretStyle != null || caretColor != null, 'A caretStyle or a caretColor is required.'),
-        assert(
-            caretStyle == null || caretColor == null,
-            'Cannot provide both caretStyle and caretColor.\n'
-            'Use "caretStyle: CaretStyle(color: color)"'),
-        super(key: key);
+  }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -72,15 +66,8 @@ class SuperAndroidTextField extends StatefulWidget {
   /// To easily build a hint with styled text, see [StyledHintBuilder].
   final WidgetBuilder? hintBuilder;
 
-  /// Color of the caret.
-  ///
-  /// If the [caretStyle] is used, this property must be null.
-  final Color? caretColor;
-
   /// The visual representation of the caret.
-  ///
-  /// If the [caretColor] is used, this property must be null.
-  final CaretStyle? caretStyle;
+  final CaretStyle caretStyle;
 
   /// Color of the selection rectangle for selected text.
   final Color selectionColor;
@@ -546,10 +533,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           highlightStyle: SelectionHighlightStyle(
             color: widget.selectionColor,
           ),
-          caretStyle: widget.caretStyle ??
-              CaretStyle(
-                color: widget.caretColor!,
-              ),
+          caretStyle: widget.caretStyle,
           selection: _textEditingController.selection,
           hasCaret: _focusNode.hasFocus,
         ),

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -39,14 +39,20 @@ class SuperIOSTextField extends StatefulWidget {
     this.minLines,
     this.maxLines = 1,
     this.lineHeight,
-    required this.caretColor,
+    this.caretColor,
+    this.caretStyle,
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
-  }) : super(key: key);
+  })  : assert(caretStyle != null || caretColor != null, 'A caretStyle or a caretColor is required.'),
+        assert(
+            caretStyle == null || caretColor == null,
+            'Cannot provide both caretStyle and caretColor.\n'
+            'Use "caretStyle: CaretStyle(color: color)"'),
+        super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -71,7 +77,14 @@ class SuperIOSTextField extends StatefulWidget {
   final WidgetBuilder? hintBuilder;
 
   /// Color of the caret.
-  final Color caretColor;
+  ///
+  /// If the [caretStyle] is used, this property must be null.
+  final Color? caretColor;
+
+  /// The visual representation of the caret.
+  ///
+  /// If the [caretColor] is used, this property must be null.
+  final CaretStyle? caretStyle;
 
   /// Color of the selection rectangle for selected text.
   final Color selectionColor;
@@ -528,6 +541,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         ? _textEditingController.text.computeTextSpan(widget.textStyleBuilder)
         : AttributedText(text: "").computeTextSpan(widget.textStyleBuilder);
 
+    final caretColorOverride = _floatingCursorController.isShowingFloatingCursor ? Colors.grey : null;
+
     return FillWidthIfConstrained(
       child: SuperTextWithSelection.single(
         key: _textContentKey,
@@ -537,9 +552,12 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           highlightStyle: SelectionHighlightStyle(
             color: widget.selectionColor,
           ),
-          caretStyle: CaretStyle(
-            color: _floatingCursorController.isShowingFloatingCursor ? Colors.grey : widget.caretColor,
-          ),
+          caretStyle: widget.caretStyle?.copyWith(
+                color: caretColorOverride ?? widget.caretStyle!.color,
+              ) ??
+              CaretStyle(
+                color: caretColorOverride ?? widget.caretColor!,
+              ),
           selection: _textEditingController.selection,
           hasCaret: _focusNode.hasFocus,
         ),

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -39,20 +39,14 @@ class SuperIOSTextField extends StatefulWidget {
     this.minLines,
     this.maxLines = 1,
     this.lineHeight,
-    this.caretColor,
-    this.caretStyle,
+    required this.caretStyle,
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
-  })  : assert(caretStyle != null || caretColor != null, 'A caretStyle or a caretColor is required.'),
-        assert(
-            caretStyle == null || caretColor == null,
-            'Cannot provide both caretStyle and caretColor.\n'
-            'Use "caretStyle: CaretStyle(color: color)"'),
-        super(key: key);
+  }) : super(key: key);
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
@@ -76,15 +70,8 @@ class SuperIOSTextField extends StatefulWidget {
   /// To easily build a hint with styled text, see [StyledHintBuilder].
   final WidgetBuilder? hintBuilder;
 
-  /// Color of the caret.
-  ///
-  /// If the [caretStyle] is used, this property must be null.
-  final Color? caretColor;
-
   /// The visual representation of the caret.
-  ///
-  /// If the [caretColor] is used, this property must be null.
-  final CaretStyle? caretStyle;
+  final CaretStyle caretStyle;
 
   /// Color of the selection rectangle for selected text.
   final Color selectionColor;
@@ -541,10 +528,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         ? _textEditingController.text.computeTextSpan(widget.textStyleBuilder)
         : AttributedText(text: "").computeTextSpan(widget.textStyleBuilder);
 
-    CaretStyle caretStyle = widget.caretStyle ??
-        CaretStyle(
-          color: widget.caretColor!,
-        );
+    CaretStyle caretStyle = widget.caretStyle;
 
     final caretColorOverride = _floatingCursorController.isShowingFloatingCursor ? Colors.grey : null;
     if (caretColorOverride != null) {

--- a/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/ios/ios_textfield.dart
@@ -541,7 +541,15 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         ? _textEditingController.text.computeTextSpan(widget.textStyleBuilder)
         : AttributedText(text: "").computeTextSpan(widget.textStyleBuilder);
 
+    CaretStyle caretStyle = widget.caretStyle ??
+        CaretStyle(
+          color: widget.caretColor!,
+        );
+
     final caretColorOverride = _floatingCursorController.isShowingFloatingCursor ? Colors.grey : null;
+    if (caretColorOverride != null) {
+      caretStyle = caretStyle.copyWith(color: caretColorOverride);
+    }
 
     return FillWidthIfConstrained(
       child: SuperTextWithSelection.single(
@@ -552,12 +560,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           highlightStyle: SelectionHighlightStyle(
             color: widget.selectionColor,
           ),
-          caretStyle: widget.caretStyle?.copyWith(
-                color: caretColorOverride ?? widget.caretStyle!.color,
-              ) ??
-              CaretStyle(
-                color: caretColorOverride ?? widget.caretColor!,
-              ),
+          caretStyle: caretStyle,
           selection: _textEditingController.selection,
           hasCaret: _focusNode.hasFocus,
         ),

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -58,6 +58,7 @@ class SuperTextField extends StatefulWidget {
     this.hintBehavior = HintBehavior.displayHintUntilFocus,
     this.hintBuilder,
     this.controlsColor,
+    this.caretStyle,
     this.selectionColor,
     this.minLines,
     this.maxLines = 1,
@@ -92,7 +93,12 @@ class SuperTextField extends StatefulWidget {
   final WidgetBuilder? hintBuilder;
 
   /// The color of the caret, drag handles, and other controls.
+  ///
+  /// If [caretStyle] is used, the color of the caret is the [caretStyle]'s color.
   final Color? controlsColor;
+
+  /// The visual representation of the caret.
+  final CaretStyle? caretStyle;
 
   /// The color of selection rectangles that appear around selected text.
   final Color? selectionColor;
@@ -235,11 +241,12 @@ class SuperTextFieldState extends State<SuperTextField> {
           selectionHighlightStyle: SelectionHighlightStyle(
             color: widget.selectionColor ?? defaultSelectionColor,
           ),
-          caretStyle: CaretStyle(
-            color: widget.controlsColor ?? defaultDesktopCaretColor,
-            width: 1,
-            borderRadius: BorderRadius.zero,
-          ),
+          caretStyle: widget.caretStyle ??
+              CaretStyle(
+                color: widget.controlsColor ?? defaultDesktopCaretColor,
+                width: 1,
+                borderRadius: BorderRadius.zero,
+              ),
           minLines: widget.minLines,
           maxLines: widget.maxLines,
           keyboardHandlers: widget.keyboardHandlers,
@@ -256,7 +263,10 @@ class SuperTextFieldState extends State<SuperTextField> {
             textStyleBuilder: widget.textStyleBuilder,
             hintBehavior: widget.hintBehavior,
             hintBuilder: widget.hintBuilder,
-            caretColor: widget.controlsColor ?? defaultAndroidControlsColor,
+            caretStyle: widget.caretStyle ??
+                CaretStyle(
+                  color: widget.controlsColor ?? defaultAndroidControlsColor,
+                ),
             selectionColor: widget.selectionColor ?? defaultSelectionColor,
             handlesColor: widget.controlsColor ?? defaultAndroidControlsColor,
             minLines: widget.minLines,
@@ -277,7 +287,10 @@ class SuperTextFieldState extends State<SuperTextField> {
             textStyleBuilder: widget.textStyleBuilder,
             hintBehavior: widget.hintBehavior,
             hintBuilder: widget.hintBuilder,
-            caretColor: widget.controlsColor ?? defaultIOSControlsColor,
+            caretStyle: widget.caretStyle ??
+                CaretStyle(
+                  color: widget.controlsColor ?? defaultIOSControlsColor,
+                ),
             selectionColor: widget.selectionColor ?? defaultSelectionColor,
             handlesColor: widget.controlsColor ?? defaultIOSControlsColor,
             minLines: widget.minLines,

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -94,10 +94,12 @@ class SuperTextField extends StatefulWidget {
 
   /// The color of the caret, drag handles, and other controls.
   ///
-  /// If [caretStyle] is used, the color of the caret is the [caretStyle]'s color.
+  /// The color in [caretStyle] overrides the [controlsColor].
   final Color? controlsColor;
 
   /// The visual representation of the caret.
+  ///
+  /// The color in [caretStyle] overrides the [controlsColor].
   final CaretStyle? caretStyle;
 
   /// The color of selection rectangles that appear around selected text.

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -119,6 +119,35 @@ void main() {
 
       expect(_isCaretPresent(tester), isTrue);
     });
+
+    testWidgetsOnAllPlatforms("uses the given caretStyle", (tester) async {
+      final controller = AttributedTextEditingController(
+        selection: const TextSelection.collapsed(offset: 0),
+      );
+
+      const caretStyle = CaretStyle(
+        color: Colors.red,
+        width: 5,
+        borderRadius: BorderRadius.all(Radius.circular(2.0)),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            focusNode: FocusNode()..requestFocus(),
+            textController: controller,
+            caretStyle: caretStyle,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final caret = tester.widget<TextLayoutCaret>(find.byType(TextLayoutCaret));
+
+      expect(caret.style.color, caretStyle.color);
+      expect(caret.style.width, caretStyle.width);
+      expect(caret.style.borderRadius, caretStyle.borderRadius);
+    });
   });
 }
 


### PR DESCRIPTION
[SuperTextField] Expose `caretStyle` property. Resolves #884

Currently, the caret customization is different between platforms:

* On desktop, a `CaretStyle` property is exposed, which configures color, width and border radius.
* On mobile, a `caretColor` property is exposed. The width and the border radius are the defaults defined in `CaretStyle` and can't be changed.

In `SuperTextField`'s public API, we only expose a `controlsColor` property, which defines the color for the caret and for the drag handles.

This PR adds an optional `caretStyle` property to `SuperTextField`. `SuperAndroidTextField` and `SuperIOSTextField` were changed to also accept a `CaretStyle`. 

IMO, we should deprecate the `caretColor` property in `SuperAndroidTextField` and `SuperIOSTextField` in favor of the new `caretStyle` property.