### PR TITLE
[SuperTextField] Add ability to update keyboard appearance (Resolves #991)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -56,7 +56,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
   /// The appearance of the software keyboard.
   ///
   /// Only used for iOS devices.
-  final Brightness keyboardAppearance;
+  Brightness keyboardAppearance;
 
   final AttributedTextEditingController _realController;
 
@@ -122,11 +122,14 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     bool enableSuggestions = true,
     TextInputAction textInputAction = TextInputAction.done,
     TextInputType textInputType = TextInputType.text,
+    Brightness keyboardAppearance = Brightness.light,
   }) {
     if (!isAttachedToIme) {
       // We're not attached to the IME, so there is nothing to update.
       return;
     }
+
+    this.keyboardAppearance = keyboardAppearance;
 
     // Close the current connection.
     _inputConnection?.close();

--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -35,12 +35,13 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     AttributedTextEditingController? controller,
     bool disposeClientController = true,
     void Function(RawFloatingCursorPoint)? onIOSFloatingCursorChange,
-    this.keyboardAppearance = Brightness.light,
+    Brightness keyboardAppearance = Brightness.light,
     TextInputConnectionFactory? inputConnectionFactory,
   })  : _realController = controller ?? AttributedTextEditingController(),
         _disposeClientController = disposeClientController,
         _inputConnectionFactory = inputConnectionFactory,
-        _onIOSFloatingCursorChange = onIOSFloatingCursorChange {
+        _onIOSFloatingCursorChange = onIOSFloatingCursorChange,
+        _keyboardAppearance = keyboardAppearance {
     _realController.addListener(_onInnerControllerChange);
   }
 
@@ -56,7 +57,8 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
   /// The appearance of the software keyboard.
   ///
   /// Only used for iOS devices.
-  Brightness keyboardAppearance;
+  Brightness get keyboardAppearance => _keyboardAppearance;
+  Brightness _keyboardAppearance;
 
   final AttributedTextEditingController _realController;
 
@@ -129,7 +131,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       return;
     }
 
-    this.keyboardAppearance = keyboardAppearance;
+    _keyboardAppearance = keyboardAppearance;
 
     // Close the current connection.
     _inputConnection?.close();

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/super_editor_test.dart';
 import 'package:super_editor_markdown/super_editor_markdown.dart';
 import 'package:text_table/text_table.dart';
 
+import '../test_tools.dart';
 import 'test_documents.dart';
 
 /// Extensions on [WidgetTester] that configure and pump [SuperEditor]
@@ -625,33 +626,5 @@ extension TestMessageInterceptor on WidgetTester {
     });
 
     return handler;
-  }
-}
-
-/// A method to handle plaftorm method calls.
-typedef PlatformMethodHandler = Future<ByteData?>? Function(MethodCall methodCall);
-
-/// Configures handlers to intercept platform method calls.
-///
-/// Use [interceptMethod] to configure a handler for a method.
-class PlatformMessageHandler {
-  final _handlers = <String, PlatformMethodHandler>{};
-
-  /// Configures a [handler] to a [method].
-  PlatformMessageHandler interceptMethod(String method, PlatformMethodHandler handler) {
-    _handlers[method] = handler;
-    return this;
-  }
-
-  /// Decodes platform messages and dispatches to the configured handlers.
-  Future<ByteData?>? handleMessage(ByteData? message) async {
-    final methodCall = const JSONMethodCodec().decodeMethodCall(message);
-    final handler = _handlers[methodCall.method];
-
-    if (handler == null) {
-      return null;
-    }
-
-    return await handler(methodCall);
   }
 }

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -1,7 +1,9 @@
 import 'dart:math';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
@@ -609,5 +611,47 @@ class FakeImageComponentBuilder implements ComponentBuilder {
         width: size.width,
       ),
     );
+  }
+}
+
+/// Extension on [WidgetTester] to easily intercept platform messages.
+extension TestMessageInterceptor on WidgetTester {
+  /// Creates a handler to intercept messages of the given [channel].
+  PlatformMessageHandler interceptChannel(String channel) {
+    final handler = PlatformMessageHandler();
+
+    binding.defaultBinaryMessenger.setMockMessageHandler(channel, (message) async {
+      return await handler.handleMessage(message);
+    });
+
+    return handler;
+  }
+}
+
+/// A method to handle plaftorm method calls.
+typedef PlatformMethodHandler = Future<ByteData?>? Function(MethodCall methodCall);
+
+/// Configures handlers to intercept platform method calls.
+///
+/// Use [interceptMethod] to configure a handler for a method.
+class PlatformMessageHandler {
+  final _handlers = <String, PlatformMethodHandler>{};
+
+  /// Configures a [handler] to a [method].
+  PlatformMessageHandler interceptMethod(String method, PlatformMethodHandler handler) {
+    _handlers[method] = handler;
+    return this;
+  }
+
+  /// Decodes platform messages and dispatches to the configured handlers.
+  Future<ByteData?>? handleMessage(ByteData? message) async {
+    final methodCall = const JSONMethodCodec().decodeMethodCall(message);
+    final handler = _handlers[methodCall.method];
+
+    if (handler == null) {
+      return null;
+    }
+
+    return await handler(methodCall);
   }
 }

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -614,17 +614,3 @@ class FakeImageComponentBuilder implements ComponentBuilder {
     );
   }
 }
