### PR TITLE
[super_editor_markdown] Add justify alignment for markdown serialization (Resolves #879)

### DIFF
--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -192,6 +192,8 @@ String? _convertAlignmentToMarkdown(String alignment) {
       return ':---:';
     case 'right':
       return '---:';
+    case 'justify':
+      return '----';
     default:
       return null;
   }

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -193,7 +193,7 @@ String? _convertAlignmentToMarkdown(String alignment) {
     case 'right':
       return '---:';
     case 'justify':
-      return '----';
+      return '-::-';
     default:
       return null;
   }

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -446,8 +446,8 @@ class UnderlineSyntax extends md.TagSyntax {
 class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax {
   /// This pattern matches the text aligment notation.
   ///
-  /// Possible values are `:---`, `:---:` and `---:`
-  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:$');
+  /// Possible values are `:---`, `:---:`, `---:` and `----`.
+  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:|-{4}$');
 
   const _ParagraphWithAlignmentSyntax();
 
@@ -506,6 +506,8 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
         return 'center';
       case '---:':
         return 'right';
+      case '----':
+        return 'justify';
       // As we already check that the input matches the notation,
       // we shouldn't reach this point.
       default:

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -446,8 +446,8 @@ class UnderlineSyntax extends md.TagSyntax {
 class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax {
   /// This pattern matches the text aligment notation.
   ///
-  /// Possible values are `:---`, `:---:`, `---:` and `----`.
-  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:|-{4}$');
+  /// Possible values are `:---`, `:---:`, `---:` and `-::-`.
+  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:|-::-$');
 
   const _ParagraphWithAlignmentSyntax();
 
@@ -506,7 +506,7 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
         return 'center';
       case '---:':
         return 'right';
-      case '----':
+      case '-::-':
         return 'justify';
       // As we already check that the input matches the notation,
       // we shouldn't reach this point.

--- a/super_editor_markdown/lib/src/super_editor_syntax.dart
+++ b/super_editor_markdown/lib/src/super_editor_syntax.dart
@@ -14,5 +14,7 @@ enum MarkdownSyntax {
   /// `:---:` represents center alignment.
   ///
   /// `---:` represents right alignment.
+  ///
+  /// `----` represents justify alignment.
   superEditor,
 }

--- a/super_editor_markdown/lib/src/super_editor_syntax.dart
+++ b/super_editor_markdown/lib/src/super_editor_syntax.dart
@@ -15,6 +15,6 @@ enum MarkdownSyntax {
   ///
   /// `---:` represents right alignment.
   ///
-  /// `----` represents justify alignment.
+  /// `-::-` represents justify alignment.
   superEditor,
 }

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -401,6 +401,20 @@ This is some code
         expect(serializeDocumentToMarkdown(doc), '---:\nParagraph1');
       });
 
+      test('paragraph with justify alignment', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText(text: 'Paragraph1'),
+            metadata: {
+              'textAlign': 'justify',
+            },
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '----\nParagraph1');
+      });
+
       test("doesn't serialize text alignment when not using supereditor syntax", () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
@@ -993,6 +1007,14 @@ This is some code
 
         final paragraph = doc.nodes.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'right');
+        expect(paragraph.text.text, 'Paragraph1');
+      });
+
+      test('paragraph with justify alignment', () {
+        final doc = deserializeMarkdownToDocument('----\nParagraph1');
+
+        final paragraph = doc.nodes.first as ParagraphNode;
+        expect(paragraph.getMetadataValue('textAlign'), 'justify');
         expect(paragraph.text.text, 'Paragraph1');
       });
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -412,7 +412,7 @@ This is some code
           ),
         ]);
 
-        expect(serializeDocumentToMarkdown(doc), '----\nParagraph1');
+        expect(serializeDocumentToMarkdown(doc), '-::-\nParagraph1');
       });
 
       test("doesn't serialize text alignment when not using supereditor syntax", () {
@@ -1011,7 +1011,7 @@ This is some code
       });
 
       test('paragraph with justify alignment', () {
-        final doc = deserializeMarkdownToDocument('----\nParagraph1');
+        final doc = deserializeMarkdownToDocument('-::-\nParagraph1');
 
         final paragraph = doc.nodes.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'justify');
@@ -1135,7 +1135,7 @@ Paragraph4""";
         expect(doc.nodes.last, isA<ParagraphNode>());
         expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
       });
-    
+
       test('document ending with an empty paragraph', () {
         final doc = deserializeMarkdownToDocument("""
 First Paragraph.


### PR DESCRIPTION
[super_editor_markdown] Add justify alignment for markdown serialization. Resolves #879

Currently, SuperEditor supports left, right and center alignment when using `MarkdownSyntax.superEditor`.

This PR adds the `justify` alignment to super_editor_markdown. 

As there isn't a spec for a justify alignment token, this PR introduces the  `----` token.