### PR TITLE
[SuperEditor][mac] Fix upstream selection using keyboard (Resolves #913)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -255,19 +255,15 @@ class DocumentImeSerializer {
   TextSelection documentToImeSelection(DocumentSelection docSelection) {
     editorImeLog.fine("Converting doc selection to ime selection: $docSelection");
     final selectionAffinity = _doc.getAffinityForSelection(docSelection);
-
-    final startDocPosition = selectionAffinity == TextAffinity.downstream ? docSelection.base : docSelection.extent;
-    final startImePosition = _documentToImePosition(startDocPosition);
-
-    final endDocPosition = selectionAffinity == TextAffinity.downstream ? docSelection.extent : docSelection.base;
-    final endImePosition = _documentToImePosition(endDocPosition);
+    final startImePosition = _documentToImePosition(docSelection.base);
+    final endImePosition = _documentToImePosition(docSelection.extent);
 
     editorImeLog.fine("Start IME position: $startImePosition");
     editorImeLog.fine("End IME position: $endImePosition");
     return TextSelection(
       baseOffset: startImePosition.offset,
       extentOffset: endImePosition.offset,
-      affinity: startImePosition == endImePosition ? endImePosition.affinity : TextAffinity.downstream,
+      affinity: selectionAffinity,
     );
   }
 


### PR DESCRIPTION
[SuperEditor][mac] Fix upstream selection using keyboard. Resolves #913 

Trying to expand the selection upstream using shift + up or shift + left arrow is causing the selection to be collapsed.

This was introduced in https://github.com/superlistapp/super_editor/pull/877 when non-text delta handling was implemented.

In macOS, after we send our text editing value, we always get back a non-text delta. When we convert a `DocumentSelection` to a `TextSelection` to be sent to IME, we are inverting the selection `base` and `extent`, if we have an upstream selection. We send it to the IME and we get back a non-text delta with a downstream selection. This causes the bug.

This PR changes the `DocumentImeSerializer` to always use the same `base`, `extent`, and `affinity` from the selection.

I tested in windows, mac, android and iOS (simulator) and everything seems to be working correctly.
