### PR TITLE
Change `DeltaTextInputClientDecorator` to mix in `DeltaTextInputClient`

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -67,7 +67,7 @@ abstract class TextInputConnectionDecorator implements TextInputConnection {
 /// Subclass [DeltaTextInputClientDecorator] to override specific
 /// [DeltaTextInputClient] messages. To add behavior, instead of replacing it,
 /// call the `super` method within an override.
-class DeltaTextInputClientDecorator implements DeltaTextInputClient {
+class DeltaTextInputClientDecorator with TextInputClient, DeltaTextInputClient {
   DeltaTextInputClientDecorator([this._client]);
 
   set client(DeltaTextInputClient? client) => _client = client;


### PR DESCRIPTION
Change `DeltaTextInputClientDecorator` to mix in `DeltaTextInputClient`

Flutter added a new method to `TextInputClient`. As `DeltaTextInputClientDecorator` is implementing `DeltaTextInputClient`, the CI is failing to build using the Flutter master branch.

The `DocumentImeInputClient` already uses the `with` keyword.

The added method was:

```dart
  /// Notify client about new content insertion from Android keyboard.
  void insertContent(KeyboardInsertedContent content) {}
```

The `KeyboardInsertedContent` dart doc is:

```dart
/// A class representing rich content (such as a PNG image) inserted via the
/// system input method.
///
/// The following data is represented in this class:
///  - MIME Type
///  - Bytes
///  - URI
```