### PR TITLE
[SuperEditor] Fix caret display when document layout changes due to animations (Resolves #1022)

### DIFF
--- a/super_editor/example/lib/demos/super_document/demo_read_only_scrolling_document.dart
+++ b/super_editor/example/lib/demos/super_document/demo_read_only_scrolling_document.dart
@@ -16,6 +16,7 @@ class ReadOnlyCustomScrollViewDemo extends StatefulWidget {
 
 class _ReadOnlyCustomScrollViewDemoState extends State<ReadOnlyCustomScrollViewDemo> {
   late Document _doc;
+  ValueNotifier<DocumentSelection?> _selection = ValueNotifier(null);
 
   @override
   void initState() {
@@ -25,6 +26,7 @@ class _ReadOnlyCustomScrollViewDemoState extends State<ReadOnlyCustomScrollViewD
 
   @override
   void dispose() {
+    _selection.dispose();
     super.dispose();
   }
 
@@ -74,6 +76,8 @@ class _ReadOnlyCustomScrollViewDemoState extends State<ReadOnlyCustomScrollViewD
           ],
         ),
         componentBuilders: defaultComponentBuilders,
+        document: _doc,
+        selectionNotifier: _selection,
       ),
     );
   }

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -73,6 +73,11 @@ abstract class DocumentLayout {
 
   /// Returns the [DocumentPosition] at the end of the last selectable component.
   DocumentPosition? findLastSelectablePosition();
+
+  /// Holds the [LayerLink]s linked to the caret and handle positions.
+  ///
+  /// Use a [CompositedTransformFollower] to display widgets at these positions.
+  LayoutLinks get layerLinks;
 }
 
 /// Contract for all widgets that operate as document components
@@ -438,4 +443,16 @@ class MovementModifier {
 
   @override
   int get hashCode => id.hashCode;
+}
+
+/// Holds [LayerLink]s for the caret and the drag handles.
+class LayoutLinks {
+  LayoutLinks({
+    required this.caret,
+    required this.upstreamHandle,
+    required this.downstreamHandle,
+  });
+  final LayerLink caret;
+  final LayerLink upstreamHandle;
+  final LayerLink downstreamHandle;
 }

--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -1,6 +1,5 @@
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
-import 'package:super_text_layout/super_text_layout.dart';
 
 import 'document_composer.dart';
 import 'document_editor.dart';
@@ -21,9 +20,9 @@ class EditContext {
   EditContext({
     required this.editor,
     required DocumentLayout Function() getDocumentLayout,
+    required this.isDocumentLayoutAvailable,
     required this.composer,
     required this.commonOps,
-    required this.componentSizeNotifier,
   }) : _getDocumentLayout = getDocumentLayout;
 
   /// The editor of the [Document] that allows executing commands that alter the
@@ -36,6 +35,11 @@ class EditContext {
   DocumentLayout get documentLayout => _getDocumentLayout();
   final DocumentLayout Function() _getDocumentLayout;
 
+  /// Returns whether or not we can access the document layout.
+  ///
+  /// When this method returns `true`, we assume it's safe to access the [documentLayout].
+  final bool Function() isDocumentLayoutAvailable;
+
   /// The [DocumentComposer] that maintains selection and attributions to work
   /// in conjunction with the [editor] to apply changes to the document.
   final DocumentComposer composer;
@@ -44,6 +48,8 @@ class EditContext {
   /// the document.
   final CommonEditorOperations commonOps;
 
-  /// A [ChangeNotifier] that is triggered whenever a component changes its size.
-  final SignalListenable componentSizeNotifier;
+  /// Holds the [LayerLink]s linked to the caret and handle positions.
+  ///
+  /// Use a [CompositedTransformFollower] to display widgets at these positions.
+  LayoutLinks get layoutLinks => _getDocumentLayout().layerLinks;
 }

--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -1,5 +1,6 @@
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import 'document_composer.dart';
 import 'document_editor.dart';
@@ -22,6 +23,7 @@ class EditContext {
     required DocumentLayout Function() getDocumentLayout,
     required this.composer,
     required this.commonOps,
+    required this.componentSizeNotifier,
   }) : _getDocumentLayout = getDocumentLayout;
 
   /// The editor of the [Document] that allows executing commands that alter the
@@ -41,4 +43,7 @@ class EditContext {
   /// Common operations that can be executed to apply common, complex changes to
   /// the document.
   final CommonEditorOperations commonOps;
+
+  /// A [ChangeNotifier] that is triggered whenever a component changes its size.
+  final SignalListenable componentSizeNotifier;
 }

--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -108,30 +108,7 @@ class _CaretDocumentOverlayState extends State<CaretDocumentOverlay> with Single
     _blinkController.jumpToOpaque();
 
     final documentLayout = widget.documentLayoutResolver();
-    final newCaretRect = documentLayout.getRectForPosition(documentSelection.extent)!;
-
-    if (_caret.value == newCaretRect) {
-      // The caret is already positioned at the correct place. No need to update.
-      return;
-    }
-
-    _caret.value = newCaretRect;
-
-    // The document might have components that animate their sizes.
-    //
-    // Consider this case where components shrink their sizes when they lose selection:
-    //
-    // After we move the selection from one component to a component bellow it,
-    // the caret offset is calculated considering that the previous component
-    // still has its expanded height.
-    //
-    // After this, the previously selected component shrinks its size, moving the selected
-    // component up and leaving the caret siting at an incorret offset.
-    //
-    // Schedule a caret update so we can see the selected component updated offset.
-    //
-    // Stop scheduling updates when we get the same caret position for two consecutive frames.
-    _scheduleCaretUpdate();
+    _caret.value = documentLayout.getRectForPosition(documentSelection.extent)!;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -349,21 +349,61 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     });
   }
 
