### PR TITLE
[SuperEditor] Make links tappable when in "interaction mode" (Resolves #1024)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -61,7 +61,8 @@ class _EditorToolbarState extends State<EditorToolbar> {
   void initState() {
     super.initState();
     _urlFocusNode = FocusNode();
-    _urlController = SingleLineAttributedTextEditingController(_applyLink);
+    _urlController = SingleLineAttributedTextEditingController(_applyLink) //
+      ..text = AttributedText(text: "https://");
   }
 
   @override

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -35,11 +35,11 @@ import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
 Future<void> main() async {
-  initLoggers(Level.FINEST, {
+  initLoggers(Level.FINE, {
     // editorScrollingLog,
     // editorGesturesLog,
     // editorImeLog,
-    // editorKeyLog,
+    editorKeyLog,
     // editorOpsLog,
     // editorLayoutLog,
     // editorDocLog,

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -35,11 +35,11 @@ import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
 Future<void> main() async {
-  initLoggers(Level.FINE, {
+  initLoggers(Level.FINEST, {
     // editorScrollingLog,
     // editorGesturesLog,
     // editorImeLog,
-    editorKeyLog,
+    // editorKeyLog,
     // editorOpsLog,
     // editorLayoutLog,
     // editorDocLog,

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -119,6 +119,13 @@ class DocumentComposer with ChangeNotifier {
   /// Only valid when editing a document with an IME input method.
   final composingRegion = ValueNotifier<DocumentRange?>(null);
 
+  /// Whether the editor should allow special user interactions with the
+  /// document content, such as clicking to open a link.
+  ///
+  /// Typically, this mode should be enabled and disabled with a special
+  /// keyboard key such as `cmd` or `ctrl`.
+  ValueNotifier<bool> isInInteractionMode = ValueNotifier(false);
+
   final ComposerPreferences _preferences;
 
   /// Returns the composition preferences for this composer.

--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -124,6 +124,14 @@ class DocumentComposer with ChangeNotifier {
   ///
   /// Typically, this mode should be enabled and disabled with a special
   /// keyboard key such as `cmd` or `ctrl`.
+  ///
+  /// On desktop, when using interaction mode to launch URLs, window focus
+  /// will jump from the Flutter app to the new browser window. This jump
+  /// prevents the `cmd` or `ctrl` key release from being processed by Flutter,
+  /// thereby locking the Flutter app in interaction mode. If this happens in
+  /// your app, consider using the `window_manager` plugin to find out when
+  /// your app window loses focus (called "blurring") and then set this value
+  /// to `false`.
   ValueNotifier<bool> isInInteractionMode = ValueNotifier(false);
 
   final ComposerPreferences _preferences;

--- a/super_editor/lib/src/default_editor/document_gestures_interaction_overrides.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_interaction_overrides.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/edit_context.dart';
+
+typedef ContentTapDelegateFactory = ContentTapDelegate Function(EditContext editContext);
+
+/// Delegate for mouse status and clicking on special types of content,
+/// e.g., tapping on a link open the URL.
+///
+/// Listeners are notified when any time that the desired mouse cursor
+/// may have changed.
+abstract class ContentTapDelegate with ChangeNotifier {
+  MouseCursor? mouseCursorForContentHover(DocumentPosition hoverPosition) {
+    return null;
+  }
+
+  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+
+  TapHandlingInstruction onDoubleTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+
+  TapHandlingInstruction onTripleTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+}
+
+enum TapHandlingInstruction {
+  halt,
+  continueHandling,
+}

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -43,6 +43,7 @@ class DocumentMouseInteractor extends StatefulWidget {
     required this.getDocumentLayout,
     required this.selectionNotifier,
     required this.selectionChanges,
+    this.contentTapHandler,
     required this.autoScroller,
     this.showDebugPaint = false,
     required this.child,
@@ -54,6 +55,10 @@ class DocumentMouseInteractor extends StatefulWidget {
   final DocumentLayoutResolver getDocumentLayout;
   final Stream<DocumentSelectionChange> selectionChanges;
   final ValueNotifier<DocumentSelection?> selectionNotifier;
+
+  /// Optional handler that responds to taps on content, e.g., opening
+  /// a link when the user taps on text with a link attribution.
+  final ContentTapDelegate? contentTapHandler;
 
   /// Auto-scrolling delegate.
   final AutoScrollController autoScroller;
@@ -87,12 +92,18 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
 
   DocumentSelection? get _currentSelection => widget.selectionNotifier.value;
 
+  final _mouseCursor = ValueNotifier<MouseCursor>(SystemMouseCursors.text);
+  Offset? _lastHoverOffset;
+
   @override
   void initState() {
     super.initState();
     _focusNode = widget.focusNode ?? FocusNode();
     _selectionSubscription = widget.selectionChanges.listen(_onSelectionChange);
-    widget.autoScroller.addListener(_updateDragSelection);
+    widget.autoScroller
+      ..addListener(_updateDragSelection)
+      ..addListener(_updateMouseCursorAtLatestOffset);
+    widget.contentTapHandler?.addListener(_updateMouseCursorAtLatestOffset);
   }
 
   @override
@@ -106,18 +117,29 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       _selectionSubscription = widget.selectionChanges.listen(_onSelectionChange);
     }
     if (widget.autoScroller != oldWidget.autoScroller) {
-      oldWidget.autoScroller.removeListener(_updateDragSelection);
-      widget.autoScroller.addListener(_updateDragSelection);
+      oldWidget.autoScroller
+        ..removeListener(_updateDragSelection)
+        ..removeListener(_updateMouseCursorAtLatestOffset);
+      widget.autoScroller
+        ..addListener(_updateDragSelection)
+        ..addListener(_updateMouseCursorAtLatestOffset);
+    }
+    if (widget.contentTapHandler != oldWidget.contentTapHandler) {
+      oldWidget.contentTapHandler?.removeListener(_updateMouseCursorAtLatestOffset);
+      widget.contentTapHandler?.addListener(_updateMouseCursorAtLatestOffset);
     }
   }
 
   @override
   void dispose() {
+    widget.contentTapHandler?.removeListener(_updateMouseCursorAtLatestOffset);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
     _selectionSubscription.cancel();
-    widget.autoScroller.removeListener(_updateDragSelection);
+    widget.autoScroller
+      ..removeListener(_updateDragSelection)
+      ..removeListener(_updateMouseCursorAtLatestOffset);
     super.dispose();
   }
 
@@ -212,6 +234,15 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       return;
     }
 
+    if (widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
+
     final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
     final expandSelection = _isShiftPressed && _currentSelection != null;
 
@@ -244,6 +275,15 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     editorGesturesLog.fine(" - document offset: $docOffset");
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
+
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
 
     if (docPosition != null) {
       final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
@@ -602,11 +642,36 @@ Updating drag selection:
     }
   }
 
+  void _onMouseMove(PointerHoverEvent event) {
+    _cancelScrollMomentum();
+    _updateMouseCursor(event.position);
+    _lastHoverOffset = event.position;
+  }
+
+  void _updateMouseCursorAtLatestOffset() {
+    if (_lastHoverOffset == null) {
+      return;
+    }
+    _updateMouseCursor(_lastHoverOffset!);
+  }
+
+  void _updateMouseCursor(Offset globalPosition) {
+    final docOffset = _getDocOffsetFromGlobalOffset(globalPosition);
+    final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
+    if (docPosition == null) {
+      _mouseCursor.value = SystemMouseCursors.text;
+      return;
+    }
+
+    final cursorForContent = widget.contentTapHandler?.mouseCursorForContentHover(docPosition);
+    _mouseCursor.value = cursorForContent ?? SystemMouseCursors.text;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Listener(
       onPointerSignal: _scrollOnMouseWheel,
-      onPointerHover: (event) => _cancelScrollMomentum(),
+      onPointerHover: _onMouseMove,
       onPointerDown: (event) => _cancelScrollMomentum(),
       onPointerPanZoomStart: (event) => _cancelScrollMomentum(),
       child: _buildCursorStyle(
@@ -622,8 +687,15 @@ Updating drag selection:
   Widget _buildCursorStyle({
     required Widget child,
   }) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.text,
+    return ValueListenableBuilder(
+      valueListenable: _mouseCursor,
+      builder: (context, value, child) {
+        return MouseRegion(
+          cursor: _mouseCursor.value,
+          onExit: (_) => _lastHoverOffset = null,
+          child: child,
+        );
+      },
       child: child,
     );
   }
@@ -734,6 +806,34 @@ Updating drag selection:
         ),
     ];
   }
+}
+
+/// Delegate for mouse status and clicking on special types of content,
+/// e.g., tapping on a link open the URL.
+///
+/// Listeners are notified when any time that the desired mouse cursor
+/// may have changed.
+abstract class ContentTapDelegate with ChangeNotifier {
+  MouseCursor? mouseCursorForContentHover(DocumentPosition hoverPosition) {
+    return null;
+  }
+
+  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+
+  TapHandlingInstruction onDoubleTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+
+  TapHandlingInstruction onTripleTap(DocumentPosition tapPosition) {
+    return TapHandlingInstruction.continueHandling;
+  }
+}
+
+enum TapHandlingInstruction {
+  halt,
+  continueHandling,
 }
 
 /// Paints a rectangle border around the given `selectionRect`.

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -16,6 +16,8 @@ import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 
+import 'document_gestures_interaction_overrides.dart';
+
 /// Governs mouse gesture interaction with a document, such as scrolling
 /// a document with a scroll wheel, tapping to place a caret, and
 /// tap-and-dragging to create an expanded selection.
@@ -358,6 +360,15 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     editorGesturesLog.fine(" - document offset: $docOffset");
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
+
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
 
     if (docPosition != null) {
       final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
@@ -806,34 +817,6 @@ Updating drag selection:
         ),
     ];
   }
-}
-
-/// Delegate for mouse status and clicking on special types of content,
-/// e.g., tapping on a link open the URL.
-///
-/// Listeners are notified when any time that the desired mouse cursor
-/// may have changed.
-abstract class ContentTapDelegate with ChangeNotifier {
-  MouseCursor? mouseCursorForContentHover(DocumentPosition hoverPosition) {
-    return null;
-  }
-
-  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
-    return TapHandlingInstruction.continueHandling;
-  }
-
-  TapHandlingInstruction onDoubleTap(DocumentPosition tapPosition) {
-    return TapHandlingInstruction.continueHandling;
-  }
-
-  TapHandlingInstruction onTripleTap(DocumentPosition tapPosition) {
-    return TapHandlingInstruction.continueHandling;
-  }
-}
-
-enum TapHandlingInstruction {
-  halt,
-  continueHandling,
 }
 
 /// Paints a rectangle border around the given `selectionRect`.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -19,6 +19,7 @@ import 'package:super_editor/src/infrastructure/touch_controls.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../infrastructure/document_gestures.dart';
+import 'document_gestures_interaction_overrides.dart';
 import 'document_gestures_touch.dart';
 import 'selection_upstream_downstream.dart';
 
@@ -32,6 +33,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.documentKey,
     required this.getDocumentLayout,
     required this.selection,
+    this.contentTapHandler,
     this.scrollController,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
     required this.handleColor,
@@ -48,6 +50,10 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
   final GlobalKey documentKey;
   final DocumentLayout Function() getDocumentLayout;
   final ValueNotifier<DocumentSelection?> selection;
+
+  /// Optional handler that responds to taps on content, e.g., opening
+  /// a link when the user taps on text with a link attribution.
+  final ContentTapDelegate? contentTapHandler;
 
   final ScrollController? scrollController;
 
@@ -440,6 +446,15 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
+    if (widget.contentTapHandler != null && docPosition != null) {
+      final result = widget.contentTapHandler!.onTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
+
     if (docPosition != null) {
       final selection = widget.selection.value;
       final didTapOnExistingSelection = selection != null && selection.isCollapsed && selection.extent == docPosition;
@@ -486,6 +501,15 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     editorGesturesLog.fine(" - document offset: $docOffset");
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
+
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
 
     if (docPosition != null) {
       // The user tapped a non-selectable component, so we can't select a word.
@@ -554,6 +578,15 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     editorGesturesLog.fine(" - document offset: $docOffset");
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
+
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
 
     if (docPosition != null) {
       // The user tapped a non-selectable component, so we can't select a paragraph.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -14,6 +14,7 @@ import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart'
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 
 import '../infrastructure/document_gestures.dart';
+import 'document_gestures_interaction_overrides.dart';
 import 'document_gestures_touch.dart';
 import 'selection_upstream_downstream.dart';
 
@@ -27,6 +28,7 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
     required this.documentKey,
     required this.getDocumentLayout,
     required this.selection,
+    this.contentTapHandler,
     this.scrollController,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
     required this.handleColor,
@@ -44,6 +46,10 @@ class IOSDocumentTouchInteractor extends StatefulWidget {
   final GlobalKey documentKey;
   final DocumentLayout Function() getDocumentLayout;
   final ValueNotifier<DocumentSelection?> selection;
+
+  /// Optional handler that responds to taps on content, e.g., opening
+  /// a link when the user taps on text with a link attribution.
+  final ContentTapDelegate? contentTapHandler;
 
   final ScrollController? scrollController;
 
@@ -455,6 +461,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
+    if (widget.contentTapHandler != null && docPosition != null) {
+      final result = widget.contentTapHandler!.onTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
+
     if (docPosition != null &&
         selection != null &&
         !selection.isCollapsed &&
@@ -523,6 +538,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
+
     if (docPosition != null) {
       final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
       if (!tappedComponent.isVisualSelectionSupported()) {
@@ -584,6 +608,15 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     editorGesturesLog.fine(" - document offset: $docOffset");
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
+
+    if (docPosition != null && widget.contentTapHandler != null) {
+      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      if (result == TapHandlingInstruction.halt) {
+        // The custom tap handler doesn't want us to react at all
+        // to the tap.
+        return;
+      }
+    }
 
     if (docPosition != null) {
       final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -7,12 +7,32 @@ import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
+
+ExecutionInstruction toggleInteractionModeWhenCmdOrCtrlPressed({
+  required EditContext editContext,
+  required RawKeyEvent keyEvent,
+}) {
+  if (keyEvent.isPrimaryShortcutKeyPressed && !editContext.composer.isInInteractionMode.value) {
+    editorKeyLog.fine("Activating editor interaction mode");
+    editContext.composer.isInInteractionMode.value = true;
+  } else if (editContext.composer.isInInteractionMode.value) {
+    editorKeyLog.fine("De-activating editor interaction mode");
+    editContext.composer.isInInteractionMode.value = false;
+  }
+
+  return ExecutionInstruction.continueExecution;
+}
 
 ExecutionInstruction doNothingWhenThereIsNoSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (editContext.composer.selection == null) {
     return ExecutionInstruction.haltExecution;
   } else {
@@ -24,6 +44,10 @@ ExecutionInstruction pasteWhenCmdVIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyV) {
     return ExecutionInstruction.continueExecution;
   }
@@ -40,6 +64,10 @@ ExecutionInstruction selectAllWhenCmdAIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyA) {
     return ExecutionInstruction.continueExecution;
   }
@@ -52,6 +80,10 @@ ExecutionInstruction copyWhenCmdCIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyC) {
     return ExecutionInstruction.continueExecution;
   }
@@ -72,6 +104,10 @@ ExecutionInstruction cutWhenCmdXIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyX) {
     return ExecutionInstruction.continueExecution;
   }
@@ -92,6 +128,10 @@ ExecutionInstruction cmdBToToggleBold({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyB) {
     return ExecutionInstruction.continueExecution;
   }
@@ -109,6 +149,10 @@ ExecutionInstruction cmdIToToggleItalics({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyI) {
     return ExecutionInstruction.continueExecution;
   }
@@ -126,6 +170,10 @@ ExecutionInstruction anyCharacterOrDestructiveKeyToDeleteSelection({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (editContext.composer.selection == null || editContext.composer.selection!.isCollapsed) {
     return ExecutionInstruction.continueExecution;
   }
@@ -179,6 +227,10 @@ ExecutionInstruction backspaceToRemoveUpstreamContent({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }
@@ -196,6 +248,10 @@ ExecutionInstruction mergeNodeWithNextWhenDeleteIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.delete) {
     return ExecutionInstruction.continueExecution;
   }
@@ -242,6 +298,10 @@ ExecutionInstruction moveUpDownLeftAndRightWithArrowKeys({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   const arrowKeys = [
     LogicalKeyboardKey.arrowLeft,
     LogicalKeyboardKey.arrowRight,
@@ -300,6 +360,10 @@ ExecutionInstruction moveToLineStartOrEndWithCtrlAOrE({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (defaultTargetPlatform == TargetPlatform.macOS) {
     return ExecutionInstruction.continueExecution;
   }
@@ -330,6 +394,10 @@ ExecutionInstruction moveToLineStartWithHome({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (defaultTargetPlatform != TargetPlatform.windows && defaultTargetPlatform != TargetPlatform.linux) {
     return ExecutionInstruction.continueExecution;
   }
@@ -349,6 +417,10 @@ ExecutionInstruction moveToLineEndWithEnd({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (defaultTargetPlatform != TargetPlatform.windows && defaultTargetPlatform != TargetPlatform.linux) {
     return ExecutionInstruction.continueExecution;
   }
@@ -368,6 +440,10 @@ ExecutionInstruction deleteLineWithCmdBksp({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }
@@ -394,6 +470,10 @@ ExecutionInstruction deleteWordWithAltBksp({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (!keyEvent.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }
@@ -423,6 +503,10 @@ ExecutionInstruction collapseSelectionWhenEscIsPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.escape) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
@@ -69,11 +69,6 @@ class _SuperEditorHardwareKeyHandlerState extends State<SuperEditorHardwareKeyHa
   }
 
   KeyEventResult _onKeyPressed(FocusNode node, RawKeyEvent keyEvent) {
-    if (keyEvent is! RawKeyDownEvent) {
-      editorKeyLog.finer("Received key event, but ignoring because it's not a down event: $keyEvent");
-      return KeyEventResult.handled;
-    }
-
     editorKeyLog.info("Handling key press: $keyEvent");
     ExecutionInstruction instruction = ExecutionInstruction.continueExecution;
     int index = 0;

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -600,6 +600,10 @@ ExecutionInstruction tabToIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.tab) {
     return ExecutionInstruction.continueExecution;
   }
@@ -616,6 +620,10 @@ ExecutionInstruction shiftTabToUnIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.tab) {
     return ExecutionInstruction.continueExecution;
   }
@@ -632,6 +640,10 @@ ExecutionInstruction backspaceToUnIndentListItem({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }
@@ -660,6 +672,10 @@ ExecutionInstruction splitListItemWhenEnterPressed({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.enter) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -302,6 +302,10 @@ ExecutionInstruction anyCharacterToInsertInParagraph({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (editContext.composer.selection == null) {
     return ExecutionInstruction.continueExecution;
   }
@@ -405,6 +409,10 @@ ExecutionInstruction enterToInsertBlockNewline({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.enter && keyEvent.logicalKey != LogicalKeyboardKey.numpadEnter) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -18,19 +18,19 @@ import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_text_layout/super_text_layout.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../infrastructure/platforms/mobile_documents.dart';
 import 'attributions.dart';
 import 'blockquote.dart';
 import 'document_caret_overlay.dart';
-import 'document_gestures_mouse.dart';
-import 'document_ime/document_input_ime.dart';
-import 'document_hardware_keyboard/document_input_keyboard.dart';
 import 'document_focus_and_selection_policies.dart';
+import 'document_gestures_mouse.dart';
+import 'document_hardware_keyboard/document_input_keyboard.dart';
+import 'document_ime/document_input_ime.dart';
 import 'horizontal_rule.dart';
 import 'image.dart';
 import 'layout_single_column/layout_single_column.dart';
@@ -1046,7 +1046,7 @@ class LaunchLinkTapHandler extends ContentTapDelegate {
     final link = _getLinkAtPosition(tapPosition);
     if (link != null) {
       // The user tapped on a link. Launch it.
-      launchUrl(link);
+      UrlLauncher.instance.launchUrl(link);
       return TapHandlingInstruction.halt;
     } else {
       // The user didn't tap on a link.

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -274,6 +274,10 @@ ExecutionInstruction enterToInsertNewTask({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   // We only care about ENTER.
   if (keyEvent.logicalKey != LogicalKeyboardKey.enter && keyEvent.logicalKey != LogicalKeyboardKey.numpadEnter) {
     return ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1165,6 +1165,10 @@ ExecutionInstruction anyCharacterToInsertInTextContent({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   // Do nothing if CMD or CTRL are pressed because this signifies an attempted
   // shortcut.
   if (keyEvent.isControlPressed || keyEvent.isMetaPressed) {
@@ -1240,6 +1244,10 @@ ExecutionInstruction deleteToRemoveDownstreamContent({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.delete) {
     return ExecutionInstruction.continueExecution;
   }
@@ -1253,6 +1261,10 @@ ExecutionInstruction shiftEnterToInsertNewlineInBlock({
   required EditContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.enter && keyEvent.logicalKey != LogicalKeyboardKey.numpadEnter) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/lib/src/infrastructure/links.dart
+++ b/super_editor/lib/src/infrastructure/links.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/cupertino.dart';
+import 'package:url_launcher/url_launcher.dart' as url_plugin;
+
+/// Launches URLs, with support for testing overrides.
+class UrlLauncher {
+  static UrlLauncher get instance {
+    _instance ??= UrlLauncher();
+    return _instance!;
+  }
+
+  static UrlLauncher? _instance;
+
+  @visibleForTesting
+  static set instance(UrlLauncher? newInstance) {
+    _instance = newInstance ?? UrlLauncher();
+  }
+
+  Future<bool> launchUrl(Uri url) {
+    return url_plugin.launchUrl(url);
+  }
+}

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -14,7 +14,7 @@ extension SuperEditorRobot on WidgetTester {
   /// The simulated user gesture is probably a tap, but the only guarantee is that
   /// the caret is placed with a gesture.
   ///
-  /// To explicitly simulate a tap within a paragraph, user [tapInParagraph].
+  /// To explicitly simulate a tap within a paragraph, use [tapInParagraph].
   Future<void> placeCaretInParagraph(
     String nodeId,
     int offset, {

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -13,7 +13,28 @@ extension SuperEditorRobot on WidgetTester {
   ///
   /// The simulated user gesture is probably a tap, but the only guarantee is that
   /// the caret is placed with a gesture.
+  ///
+  /// To explicitly simulate a tap within a paragraph, user [tapInParagraph].
   Future<void> placeCaretInParagraph(
+    String nodeId,
+    int offset, {
+    TextAffinity affinity = TextAffinity.downstream,
+    Finder? superEditorFinder,
+  }) async {
+    await _tapInParagraph(nodeId, offset, affinity, 1, superEditorFinder);
+  }
+
+  /// Simulates a tap at the given [offset] within the paragraph with the
+  /// given [nodeId].
+  ///
+  /// This simulated interaction is intended primarily for purposes other
+  /// than changing the document selection, such as tapping on a link to
+  /// launch a URL.
+  ///
+  /// To place the caret in a paragraph, consider using [placeCaretInParagraph],
+  /// which might choose a different execution path to simulate the selection
+  /// change.
+  Future<void> tapInParagraph(
     String nodeId,
     int offset, {
     TextAffinity affinity = TextAffinity.downstream,

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -25,6 +25,7 @@ export 'src/default_editor/document_focus_and_selection_policies.dart';
 export 'src/infrastructure/document_gestures.dart';
 export 'src/default_editor/document_gestures_mouse.dart';
 export 'src/default_editor/document_gestures_touch.dart';
+export 'src/default_editor/document_gestures_interaction_overrides.dart';
 export 'src/default_editor/document_ime/document_input_ime.dart';
 export 'src/default_editor/document_hardware_keyboard/document_input_keyboard.dart';
 export 'src/default_editor/horizontal_rule.dart';

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   linkify: ^4.0.0
   logging: ^1.0.1
   super_text_layout: ^0.1.4
+  url_launcher: ^6.1.9
   uuid: ^3.0.3
 
   # Dependencies for testing tools that we ship with super_editor

--- a/super_editor/test/src/_text_entry_test_tools.dart
+++ b/super_editor/test/src/_text_entry_test_tools.dart
@@ -3,16 +3,16 @@ import 'package:flutter/services.dart';
 /// Concrete version of [RawKeyEvent] used to manually simulate
 /// a specific key event sent from Flutter.
 ///
-/// [FakeRawKeyEvent] does not validate its configuration. It will
+/// [FakeRawKeyDownEvent] does not validate its configuration. It will
 /// reflect whatever information you provide in the constructor, even
 /// if that configuration couldn't exist in reality.
 ///
-/// [FakeRawKeyEvent] might lack some controls or functionality. It's
+/// [FakeRawKeyDownEvent] might lack some controls or functionality. It's
 /// a tool designed to meet the needs of specific tests. If new tests
 /// require broader functionality, then that functionality should be
-/// added to [FakeRawKeyEvent] and other associated classes.
-class FakeRawKeyEvent extends RawKeyEvent {
-  const FakeRawKeyEvent({
+/// added to [FakeRawKeyDownEvent] and other associated classes.
+class FakeRawKeyDownEvent extends RawKeyDownEvent {
+  const FakeRawKeyDownEvent({
     required RawKeyEventData data,
     String? character,
   }) : super(data: data, character: character);

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -460,7 +460,7 @@ void main() {
               final editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                   data: FakeRawKeyEventData(
                     logicalKey: LogicalKeyboardKey.keyC,
                     physicalKey: PhysicalKeyboardKey.keyC,
@@ -482,7 +482,7 @@ void main() {
               final editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                   data: FakeRawKeyEventData(
                     logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
@@ -504,7 +504,7 @@ void main() {
               final editContext = createEditContext(document: MutableDocument());
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                     data: FakeRawKeyEventData(
                       logicalKey: LogicalKeyboardKey.keyA,
                       physicalKey: PhysicalKeyboardKey.keyA,
@@ -534,7 +534,7 @@ void main() {
               );
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                   data: FakeRawKeyEventData(
                     logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
@@ -581,7 +581,7 @@ void main() {
               );
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                   data: FakeRawKeyEventData(
                     logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
@@ -632,7 +632,7 @@ void main() {
               );
               var result = selectAllWhenCmdAIsPressed(
                 editContext: editContext,
-                keyEvent: const FakeRawKeyEvent(
+                keyEvent: const FakeRawKeyDownEvent(
                   data: FakeRawKeyEventData(
                     logicalKey: LogicalKeyboardKey.keyA,
                     physicalKey: PhysicalKeyboardKey.keyA,
@@ -692,7 +692,7 @@ void main() {
 
           var result = anyCharacterOrDestructiveKeyToDeleteSelection(
             editContext: editContext,
-            keyEvent: const FakeRawKeyEvent(
+            keyEvent: const FakeRawKeyDownEvent(
               data: FakeRawKeyEventData(
                 logicalKey: LogicalKeyboardKey.backspace,
                 physicalKey: PhysicalKeyboardKey.backspace,
@@ -745,7 +745,7 @@ void main() {
 
           var result = anyCharacterOrDestructiveKeyToDeleteSelection(
             editContext: editContext,
-            keyEvent: const FakeRawKeyEvent(
+            keyEvent: const FakeRawKeyDownEvent(
               data: FakeRawKeyEventData(
                 logicalKey: LogicalKeyboardKey.delete,
                 physicalKey: PhysicalKeyboardKey.delete,
@@ -798,7 +798,7 @@ void main() {
 
           var result = anyCharacterOrDestructiveKeyToDeleteSelection(
             editContext: editContext,
-            keyEvent: const FakeRawKeyEvent(
+            keyEvent: const FakeRawKeyDownEvent(
               data: FakeRawKeyEventData(
                 logicalKey: LogicalKeyboardKey.keyA,
                 physicalKey: PhysicalKeyboardKey.keyA,
@@ -854,7 +854,7 @@ void main() {
 
           final result = collapseSelectionWhenEscIsPressed(
             editContext: editContext,
-            keyEvent: const FakeRawKeyEvent(
+            keyEvent: const FakeRawKeyDownEvent(
               data: FakeRawKeyEventData(
                 logicalKey: LogicalKeyboardKey.escape,
                 physicalKey: PhysicalKeyboardKey.escape,
@@ -948,7 +948,7 @@ void main() {
 
         final result = collapseSelectionWhenEscIsPressed(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.escape,
               physicalKey: PhysicalKeyboardKey.escape,

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -18,21 +18,21 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.period,
               physicalKey: PhysicalKeyboardKey.period,
             ),
             character: '.',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -50,28 +50,28 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
             ),
             character: ' ',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.period,
               physicalKey: PhysicalKeyboardKey.period,
             ),
             character: '.',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -89,21 +89,21 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.parenthesisRight,
               physicalKey: PhysicalKeyboardKey.digit0,
             ),
             character: ')',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -121,28 +121,28 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
             ),
             character: ' ',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.parenthesisRight,
               physicalKey: PhysicalKeyboardKey.digit0,
             ),
             character: ')',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -160,14 +160,14 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -185,21 +185,21 @@ void main() {
         final editContext = _createEditContextWithParagraph();
 
         _typeKeys(editContext, [
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
             ),
             character: ' ',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.numpad1,
               physicalKey: PhysicalKeyboardKey.numpad1,
             ),
             character: '1',
           ),
-          const FakeRawKeyEvent(
+          const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.space,
               physicalKey: PhysicalKeyboardKey.space,
@@ -451,7 +451,7 @@ EditContext _createEditContextWithParagraph() {
   );
 }
 
-void _typeKeys(EditContext editContext, List<FakeRawKeyEvent> keys) {
+void _typeKeys(EditContext editContext, List<FakeRawKeyDownEvent> keys) {
   for (final key in keys) {
     anyCharacterToInsertInParagraph(
       editContext: editContext,

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -55,7 +55,7 @@ void main() {
         // Press just the meta key.
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.meta,
               physicalKey: PhysicalKeyboardKey.metaLeft,
@@ -71,7 +71,7 @@ void main() {
         // Press "a" + meta key
         result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,
               physicalKey: PhysicalKeyboardKey.keyA,
@@ -91,7 +91,7 @@ void main() {
         // Try to type a character.
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,
               physicalKey: PhysicalKeyboardKey.keyA,
@@ -129,7 +129,7 @@ void main() {
         // Try to type a character.
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,
               physicalKey: PhysicalKeyboardKey.keyA,
@@ -160,7 +160,7 @@ void main() {
         // Try to type a character.
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,
               physicalKey: PhysicalKeyboardKey.keyA,
@@ -194,7 +194,7 @@ void main() {
         // Press the "alt" key
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             character: null,
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.alt,
@@ -210,7 +210,7 @@ void main() {
         // Press the "enter" key
         result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             character: '', // Empirically, pressing enter sends '' as the character instead of null
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.enter,
@@ -245,7 +245,7 @@ void main() {
         // Press the "a" key
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             character: 'a',
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,
@@ -284,7 +284,7 @@ void main() {
         // Type a non-English character
         var result = anyCharacterToInsertInTextContent(
           editContext: editContext,
-          keyEvent: const FakeRawKeyEvent(
+          keyEvent: const FakeRawKeyDownEvent(
             character: 'ß',
             data: FakeRawKeyEventData(
               logicalKey: LogicalKeyboardKey.keyA,

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -66,6 +66,13 @@ class TestDocumentSelector {
     );
   }
 
+  TestDocumentConfigurator withSingleParagraphAndLink() {
+    return TestDocumentConfigurator._(
+      _widgetTester,
+      singleParagraphWithLinkDoc(),
+    );
+  }
+
   TestDocumentConfigurator withTwoEmptyParagraphs() {
     return TestDocumentConfigurator._(
       _widgetTester,

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -1,6 +1,7 @@
-import 'dart:ui';
-
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -489,6 +490,66 @@ spans multiple lines.''',
       // Ensure no drag handle is displayed.
       expect(find.byType(AndroidSelectionHandle), findsNothing);
       expect(find.byType(IosDocumentTouchEditingControls), findsNothing);
+    });
+
+    group("interaction mode", () {
+      group("when active", () {
+        testWidgetsOnDesktop("launches URL on tap", (tester) async {
+          // Setup test version of UrlLauncher to log URL launches.
+          final testUrlLauncher = TestUrlLauncher();
+          UrlLauncher.instance = testUrlLauncher;
+          addTearDown(() => UrlLauncher.instance = null);
+
+          // Pump the UI.
+          final context = await tester //
+              .createDocument()
+              .withSingleParagraphAndLink()
+              .autoFocus(true)
+              .pump();
+
+          // Activate interaction mode.
+          if (defaultTargetPlatform == TargetPlatform.macOS) {
+            await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+          } else {
+            await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+          }
+
+          // Ensure that interaction mode is "on".
+          expect(context.editContext.composer.isInInteractionMode.value, isTrue);
+
+          // Tap on the link.
+          await tester.tapInParagraph("1", 27);
+
+          // Ensure that we tried to launch the URL.
+          expect(testUrlLauncher.urlLaunchLog.length, 1);
+          expect(testUrlLauncher.urlLaunchLog.first.toString(), "https://fake.url");
+        });
+      });
+
+      group("when inactive", () {
+        testWidgetsOnDesktop("doesn't launch URL on tap", (tester) async {
+          // Setup test version of UrlLauncher to log URL launches.
+          final testUrlLauncher = TestUrlLauncher();
+          UrlLauncher.instance = testUrlLauncher;
+          addTearDown(() => UrlLauncher.instance = null);
+
+          // Pump the UI.
+          final context = await tester //
+              .createDocument()
+              .withSingleParagraphAndLink()
+              .autoFocus(true)
+              .pump();
+
+          // Ensure that interaction mode is "off".
+          expect(context.editContext.composer.isInInteractionMode.value, isFalse);
+
+          // Tap on the link.
+          await tester.tapInParagraph("1", 27);
+
+          // Ensure that we DIDN'T try to launch the URL.
+          expect(testUrlLauncher.urlLaunchLog.length, 0);
+        });
+      });
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -494,7 +494,7 @@ spans multiple lines.''',
 
     group("interaction mode", () {
       group("when active", () {
-        testWidgetsOnDesktop("launches URL on tap", (tester) async {
+        testWidgetsOnAllPlatforms("launches URL on tap", (tester) async {
           // Setup test version of UrlLauncher to log URL launches.
           final testUrlLauncher = TestUrlLauncher();
           UrlLauncher.instance = testUrlLauncher;
@@ -508,9 +508,18 @@ spans multiple lines.''',
               .pump();
 
           // Activate interaction mode.
-          if (defaultTargetPlatform == TargetPlatform.macOS) {
+          if (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) {
+            // On mobile, there's no hardware keyboard to easily activate
+            // interaction mode. In practice, app developers will decide
+            // when/how to activate interaction mode on mobile. Rather than
+            // add buttons in our test just for this purpose, we'll explicitly
+            // activate interaction mode.
+            context.editContext.composer.isInInteractionMode.value = true;
+          } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+            // Press CMD to activate interaction mode on Mac.
             await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
           } else {
+            // Press CTRL to activate interaction mode on Windows and Linux.
             await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
           }
 
@@ -527,7 +536,7 @@ spans multiple lines.''',
       });
 
       group("when inactive", () {
-        testWidgetsOnDesktop("doesn't launch URL on tap", (tester) async {
+        testWidgetsOnAllPlatforms("doesn't launch URL on tap", (tester) async {
           // Setup test version of UrlLauncher to log URL launches.
           final testUrlLauncher = TestUrlLauncher();
           UrlLauncher.instance = testUrlLauncher;

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -48,6 +48,30 @@ MutableDocument singleParagraphDoc() => MutableDocument(
       ],
     );
 
+MutableDocument singleParagraphWithLinkDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            // "link" is 26->30
+            text: "This paragraph includes a link that the user can tap",
+            spans: AttributedSpans(
+              attributions: [
+                SpanMarker(
+                    attribution: LinkAttribution(url: Uri.parse("https://fake.url")),
+                    offset: 26,
+                    markerType: SpanMarkerType.start),
+                SpanMarker(
+                    attribution: LinkAttribution(url: Uri.parse("https://fake.url")),
+                    offset: 30,
+                    markerType: SpanMarkerType.end),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
 MutableDocument singleBlockDoc() => MutableDocument(
       nodes: [
         HorizontalRuleNode(id: "1"),

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:meta/meta.dart';
+import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/super_editor.dart';
 
 @isTestGroup
@@ -355,5 +356,19 @@ class PlatformMessageHandler {
     }
 
     return await handler(methodCall);
+  }
+}
+
+class TestUrlLauncher implements UrlLauncher {
+  final _urlLaunchLog = <Uri>[];
+
+  List<Uri> get urlLaunchLog => _urlLaunchLog;
+
+  void clearUrlLaunchLog() => _urlLaunchLog.clear();
+
+  @override
+  Future<bool> launchUrl(Uri url) async {
+    _urlLaunchLog.add(url);
+    return true;
   }
 }

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -359,6 +359,8 @@ class PlatformMessageHandler {
   }
 }
 
+/// A [UrlLauncher] that logs each attempt to launch a URL, but doesn't
+/// attempt to actually launch the URLs.
 class TestUrlLauncher implements UrlLauncher {
   final _urlLaunchLog = <Uri>[];
 


### PR DESCRIPTION
Make links tappable when in "interaction mode" (Resolves #1024)

This PR introduces the concept of an "interaction mode", which is a special mode that results in different user interaction behaviors compared to normal.

The interaction mode concept is added to the `DocumentComposer`, because the `DocumentComposer` represents transient UI modes.

The mouse gesture interactor adds the concept of a content delegate, which can express a desired mouse cursor when hovering over a piece of content, and also take action on single, double, or triple taps, instead of the mouse gesture interactor changing the document selection.

The mouse gesture content delegate is set to a link click delegate, by default.

The mouse gesture interactor needed to be updated to report key up events, so that we can turn off "interaction mode" when the CMD or CTRL key is released. This also requires that every existing keyboard handler check whether the event is "up" or "down". Most of the changes in this PR are those handler updates.