### PR TITLE
Cherry-pick "[SuperEditor] Expose TextComponentState"

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -439,7 +439,6 @@ class TextComponent extends StatefulWidget {
   TextComponentState createState() => TextComponentState();
 }
 
-@visibleForTesting
 class TextComponentState extends State<TextComponent> with DocumentComponent implements TextComposable {
   final _textKey = GlobalKey<ProseTextState>();
 


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Expose TextComponentState (Resolves #1025) #1026" to `main`