### PR TITLE
Reset our cached IME TextEditingValues when the IME connection re-opens (Resolves #954) (#955)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -74,6 +74,11 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
     client = imeConnection.value;
 
     if (attached) {
+      // This is a new IME connection for us. As far as we're concerned, there is no current
+      // IME value.
+      _currentTextEditingValue = const TextEditingValue();
+      _platformTextEditingValue = const TextEditingValue();
+
       _sendDocumentToIme();
     }
   }
@@ -99,6 +104,9 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       return;
     }
 
+    editorImeLog.fine("Wants to send a value to IME: $newValue");
+    editorImeLog.fine("The current local IME value: $_currentTextEditingValue");
+    editorImeLog.fine("The current platform IME value: $_currentTextEditingValue");
     if (newValue != _platformTextEditingValue) {
       // We've been given a new IME value. We compare its value to _platformTextEditingValue
       // instead of _currentTextEditingValue. Why is that?
@@ -195,12 +203,14 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
 
   void _sendDocumentToIme() {
     if (_isApplyingDeltas) {
-      editorImeLog.fine("[DocumentImeInputClient] - Tried to send document to IME, but we're applying deltas. Fizzling.");
+      editorImeLog
+          .fine("[DocumentImeInputClient] - Tried to send document to IME, but we're applying deltas. Fizzling.");
       return;
     }
 
     if (_isSendingToIme) {
-      editorImeLog.warning("[DocumentImeInputClient] - Tried to send document to IME, while we're sending document to IME.");
+      editorImeLog
+          .warning("[DocumentImeInputClient] - Tried to send document to IME, while we're sending document to IME.");
       return;
     }
     _isSendingToIme = true;

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -12,7 +12,78 @@ import '../_document_test_tools.dart';
 
 void main() {
   group('IME input', () {
-    testWidgets('allows apps to handle performAction in their own way', (tester) async {
+    group('types characters', () {
+      testWidgetsOnAllPlatforms('at the beginning of existing text', (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText(text: "<- text here")),
+          ],
+        );
+
+        await tester //
+            .createDocument()
+            .withCustomContent(document)
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place caret at the beginning of the paragraph content.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type some text.
+        await tester.typeImeText("Hello");
+
+        // Ensure the text was typed.
+        expect((document.nodes.first as ParagraphNode).text.text, "Hello<- text here");
+      });
+
+      testWidgetsOnAllPlatforms('in the middle of existing text', (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText(text: "text here -><---")),
+          ],
+        );
+
+        await tester //
+            .createDocument()
+            .withCustomContent(document)
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place caret at the beginning of the paragraph content.
+        await tester.placeCaretInParagraph("1", 12);
+
+        // Type some text.
+        await tester.typeImeText("Hello");
+
+        // Ensure the text was typed.
+        expect((document.nodes.first as ParagraphNode).text.text, "text here ->Hello<---");
+      });
+
+      testWidgetsOnAllPlatforms('at the end of existing text', (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText(text: "text here ->")),
+          ],
+        );
+
+        await tester //
+            .createDocument()
+            .withCustomContent(document)
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place caret at the beginning of the paragraph content.
+        await tester.placeCaretInParagraph("1", 12);
+
+        // Type some text.
+        await tester.typeImeText("Hello");
+
+        // Ensure the text was typed.
+        expect((document.nodes.first as ParagraphNode).text.text, "text here ->Hello");
+      });
+    });
+
+    testWidgetsOnAllPlatforms('allows apps to handle performAction in their own way', (tester) async {
       final document = singleParagraphEmptyDoc();
 
       int performActionCount = 0;
@@ -26,7 +97,7 @@ void main() {
 
       await tester //
           .createDocument()
-          .withSingleEmptyParagraph()
+          .withCustomContent(document)
           .withInputSource(TextInputSource.ime)
           .withImeOverrides(imeOverrides)
           .pump();


### PR DESCRIPTION
Cherry pick: Reset our cached IME TextEditingValues when the IME connection re-opens (Resolves #954) (#955)