### PR TITLE
[AttributedText] Move test dependency to dev_dependencies (Resolves #894, #986)

### DIFF
--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   collection: ^1.15.0
   logging: ^1.0.1
   meta: ^1.7.0
-  test: ^1.19.4
 
 dev_dependencies:
   flutter_lints: ^2.0.1
   mockito: ^5.0.4
+  test: ^1.19.4


### PR DESCRIPTION
[AttributedText] Move test dependency to dev_dependencies. Resolves #894, resolves #986

Depending on both `super_editor` and `build_runner` results in conflicting dependency versions.

This PR moves the dependency on the `test` package  from `dependencies` to `dev_dependencies`.