-
-/// Extension on [WidgetTester] to easily intercept platform messages.
-extension TestMessageInterceptor on WidgetTester {
-  /// Creates a handler to intercept messages of the given [channel].
-  PlatformMessageHandler interceptChannel(String channel) {
-    final handler = PlatformMessageHandler();
-
-    binding.defaultBinaryMessenger.setMockMessageHandler(channel, (message) async {
-      return await handler.handleMessage(message);
-    });
-
-    return handler;
-  }
-}

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -1,16 +1,13 @@
 import 'dart:math';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 import 'package:super_editor_markdown/super_editor_markdown.dart';
 import 'package:text_table/text_table.dart';
 
-import '../test_tools.dart';
 import 'test_documents.dart';
 
 /// Extensions on [WidgetTester] that configure and pump [SuperEditor]

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -200,6 +200,46 @@ void main() {
         // Ensure the given keyboardAppearance was applied.
         expect(keyboardAppearance, 'Brightness.dark');
       });
+
+      testWidgetsOnIos('updates keyboard appearance', (tester) async {
+        final controller = ImeAttributedTextEditingController(
+          keyboardAppearance: Brightness.light,
+        );
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              textController: controller,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap the text field to show the software keyboard with the light appearance.
+        await tester.placeCaretInSuperTextField(0);
+
+        // Holds the keyboard appearance sent to the platform.
+        String? keyboardAppearance;
+
+        // Intercept messages sent to the platform.
+        tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) async {
+          final methodCall = const JSONMethodCodec().decodeMethodCall(message);
+          if (methodCall.method == 'TextInput.setClient') {
+            final params = methodCall.arguments[1] as Map;
+            keyboardAppearance = params['keyboardAppearance'];
+          }
+          return null;
+        });
+
+        // Change the keyboard appearance from light to dark.
+        controller.updateTextInputConfiguration(
+          keyboardAppearance: Brightness.dark,
+        );
+        await tester.pumpAndSettle();
+
+        // Ensure the given keyboardAppearance was applied.
+        expect(keyboardAppearance, 'Brightness.dark');
+      });
     });
 
     group("selection", () {

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -216,9 +216,6 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // Tap the text field to show the software keyboard with the light appearance.
-        await tester.placeCaretInSuperTextField(0);
-
         // Holds the keyboard appearance sent to the platform.
         String? keyboardAppearance;
 
@@ -234,11 +231,17 @@ void main() {
           },
         );
 
+        // Tap the text field to show the software keyboard with the light appearance.
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure the initial keyboardAppearance was applied.
+        expect(keyboardAppearance, 'Brightness.light');
+
         // Change the keyboard appearance from light to dark.
         controller.updateTextInputConfiguration(
           keyboardAppearance: Brightness.dark,
         );
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         // Ensure the given keyboardAppearance was applied.
         expect(keyboardAppearance, 'Brightness.dark');

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import '../super_editor/document_test_tools.dart';
 import '../test_tools.dart';
 import 'super_textfield_robot.dart';
 
@@ -221,15 +222,17 @@ void main() {
         // Holds the keyboard appearance sent to the platform.
         String? keyboardAppearance;
 
-        // Intercept messages sent to the platform.
-        tester.binding.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.textInput.name, (message) async {
-          final methodCall = const JSONMethodCodec().decodeMethodCall(message);
-          if (methodCall.method == 'TextInput.setClient') {
+        // Intercept the setClient message sent to the platform.
+        tester
+            .interceptChannel(SystemChannels.textInput.name) //
+            .interceptMethod(
+          'TextInput.setClient',
+          (methodCall) {
             final params = methodCall.arguments[1] as Map;
             keyboardAppearance = params['keyboardAppearance'];
-          }
-          return null;
-        });
+            return null;
+          },
+        );
 
         // Change the keyboard appearance from light to dark.
         controller.updateTextInputConfiguration(

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
-import '../super_editor/document_test_tools.dart';
 import '../test_tools.dart';
 import 'super_textfield_robot.dart';
 

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -316,6 +316,20 @@ void testWidgetsOnIos(
   }, skip: skip);
 }
 
+/// Extension on [WidgetTester] to easily intercept platform messages.
+extension TestMessageInterceptor on WidgetTester {
+  /// Creates a handler to intercept messages of the given [channel].
+  PlatformMessageHandler interceptChannel(String channel) {
+    final handler = PlatformMessageHandler();
+
+    binding.defaultBinaryMessenger.setMockMessageHandler(channel, (message) async {
+      return await handler.handleMessage(message);
+    });
+
+    return handler;
+  }
+}
+
 /// A method to handle plaftorm method calls.
 typedef PlatformMethodHandler = Future<ByteData?>? Function(MethodCall methodCall);
 


### PR DESCRIPTION
[SuperTextField] Add ability to update keyboard appearance. Resolves #991

Currently, it isn't possible to update the keyboard appearance after the `ImeAttributedTextEditingController` creation.

This PR adds the ability of changing the `keyboardAppearance` in the `updateTextInputConfiguration` method. 

We could also change the  `updateTextInputConfiguration` parameters to be nullable and use the previous values for the parameters that were not passed.

This PR also introduces a proposed class to facilitate intercepting platform messages.