### PR TITLE
Cherry-pick "[SuperEditor][SuperTextField] Avoid handling non-text deltas in the same frame we set the editing state (Resolves #930, #971, #970) (#974)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -62,6 +62,9 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   // TODO: get floating cursor out of here. Use a multi-client IME decorator to split responsibilities
   late FloatingCursorController? _floatingCursorController;
 
+  /// Whether we should handle [TextEditingDeltaNonTextUpdate]s.
+  bool _allowNonTextDeltas = true;
+
   void _onContentChange() {
     if (!attached) {
       return;
@@ -163,7 +166,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
     // Apply the deltas to the previous platform-side IME value, to find out
     // what the platform thinks the IME value is, right now.
     for (final delta in textEditingDeltas) {
-      delta.apply(_platformTextEditingValue);
+      _platformTextEditingValue = delta.apply(_platformTextEditingValue);
     }
   }
 
@@ -185,16 +188,29 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       editorImeLog.fine("$delta");
     }
 
+    // After we call setEditingState(), we ignore non-text deltas until the end of the current frame.
+    //
+    // This is because, in some platforms, we get a TextEditingDeltaNonTextUpdate after this call.
+    // The engine sends this delta to synchronize the editing value.
+    //
+    // Handling this synchronization delta may cause endless loops.
+    final allowedDeltas = _allowNonTextDeltas
+        ? textEditingDeltas
+        : textEditingDeltas.where((e) => e is! TextEditingDeltaNonTextUpdate).toList();
+    if (allowedDeltas.isEmpty) {
+      return;
+    }
+
     final imeValueBeforeChange = currentTextEditingValue;
     editorImeLog.fine("IME value before applying deltas: $imeValueBeforeChange");
 
     _isApplyingDeltas = true;
     editorImeLog.fine("===================================================");
     // Update our local knowledge of what the platform thinks the IME value is right now.
-    _updatePlatformImeValueWithDeltas(textEditingDeltas);
+    _updatePlatformImeValueWithDeltas(allowedDeltas);
 
     // Apply the deltas to our document, selection, and composing region.
-    textDeltasDocumentEditor.applyDeltas(textEditingDeltas);
+    textDeltasDocumentEditor.applyDeltas(allowedDeltas);
     editorImeLog.fine("===================================================");
     _isApplyingDeltas = false;
 
@@ -222,6 +238,21 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       editorImeLog.fine("[DocumentImeInputClient] - There's no document selection. Not sending anything to IME.");
       return;
     }
+
+    // In some platforms, like macOS, whenever we call setEditingState(), the engine send us back a
+    // non-text delta to sync its state with our state.
+    //
+    // We have no way to know if the delta means that the selection/composing region changed,
+    // or if it means that the engine is syncing its state.
+    //
+    // If we always handle the non-text deltas, we might end up in an endless loop of deltas.
+    // To avoid this, we don't handle any non-text deltas until the next frame, after we call setEditingState.
+    //
+    // Remove this as soon as https://github.com/flutter/flutter/issues/118759 is resolved.
+    _allowNonTextDeltas = false;
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      _allowNonTextDeltas = true;
+    });
 
     _isSendingToIme = true;
     editorImeLog.fine("[DocumentImeInputClient] - Serializing and sending document and selection to IME");

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -2,6 +2,7 @@ import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document_layout.dart';
+import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/super_textfield/super_textfield.dart';
 import 'package:super_text_layout/super_text_layout.dart';
@@ -178,6 +179,9 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
   // to the platform as changes. This flag differentiates between the two situations.
   bool _sendTextChangesToPlatform = true;
 
+  /// Whether we should handle [TextEditingDeltaNonTextUpdate]s.
+  bool _allowNonTextDeltas = true;
+
   void _onInnerControllerChange() {
     if (_sendTextChangesToPlatform) {
       _sendEditingValueToPlatform();
@@ -203,11 +207,28 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
   }
 
   void _sendEditingValueToPlatform() {
-    if (isAttachedToIme) {
-      _log.fine('Sending TextEditingValue to platform: $currentTextEditingValue');
-      _latestPlatformTextEditingValue = currentTextEditingValue;
-      _inputConnection!.setEditingState(currentTextEditingValue!);
+    if (!isAttachedToIme) {
+      return;
     }
+
+    // In some platforms, like macOS, whenever we call setEditingState(), the engine send us back a
+    // non-text delta to sync its state with our state.
+    //
+    // We have no way to know if the delta means that the selection/composing region changed,
+    // or if it means that the engine is syncing its state.
+    //
+    // If we always handle the non-text deltas, we might end up in an endless loop of deltas.
+    // To avoid this, we don't handle any non-text deltas until the next frame, after we call setEditingState.
+    //
+    // Remove this as soon as https://github.com/flutter/flutter/issues/118759 is resolved.
+    _allowNonTextDeltas = false;
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      _allowNonTextDeltas = true;
+    });
+
+    _log.fine('Sending TextEditingValue to platform: $currentTextEditingValue');
+    _latestPlatformTextEditingValue = currentTextEditingValue;
+    _inputConnection!.setEditingState(currentTextEditingValue!);
   }
 
   void Function(TextInputAction)? _onPerformActionPressed;
@@ -242,11 +263,23 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       return;
     }
 
+    // After we call setEditingState(), we ignore non-text deltas until the end of the current frame.
+    //
+    // This is because, in some platforms, we get a TextEditingDeltaNonTextUpdate after this call.
+    // The engine sends this delta to synchronize the editing value.
+    //
+    // Handling this synchronization delta may cause endless loops.
+    final allowedDeltas =
+        _allowNonTextDeltas ? deltas : deltas.where((e) => e is! TextEditingDeltaNonTextUpdate).toList();
+    if (allowedDeltas.isEmpty) {
+      return;
+    }
+
     // Prevent us from sending these changes back to the platform as we alter
     // the _realController. Turn this flag back to `true` after the changes.
     _sendTextChangesToPlatform = false;
 
-    for (final delta in deltas) {
+    for (final delta in allowedDeltas) {
       if (delta is TextEditingDeltaInsertion) {
         _log.fine('Processing insertion: $delta');
         if (selection.isCollapsed && delta.insertionOffset == selection.extentOffset) {


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor][SuperTextField] Avoid handling non-text deltas in the same frame we set the editing state (Resolves #930, #971, #970) (#974)" to stable