### PR TITLE
Moved tasks into Super Editor and fixed bug that prevented creating new tasks after texisting tasks (Resolves #923)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/rendering.dart';
 import 'package:super_editor/super_editor.dart';
 
-import '_task.dart';
-
 Document createInitialDocument() {
   return MutableDocument(
     nodes: [

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -607,6 +607,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
                   textController: _urlController,
                   minLines: 1,
                   maxLines: 1,
+                  inputSource: TextInputSource.ime,
                   hintBehavior: HintBehavior.displayHintUntilTextEntered,
                   hintBuilder: (context) {
                     return Text(

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -38,7 +38,7 @@ Future<void> main() async {
   initLoggers(Level.FINEST, {
     // editorScrollingLog,
     // editorGesturesLog,
-    editorImeLog,
+    // editorImeLog,
     // editorKeyLog,
     // editorOpsLog,
     // editorLayoutLog,

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -272,78 +272,103 @@ mixin DocumentComponent<T extends StatefulWidget> on State<T> {
 /// to provide is [childDocumentComponentKey], which is a `GlobalKey` that provides
 /// access to the child [DocumentComponent].
 mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentComponent<T> {
+  @protected
   GlobalKey get childDocumentComponentKey;
 
-  DocumentComponent get childDocumentComponent => childDocumentComponentKey.currentState as DocumentComponent;
+  DocumentComponent get _childDocumentComponent => childDocumentComponentKey.currentState as DocumentComponent;
+
+  Offset _getChildOffset(Offset myOffset) {
+    final myBox = context.findRenderObject() as RenderBox;
+    final childBox = childDocumentComponentKey.currentContext!.findRenderObject() as RenderBox;
+    return childBox.globalToLocal(myOffset, ancestor: myBox);
+  }
+
+  Offset _getOffsetFromChild(Offset childOffset) {
+    final myBox = context.findRenderObject() as RenderBox;
+    final childBox = childDocumentComponentKey.currentContext!.findRenderObject() as RenderBox;
+    return childBox.localToGlobal(childOffset, ancestor: myBox);
+  }
+
+  Rect _getRectFromChild(Rect childRect) {
+    return Rect.fromPoints(
+      _getOffsetFromChild(childRect.topLeft),
+      _getOffsetFromChild(childRect.bottomRight),
+    );
+  }
 
   @override
   NodePosition? getPositionAtOffset(Offset localOffset) {
-    return childDocumentComponent.getPositionAtOffset(localOffset);
+    return _childDocumentComponent.getPositionAtOffset(_getChildOffset(localOffset));
   }
 
   @override
   Offset getOffsetForPosition(NodePosition nodePosition) {
-    return childDocumentComponent.getOffsetForPosition(nodePosition);
+    return _childDocumentComponent.getOffsetForPosition(nodePosition);
   }
 
   @override
   Rect getRectForPosition(NodePosition nodePosition) {
-    return childDocumentComponent.getRectForPosition(nodePosition);
+    final childRect = _childDocumentComponent.getRectForPosition(nodePosition);
+    return _getRectFromChild(childRect);
   }
 
   @override
   Rect getRectForSelection(NodePosition baseNodePosition, NodePosition extentNodePosition) {
-    return childDocumentComponent.getRectForSelection(baseNodePosition, extentNodePosition);
+    final childRect = _childDocumentComponent.getRectForSelection(baseNodePosition, extentNodePosition);
+    return _getRectFromChild(childRect);
   }
 
   @override
   NodePosition getBeginningPosition() {
-    return childDocumentComponent.getBeginningPosition();
+    return _childDocumentComponent.getBeginningPosition();
   }
 
   @override
   NodePosition getBeginningPositionNearX(double x) {
-    return childDocumentComponent.getBeginningPositionNearX(x);
+    return _childDocumentComponent.getBeginningPositionNearX(_getChildOffset(Offset(x, 0)).dx);
   }
 
   @override
   NodePosition? movePositionLeft(NodePosition currentPosition, [MovementModifier? movementModifier]) {
-    return childDocumentComponent.movePositionLeft(currentPosition, movementModifier);
+    return _childDocumentComponent.movePositionLeft(currentPosition, movementModifier);
   }
 
   @override
   NodePosition? movePositionRight(NodePosition currentPosition, [MovementModifier? movementModifier]) {
-    return childDocumentComponent.movePositionRight(currentPosition, movementModifier);
+    return _childDocumentComponent.movePositionRight(currentPosition, movementModifier);
   }
 
   @override
   NodePosition? movePositionUp(NodePosition currentPosition) {
-    return childDocumentComponent.movePositionUp(currentPosition);
+    return _childDocumentComponent.movePositionUp(currentPosition);
   }
 
   @override
   NodePosition? movePositionDown(NodePosition currentPosition) {
-    return childDocumentComponent.movePositionDown(currentPosition);
+    return _childDocumentComponent.movePositionDown(currentPosition);
   }
 
   @override
   NodePosition getEndPosition() {
-    return childDocumentComponent.getEndPosition();
+    return _childDocumentComponent.getEndPosition();
   }
 
   @override
   NodePosition getEndPositionNearX(double x) {
-    return childDocumentComponent.getEndPositionNearX(x);
+    return _childDocumentComponent.getEndPositionNearX(_getChildOffset(Offset(x, 0)).dx);
   }
 
   @override
   NodeSelection? getSelectionInRange(Offset localBaseOffset, Offset localExtentOffset) {
-    return childDocumentComponent.getSelectionInRange(localBaseOffset, localExtentOffset);
+    return _childDocumentComponent.getSelectionInRange(
+      _getChildOffset(localBaseOffset),
+      _getChildOffset(localExtentOffset),
+    );
   }
 
   @override
   NodeSelection getCollapsedSelectionAt(NodePosition nodePosition) {
-    return childDocumentComponent.getCollapsedSelectionAt(nodePosition);
+    return _childDocumentComponent.getCollapsedSelectionAt(nodePosition);
   }
 
   @override
@@ -351,20 +376,20 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
     required NodePosition basePosition,
     required NodePosition extentPosition,
   }) {
-    return childDocumentComponent.getSelectionBetween(basePosition: basePosition, extentPosition: extentPosition);
+    return _childDocumentComponent.getSelectionBetween(basePosition: basePosition, extentPosition: extentPosition);
   }
 
   @override
   NodeSelection getSelectionOfEverything() {
-    return childDocumentComponent.getSelectionOfEverything();
+    return _childDocumentComponent.getSelectionOfEverything();
   }
 
   @override
-  bool isVisualSelectionSupported() => childDocumentComponent.isVisualSelectionSupported();
+  bool isVisualSelectionSupported() => _childDocumentComponent.isVisualSelectionSupported();
 
   @override
   MouseCursor? getDesiredCursorAtOffset(Offset localOffset) {
-    return childDocumentComponent.getDesiredCursorAtOffset(localOffset);
+    return _childDocumentComponent.getDesiredCursorAtOffset(_getChildOffset(localOffset));
   }
 }
 

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -14,6 +14,7 @@ import 'package:super_editor/src/default_editor/document_gestures_touch_android.
 import 'package:super_editor/src/default_editor/document_gestures_touch_ios.dart';
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_text_layout/super_text_layout.dart';
@@ -695,6 +696,7 @@ final defaultKeyboardActions = <DocumentKeyboardAction>[
   cmdBToToggleBold,
   cmdIToToggleItalics,
   shiftEnterToInsertNewlineInBlock,
+  enterToInsertNewTask,
   enterToInsertBlockNewline,
   backspaceToRemoveUpstreamContent,
   deleteToRemoveDownstreamContent,
@@ -720,6 +722,8 @@ final defaultImeKeyboardActions = <DocumentKeyboardAction>[
   moveUpDownLeftAndRightWithArrowKeys,
   moveToLineStartWithHome,
   moveToLineEndWithEnd,
+  enterToInsertNewTask,
+  enterToInsertBlockNewline,
   tabToIndentListItem,
   shiftTabToUnIndentListItem,
   backspaceToUnIndentListItem,

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -123,7 +123,7 @@ class SuperEditorInspector {
   /// {@macro supereditor_finder}
   static WidgetType findWidgetForComponent<WidgetType>(String nodeId, [Finder? superEditorFinder]) {
     final documentLayout = _findDocumentLayout(superEditorFinder);
-    final widget = (documentLayout.getComponentByNodeId(nodeId) as TextComponentState).widget;
+    final widget = (documentLayout.getComponentByNodeId(nodeId) as State).widget;
     if (widget is! WidgetType) {
       throw Exception("Looking for a component's widget. Expected type $WidgetType, but found ${widget.runtimeType}");
     }

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -44,6 +44,7 @@ extension SuperEditorRobot on WidgetTester {
     await _tapInParagraph(nodeId, offset, affinity, 3, superEditorFinder);
   }
 
+  // TODO: rename all of these related behaviors to "text" instead of "paragraph"
   Future<void> _tapInParagraph(
     String nodeId,
     int offset,

--- a/super_editor/lib/src/test/super_editor_test/tasks_test_tools.dart
+++ b/super_editor/lib/src/test/super_editor_test/tasks_test_tools.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+
+/// Queries the state of [TaskComponent]s in a [SuperEditor].
+class TaskInspector {
+  TaskInspector._();
+
+  static bool isChecked(String nodeId, [Finder? superEditorFinder]) {
+    final checkbox = _findTaskCheckbox(nodeId, superEditorFinder);
+    return checkbox.value == true;
+  }
+}
+
+/// Extension on [WidgetTester] that interacts with [TaskComponent]s in a [SuperEditor].
+extension TaskRobot on WidgetTester {
+  Future<void> tapOnCheckbox(String nodeId, [Finder? superEditorFinder]) async {
+    final checkbox = _findTaskCheckbox(nodeId, superEditorFinder);
+    await tap(find.byWidget(checkbox));
+    await pumpAndSettle();
+  }
+}
+
+TaskComponent _findTaskComponent(String nodeId, [Finder? superEditorFinder]) {
+  return SuperEditorInspector.findWidgetForComponent(nodeId, superEditorFinder) as TaskComponent;
+}
+
+Checkbox _findTaskCheckbox(String nodeId, [Finder? superEditorFinder]) {
+  final taskWidget = _findTaskComponent(nodeId, superEditorFinder);
+
+  final checkboxes = find.descendant(of: find.byWidget(taskWidget), matching: find.byType(Checkbox)).evaluate();
+  assert(checkboxes.isNotEmpty, "Couldn't find the Checkbox widget within a task widget with node ID: $nodeId");
+  assert(checkboxes.length == 1,
+      "Found multiple Checkbox widgets within a task widget. We don't know which one to use. Node id: $nodeId");
+  return checkboxes.first.widget as Checkbox;
+}

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -34,6 +34,7 @@ export 'src/default_editor/paragraph.dart';
 export 'src/default_editor/selection_binary.dart';
 export 'src/default_editor/selection_upstream_downstream.dart';
 export 'src/default_editor/super_editor.dart';
+export 'src/default_editor/tasks.dart';
 export 'src/default_editor/text.dart';
 export 'src/default_editor/text_tools.dart';
 export 'src/default_editor/unknown_component.dart';

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/src/test/super_editor_test/tasks_test_tools.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../../test_tools.dart';
+
+void main() {
+  group("SuperEditor task component", () {
+    // TODO: combine with mobile test when #927 is resolved
+    testWidgetsOnDesktop("toggles on tap", (tester) async {
+      final editor = DocumentEditor(
+          document: MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Ensure the task isn't checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, false);
+      expect(TaskInspector.isChecked("1"), false);
+
+      // Tap to check the box.
+      await tester.tapOnCheckbox("1");
+
+      // Ensure the task is checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, true);
+      expect(TaskInspector.isChecked("1"), true);
+
+      // Tap to uncheck the box.
+      await tester.tapOnCheckbox("1");
+
+      // Ensure the task isn't checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, false);
+      expect(TaskInspector.isChecked("1"), false);
+    });
+
+    // TODO: combine with desktop test when #927 is resolved
+    testWidgetsOnMobile("toggles on tap", (tester) async {
+      final editor = DocumentEditor(
+          document: MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Ensure the task isn't checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, false);
+      expect(TaskInspector.isChecked("1"), false);
+
+      // Tap to check the box.
+      await tester.tapOnCheckbox("1");
+
+      // Ensure the task is checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, true);
+      expect(TaskInspector.isChecked("1"), true);
+
+      // Tap to uncheck the box.
+      await tester.tapOnCheckbox("1");
+
+      // Ensure the task isn't checked.
+      expect((editor.document.nodes.first as TaskNode).isComplete, false);
+      expect(TaskInspector.isChecked("1"), false);
+    }, skip: true);
+
+    testWidgetsOnAllPlatforms("can be created from empty paragraph", (tester) async {
+      final editor = DocumentEditor(
+          document: MutableDocument(
+        nodes: [
+          ParagraphNode(id: "1", text: AttributedText(text: "This will be a task")),
+        ],
+      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Convert the paragraph to a task.
+      editor.executeCommand(const ConvertParagraphToTaskCommand(nodeId: "1"));
+
+      // Ensure the node is now a task.
+      expect(editor.document.nodes.length, 1);
+      expect(editor.document.nodes.first, isA<TaskNode>());
+      expect((editor.document.nodes.first as TaskNode).text.text, "This will be a task");
+    });
+
+    testWidgetsOnAllPlatforms("inserts new task on ENTER at end of existing task", (tester) async {
+      final editor = DocumentEditor(
+          document: MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      ));
+      final task = editor.document.getNodeAt(0) as TaskNode;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at the end of the task.
+      await tester.placeCaretInParagraph("1", task.text.text.length);
+
+      // Press enter to create a new, empty task, below the original task.
+      await tester.pressEnter();
+
+      // Ensure that a new, empty task was created.
+      expect(editor.document.nodes.length, 2);
+      expect(editor.document.nodes.first, isA<TaskNode>());
+      expect((editor.document.nodes.first as TaskNode).text.text, "This is a task");
+      expect(editor.document.nodes.last, isA<TaskNode>());
+      expect((editor.document.nodes.last as TaskNode).text.text, "");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: editor.document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnAllPlatforms("splits task into two on ENTER in middle of existing task", (tester) async {
+      final editor = DocumentEditor(
+          document: MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at "This is |a task"
+      await tester.placeCaretInParagraph("1", 8);
+
+      // Press enter to split the existing task into two.
+      await tester.pressEnter();
+
+      // Ensure that a new task was created with part of the previous task.
+      expect(editor.document.nodes.length, 2);
+      expect(editor.document.nodes.first, isA<TaskNode>());
+      expect((editor.document.nodes.first as TaskNode).text.text, "This is ");
+      expect(editor.document.nodes.last, isA<TaskNode>());
+      expect((editor.document.nodes.last as TaskNode).text.text, "a task");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: editor.document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Moved tasks into Super Editor and fixed bug that prevented creating new tasks after texisting tasks (Resolves #923)

At some point we lost the ability to press ENTER at the end of a task in the example app and create a new task. This PR fixes that. I'm not sure how it was ever working. We have code in the ENTER handler that rejects any text node that isn't a `ParagraphNode`. I added a new key handler that specifically handles this case.

This PR also moves tasks into Super Editor as a standard content type. I also added tests to ensure that `TaskNode`s and `TaskComponent`s do the right thing within a `SuperEditor`.

I tried adding tests for tapping the checkbox. Those tests work on desktop, but not on mobile. At least part of the problem on mobile is that the mobile gesture recognizer still sits on top of the document, instead of beneath the document, like desktop. I filed https://github.com/superlistapp/super_editor/issues/927 to solve that problem. When it's solved, the mobile tests that are skipped in this PR should be combined with the desktop tests.

I changed how the demo app deals with brightness. Instead of making the setting a local `bool`, I switched to `Brightness` and applied it with a `Theme` widget. This way, any given component can lookup the current brightness and base its appearance on the right value.

I also discovered that the `ProxyDocumentComponent` implementation didn't deal with the possibility that the inner component might not take up all the space of the proxy component. I added offset calculations to deal with that.