### PR TITLE
[SuperEditor] Fix visual styles when combining a paragraph with an empty list item (Resolves #980)

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -222,7 +222,13 @@ class CombineParagraphsCommand implements EditorCommand {
     // Combine the text and delete the currently selected node.
     final isTopNodeEmpty = nodeAbove.text.text.isEmpty;
     nodeAbove.text = nodeAbove.text.copyAndAppend(secondNode.text);
-    if (isTopNodeEmpty) {
+
+    // Avoid overring the metadata when the nodeAbove isn't a ParagraphNode.
+    //
+    // If we are combining different kinds of nodes, e.g., a list item and a paragraph,
+    // overriding the metadata will cause the nodeAbove to end up with an incorrect blockType.
+    // This will cause incorrect styles to be applied.
+    if (isTopNodeEmpty && nodeAbove is ParagraphNode) {
       // If the top node was empty, we want to retain everything in the
       // bottom node, including the block attribution and styles.
       nodeAbove.metadata = secondNode.metadata;


### PR DESCRIPTION
[SuperEditor] Fix visual styles when combining a paragraph with an empty list item. Resolves #980 

When creating a document with an empty list item and a paragraph node, combining both nodes causes the list item to end up with an incorrect style.

The cause is that the `CombineParagraphsCommand`, when the first node is empty, overrides the node's metadata with the second node's metadata. Because of this, we end up with a `ListItemNode` which doesn't have the `listItem` `blocktype` metadata. This causes the editor to apply the paragraph style to the list item node.

This PR changes the `CombineParagraphsCommand` to avoid overriding the `metadata` if the node above isn't a `ParagraphNode`. I chose this approach because it's closer to what we have (we maintain the `ListItemNode`).  Another option is to just delete the node above if it's empty.

This PR is based on @jmatth's investigation.