### PR TITLE
[SuperEditor] Fix performAction override for TextInputAction.newline (Resolves #1012)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -23,7 +23,13 @@ class TextDeltasDocumentEditor {
   final ValueNotifier<DocumentRange?> composingRegion;
   final CommonEditorOperations commonOps;
 
-  /// Override the handling of a [TextInputAction]s.
+  /// Callback invoked when the client should handle a given [TextInputAction].
+  ///
+  /// Typically, [TextInputAction]s are reported through a different part of Flutter's IME
+  /// API. However, some actions, on some platforms, are converted into text editing
+  /// deltas, rather than reported as explicit actions. For example, on Android, the `newline`
+  /// action is reported as a text insertion with a `\n` character. That change is intercepted
+  /// by this editor and reported as a [TextInputAction.newline] instead.
   final void Function(TextInputAction action)? onPerformAction;
 
   /// Applies the given [textEditingDeltas] to the [Document].

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -15,7 +15,7 @@ class TextDeltasDocumentEditor {
     required this.selection,
     required this.composingRegion,
     required this.commonOps,
-    this.onPerformAction,
+    required this.onPerformAction,
   });
 
   final DocumentEditor editor;
@@ -30,7 +30,7 @@ class TextDeltasDocumentEditor {
   /// deltas, rather than reported as explicit actions. For example, on Android, the `newline`
   /// action is reported as a text insertion with a `\n` character. That change is intercepted
   /// by this editor and reported as a [TextInputAction.newline] instead.
-  final void Function(TextInputAction action)? onPerformAction;
+  final void Function(TextInputAction action) onPerformAction;
 
   /// Applies the given [textEditingDeltas] to the [Document].
   void applyDeltas(List<TextEditingDelta> textEditingDeltas) {
@@ -94,7 +94,7 @@ class TextDeltasDocumentEditor {
       // we forward the newline action to performAction.
       if (defaultTargetPlatform == TargetPlatform.android || kIsWeb) {
         editorImeLog.fine("Received a newline insertion on Android. Forwarding to newline input action.");
-        _dispatchTextInputAction(TextInputAction.newline);
+        onPerformAction(TextInputAction.newline);
       } else {
         editorImeLog.fine("Skipping insertion delta because its a newline");
       }
@@ -138,7 +138,7 @@ class TextDeltasDocumentEditor {
       // we forward the newline action to performAction.
       if (defaultTargetPlatform == TargetPlatform.android || kIsWeb) {
         editorImeLog.fine("Received a newline replacement on Android. Forwarding to newline input action.");
-        _dispatchTextInputAction(TextInputAction.newline);
+        onPerformAction(TextInputAction.newline);
       } else {
         editorImeLog.fine("Skipping replacement delta because its a newline");
       }
@@ -222,7 +222,7 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine('With text: "$replacementText"');
 
     if (replacementText == "\n") {
-      _dispatchTextInputAction(TextInputAction.newline);
+      onPerformAction(TextInputAction.newline);
       return;
     }
 
@@ -262,38 +262,10 @@ class TextDeltasDocumentEditor {
     commonOps.deleteSelection();
   }
 
-  void performAction(TextInputAction action) {
-    switch (action) {
-      case TextInputAction.newline:
-        if (!selection.value!.isCollapsed) {
-          commonOps.deleteSelection();
-        }
-        commonOps.insertBlockLevelNewline();
-        break;
-      case TextInputAction.none:
-        // no-op
-        break;
-      case TextInputAction.done:
-      case TextInputAction.go:
-      case TextInputAction.search:
-      case TextInputAction.send:
-      case TextInputAction.next:
-      case TextInputAction.previous:
-      case TextInputAction.continueAction:
-      case TextInputAction.join:
-      case TextInputAction.route:
-      case TextInputAction.emergencyCall:
-      case TextInputAction.unspecified:
-        editorImeLog.warning("User pressed unhandled action button: $action");
-        break;
+  void insertNewline() {
+    if (!selection.value!.isCollapsed) {
+      commonOps.deleteSelection();
     }
-  }
-
-  void _dispatchTextInputAction(TextInputAction action) {
-    if (onPerformAction != null) {
-      onPerformAction!(action);
-    } else {
-      performAction(action);
-    }
+    commonOps.insertBlockLevelNewline();
   }
 }

--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -278,16 +278,8 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   @override
   void performAction(TextInputAction action) {
     editorImeLog.fine("IME says to perform action: $action");
-    switch (action) {
-      case TextInputAction.newline:
-        textDeltasDocumentEditor.insertNewline();
-        break;
-      case TextInputAction.none:
-        // no-op
-        break;
-      default:
-        editorImeLog.warning("User pressed unhandled action button: $action");
-        break;
+    if (action == TextInputAction.newline) {
+      textDeltasDocumentEditor.insertNewline();
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -278,7 +278,17 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   @override
   void performAction(TextInputAction action) {
     editorImeLog.fine("IME says to perform action: $action");
-    textDeltasDocumentEditor.performAction(action);
+    switch (action) {
+      case TextInputAction.newline:
+        textDeltasDocumentEditor.insertNewline();
+        break;
+      case TextInputAction.none:
+        // no-op
+        break;
+      default:
+        editorImeLog.warning("User pressed unhandled action button: $action");
+        break;
+    }
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -131,7 +131,6 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   void initState() {
     super.initState();
     _focusNode = (widget.focusNode ?? FocusNode());
-    _imeClient = DeltaTextInputClientDecorator();
 
     _textDeltasDocumentEditor = TextDeltasDocumentEditor(
       editor: widget.editContext.editor,
@@ -148,6 +147,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       floatingCursorController: widget.floatingCursorController,
     );
 
+    _imeClient = DeltaTextInputClientDecorator();
     _configureImeClientDecorators();
 
     _imeConnection.addListener(_onImeConnectionChange);

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -131,12 +131,14 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   void initState() {
     super.initState();
     _focusNode = (widget.focusNode ?? FocusNode());
+    _imeClient = DeltaTextInputClientDecorator();
 
     _textDeltasDocumentEditor = TextDeltasDocumentEditor(
       editor: widget.editContext.editor,
       selection: widget.editContext.composer.selectionNotifier,
       composingRegion: widget.editContext.composer.composingRegion,
       commonOps: widget.editContext.commonOps,
+      onPerformAction: (action) => _imeClient.performAction(action),
     );
     _documentImeClient = DocumentImeInputClient(
       selection: widget.editContext.composer.selectionNotifier,
@@ -146,7 +148,6 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       floatingCursorController: widget.floatingCursorController,
     );
 
-    _imeClient = DeltaTextInputClientDecorator();
     _configureImeClientDecorators();
 
     _imeConnection.addListener(_onImeConnectionChange);

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -126,8 +126,7 @@ void main() {
       expect(document.nodes.length, 1);
     });
 
-    testWidgetsOnAndroid('allows apps to handle performAction in their own way upon new line insertion',
-        (tester) async {
+    testWidgetsOnAndroid('allows app to handle newline action', (tester) async {
       // On Android, when the user presses an action button configured as TextInputAction.newline,
       // instead of dispatching the action, the OS sends an insertion delta of '\n'.
       //

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -126,6 +126,47 @@ void main() {
       expect(document.nodes.length, 1);
     });
 
+    testWidgetsOnAndroid('allows apps to handle performAction in their own way upon new line insertion',
+        (tester) async {
+      // On Android, when the user presses an action button configured as TextInputAction.newline,
+      // instead of dispatching the action, the OS sends an insertion delta of '\n'.
+      //
+      // Then, the IME code that handles deltas translates this insertion into a performAction call.
+      // This test ensures that this performAction call honors the IME overrides.
+
+      final document = singleParagraphEmptyDoc();
+
+      int performActionCount = 0;
+      TextInputAction? performedAction;
+      final imeOverrides = _TestImeOverrides(
+        (action) {
+          performActionCount += 1;
+          performedAction = action;
+        },
+      );
+
+      await tester //
+          .createDocument()
+          .withCustomContent(document)
+          .withInputSource(TextInputSource.ime)
+          .withImeOverrides(imeOverrides)
+          .pump();
+
+      // Place the caret in the document so that we open an IME connection.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Simulate the user pressing an action button that generates an insertion of a new line.
+      await tester.typeImeText('\n');
+
+      // Ensure that our override got the performAction call.
+      expect(performActionCount, 1);
+      expect(performedAction, TextInputAction.newline);
+
+      // Ensure that the editor didn't receive the performAction call, and didn't
+      // insert a new node.
+      expect(document.nodes.length, 1);
+    });
+
     group('delta use-cases', () {
       test('can handle an auto-inserted period', () {
         // On iOS, adding 2 spaces causes the two spaces to be replaced by a

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -200,6 +200,7 @@ void main() {
           selection: composer.selectionNotifier,
           composingRegion: composer.composingRegion,
           commonOps: commonOps,
+          onPerformAction: (_) {},
         );
 
         softwareKeyboardHandler.applyDeltas([


### PR DESCRIPTION
[SuperEditor] Fix `performAction` override for `TextInputAction.newline`. Resolves #1012

When `SuperEditor` is configured to use `TextInputAction.newline`,  pressing the action button doesn't call `performAction` in the given `imeOverrides`. 

The cause is that, on Android, pressing an action button configured as `TextInputAction.newline` generates an insertion delta of `\n` instead of calling `performAction`. `TextDeltasDocumentEditor` translates the insertion into a `performAction` call. However, the call is handled inside `TextDeltasDocumentEditor` as it doesn't know about the overrides.

This PR changes `TextDeltasDocumentEditor` to accept a new property to override `performAction`.