+  /// Updates the caret and handle positions at the end of the current frame.
+  void _scheduleCaretUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (!mounted) {
+        return;
+      }
+      _updateHandlesAfterSelectionOrLayoutChange();
+    });
+  }
+
+  void _removeCaretAndHandles() {
+    _editingController
+      ..removeCaret()
+      ..hideToolbar()
+      ..collapsedHandleOffset = null
+      ..upstreamHandleOffset = null
+      ..downstreamHandleOffset = null
+      ..collapsedHandleOffset = null
+      ..cancelCollapsedHandleAutoHideCountdown();
+  }
+
+  void _updateCaretAndCollapsedHandle() {
+    final newCaretRect = _docLayout.getRectForPosition(widget.selection.value!.extent)!;
+    if (newCaretRect.top == _editingController.caretTop?.dy && newCaretRect.left == _editingController.caretTop?.dx) {
+      // The caret is already positioned at the correct place. No need to update.
+      return;
+    }
+
+    _positionCaret();
+    _positionCollapsedHandle();
+
+    // The document might have components that animate their sizes.
+    //
+    // Consider this case where components shrink their sizes when they lose selection:
+    //
+    // After we move the selection from one component to a component bellow it,
+    // the caret offset is calculated considering that the previous component
+    // still has its expanded height.
+    //
+    // After this, the previously selected component shrinks its size, moving the selected
+    // component up and leaving the caret siting at an incorret offset.
+    //
+    // Schedule a caret update so we can see the selected component updated offset.
+    //
+    // Stop scheduling updates when we get the same caret position for two consecutive frames.
+    _scheduleCaretUpdate();
+  }
+
   void _updateHandlesAfterSelectionOrLayoutChange() {
     final newSelection = widget.selection.value;
 
     if (newSelection == null) {
-      _editingController
-        ..removeCaret()
-        ..hideToolbar()
-        ..collapsedHandleOffset = null
-        ..upstreamHandleOffset = null
-        ..downstreamHandleOffset = null
-        ..collapsedHandleOffset = null
-        ..cancelCollapsedHandleAutoHideCountdown();
+      _removeCaretAndHandles();
     } else if (newSelection.isCollapsed) {
-      _positionCaret();
-      _positionCollapsedHandle();
+      _updateCaretAndCollapsedHandle();
     } else {
       // The selection is expanded
       _positionExpandedHandles();
@@ -792,12 +832,34 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     late Offset upstreamHandleOffset = affinity == TextAffinity.downstream ? baseHandleOffset : extentHandleOffset;
     late Offset downstreamHandleOffset = affinity == TextAffinity.downstream ? extentHandleOffset : baseHandleOffset;
 
+    if (upstreamHandleOffset == _editingController.upstreamHandleOffset &&
+        downstreamHandleOffset == _editingController.downstreamHandleOffset) {
+      // The caret is already positioned at the correct place. No need to update.
+      return;
+    }
+
     _editingController
       ..removeCaret()
       ..collapsedHandleOffset = null
       ..upstreamHandleOffset = upstreamHandleOffset
       ..downstreamHandleOffset = downstreamHandleOffset
       ..cancelCollapsedHandleAutoHideCountdown();
+
+    // The document might have components that animate their sizes.
+    //
+    // Consider this case where components shrink their sizes when they lose selection:
+    //
+    // After we move the selection from one component to a component bellow it,
+    // the caret offset is calculated considering that the previous component
+    // still has its expanded height.
+    //
+    // After this, the previously selected component shrinks its size, moving the selected
+    // component up and leaving the caret siting at an incorret offset.
+    //
+    // Schedule a caret update so we can see the selected component updated offset.
+    //
+    // Stop scheduling updates when we get the same caret position for two consecutive frames.
+    _scheduleCaretUpdate();
   }
 
   void _positionCaret() {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -171,11 +171,11 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     );
 
     widget.document.addListener(_onDocumentChange);
-    widget.selection.addListener(_scheduleCaretUpdate);
+    widget.selection.addListener(_onSelectionChange);
 
     // If we already have a selection, we need to display the caret.
     if (widget.selection.value != null) {
-      _scheduleCaretUpdate();
+      _onSelectionChange();
     }
 
     WidgetsBinding.instance.addObserver(this);
@@ -220,12 +220,12 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     }
 
     if (widget.selection != oldWidget.selection) {
-      oldWidget.selection.removeListener(_scheduleCaretUpdate);
-      widget.selection.addListener(_scheduleCaretUpdate);
+      oldWidget.selection.removeListener(_onSelectionChange);
+      widget.selection.addListener(_onSelectionChange);
 
       // Selection has changed, we need to update the caret.
       if (widget.selection.value != oldWidget.selection.value) {
-        _scheduleCaretUpdate();
+        _onSelectionChange();
       }
     }
 
