### PR TITLE
[SuperTextField][Mobile] Expose TextInputAction

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -162,9 +162,9 @@ class SuperTextField extends StatefulWidget {
   /// scrollable viewport.
   final EdgeInsets? padding;
 
-  /// The main action for the virtual keyboard. When `null`, it depends on whether the text
-  /// field is multiline or single line.
+  /// The main action for the virtual keyboard, e.g. [TextInputAction.done].
   ///
+  /// When `null`, it depends on whether the text field is multiline or single line.
   /// Only used on mobile.
   final TextInputAction? textInputAction;
 

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -162,9 +162,9 @@ class SuperTextField extends StatefulWidget {
   /// scrollable viewport.
   final EdgeInsets? padding;
 
-  /// The main action for the virtual keyboard, e.g. [TextInputAction.done].
+  /// The main action for the virtual keyboard. When `null`, it depends on whether the text
+  /// field is multiline or single line.
   ///
-  /// When `null`, it depends on whether the text field is multiline or single line.
   /// Only used on mobile.
   final TextInputAction? textInputAction;
 
@@ -208,12 +208,8 @@ class SuperTextFieldState extends State<SuperTextField> {
 
   bool get _isMultiline => (widget.minLines ?? 1) != 1 || widget.maxLines != 1;
 
-  TextInputAction get _textInputAction {
-    if (widget.textInputAction != null) {
-      return widget.textInputAction!;
-    }
-    return _isMultiline ? TextInputAction.newline : TextInputAction.done;
-  }
+  TextInputAction get _textInputAction =>
+      widget.textInputAction ?? (_isMultiline ? TextInputAction.newline : TextInputAction.done);
 
   SuperTextFieldPlatformConfiguration get _configuration {
     if (widget.configuration != null) {

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -162,9 +162,9 @@ class SuperTextField extends StatefulWidget {
   /// scrollable viewport.
   final EdgeInsets? padding;
 
-  /// The main action for the virtual keyboard. When `null`, it depends on whether the text
-  /// field is multiline or single line.
+  /// The main action for the virtual keyboard, e.g. [TextInputAction.done].
   ///
+  /// When `null`, it depends on whether the text field is multiline or single line.
   /// Only used on mobile.
   final TextInputAction? textInputAction;
 
@@ -208,7 +208,12 @@ class SuperTextFieldState extends State<SuperTextField> {
 
   bool get _isMultiline => (widget.minLines ?? 1) != 1 || widget.maxLines != 1;
 
-  TextInputAction get _defaultTextInputAction => _isMultiline ? TextInputAction.newline : TextInputAction.done;
+  TextInputAction get _textInputAction {
+    if (widget.textInputAction != null) {
+      return widget.textInputAction!;
+    }
+    return _isMultiline ? TextInputAction.newline : TextInputAction.done;
+  }
 
   SuperTextFieldPlatformConfiguration get _configuration {
     if (widget.configuration != null) {
@@ -311,7 +316,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             minLines: widget.minLines,
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
-            textInputAction: widget.textInputAction ?? _defaultTextInputAction,
+            textInputAction: _textInputAction,
             padding: widget.padding,
           ),
         );
@@ -335,7 +340,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             minLines: widget.minLines,
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
-            textInputAction: widget.textInputAction ?? _defaultTextInputAction,
+            textInputAction: _textInputAction,
             padding: widget.padding,
           ),
         );

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -162,9 +162,10 @@ class SuperTextField extends StatefulWidget {
   /// scrollable viewport.
   final EdgeInsets? padding;
 
-  /// Only used on mobile: sets the action for the virtual keyboard.
+  /// The main action for the virtual keyboard. When `null`, it depends on whether the text
+  /// field is multiline or single line.
   ///
-  /// When null, it depends on weather the text field is multiline or not.
+  /// Only used on mobile.
   final TextInputAction? textInputAction;
 
   @override

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -67,6 +67,7 @@ class SuperTextField extends StatefulWidget {
     this.inputSource,
     this.keyboardHandlers = defaultTextFieldKeyboardHandlers,
     this.padding,
+    this.textInputAction,
   }) : super(key: key);
 
   final FocusNode? focusNode;
@@ -161,6 +162,11 @@ class SuperTextField extends StatefulWidget {
   /// scrollable viewport.
   final EdgeInsets? padding;
 
+  /// Only used on mobile: sets the action for the virtual keyboard.
+  ///
+  /// When null, it depends on weather the text field is multiline or not.
+  final TextInputAction? textInputAction;
+
   @override
   State<SuperTextField> createState() => SuperTextFieldState();
 }
@@ -200,6 +206,8 @@ class SuperTextFieldState extends State<SuperTextField> {
   ProseTextLayout get textLayout => (_platformFieldKey.currentState as ProseTextBlock).textLayout;
 
   bool get _isMultiline => (widget.minLines ?? 1) != 1 || widget.maxLines != 1;
+
+  TextInputAction get _defaultTextInputAction => _isMultiline ? TextInputAction.newline : TextInputAction.done;
 
   SuperTextFieldPlatformConfiguration get _configuration {
     if (widget.configuration != null) {
@@ -302,7 +310,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             minLines: widget.minLines,
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
-            textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
+            textInputAction: widget.textInputAction ?? _defaultTextInputAction,
             padding: widget.padding,
           ),
         );
@@ -326,7 +334,7 @@ class SuperTextFieldState extends State<SuperTextField> {
             minLines: widget.minLines,
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
-            textInputAction: _isMultiline ? TextInputAction.newline : TextInputAction.done,
+            textInputAction: widget.textInputAction ?? _defaultTextInputAction,
             padding: widget.padding,
           ),
         );

--- a/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/super_textfield.dart
@@ -164,7 +164,9 @@ class SuperTextField extends StatefulWidget {
 
   /// The main action for the virtual keyboard, e.g. [TextInputAction.done].
   ///
-  /// When `null`, it depends on whether the text field is multiline or single line.
+  /// When `null`, and in single-line mode, the action will be [TextInputAction.done],
+  /// and when in multi-line mode, the action will be  [TextInputAction.newline].
+  ///
   /// Only used on mobile.
   final TextInputAction? textInputAction;
 

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -173,6 +173,38 @@ void main() {
         });
       });
     });
+
+    group('textInputAction', () {
+      group("is applied when configured", () {
+        testWidgetsOnAndroid('(on Android)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                textInputAction: TextInputAction.next,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+
+          expect(innerTextField.textInputAction, TextInputAction.next);
+        });
+
+        testWidgetsOnIos('(on iOS)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                textInputAction: TextInputAction.next,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+          expect(innerTextField.textInputAction, TextInputAction.next);
+        });
+      });
+    });
   });
 
   group('SuperTextField on some bad Android software keyboards', () {
@@ -298,6 +330,19 @@ Future<void> _pumpScaffoldForBuggyKeyboards(
             textController: controller,
           ),
         ),
+      ),
+    ),
+  );
+}
+
+Widget _buildScaffold({
+  required Widget child,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 300,
+        child: child,
       ),
     ),
   );

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' hide SelectableText;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:super_editor/super_editor.dart';
@@ -174,36 +175,33 @@ void main() {
       });
     });
 
