### PR TITLE
Added focus and IME debug visuals to Super Editor (Resolves #942)

### DIFF
--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -32,10 +32,17 @@ class _LoseFocusDemoState extends State<LoseFocusDemo> {
         children: [
           _buildTextField(),
           Expanded(
-            child: SuperEditor(
-              editor: _docEditor,
-              stylesheet: defaultStylesheet.copyWith(
-                documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+            child: SuperEditorDebugVisuals(
+              config: SuperEditorDebugVisualsConfig(
+                showFocus: true,
+                showImeConnection: true,
+              ),
+              child: SuperEditor(
+                editor: _docEditor,
+                inputSource: TextInputSource.ime,
+                stylesheet: defaultStylesheet.copyWith(
+                  documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+                ),
               ),
             ),
           ),

--- a/super_editor/lib/src/default_editor/debug_visualization.dart
+++ b/super_editor/lib/src/default_editor/debug_visualization.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class SuperEditorDebugVisuals extends InheritedWidget {
+  static SuperEditorDebugVisualsConfig of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<SuperEditorDebugVisuals>()!.config;
+  }
+
+  static SuperEditorDebugVisualsConfig? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<SuperEditorDebugVisuals>()?.config;
+  }
+
+  const SuperEditorDebugVisuals({
+    this.config = const SuperEditorDebugVisualsConfig(),
+    required Widget child,
+  }) : super(child: child);
+
+  final SuperEditorDebugVisualsConfig config;
+
+  @override
+  bool updateShouldNotify(SuperEditorDebugVisuals oldWidget) {
+    return config != oldWidget.config;
+  }
+}
+
+class SuperEditorDebugVisualsConfig {
+  const SuperEditorDebugVisualsConfig({
+    this.showFocus = false,
+    this.showImeConnection = false,
+  });
+
+  final bool showFocus;
+  final bool showImeConnection;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SuperEditorDebugVisualsConfig &&
+          runtimeType == other.runtimeType &&
+          showFocus == other.showFocus &&
+          showImeConnection == other.showImeConnection;
+
+  @override
+  int get hashCode => showFocus.hashCode ^ showImeConnection.hashCode;
+}
+
+class SuperEditorFocusDebugVisuals extends StatelessWidget {
+  const SuperEditorFocusDebugVisuals({
+    Key? key,
+    required this.focusNode,
+    required this.child,
+  }) : super(key: key);
+
+  final FocusNode focusNode;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final config = SuperEditorDebugVisuals.maybeOf(context);
+    if (config == null || !config.showFocus) {
+      return child;
+    }
+
+    return AnimatedBuilder(
+      animation: focusNode,
+      builder: (context, value) {
+        final color = focusNode.hasPrimaryFocus
+            ? Colors.lightGreenAccent
+            : focusNode.hasFocus
+                ? Colors.red
+                : Colors.grey;
+
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: color,
+              width: 2,
+            ),
+          ),
+          position: DecorationPosition.foreground,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+class SuperEditorImeDebugVisuals extends StatelessWidget {
+  const SuperEditorImeDebugVisuals({
+    Key? key,
+    required this.imeConnection,
+    required this.child,
+  }) : super(key: key);
+
+  final ValueListenable<TextInputConnection?> imeConnection;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final config = SuperEditorDebugVisuals.maybeOf(context);
+    if (config == null || !config.showImeConnection) {
+      return child;
+    }
+
+    return AnimatedBuilder(
+      animation: imeConnection,
+      builder: (context, value) {
+        final color = imeConnection.value == null
+            ? Colors.grey
+            : imeConnection.value!.attached
+                ? Colors.greenAccent
+                : Colors.red;
+
+        final message = imeConnection.value == null
+            ? "NO IME CONNECTION"
+            : imeConnection.value!.attached
+                ? "ATTACHED TO IME"
+                : "DETACHED FROM IME";
+
+        return Stack(
+          children: [
+            // Super Editor
+            child,
+            // Debug Info
+            Align(
+              alignment: Alignment.topCenter,
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                decoration: BoxDecoration(
+                  color: color,
+                  borderRadius: const BorderRadius.only(
+                    bottomLeft: Radius.circular(8),
+                    bottomRight: Radius.circular(8),
+                  ),
+                ),
+                child: Text(
+                  message,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/default_editor/debug_visualization.dart';
 import 'package:super_editor/src/infrastructure/ime_input_owner.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 
@@ -205,36 +206,39 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
 
   @override
   Widget build(BuildContext context) {
-    return SuperEditorHardwareKeyHandler(
-      focusNode: _focusNode,
-      editContext: widget.editContext,
-      keyboardActions: widget.hardwareKeyboardActions,
-      autofocus: widget.autofocus,
-      child: DocumentSelectionOpenAndCloseImePolicy(
+    return SuperEditorImeDebugVisuals(
+      imeConnection: _imeConnection,
+      child: SuperEditorHardwareKeyHandler(
         focusNode: _focusNode,
-        selection: widget.editContext.composer.selectionNotifier,
-        imeConnection: _imeConnection,
-        imeClientFactory: () => _imeClient,
-        imeConfiguration: _textInputConfiguration,
-        openKeyboardOnSelectionChange: widget.imePolicies.openKeyboardOnSelectionChange,
-        closeKeyboardOnSelectionLost: widget.imePolicies.closeKeyboardOnSelectionLost,
-        clearSelectionWhenImeConnectionCloses: widget.clearSelectionWhenImeConnectionCloses,
-        child: ImeFocusPolicy(
+        editContext: widget.editContext,
+        keyboardActions: widget.hardwareKeyboardActions,
+        autofocus: widget.autofocus,
+        child: DocumentSelectionOpenAndCloseImePolicy(
           focusNode: _focusNode,
+          selection: widget.editContext.composer.selectionNotifier,
           imeConnection: _imeConnection,
           imeClientFactory: () => _imeClient,
           imeConfiguration: _textInputConfiguration,
-          child: SoftwareKeyboardOpener(
-            controller: widget.softwareKeyboardController,
+          openKeyboardOnSelectionChange: widget.imePolicies.openKeyboardOnSelectionChange,
+          closeKeyboardOnSelectionLost: widget.imePolicies.closeKeyboardOnSelectionLost,
+          clearSelectionWhenImeConnectionCloses: widget.clearSelectionWhenImeConnectionCloses,
+          child: ImeFocusPolicy(
+            focusNode: _focusNode,
             imeConnection: _imeConnection,
-            createImeClient: () => _documentImeClient,
-            createImeConfiguration: () => _textInputConfiguration,
-            child: DocumentToImeSynchronizer(
-              document: widget.editContext.editor.document,
-              selection: widget.editContext.composer.selectionNotifier,
-              composingRegion: widget.editContext.composer.composingRegion,
-              imeConnection: _documentImeConnection,
-              child: widget.child,
+            imeClientFactory: () => _imeClient,
+            imeConfiguration: _textInputConfiguration,
+            child: SoftwareKeyboardOpener(
+              controller: widget.softwareKeyboardController,
+              imeConnection: _imeConnection,
+              createImeClient: () => _documentImeClient,
+              createImeConfiguration: () => _textInputConfiguration,
+              child: DocumentToImeSynchronizer(
+                document: widget.editContext.editor.document,
+                selection: widget.editContext.composer.selectionNotifier,
+                composingRegion: widget.editContext.composer.composingRegion,
+                imeConnection: _documentImeConnection,
+                child: widget.child,
+              ),
             ),
           ),
         ),

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_editor/src/default_editor/debug_visualization.dart';
 import 'package:super_editor/src/default_editor/document_gestures_touch_android.dart';
 import 'package:super_editor/src/default_editor/document_gestures_touch_ios.dart';
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
@@ -487,20 +488,23 @@ class SuperEditorState extends State<SuperEditor> {
 
   @override
   Widget build(BuildContext context) {
-    return EditorSelectionAndFocusPolicy(
+    return SuperEditorFocusDebugVisuals(
       focusNode: _focusNode,
-      selection: _composer.selectionNotifier,
-      getDocumentLayout: () => editContext.documentLayout,
-      placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
-      restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,
-      clearSelectionWhenEditorLosesFocus: widget.selectionPolicies.clearSelectionWhenEditorLosesFocus,
-      child: _buildInputSystem(
-        child: _buildGestureSystem(
-          documentLayout: SingleColumnDocumentLayout(
-            key: _docLayoutKey,
-            presenter: _docLayoutPresenter!,
-            componentBuilders: widget.componentBuilders,
-            showDebugPaint: widget.debugPaint.layout,
+      child: EditorSelectionAndFocusPolicy(
+        focusNode: _focusNode,
+        selection: _composer.selectionNotifier,
+        getDocumentLayout: () => editContext.documentLayout,
+        placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
+        restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,
+        clearSelectionWhenEditorLosesFocus: widget.selectionPolicies.clearSelectionWhenEditorLosesFocus,
+        child: _buildInputSystem(
+          child: _buildGestureSystem(
+            documentLayout: SingleColumnDocumentLayout(
+              key: _docLayoutKey,
+              presenter: _docLayoutPresenter!,
+              componentBuilders: widget.componentBuilders,
+              showDebugPaint: widget.debugPaint.layout,
+            ),
           ),
         ),
       ),

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -19,6 +19,7 @@ export 'src/default_editor/attributions.dart';
 export 'src/default_editor/blockquote.dart';
 export 'src/default_editor/box_component.dart';
 export 'src/default_editor/common_editor_operations.dart';
+export 'src/default_editor/debug_visualization.dart';
 export 'src/default_editor/document_caret_overlay.dart';
 export 'src/default_editor/document_focus_and_selection_policies.dart';
 export 'src/infrastructure/document_gestures.dart';


### PR DESCRIPTION
Added focus and IME debug visuals to Super Editor (Resolves #942)

Focus is visualized with a colored border. Green for primary, red for non-primary, and gray for no focus.

IME is visualized with a little billboard at the top center. Could be "ATTACHED TO IME", "DETACHED FROM IME", or "NO IME CONNECTION".


https://user-images.githubusercontent.com/7259036/212573356-45f3d0f2-aa1c-4e62-9b90-cff3e5b06a61.mov

