### PR TITLE
[SuperEditor] Fix selection when the editor has autofocus (Resolves #883)

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -60,6 +60,8 @@ dependency_overrides:
     path: ../../super_editor_markdown
   super_text_layout:
     path: ../../super_text_layout
+  attributed_text:
+    path: ../../attributed_text
 
 
 dev_dependencies:

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -507,7 +507,7 @@ class SuperEditorState extends State<SuperEditor> {
       child: EditorSelectionAndFocusPolicy(
         focusNode: _focusNode,
         selection: _composer.selectionNotifier,
-        documentLayoutKey: _docLayoutKey,
+        isDocumentLayoutAvailable: () => _docLayoutKey.currentContext != null,
         getDocumentLayout: () => editContext.documentLayout,
         placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
         restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -507,6 +507,7 @@ class SuperEditorState extends State<SuperEditor> {
       child: EditorSelectionAndFocusPolicy(
         focusNode: _focusNode,
         selection: _composer.selectionNotifier,
+        documentLayoutKey: _docLayoutKey,
         getDocumentLayout: () => editContext.documentLayout,
         placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
         restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,


### PR DESCRIPTION
[SuperEditor] Fix selection when the editor has autofocus. Resolves #883

When the editor has `autofocus`, the selection isn't set and we get the following exception:

```
flutter: Initializing logger: ExampleApp

════════ Exception caught by foundation library ════════════════════════════════
The following NoSuchMethodError was thrown while dispatching notifications for FocusNode:
The method 'findLastSelectablePosition' was called on null.
Receiver: null
Tried calling: findLastSelectablePosition()

When the exception was thrown, this was the stack
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
#1      _EditorSelectionAndFocusPolicyState._onFocusChange
package:super_editor/…/default_editor/document_focus_and_selection_policies.dart:110
#2      ChangeNotifier.notifyListeners
package:flutter/…/foundation/change_notifier.dart:351
#3      FocusNode._notify
package:flutter/…/widgets/focus_manager.dart:1038
#4      FocusManager._applyFocusChange
package:flutter/…/widgets/focus_manager.dart:1804
(elided 2 frames from dart:async)
The FocusNode sending notification was: FocusNode#2c45c([PRIMARY FOCUS])
    context: Focus
    PRIMARY FOCUS
════════════════════════════════════════════════════════════════════════════════
```

The cause is that the focus change listener is called before we can access the document layout. We have tests to ensure the selection is set when the editor has `autofocus`, but this doesn't seem to happen during tests.

This PR changes `EditorSelectionAndFocusPolicy` to check if we can access the document layout before we try to find the last selectable position. 

Other possible solutions: 

1. Change `EditorSelectionAndFocusPolicy` to receive a function that returns a `bool` indicating if the document has been laid out, instead of a `GlobalKey` to the `DocumentLayout`.
2. Change `DocumentLayoutResolver` to return a nullable `DocumentLayout`. This approach might be the more appropriate one, but it will require changes in many places.

This PR also overrides the `attributed_text` dependency, because we have a method that isn't present yet in the pub.dev released version.