### PR TITLE
[SuperEditor][SuperTextField] Avoid handling non-text deltas in the same frame we set the editing state (Resolves #930, #971, #970)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -188,6 +188,12 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       editorImeLog.fine("$delta");
     }
 
+    // After we call setEditingState(), we ignore non-text deltas until the end of the current frame.
+    //
+    // This is because, in some platforms, we get a TextEditingDeltaNonTextUpdate after this call.
+    // The engine sends this delta to synchronize the editing value.
+    //
+    // Handling this synchronization delta may cause endless loops.
     final allowedDeltas = _allowNonTextDeltas
         ? textEditingDeltas
         : textEditingDeltas.where((e) => e is! TextEditingDeltaNonTextUpdate).toList();
@@ -233,7 +239,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       return;
     }
 
-    // In some platforms, like macOS, whenever we call setEditing state, the engine send us back a
+    // In some platforms, like macOS, whenever we call setEditingState(), the engine send us back a
     // non-text delta to sync its state with our state.
     //
     // We have no way to know if the delta means that the selection/composing region changed,

--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -166,7 +166,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
     // Apply the deltas to the previous platform-side IME value, to find out
     // what the platform thinks the IME value is, right now.
     for (final delta in textEditingDeltas) {
-      delta.apply(_platformTextEditingValue);
+      _platformTextEditingValue = delta.apply(_platformTextEditingValue);
     }
   }
 

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -211,7 +211,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       return;
     }
 
-    // In some platforms, like macOS, whenever we call setEditing state, the engine send us back a
+    // In some platforms, like macOS, whenever we call setEditingState(), the engine send us back a
     // non-text delta to sync its state with our state.
     //
     // We have no way to know if the delta means that the selection/composing region changed,
@@ -263,6 +263,12 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       return;
     }
 
+    // After we call setEditingState(), we ignore non-text deltas until the end of the current frame.
+    //
+    // This is because, in some platforms, we get a TextEditingDeltaNonTextUpdate after this call.
+    // The engine sends this delta to synchronize the editing value.
+    //
+    // Handling this synchronization delta may cause endless loops.
     final allowedDeltas =
         _allowNonTextDeltas ? deltas : deltas.where((e) => e is! TextEditingDeltaNonTextUpdate).toList();
     if (allowedDeltas.isEmpty) {


### PR DESCRIPTION
[SuperEditor][SuperTextField] Avoid handling non-text deltas in the same frame we set the editing state. Resolves #930,  #971, #970.

In some platforms, like macOS, whenever we call `setEditingState`, the engine sends us back a `TextEditingDeltaNonTextUpdate` to sync its state. We are always handling `TextEditingDeltaNonTextUpdate`s to change our selection, so this behavior causes various problems related to the selection, including some infinite loops.

We have no way to know if the `TextEditingDeltaNonTextUpdate` means that the selection/composing region changed, or if it means that the engine is trying to sync its state. I filed https://github.com/flutter/flutter/issues/118759 to track this.

This PR changes the IME code of both SuperEditor and SuperTextField to avoid handling `TextEditingDeltaNonTextUpdate` in the same frame we call `setEditingState`. By doing this we avoid selection bugs and the software keyboard gestures (swipe keyboard to change the selection, etc...) still work.

I also found a bug in `_updatePlatformImeValueWithDeltas` which caused the issue mentioned in #970 

