### PR TITLE
[SuperEditor] Fix image insertion at the middle of a paragraph (Resolves #1018)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1815,7 +1815,17 @@ class CommonEditorOperations {
       return false;
     }
 
-    return _insertBlockLevelContent(ImageNode(id: DocumentEditor.createNodeId(), imageUrl: url));
+    final node = editor.document.getNodeById(composer.selection!.base.nodeId);
+    if (node is! ParagraphNode) {
+      return false;
+    }
+
+    // When the selected node is empty, we convert it to an ImageNode.
+    final nodeId = node.text.text.isEmpty //
+        ? composer.selection!.base.nodeId
+        : DocumentEditor.createNodeId();
+
+    return _insertBlockLevelContent(ImageNode(id: nodeId, imageUrl: url));
   }
 
   /// Inserts horizontal rule at the current selection extent.
@@ -1844,7 +1854,17 @@ class CommonEditorOperations {
       return false;
     }
 
-    return _insertBlockLevelContent(HorizontalRuleNode(id: DocumentEditor.createNodeId()));
+    final node = editor.document.getNodeById(composer.selection!.base.nodeId);
+    if (node is! ParagraphNode) {
+      return false;
+    }
+
+    // When the selected node is empty, we convert it to a HorizontalRuleNode.
+    final nodeId = node.text.text.isEmpty //
+        ? composer.selection!.base.nodeId
+        : DocumentEditor.createNodeId();
+
+    return _insertBlockLevelContent(HorizontalRuleNode(id: nodeId));
   }
 
   /// Inserts the given [blockNode] after the caret.

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1806,7 +1806,7 @@ class CommonEditorOperations {
   ///
   /// If the selection extent sits in any other kind of node, nothing happens.
   ///
-  /// Returns [true] if an image was inserted, [false] if it wasn't.
+  /// Returns `true` if an image was inserted, `false` if it wasn't.
   bool insertImage(String url) {
     if (composer.selection == null) {
       return false;
@@ -1815,8 +1815,7 @@ class CommonEditorOperations {
       return false;
     }
 
-    final nodeId = composer.selection!.base.nodeId;
-    return _insertBlockLevelContent(ImageNode(id: nodeId, imageUrl: url));
+    return _insertBlockLevelContent(ImageNode(id: DocumentEditor.createNodeId(), imageUrl: url));
   }
 
   /// Inserts horizontal rule at the current selection extent.
@@ -1845,8 +1844,7 @@ class CommonEditorOperations {
       return false;
     }
 
-    final nodeId = composer.selection!.base.nodeId;
-    return _insertBlockLevelContent(HorizontalRuleNode(id: nodeId));
+    return _insertBlockLevelContent(HorizontalRuleNode(id: DocumentEditor.createNodeId()));
   }
 
   /// Inserts the given [blockNode] after the caret.
@@ -1866,7 +1864,7 @@ class CommonEditorOperations {
   ///
   /// If the selection extent sits in any other kind of node, nothing happens.
   ///
-  /// Returns [true] if the [blockNode] was inserted, [false] if it wasn't.
+  /// Returns `true` if the [blockNode] was inserted, `false` if it wasn't.
   bool _insertBlockLevelContent(DocumentNode blockNode) {
     if (composer.selection == null) {
       return false;
@@ -1888,23 +1886,32 @@ class CommonEditorOperations {
 
         DocumentSelection newSelection;
         if (node.text.text.isEmpty) {
-          // Convert empty paragraph to block item.
-          transaction.replaceNode(oldNode: node, newNode: blockNode);
+          final emptyParagraph = ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText());
+
+          // Convert empty paragraph to block item and add an empty paragraph.
+          transaction
+            ..replaceNode(oldNode: node, newNode: blockNode)
+            ..insertNodeAfter(existingNode: blockNode, newNode: emptyParagraph);
 
           newSelection = DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: nodeId,
-              nodePosition: blockNode.endPosition,
+              nodeId: emptyParagraph.id,
+              nodePosition: emptyParagraph.beginningPosition,
             ),
           );
-        } else if (paragraphPosition == endOfParagraph) {
-          // Insert block item after the paragraph.
-          transaction.insertNodeAfter(existingNode: node, newNode: blockNode);
+        } else if (paragraphPosition.offset == endOfParagraph.offset) {
+          final emptyParagraph = ParagraphNode(id: DocumentEditor.createNodeId(), text: AttributedText());
 
+          // Insert block item after the paragraph and insert a new empty paragraph.
+          transaction
+            ..insertNodeAfter(existingNode: node, newNode: blockNode)
+            ..insertNodeAfter(existingNode: blockNode, newNode: emptyParagraph);
+
+          // Place the selection at the empty paragraph.
           newSelection = DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: nodeId,
-              nodePosition: blockNode.endPosition,
+              nodeId: emptyParagraph.id,
+              nodePosition: emptyParagraph.beginningPosition,
             ),
           );
         } else {
@@ -1922,7 +1929,7 @@ class CommonEditorOperations {
 
           newSelection = DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: nodeId,
+              nodeId: newParagraph.id,
               nodePosition: newParagraph.beginningPosition,
             ),
           );

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1820,7 +1820,8 @@ class CommonEditorOperations {
       return false;
     }
 
-    // When the selected node is empty, we convert it to an ImageNode.
+    // When the selected node is empty, we convert it to an ImageNode by reusing the same id.
+    // Otherwise, generate a new id and insert the node as a new one.
     final nodeId = node.text.text.isEmpty //
         ? composer.selection!.base.nodeId
         : DocumentEditor.createNodeId();
@@ -1859,7 +1860,8 @@ class CommonEditorOperations {
       return false;
     }
 
