### PR TITLE
Re-connect IME client to the IME overrides in SuperEditorImeInteractor when connection re-opens (Resolves #946)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
@@ -283,7 +283,7 @@ class _DocumentSelectionOpenAndCloseImePolicyState extends State<DocumentSelecti
       return;
     }
 
-    if (widget.selection.value != null && widget.openKeyboardOnSelectionChange) {
+    if (widget.selection.value != null && widget.focusNode.hasPrimaryFocus && widget.openKeyboardOnSelectionChange) {
       // There's a new document selection, and our policy wants the keyboard to be
       // displayed whenever the selection changes. Show the keyboard.
       if (widget.imeConnection.value == null || !widget.imeConnection.value!.attached) {


### PR DESCRIPTION
Re-connect IME client to the IME overrides in SuperEditorImeInteractor when connection re-opens (Resolves #946)

This PR also adds `hasPrimaryFocus` as a condition to the automatic IME connection when selection changes.