-    group('textInputAction', () {
-      group("is applied when configured", () {
-        testWidgetsOnAndroid('(on Android)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                textInputAction: TextInputAction.next,
-              ),
-            ),
-          );
+    testWidgetsOnMobile('configures the software keyboard action button', (tester) async {
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: const SuperTextField(
+            textInputAction: TextInputAction.next,
+          ),
+        ),
+      );
 
-          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+      // Holds the keyboard input action sent to the platform.
+      String? inputAction;
 
-          expect(innerTextField.textInputAction, TextInputAction.next);
-        });
-
-        testWidgetsOnIos('(on iOS)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                textInputAction: TextInputAction.next,
-              ),
-            ),
-          );
-
-          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
-
-          expect(innerTextField.textInputAction, TextInputAction.next);
-        });
+      // Intercept messages sent to the platform.
+      tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) async {
+        final methodCall = const JSONMethodCodec().decodeMethodCall(message);
+        if (methodCall.method == 'TextInput.setClient') {
+          final params = methodCall.arguments[1] as Map;
+          inputAction = params['inputAction'];
+        }
+        return null;
       });
+
+      // Tap the text field to show the software keyboard.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Ensure the given TextInputAction was applied.
+      expect(inputAction, 'TextInputAction.next');
     });
   });
 

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -289,6 +289,38 @@ void main() {
       });
     });
 
+    group('textInputAction', () {
+      group("is applied when configured", () {
+        testWidgetsOnAndroid('(on Android)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                textInputAction: TextInputAction.next,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+
+          expect(innerTextField.textInputAction, TextInputAction.next);
+        });
+
+        testWidgetsOnIos('(on iOS)', (tester) async {
+          await tester.pumpWidget(
+            _buildScaffold(
+              child: const SuperTextField(
+                textInputAction: TextInputAction.next,
+              ),
+            ),
+          );
+
+          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+          expect(innerTextField.textInputAction, TextInputAction.next);
+        });
+      });
+    });
+
     testWidgetsOnAllPlatforms('recalculates its viewport height when text changes for text smaller than maxLines',
         (tester) async {
       final controller = AttributedTextEditingController();

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -289,38 +289,6 @@ void main() {
       });
     });
 
-    group('textInputAction', () {
-      group("is applied when configured", () {
-        testWidgetsOnAndroid('(on Android)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                textInputAction: TextInputAction.next,
-              ),
-            ),
-          );
-
-          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
-
-          expect(innerTextField.textInputAction, TextInputAction.next);
-        });
-
-        testWidgetsOnIos('(on iOS)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                textInputAction: TextInputAction.next,
-              ),
-            ),
-          );
-
-          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
-
-          expect(innerTextField.textInputAction, TextInputAction.next);
-        });
-      });
-    });
-
     testWidgetsOnAllPlatforms('recalculates its viewport height when text changes for text smaller than maxLines',
         (tester) async {
       final controller = AttributedTextEditingController();


### PR DESCRIPTION
In order to modify the virtual keyboard action on Mobile, `TextInputAction` needs to be exposed and configurable.

At Superlist mobile we have a multiline SuperTextField, but pressing enter on the virtual keyboard should not add a line break but be done instead. This is not possible because TextInputAction currently depends only on maxLines.