@@ -264,7 +264,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     WidgetsBinding.instance.removeObserver(this);
 
     widget.document.removeListener(_onDocumentChange);
-    widget.selection.removeListener(_scheduleCaretUpdate);
+    widget.selection.removeListener(_onSelectionChange);
 
     _removeEditingOverlayControls();
 
@@ -346,7 +346,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     });
   }
 
-  void _scheduleCaretUpdate() {
+  void _onSelectionChange() {
     // The selection change might correspond to new content that's not
     // laid out yet. Wait until the next frame to update visuals.
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -358,50 +358,20 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     });
   }
 
-  void _removeCaretAndHandles() {
-    _editingController
-      ..removeCaret()
-      ..hideToolbar()
-      ..collapsedHandleOffset = null
-      ..upstreamHandleOffset = null
-      ..downstreamHandleOffset = null
-      ..collapsedHandleOffset = null;
-  }
-
-  void _updateCaretAndCollapsedHandle() {
-    final extentRect = _docLayout.getRectForPosition(widget.selection.value!.extent)!;
-    if (extentRect.top == _editingController.caretTop?.dy && extentRect.left == _editingController.caretTop?.dx) {
-      // The caret is already positioned at the correct place. No need to update.
-      return;
-    }
-
-    _positionCaret();
-    _positionCollapsedHandle();
-
-    // The document might have components that animate their sizes.
-    //
-    // Consider this case where components shrink their sizes when they lose selection:
-    //
-    // After we move the selection from one component to a component bellow it,
-    // the caret offset is calculated considering that the previous component
-    // still has its expanded height.
-    //
-    // After this, the previously selected component shrinks its size, moving the selected
-    // component up and leaving the caret siting at an incorret offset.
-    //
-    // Schedule a caret update so we can see the selected component updated offset.
-    //
-    // Stop scheduling updates when we get the same caret position for two consecutive frames.
-    _scheduleCaretUpdate();
-  }
-
   void _updateHandlesAfterSelectionOrLayoutChange() {
     final newSelection = widget.selection.value;
 
     if (newSelection == null) {
-      _removeCaretAndHandles();
+      _editingController
+        ..removeCaret()
+        ..hideToolbar()
+        ..collapsedHandleOffset = null
+        ..upstreamHandleOffset = null
+        ..downstreamHandleOffset = null
+        ..collapsedHandleOffset = null;
     } else if (newSelection.isCollapsed) {
-      _updateCaretAndCollapsedHandle();
+      _positionCaret();
+      _positionCollapsedHandle();
     } else {
       // The selection is expanded
       _positionExpandedSelectionHandles();
@@ -958,12 +928,6 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     final downstreamHandleOffset = affinity == TextAffinity.downstream ? extentHandleOffset : baseHandleOffset;
     final downstreamHandleHeight = affinity == TextAffinity.downstream ? extentRect.height : baseRect.height;
 
-    if (upstreamHandleOffset == _editingController.upstreamHandleOffset &&
-        downstreamHandleOffset == _editingController.downstreamHandleOffset) {
-      // The caret is already positioned at the correct place. No need to update.
-      return;
-    }
-
     _editingController
       ..removeCaret()
       ..collapsedHandleOffset = null
@@ -971,22 +935,6 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       ..upstreamCaretHeight = upstreamHandleHeight
       ..downstreamHandleOffset = downstreamHandleOffset
       ..downstreamCaretHeight = downstreamHandleHeight;
-
-    // The document might have components that animate their sizes.
-    //
-    // Consider this case where components shrink their sizes when they lose selection:
-    //
-    // After we move the selection from one component to a component bellow it,
-    // the caret offset is calculated considering that the previous component
-    // still has its expanded height.
-    //
-    // After this, the previously selected component shrinks its size, moving the selected
-    // component up and leaving the caret siting at an incorret offset.
-    //
-    // Schedule a caret update so we can see the selected component updated offset.
-    //
-    // Stop scheduling updates when we get the same caret position for two consecutive frames.
-    _scheduleCaretUpdate();
   }
 
   void _positionToolbar() {

--- a/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
@@ -897,13 +897,15 @@ class _Component extends StatelessWidget {
     for (final componentBuilder in componentBuilders) {
       var component = componentBuilder.createComponent(componentContext, componentViewModel);
       if (component != null) {
-        component = ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: componentViewModel.maxWidth ?? double.infinity),
-          child: SizedBox(
-            width: double.infinity,
-            child: Padding(
-              padding: componentViewModel.padding,
-              child: component,
+        component = SizeChangedLayoutNotifier(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: componentViewModel.maxWidth ?? double.infinity),
+            child: SizedBox(
+              width: double.infinity,
+              child: Padding(
+                padding: componentViewModel.padding,
+                child: component,
+              ),
             ),
           ),
         );

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -285,6 +285,9 @@ class SuperEditorState extends State<SuperEditor> {
   @visibleForTesting
   SingleColumnLayoutPresenter get presenter => _docLayoutPresenter!;
 
+  /// A [ChangeNotifier] that is triggered whenever a component changes its size.
+  final SignalListenable _componentSizeNotifier = SignalListenable();
+
   @override
   void initState() {
     super.initState();
@@ -353,6 +356,8 @@ class SuperEditorState extends State<SuperEditor> {
       _focusNode.dispose();
     }
 
+    _componentSizeNotifier.dispose();
+
     super.dispose();
   }
 
@@ -366,6 +371,7 @@ class SuperEditorState extends State<SuperEditor> {
         composer: _composer,
         documentLayoutResolver: () => _docLayoutKey.currentState as DocumentLayout,
       ),
+      componentSizeNotifier: _componentSizeNotifier,
     );
   }
 
@@ -500,6 +506,12 @@ class SuperEditorState extends State<SuperEditor> {
     }
   }
 
+  bool _componentSizeChanged(SizeChangedLayoutNotification notification) {
+    // Let layers and editing controls to react to size changes.
+    _componentSizeNotifier.sendSignal();
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     return SuperEditorFocusDebugVisuals(
@@ -514,11 +526,14 @@ class SuperEditorState extends State<SuperEditor> {
         clearSelectionWhenEditorLosesFocus: widget.selectionPolicies.clearSelectionWhenEditorLosesFocus,
         child: _buildInputSystem(
           child: _buildGestureSystem(
-            documentLayout: SingleColumnDocumentLayout(
-              key: _docLayoutKey,
-              presenter: _docLayoutPresenter!,
-              componentBuilders: widget.componentBuilders,
-              showDebugPaint: widget.debugPaint.layout,
+            documentLayout: NotificationListener<SizeChangedLayoutNotification>(
+              onNotification: _componentSizeChanged,
+              child: SingleColumnDocumentLayout(
+                key: _docLayoutKey,
+                presenter: _docLayoutPresenter!,
+                componentBuilders: widget.componentBuilders,
+                showDebugPaint: widget.debugPaint.layout,
+              ),
             ),
           ),
         ),
@@ -578,6 +593,7 @@ class SuperEditorState extends State<SuperEditor> {
           popoverToolbarBuilder: widget.androidToolbarBuilder ?? (_) => const SizedBox(),
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           overlayController: widget.overlayController,
+          componentSizeNotifier: editContext.componentSizeNotifier,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );
@@ -594,6 +610,7 @@ class SuperEditorState extends State<SuperEditor> {
           floatingCursorController: _floatingCursorController,
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           overlayController: widget.overlayController,
+          componentSizeNotifier: editContext.componentSizeNotifier,
           showDebugPaint: widget.debugPaint.gestures,
           child: documentLayout,
         );
@@ -758,6 +775,7 @@ class DefaultCaretOverlayBuilder implements DocumentLayerBuilder {
       documentLayoutResolver: () => editContext.documentLayout,
       caretStyle: caretStyle,
       document: editContext.editor.document,
+      componentSizeNotifier: editContext.componentSizeNotifier,
     );
   }
 }

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -33,93 +33,16 @@ class AndroidDocumentGestureEditingController extends GestureEditingController {
   LayerLink get documentLayoutLink => _documentLayoutLink;
   final LayerLink _documentLayoutLink;
 
-  /// Whether or not a caret should be displayed.
-  bool get hasCaret => caretTop != null;
-
-  /// The offset of the top of the caret, or `null` if no caret should
-  /// be displayed.
-  ///
-  /// When the caret is drawn, the caret will have a thickness. That width
-  /// should be placed either on the left or right of this offset, based on
-  /// whether the [caretAffinity] is upstream or downstream, respectively.
-  Offset? get caretTop => _caretTop;
-  Offset? _caretTop;
-
   /// The height of the caret, or `null` if no caret should be displayed.
   double? get caretHeight => _caretHeight;
+  set caretHeight(double? value) {
+    if (value != _caretHeight) {
+      _caretHeight = value;
+      notifyListeners();
+    }
+  }
+
   double? _caretHeight;
-
-  /// Updates the caret's size and position.
-  ///
-  /// The [top] offset is in the document layout's coordinate space.
-  void updateCaret({
-    Offset? top,
-    double? height,
-  }) {
-    bool changed = false;
-    if (top != null) {
-      _caretTop = top;
-      changed = true;
-    }
-    if (height != null) {
-      _caretHeight = height;
-      changed = true;
-    }
-
-    if (changed) {
-      notifyListeners();
-    }
-  }
-
-  /// Removes the caret from the display.
-  void removeCaret() {
-    if (!hasCaret) {
-      return;
-    }
-
-    _caretTop = null;
-    _caretHeight = null;
-    notifyListeners();
-  }
-
-  /// Whether a collapsed handle should be displayed.
-  bool get shouldDisplayCollapsedHandle => _collapsedHandleOffset != null;
-
-  /// The offset of the collapsed handle focal point, within the coordinate space
-  /// of the document layout, or `null` if no collapsed handle should be displayed.
-  Offset? get collapsedHandleOffset => _collapsedHandleOffset;
-  Offset? _collapsedHandleOffset;
-  set collapsedHandleOffset(Offset? offset) {
-    if (offset != _collapsedHandleOffset) {
-      _collapsedHandleOffset = offset;
-      notifyListeners();
-    }
-  }
-
-  /// Whether the expanded handles (base + extent) should be displayed.
-  bool get shouldDisplayExpandedHandles => _upstreamHandleOffset != null && _downstreamHandleOffset != null;
-
-  /// The offset of the upstream handle focal point, within the coordinate space
-  /// of the document layout, or `null` if no upstream handle should be displayed.
-  Offset? get upstreamHandleOffset => _upstreamHandleOffset;
-  Offset? _upstreamHandleOffset;
-  set upstreamHandleOffset(Offset? offset) {
-    if (offset != _upstreamHandleOffset) {
-      _upstreamHandleOffset = offset;
-      notifyListeners();
-    }
-  }
-
-  /// The offset of the downstream handle focal point, within the coordinate space
-  /// of the document layout, or `null` if no downstream handle should be displayed.
-  Offset? get downstreamHandleOffset => _downstreamHandleOffset;
-  Offset? _downstreamHandleOffset;
-  set downstreamHandleOffset(Offset? offset) {
-    if (offset != _downstreamHandleOffset) {
-      _downstreamHandleOffset = offset;
-      notifyListeners();
-    }
-  }
 
   final Duration _collapsedHandleAutoHideDuration = const Duration(seconds: 4);
   Timer? _collapsedHandleAutoHideTimer;

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -143,6 +143,18 @@ class GestureEditingController with ChangeNotifier {
   /// Whether the magnifier should be displayed.
   bool get shouldDisplayMagnifier => _overlayController.shouldDisplayMagnifier;
 
+  /// Whether the caret should be displayed.
+  bool get shouldDisplayCaret => _shouldDisplayCaret;
+  bool _shouldDisplayCaret = false;
+
+  /// Whether the expanded handles should be displayed.
+  bool get shouldDisplayExpandedHandles => _shouldDisplayExpandedHandles;
+  bool _shouldDisplayExpandedHandles = false;
+
+  /// Whether the collapsed handle should be displayed.
+  bool get shouldDisplayCollapsedHandle => _shouldDisplayCollapsedHandle;
+  bool _shouldDisplayCollapsedHandle = false;
+
   /// The point about which the floating toolbar should focus, when the toolbar
   /// appears above the selected content.
   ///
@@ -180,6 +192,42 @@ class GestureEditingController with ChangeNotifier {
   /// Toggles the toolbar from visible to not visible, or vis-a-versa.
   void toggleToolbar() {
     _overlayController.toggleToolbar();
+  }
+
+  /// Shows the caret.
+  void showCaret() {
+    _shouldDisplayCaret = true;
+    notifyListeners();
+  }
+
+  /// Hides the caret.
+  void hideCaret() {
+    _shouldDisplayCaret = false;
+    notifyListeners();
+  }
+
+  /// Shows the expanded handles.
+  void showExpandedHandles() {
+    _shouldDisplayExpandedHandles = true;
+    notifyListeners();
+  }
+
+  /// Hides the expanded handles.
+  void hideExpandedHandles() {
+    _shouldDisplayExpandedHandles = false;
+    notifyListeners();
+  }
+
+  /// Shows the collapsed handle.
+  void showCollapsedHandle() {
+    _shouldDisplayCollapsedHandle = true;
+    notifyListeners();
+  }
+
+  /// Hides the collapsed handle.
+  void hideCollapsedHandle() {
+    _shouldDisplayCollapsedHandle = false;
+    notifyListeners();
   }
 
   /// Sets the toolbar's position to the given [topAnchor] and [bottomAnchor].

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -279,8 +279,10 @@ class SuperReaderState extends State<SuperReader> {
       child: _buildGestureSystem(
         documentLayout: SingleColumnDocumentLayout(
           key: _docLayoutKey,
+          document: widget.document,
           presenter: _docLayoutPresenter!,
           componentBuilders: widget.componentBuilders,
+          selectionNotifier: _selection,
           showDebugPaint: widget.debugPaint.layout,
         ),
       ),

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -92,13 +92,15 @@ class SuperEditorInspector {
     final androidControls = find.byType(AndroidDocumentTouchEditingControls).evaluate().lastOrNull?.widget
         as AndroidDocumentTouchEditingControls?;
     if (androidControls != null) {
-      return androidControls.editingController.caretTop!;
+      final documentLayout = _findDocumentLayout(finder);
+      return documentLayout.layerLinks.caret.leader!.offset;
     }
 
     final iOSControls =
         find.byType(IosDocumentTouchEditingControls).evaluate().lastOrNull?.widget as IosDocumentTouchEditingControls?;
     if (iOSControls != null) {
-      return iOSControls.editingController.caretTop!;
+      final documentLayout = _findDocumentLayout(finder);
+      return documentLayout.layerLinks.caret.leader!.offset;
     }
 
     throw Exception('Could not locate caret in document');

--- a/super_editor/test/src/_document_test_tools.dart
+++ b/super_editor/test/src/_document_test_tools.dart
@@ -1,5 +1,6 @@
 import 'package:mockito/mockito.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 /// Fake [DocumentLayout], intended for tests that interact with
 /// a logical [DocumentLayout] but do not depend upon a real
@@ -16,6 +17,7 @@ EditContext createEditContext({
   final editor = documentEditor ?? DocumentEditor(document: document);
   DocumentLayout layoutResolver() => documentLayout ?? FakeDocumentLayout();
   final composer = documentComposer ?? DocumentComposer();
+  final componentSizeNotifier = SignalListenable();
 
   return EditContext(
     editor: editor,
@@ -27,6 +29,7 @@ EditContext createEditContext({
           composer: composer,
           documentLayoutResolver: layoutResolver,
         ),
+    componentSizeNotifier: componentSizeNotifier,
   );
 }
 

--- a/super_editor/test/src/_document_test_tools.dart
+++ b/super_editor/test/src/_document_test_tools.dart
@@ -13,15 +13,16 @@ EditContext createEditContext({
   DocumentLayout? documentLayout,
   DocumentComposer? documentComposer,
   CommonEditorOperations? commonOps,
+  bool Function()? isDocumentLayoutAvailable,
 }) {
   final editor = documentEditor ?? DocumentEditor(document: document);
   DocumentLayout layoutResolver() => documentLayout ?? FakeDocumentLayout();
   final composer = documentComposer ?? DocumentComposer();
-  final componentSizeNotifier = SignalListenable();
 
   return EditContext(
     editor: editor,
     getDocumentLayout: layoutResolver,
+    isDocumentLayoutAvailable: isDocumentLayoutAvailable ?? () => true,
     composer: composer,
     commonOps: commonOps ??
         CommonEditorOperations(
@@ -29,7 +30,6 @@ EditContext createEditContext({
           composer: composer,
           documentLayoutResolver: layoutResolver,
         ),
-    componentSizeNotifier: componentSizeNotifier,
   );
 }
 

--- a/super_editor/test/src/default_editor/caret_test.dart
+++ b/super_editor/test/src/default_editor/caret_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/default_editor/document_gestures_touch_android.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -193,7 +192,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Ensure that the caret is displayed at the correct (x,y) in the document before phone rotation
-          final initialCaretOffset = _getCurrentAndroidCaretOffset(tester);
+          final initialCaretOffset = _getCurrentAndroidCaretOffset(tester, docKey);
           final expectedInitialCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(initialCaretOffset, expectedInitialCaretOffset);
 
@@ -203,7 +202,7 @@ void main() {
 
           // Ensure that after rotating the phone, the caret updated its (x,y) to match the text
           // position that was pushed up to the preceding line.
-          final finalCaretOffset = _getCurrentAndroidCaretOffset(tester);
+          final finalCaretOffset = _getCurrentAndroidCaretOffset(tester, docKey);
           final expectedFinalCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(finalCaretOffset, expectedFinalCaretOffset);
         });
@@ -229,7 +228,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Ensure that the caret is displayed at the correct (x,y) in the document before phone rotation
-          final initialCaretOffset = _getCurrentAndroidCaretOffset(tester);
+          final initialCaretOffset = _getCurrentAndroidCaretOffset(tester, docKey);
           final expectedInitialCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(initialCaretOffset, expectedInitialCaretOffset);
 
@@ -239,7 +238,7 @@ void main() {
 
           // Ensure that after rotating the phone, the caret updated its (x,y) to match the text
           // position that was pushed down to the next line.
-          final finalCaretOffset = _getCurrentAndroidCaretOffset(tester);
+          final finalCaretOffset = _getCurrentAndroidCaretOffset(tester, docKey);
           final expectedFinalCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(finalCaretOffset, expectedFinalCaretOffset);
         });
@@ -267,7 +266,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Ensure that the caret is displayed at the correct (x,y) in the document before phone rotation
-          final initialOffset = _getIosCurrentCaretOffset(tester);
+          final initialOffset = _getIosCurrentCaretOffset(tester, docKey);
           final expectedInitialCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(initialOffset, expectedInitialCaretOffset);
 
@@ -277,7 +276,7 @@ void main() {
 
           // Ensure that after rotating the phone, the caret updated its (x,y) to match the text
           // position that was pushed up to the preceding line.
-          final finalCaretOffset = _getIosCurrentCaretOffset(tester);
+          final finalCaretOffset = _getIosCurrentCaretOffset(tester, docKey);
           final expectedFinalCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(finalCaretOffset, expectedFinalCaretOffset);
         });
@@ -303,7 +302,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Ensure that the caret is displayed at the correct (x,y) in the document before phone rotation
-          final initialOffset = _getIosCurrentCaretOffset(tester);
+          final initialOffset = _getIosCurrentCaretOffset(tester, docKey);
           final expectedInitialCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(initialOffset, expectedInitialCaretOffset);
 
@@ -313,7 +312,7 @@ void main() {
 
           // Ensure that after rotating the phone, the caret updated its (x,y) to match the text
           // position that was pushed down to the next line.
-          final finalCaretOffset = _getIosCurrentCaretOffset(tester);
+          final finalCaretOffset = _getIosCurrentCaretOffset(tester, docKey);
           final expectedFinalCaretOffset = _computeExpectedMobileCaretOffset(tester, docKey, tapPosition);
           expect(finalCaretOffset, expectedFinalCaretOffset);
         });
@@ -386,10 +385,9 @@ Offset _getOffsetForPosition(GlobalKey docKey, DocumentPosition position) {
 ///
 /// The reason for having different implementations is that depending on the gesture mode,
 /// the widget that holds the caret offset is different
-Offset _getCurrentAndroidCaretOffset(WidgetTester tester) {
-  final controls =
-      tester.widget<AndroidDocumentTouchEditingControls>(find.byType(AndroidDocumentTouchEditingControls).last);
-  return controls.editingController.caretTop!;
+Offset _getCurrentAndroidCaretOffset(WidgetTester tester, GlobalKey docKey) {
+  final docLayout = docKey.currentState as DocumentLayout;
+  return docLayout.layerLinks.caret.leader!.offset;
 }
 
 /// Find the caret in the widget tree and return it's (x,y)
@@ -398,9 +396,9 @@ Offset _getCurrentAndroidCaretOffset(WidgetTester tester) {
 ///
 /// The reason for having different implementations is that depending on the gesture mode,
 /// the widget that holds the caret offset is different
-Offset _getIosCurrentCaretOffset(WidgetTester tester) {
-  final controls = tester.widget<IosDocumentTouchEditingControls>(find.byType(IosDocumentTouchEditingControls).last);
-  return controls.editingController.caretTop!;
+Offset _getIosCurrentCaretOffset(WidgetTester tester, GlobalKey docKey) {
+  final docLayout = docKey.currentState as DocumentLayout;
+  return docLayout.layerLinks.caret.leader!.offset;
 }
 
 /// Given a [textPosition], compute the expected (x,y) for the caret

--- a/super_editor/test/src/default_editor/caret_test.dart
+++ b/super_editor/test/src/default_editor/caret_test.dart
@@ -320,7 +320,7 @@ void main() {
       });
     });
 
-    group('component height animation', () {
+    group('component height changes', () {
       testWidgetsOnAllPlatforms('updates caret position', (tester) async {
         await tester //
             .createDocument()

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -381,16 +381,15 @@ EditContext _createEditContext() {
   final documentEditor = DocumentEditor(document: document);
   final fakeLayout = FakeDocumentLayout();
   final composer = DocumentComposer();
-  final componentSizeNotifier = SignalListenable();
   return EditContext(
     editor: documentEditor,
     getDocumentLayout: () => fakeLayout,
+    isDocumentLayoutAvailable: () => true,
     composer: composer,
     commonOps: CommonEditorOperations(
       editor: documentEditor,
       composer: composer,
       documentLayoutResolver: () => fakeLayout,
     ),
-    componentSizeNotifier: componentSizeNotifier,
   );
 }

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../_document_test_tools.dart';
 import '../_text_entry_test_tools.dart';
@@ -380,6 +381,7 @@ EditContext _createEditContext() {
   final documentEditor = DocumentEditor(document: document);
   final fakeLayout = FakeDocumentLayout();
   final composer = DocumentComposer();
+  final componentSizeNotifier = SignalListenable();
   return EditContext(
     editor: documentEditor,
     getDocumentLayout: () => fakeLayout,
@@ -389,5 +391,6 @@ EditContext _createEditContext() {
       composer: composer,
       documentLayoutResolver: () => fakeLayout,
     ),
+    componentSizeNotifier: componentSizeNotifier,
   );
 }

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -322,13 +322,12 @@ class TestDocumentConfigurator {
       documentLayoutResolver: layoutResolver,
       composer: composer,
     );
-    final componentSizeNotifier = SignalListenable();
     final editContext = EditContext(
       editor: editor,
       getDocumentLayout: layoutResolver,
+      isDocumentLayoutAvailable: () => layoutKey.currentContext != null,
       composer: composer,
       commonOps: commonOps,
-      componentSizeNotifier: componentSizeNotifier,
     );
 
     return TestDocumentContext._(

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 import 'package:super_editor_markdown/super_editor_markdown.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 import 'package:text_table/text_table.dart';
 
 import 'test_documents.dart';
@@ -321,11 +322,13 @@ class TestDocumentConfigurator {
       documentLayoutResolver: layoutResolver,
       composer: composer,
     );
+    final componentSizeNotifier = SignalListenable();
     final editContext = EditContext(
       editor: editor,
       getDocumentLayout: layoutResolver,
       composer: composer,
       commonOps: commonOps,
+      componentSizeNotifier: componentSizeNotifier,
     );
 
     return TestDocumentContext._(

--- a/super_text_layout/lib/super_text_layout.dart
+++ b/super_text_layout/lib/super_text_layout.dart
@@ -4,3 +4,4 @@ export 'src/super_text_layout_with_selection.dart';
 export 'src/text_layout.dart';
 export 'src/text_selection_layer.dart';
 export 'src/infrastructure/blink_controller.dart';
+export 'src/infrastructure/signal_listenable.dart';


### PR DESCRIPTION
[SuperEditor] Fix caret display when document layout changes due to animations. Resolves #1022

When we change the selection between components that change their sizes, the caret ends up at an incorrect position:

https://user-images.githubusercontent.com/31278849/217527882-2707112d-5c3b-478e-91d7-f6c2231085c2.mov

The cause is that when we change the selection, the caret offset is computed immediately and isn't updated again. After the animation ends, the selected component sits at a different offset but the caret is still positioned at the old offset.

This PR changes the interactors and the caret overlay to schedule caret updates until we get the same offset that we have.

This isn't a perfect solution, we might need a way for the components to signal that their layout changed.