### PR TITLE
Fixed fast-typing IME errors by re-combining responsibilities for both applying deltas and serializing the document for IME (Resolves #914) (#950)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -26,7 +26,7 @@ class TextDeltasDocumentEditor {
   void applyDeltas(List<TextEditingDelta> textEditingDeltas) {
     editorImeLog.info("Applying ${textEditingDeltas.length} IME deltas to document");
 
-    editorImeLog.fine("Serializing document to perform IME operation");
+    editorImeLog.fine("Serializing document to perform IME operations");
     final serializedDocBeforeDelta = DocumentImeSerializer(
       editor.document,
       selection.value!,
@@ -35,6 +35,7 @@ class TextDeltasDocumentEditor {
 
     // Apply deltas to the document.
     for (final delta in textEditingDeltas) {
+      editorImeLog.info("---------------------------------------------------");
       editorImeLog.info("Applying delta: $delta");
       if (delta is TextEditingDeltaInsertion) {
         _applyInsertion(delta, serializedDocBeforeDelta);
@@ -47,6 +48,7 @@ class TextDeltasDocumentEditor {
       } else {
         editorImeLog.shout("Unknown IME delta type: ${delta.runtimeType}");
       }
+      editorImeLog.info("---------------------------------------------------");
     }
 
     // Update the editor's IME composing region based on the composing region

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -142,7 +142,7 @@ class DocumentImeSerializer {
         // for an empty document selection.
         editorImeLog.fine("The IME only selected invisible characters. Returning a null document selection.");
         return null;
-      } else {
+      } else if (imeSelection.start < _prependedPlaceholder.length){
         // The IME is trying to select some invisible characters and some real
         // characters. Remove the invisible characters from the IME selection before
         // converting it to a document selection.
@@ -152,9 +152,11 @@ class DocumentImeSerializer {
           extentOffset: max(imeSelection.extentOffset, _prependedPlaceholder.length),
         );
         editorImeLog.fine("Adjusted IME selection is: $imeSelection");
+      } else {
+        editorImeLog.fine("The IME only selected visible characters. No adjustment necessary.");
       }
     } else {
-      editorImeLog.fine("The IME only selected visible characters. No adjustment necessary.");
+      editorImeLog.fine("The serialization doesn't have any invisible characters. No adjustment necessary.");
     }
 
     return DocumentSelection(

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -139,6 +139,8 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       commonOps: widget.editContext.commonOps,
     );
     _documentImeClient = DocumentImeInputClient(
+      selection: widget.editContext.composer.selectionNotifier,
+      composingRegion: widget.editContext.composer.composingRegion,
       textDeltasDocumentEditor: _textDeltasDocumentEditor,
       imeConnection: _imeConnection,
       floatingCursorController: widget.floatingCursorController,
@@ -176,6 +178,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
 
     widget.imeOverrides?.client = null;
     _imeClient.client = null;
+    _documentImeClient.dispose();
 
     if (widget.focusNode == null) {
       _focusNode.dispose();
@@ -238,13 +241,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
               imeConnection: _imeConnection,
               createImeClient: () => _documentImeClient,
               createImeConfiguration: () => _textInputConfiguration,
-              child: DocumentToImeSynchronizer(
-                document: widget.editContext.editor.document,
-                selection: widget.editContext.composer.selectionNotifier,
-                composingRegion: widget.editContext.composer.composingRegion,
-                imeConnection: _documentImeConnection,
-                child: widget.child,
-              ),
+              child: widget.child,
             ),
           ),
         ),


### PR DESCRIPTION
Cherry Pick: Fixed fast-typing IME errors by re-combining responsibilities for both applying deltas and serializing the document for IME (Resolves #914) (#950)