### PR TITLE
Cherry-pick "[SuperEditor] Fix selection when the editor has autofocus (Resolves #883) (#1013)" to stable

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -59,6 +59,8 @@ dependency_overrides:
     path: ../../super_editor_markdown
   super_text_layout:
     path: ../../super_text_layout
+  attributed_text:
+    path: ../../attributed_text
 
 
 dev_dependencies:

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -507,6 +507,7 @@ class SuperEditorState extends State<SuperEditor> {
       child: EditorSelectionAndFocusPolicy(
         focusNode: _focusNode,
         selection: _composer.selectionNotifier,
+        isDocumentLayoutAvailable: () => _docLayoutKey.currentContext != null,
         getDocumentLayout: () => editContext.documentLayout,
         placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
         restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix selection when the editor has autofocus (Resolves #883) (#1013)" to stable.