### PR TITLE
SuperTextField: Don't change selection with two-finger trackpad movement (Resolves #964)

### DIFF
--- a/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
+++ b/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
@@ -82,7 +82,7 @@ class _EditorSelectionAndFocusPolicyState extends State<EditorSelectionAndFocusP
     }
 
     if (widget.selection != oldWidget.selection) {
-      oldWidget.selection.removeListener(_onFocusChange);
+      oldWidget.selection.removeListener(_onSelectionChange);
       widget.selection.addListener(_onSelectionChange);
       _onSelectionChange();
     }

--- a/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/desktop/desktop_textfield.dart
@@ -797,7 +797,9 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
               },
             ),
             PanGestureRecognizer: GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-              () => PanGestureRecognizer(),
+              () => PanGestureRecognizer(
+                supportedDevices: {PointerDeviceKind.mouse},
+              ),
               (PanGestureRecognizer recognizer) {
                 recognizer
                   ..onStart = _onPanStart

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -207,7 +207,11 @@ extension SuperTextFieldRobot on WidgetTester {
     final globalStartDragOffset = adjustedStartOffset + textFieldBox.localToGlobal(Offset.zero);
     final globalEndDragOffset = adjustedEndOffset + textFieldBox.localToGlobal(Offset.zero);
 
-    await dragFrom(globalStartDragOffset, globalEndDragOffset - globalStartDragOffset);
+    await dragFrom(
+      globalStartDragOffset,
+      globalEndDragOffset - globalStartDragOffset,
+      kind: PointerDeviceKind.mouse,
+    );
 
     return true;
   }


### PR DESCRIPTION
SuperTextField: Don't change selection with two-finger trackpad movement (Resolves #964)

Also includes a one-line fix for an unrelated mistake.