### PR TITLE
[SuperEditor][iOS] Fix caret display when floating cursor is visible (Resolves #992)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -100,8 +100,10 @@ class IosDocumentTouchEditingControls extends StatefulWidget {
 
 class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditingControls>
     with SingleTickerProviderStateMixin {
-  /// Represents the maximum distance an offset can be from the end of a text
-  /// and still be considered to be near it.
+  /// The maximum horizontal distance from the bounds of selectable text, for which we want to render
+  /// the floating cursor.
+  ///
+  /// Beyond this distance, no floating cursor is rendered.
   static const _maximumDistanceToBeNearText = 30.0;
 
   static const _defaultFloatingCursorHeight = 20.0;
@@ -287,6 +289,12 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
   }
 
   Widget _buildHandles() {
+    // When the floating cursor is over text or near text,
+    // we don't show the drag handles.
+    //
+    // Every time the floating cursor moves to a position which
+    // changes this state or when it changes its visibility,
+    // this widget is rebuilt.
     return ValueListenableBuilder<bool>(
       valueListenable: _isFloatingCursorOverOrNearText,
       builder: (context, isNearText, __) {

--- a/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
+++ b/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/blinking_caret.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+
+import '../test_tools.dart';
+import 'document_test_tools.dart';
+
+void main() {
+  group('SuperEditor', () {
+    group('floating cursor', () {
+      testWidgetsOnIos('hides caret when over text (on iOS)', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown('This is a paragraph')
+            .withEditorSize(const Size(300, 300))
+            .pump();
+
+        // Place caret at "|This is a paragraph".
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
+
+        // Moves the floating cursor to a position that is over text.
+        final floatingCursor = _FloatingCursorSimulator();
+        await floatingCursor.start();
+        await tester.pump();
+        await floatingCursor.moveTo(const Offset(10, 0));
+        await tester.pump();
+
+        // Ensure the caret isn't displayed.
+        expect(_caretFinder(), findsNothing);
+      });
+
+      testWidgetsOnIos('hides caret when near text (on iOS)', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown('This is a paragraph')
+            .withEditorSize(const Size(300, 300))
+            .pump();
+
+        // Place caret at "This is a| paragraph".
+        // This is the last position of the first line.
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 9);
+
+        // Moves the floating cursor to a position that is close to the text.
+        final floatingCursor = _FloatingCursorSimulator();
+        await floatingCursor.start();
+        await tester.pump();
+        await floatingCursor.moveTo(const Offset(10, 0));
+        await tester.pump();
+
+        // Ensure the caret isn't displayed.
+        expect(_caretFinder(), findsNothing);
+      });
+
+      testWidgetsOnIos('shows grey caret when far from text (on iOS)', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown('This is a paragraph')
+            .withEditorSize(const Size(300, 300))
+            .pump();
+
+        // Place caret at "This is a paragraph|".
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 9);
+
+        // Moves the floating cursor to a position that is far from text.
+        final floatingCursor = _FloatingCursorSimulator();
+        await floatingCursor.start();
+        await tester.pump();
+        await floatingCursor.moveTo(const Offset(60, 0));
+        await tester.pump();
+
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
+
+        // Ensure the caret is grey.
+        final caret = tester.widget<BlinkingCaret>(_caretFinder());
+        expect(caret.color, Colors.grey);
+      });
+    });
+  });
+}
+
+Finder _caretFinder() {
+  return find.byType(BlinkingCaret);
+}
+
+class _FloatingCursorSimulator {
+  /// Simulates the user holding the spacebar and starting the floating cursor gesture.
+  ///
+  /// The initial offset is at (0,0).
+  Future<void> start() async {
+    await _updateFloatingCursor(action: "FloatingCursorDragState.start", offset: Offset.zero);
+  }
+
+  /// Simulates the user swiping the spacebar by [offset].
+  ///
+  /// (0,0) means the point where the user started the gesture.
+  Future<void> moveTo(Offset offset) async {
+    await _updateFloatingCursor(action: "FloatingCursorDragState.update", offset: offset);
+  }
+
+  /// Simulates the user releasing the spacebar and stopping the floating cursor gesture.
+  Future<void> stop() async {
+    await _updateFloatingCursor(action: "FloatingCursorDragState.end", offset: Offset.zero);
+  }
+
+  Future<void> _updateFloatingCursor({required String action, required Offset offset}) async {
+    await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
+      SystemChannels.textInput.name,
+      SystemChannels.textInput.codec.encodeMethodCall(
+        MethodCall(
+          "TextInputClient.updateFloatingCursor",
+          [
+            -1,
+            action,
+            {"X": offset.dx, "Y": offset.dy}
+          ],
+        ),
+      ),
+      null,
+    );
+  }
+}

--- a/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
+++ b/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
@@ -21,6 +21,9 @@ void main() {
         // Place caret at "|This is a paragraph".
         await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
 
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
+
         // Moves the floating cursor to a position that is over text.
         final floatingCursor = _FloatingCursorSimulator();
         await floatingCursor.start();
@@ -30,6 +33,13 @@ void main() {
 
         // Ensure the caret isn't displayed.
         expect(_caretFinder(), findsNothing);
+
+        // Release the floating cursor.
+        await floatingCursor.stop();
+        await tester.pump();
+
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
       });
 
       testWidgetsOnIos('hides caret when near text (on iOS)', (tester) async {
@@ -43,6 +53,9 @@ void main() {
         // This is the last position of the first line.
         await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 9);
 
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
+
         // Moves the floating cursor to a position that is close to the text.
         final floatingCursor = _FloatingCursorSimulator();
         await floatingCursor.start();
@@ -52,6 +65,13 @@ void main() {
 
         // Ensure the caret isn't displayed.
         expect(_caretFinder(), findsNothing);
+
+        // Release the floating cursor.
+        await floatingCursor.stop();
+        await tester.pump();
+
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
       });
 
       testWidgetsOnIos('shows grey caret when far from text (on iOS)', (tester) async {
@@ -75,8 +95,19 @@ void main() {
         expect(_caretFinder(), findsOneWidget);
 
         // Ensure the caret is grey.
-        final caret = tester.widget<BlinkingCaret>(_caretFinder());
+        BlinkingCaret caret = tester.widget<BlinkingCaret>(_caretFinder());
         expect(caret.color, Colors.grey);
+
+        // Release the floating cursor.
+        await floatingCursor.stop();
+        await tester.pump();
+
+        // Ensure the caret is displayed.
+        expect(_caretFinder(), findsOneWidget);
+
+        // Ensure the caret is blue.
+        caret = tester.widget<BlinkingCaret>(_caretFinder());
+        expect(caret.color, Colors.blue);
       });
     });
   });


### PR DESCRIPTION
[SuperEditor][iOS] Fix caret display when floating cursor is visible. Resolves #992

When the iOS floating cursor is visible, we always display the "normal" caret, and the caret color isn't changed to grey, as can be seen in the video:

https://user-images.githubusercontent.com/31278849/214280623-8f5d2455-6508-4a03-aebd-da78ec3d6fc9.MP4


We already have some code to change the caret color to grey, but it isn't working.

This PR changes the iOS interactor to avoid displaying the caret when the floating cursor is over text or less than 30 pixels away from the text.

This PR also fixes the code to change the caret color to grey when the floating cursor is visible.

I had to use the `textLayout` property from `TextComponentState`, which is marked as `@visibleForTesting`, to check if the floating cursor is over text. I can change that if there is another way to do it.