### PR TITLE
Added newline key handler to IME SuperTextField to fix example app URL field issue (Resolves #925) (#931)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -1440,6 +1440,7 @@ const defaultTextFieldImeKeyboardHandlers = <TextFieldKeyboardHandler>[
   DefaultSuperTextFieldKeyboardHandlers.deleteWordWhenCtlBackSpaceIsPressedOnWindowsAndLinux,
   DefaultSuperTextFieldKeyboardHandlers.deleteTextOnLineBeforeCaretWhenShortcutKeyAndBackspaceIsPressed,
   DefaultSuperTextFieldKeyboardHandlers.deleteTextWhenBackspaceOrDeleteIsPressed,
+  DefaultSuperTextFieldKeyboardHandlers.insertNewlineWhenEnterIsPressed,
 ];
 
 class DefaultSuperTextFieldKeyboardHandlers {


### PR DESCRIPTION
Cherry pick: Added newline key handler to IME SuperTextField to fix example app URL field issue (Resolves #925) (#931)