-    // When the selected node is empty, we convert it to a HorizontalRuleNode.
+    // When the selected node is empty, we convert it to a HorizontalRuleNode by reusing the same id.
+    // Otherwise, generate a new id and insert the node as a new one.
     final nodeId = node.text.text.isEmpty //
         ? composer.selection!.base.nodeId
         : DocumentEditor.createNodeId();

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -31,7 +31,7 @@ void main() {
 
         // Insert the image at the current selection.
         context.editContext.commonOps.insertImage('http://image.fake');
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         final doc = SuperEditorInspector.findDocument()!;
 

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -1,0 +1,270 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/horizontal_rule.dart';
+import 'package:super_editor/src/default_editor/image.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+
+import '../test_tools.dart';
+import 'document_test_tools.dart';
+
+void main() {
+  group('SuperEditor', () {
+    group('inserts an image', () {
+      testWidgetsOnAllPlatforms('when the selection sits at the middle of a paragraph', (tester) async {
+        // Pump a widget with an arbitrary size for the images.
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("Before the image after the image")
+            .withAddedComponents(
+          [const FakeImageComponentBuilder(size: Size(100, 100))],
+        ).pump();
+
+        // Place caret at "Before the image| after the image".
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 16);
+
+        // Insert the image at the current selection.
+        context.editContext.commonOps.insertImage('http://image.fake');
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node has the text from before the caret.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'Before the image');
+
+        // Ensure that the image was added.
+        expect(doc.nodes[1], isA<ImageNode>());
+
+        // Ensure that the last node has the text from after the caret.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, ' after the image');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when the selection sits at the end of a paragraph', (tester) async {
+        // Pump a widget with an arbitrary size for the images.
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .withAddedComponents(
+          [const FakeImageComponentBuilder(size: Size(100, 100))],
+        ).pump();
+
+        // Place caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 15);
+
+        // Insert the image at the current selection.
+        context.editContext.commonOps.insertImage('http://image.fake');
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node remains unchanged.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure that the image was added.
+        expect(doc.nodes[1], isA<ImageNode>());
+
+        // Ensure that an empty node was added after the image.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when the selection sits at an empty paragraph', (tester) async {
+        // Pump a widget with an arbitrary size for the images.
+        final context = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withAddedComponents(
+          [const FakeImageComponentBuilder(size: Size(100, 100))],
+        ).pump();
+
+        // Place caret at the empty paragraph.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Insert the image at the current selection.
+        context.editContext.commonOps.insertImage('http://image.fake');
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that one node was inserted.
+        expect(doc.nodes.length, 2);
+
+        // Ensure that the paragraph was converted to an image.
+        expect(doc.nodes.first, isA<ImageNode>());
+
+        // Ensure that an empty node was added after the image.
+        expect(doc.nodes[1], isA<ParagraphNode>());
+        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+
+        // Ensure the selection was placed at the empty paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes[1].id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('inserts an horizontal rule', () {
+      testWidgetsOnAllPlatforms('when the selection sits at the middle of a paragraph', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("Before the hr after the hr")
+            .pump();
+
+        // Place caret at "Before the hr| after the hr".
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 13);
+
+        // Insert the horizontal rule at the current selection.
+        context.editContext.commonOps.insertHorizontalRule();
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node has the text from before the caret.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'Before the hr');
+
+        // Ensure that the horizontal rule was added.
+        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+
+        // Ensure that the last node has the text from after the caret.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, ' after the hr');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when the selection sits at the end of a paragraph', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .pump();
+
+        // Place caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 15);
+
+        // Insert the horizontal rule at the current selection.
+        context.editContext.commonOps.insertHorizontalRule();
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node remains unchanged.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure that the horizontal rule was added.
+        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+
+        // Ensure that an empty node was added at the end.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when the selection sits at an empty paragraph', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .pump();
+
+        // Place caret at the empty paragraph.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Insert the horizontal rule at the current selection.
+        context.editContext.commonOps.insertHorizontalRule();
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that one node was inserted.
+        expect(doc.nodes.length, 2);
+
+        // Ensure the paragraph was converted to a horizontal rule.
+        expect(doc.nodes.first, isA<HorizontalRuleNode>());
+
+        // Ensure that an empty node was added after the horizontal rule.
+        expect(doc.nodes[1], isA<ParagraphNode>());
+        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+
+        // Ensure that the selection was placed at the empty paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes[1].id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
[SuperEditor] Fix image insertion at the middle of a paragraph. Resolves #1018 

When placing the caret at the middle of a paragraph and trying to insert an image, the following exception is thrown:

```
Exception: Expected nodePosition of type UpstreamDownstreamNodePosition but received: TextPosition(offset: 0, affinity: TextAffinity.downstream)
```

The cause is that, when inserting a block node, we are using the same node id as the selected paragraph.

This PR changes the insertion of images and horizontal rules to use a new node id.

During tests, I found other issues.

* The `_insertBlockLevelContent` dart doc has this sentence: 
```dart
/// If the selection extent sits in an empty paragraph, that paragraph
/// is converted into the given [blockNode] and a new empty paragraph
/// is inserted after the [blockNode].
```
This isn't the case, as a new empty paragraph isn't added after the node.

This PR implements the described behavior.

* To handle the image insertion at the end of a paragraph we are doing this check:

`if (paragraphPosition == endOfParagraph)`

This comparison may return `false` as it compares the text affinity. Sometimes we get an upstream selection when placing the caret at the end of a line.

This PR changes this check to compare only the offsets. It also changes the implementation of this if branch to add an empty paragraph after the inserted node, as this is the behavior described in the dart doc.
