### PR TITLE
Bring back performAction control to SuperEditor widget (Resolves #915) (#916)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -62,74 +62,93 @@ abstract class TextInputConnectionDecorator implements TextInputConnection {
   void close() => client?.close();
 }
 
-/// A [DeltaTextInputClient] that forwards all calls to the given [_client], and
-/// also notifies [_onConnectionClosed] when the IME connection closes.
+/// A [DeltaTextInputClient] that forwards all calls to the given [_client].
 ///
-/// This decorator is needed because [TextInputConnection] has no way to listen
-/// for when its connection is closed. By wrapping its [TextInputClient] with
-/// this decorator, the code that owns the [TextInputConnection] can receive
-/// a notification when the connection closes.
-class _ClosureAwareImeClientDecorator implements DeltaTextInputClient {
-  _ClosureAwareImeClientDecorator(this._client, this._onConnectionClosed);
+/// Subclass [DeltaTextInputClientDecorator] to override specific
+/// [DeltaTextInputClient] messages. To add behavior, instead of replacing it,
+/// call the `super` method within an override.
+class DeltaTextInputClientDecorator implements DeltaTextInputClient {
+  DeltaTextInputClientDecorator([this._client]);
 
-  final DeltaTextInputClient _client;
-  final VoidCallback _onConnectionClosed;
-
-  @override
-  void connectionClosed() {
-    editorImeLog.fine("[_ClosureAwareImeClientDecorator] - IME connection was closed");
-    _onConnectionClosed();
-    _client.connectionClosed();
-  }
+  set client(DeltaTextInputClient? client) => _client = client;
+  DeltaTextInputClient? _client;
 
   @override
-  AutofillScope? get currentAutofillScope => _client.currentAutofillScope;
+  AutofillScope? get currentAutofillScope => _client?.currentAutofillScope;
 
   @override
-  TextEditingValue? get currentTextEditingValue => _client.currentTextEditingValue;
+  TextEditingValue? get currentTextEditingValue => _client?.currentTextEditingValue;
 
   @override
   void insertTextPlaceholder(Size size) {
-    _client.insertTextPlaceholder(size);
+    _client?.insertTextPlaceholder(size);
   }
 
   @override
   void performAction(TextInputAction action) {
-    _client.performAction(action);
+    _client?.performAction(action);
   }
 
   @override
   void performPrivateCommand(String action, Map<String, dynamic> data) {
-    _client.performPrivateCommand(action, data);
+    _client?.performPrivateCommand(action, data);
   }
 
   @override
   void removeTextPlaceholder() {
-    _client.removeTextPlaceholder();
+    _client?.removeTextPlaceholder();
   }
 
   @override
   void showAutocorrectionPromptRect(int start, int end) {
-    _client.showAutocorrectionPromptRect(start, end);
+    _client?.showAutocorrectionPromptRect(start, end);
   }
 
   @override
   void showToolbar() {
-    _client.showToolbar();
+    _client?.showToolbar();
   }
 
   @override
   void updateEditingValue(TextEditingValue value) {
-    _client.updateEditingValue(value);
+    _client?.updateEditingValue(value);
   }
 
   @override
   void updateEditingValueWithDeltas(List<TextEditingDelta> textEditingDeltas) {
-    _client.updateEditingValueWithDeltas(textEditingDeltas);
+    _client?.updateEditingValueWithDeltas(textEditingDeltas);
   }
 
   @override
   void updateFloatingCursor(RawFloatingCursorPoint point) {
-    _client.updateFloatingCursor(point);
+    _client?.updateFloatingCursor(point);
+  }
+
+  @override
+  void connectionClosed() {
+    _client?.connectionClosed();
+  }
+}
+
+/// A [DeltaTextInputClientDecorator] that notifies [_onConnectionClosed] when
+/// the IME connection closes.
+///
+/// This decorator is needed because [TextInputConnection] has no way to listen
+/// for when its connection is closed. By wrapping a [TextInputClient] with
+/// this decorator, the code that owns the [TextInputConnection] can receive
+/// a notification when the connection closes.
+class ClosureAwareDeltaTextInputClientDecorator extends DeltaTextInputClientDecorator {
+  ClosureAwareDeltaTextInputClientDecorator(
+    this._onConnectionClosed, [
+    DeltaTextInputClient? client,
+  ]) : super(client);
+
+  final VoidCallback _onConnectionClosed;
+
+  @override
+  void connectionClosed() {
+    editorImeLog.fine("[ClosureAwareDeltaTextInputClientDecorator] - IME connection was closed");
+    _onConnectionClosed();
+    _client?.connectionClosed();
   }
 }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -52,8 +52,11 @@ import 'unknown_component.dart';
 ///    selected text and components
 ///
 /// A [SuperEditor] determines how a physical keyboard interacts with the document
-/// by way of [keyboardActions]. Software keyboards are integrated with the
-/// [softwareKeyboardHandler].
+/// by way of [keyboardActions].
+///
+/// A [SuperEditor] works with software keyboards through the platform's Input Method
+/// Engine (IME). To customize how [SuperEditor] works with the IME, see [imePolicies],
+/// [imeConfiguration], and [softwareKeyboardController].
 ///
 /// ## Deeper explanation of core artifacts:
 ///
@@ -91,6 +94,7 @@ class SuperEditor extends StatefulWidget {
     this.softwareKeyboardController,
     this.imePolicies = const SuperEditorImePolicies(),
     this.imeConfiguration = const SuperEditorImeConfiguration(),
+    this.imeOverrides,
     List<DocumentKeyboardAction>? keyboardActions,
     this.gestureMode,
     this.androidHandleColor,
@@ -175,6 +179,19 @@ class SuperEditor extends StatefulWidget {
 
   /// Preferences for how the platform IME should look and behave during editing.
   final SuperEditorImeConfiguration imeConfiguration;
+
+  /// Overrides for IME actions.
+  ///
+  /// When the user edits document content in IME mode, those edits and actions
+  /// are reported to a [DeltaTextInputClient], which is then responsible for
+  /// applying those changes to a document. [SuperEditor] includes an implementation
+  /// for all relevant editing behaviors. However, some apps may wish to implement
+  /// their own custom behavior, such as when the user presses the action button,
+  /// such as "Next" or "Done".
+  ///
+  /// Provide a [DeltaTextInputClientDecorator], to override the default [SuperEditor]
+  /// behaviors for various IME messages.
+  final DeltaTextInputClientDecorator? imeOverrides;
 
   /// The `SuperEditor` gesture mode, e.g., mouse or touch.
   final DocumentGestureMode? gestureMode;
@@ -496,6 +513,7 @@ class SuperEditorState extends State<SuperEditor> {
           softwareKeyboardController: widget.softwareKeyboardController,
           imePolicies: widget.imePolicies,
           imeConfiguration: widget.imeConfiguration,
+          imeOverrides: widget.imeOverrides,
           hardwareKeyboardActions: widget.keyboardActions,
           floatingCursorController: _floatingCursorController,
           child: child,

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -12,6 +12,49 @@ import '../_document_test_tools.dart';
 
 void main() {
   group('IME input', () {
+    testWidgets('allows apps to handle performAction in their own way', (tester) async {
+      final document = singleParagraphEmptyDoc();
+
+      int performActionCount = 0;
+      TextInputAction? performedAction;
+      final imeOverrides = _TestImeOverrides(
+        (action) {
+          performActionCount += 1;
+          performedAction = action;
+        },
+      );
+
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(TextInputSource.ime)
+          .withImeOverrides(imeOverrides)
+          .pump();
+
+      // Place the caret in the document so that we open an IME connection.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Simulate a "Newline" action from the platform.
+      await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.textInput.name,
+        SystemChannels.textInput.codec.encodeMethodCall(
+          const MethodCall(
+            "TextInputClient.performAction",
+            [-1, "TextInputAction.newline"],
+          ),
+        ),
+        null,
+      );
+
+      // Ensure that our override got the performAction call.
+      expect(performActionCount, 1);
+      expect(performedAction, TextInputAction.newline);
+
+      // Ensure that the editor didn't receive the performAction call, and didn't
+      // insert a new node.
+      expect(document.nodes.length, 1);
+    });
+
     group('delta use-cases', () {
       test('can handle an auto-inserted period', () {
         // On iOS, adding 2 spaces causes the two spaces to be replaced by a
@@ -390,4 +433,15 @@ MutableDocument _singleParagraphWithLinkDoc() {
       )
     ],
   );
+}
+
+class _TestImeOverrides extends DeltaTextInputClientDecorator {
+  _TestImeOverrides(this.performActionCallback);
+
+  final void Function(TextInputAction) performActionCallback;
+
+  @override
+  void performAction(TextInputAction action) {
+    performActionCallback(action);
+  }
 }

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -95,6 +95,8 @@ class TestDocumentConfigurator {
   SoftwareKeyboardController? _softwareKeyboardController;
   bool _openKeyboardOnSelectionChange = true;
   bool _clearSelectionWhenImeDisconnects = true;
+  SuperEditorImeConfiguration? _imeConfiguration;
+  DeltaTextInputClientDecorator? _imeOverrides;
   ThemeData? _appTheme;
   Stylesheet? _stylesheet;
   final _addedComponents = <ComponentBuilder>[];
@@ -157,6 +159,19 @@ class TestDocumentConfigurator {
   /// the connection to the platform IME is closed, or not.
   TestDocumentConfigurator withClearSelectionWhenImeDisconnects(bool clearSelectionWhenImeDisconnects) {
     _clearSelectionWhenImeDisconnects = clearSelectionWhenImeDisconnects;
+    return this;
+  }
+
+  /// Configures the way in which the user interacts with the IME, e.g., brightness, autocorrection, etc.
+  TestDocumentConfigurator withImeConfiguration(SuperEditorImeConfiguration configuration) {
+    _imeConfiguration = configuration;
+    return this;
+  }
+
+  /// Configures the [SuperEditor] to intercept and override desired IME signals, as
+  /// determined by the given [imeOverrides].
+  TestDocumentConfigurator withImeOverrides(DeltaTextInputClientDecorator imeOverrides) {
+    _imeOverrides = imeOverrides;
     return this;
   }
 
@@ -362,6 +377,8 @@ class TestDocumentConfigurator {
         openKeyboardOnSelectionChange: _openKeyboardOnSelectionChange,
         clearSelectionWhenImeDisconnects: _clearSelectionWhenImeDisconnects,
       ),
+      imeConfiguration: _imeConfiguration ?? const SuperEditorImeConfiguration(),
+      imeOverrides: _imeOverrides,
       gestureMode: _gestureMode,
       androidToolbarBuilder: _androidToolbarBuilder,
       iOSToolbarBuilder: _iOSToolbarBuilder,


### PR DESCRIPTION
Cherry pick: Bring back performAction control to SuperEditor widget (Resolves #915) (#916)