### PR TITLE
Cherry-pick "[SuperEditor] Fix performAction override for TextInputAction.newline (Resolves #1012) (#1017)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -278,7 +278,9 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   @override
   void performAction(TextInputAction action) {
     editorImeLog.fine("IME says to perform action: $action");
-    textDeltasDocumentEditor.performAction(action);
+    if (action == TextInputAction.newline) {
+      textDeltasDocumentEditor.insertNewline();
+    }
   }
 
   @override

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -137,6 +137,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       selection: widget.editContext.composer.selectionNotifier,
       composingRegion: widget.editContext.composer.composingRegion,
       commonOps: widget.editContext.commonOps,
+      onPerformAction: (action) => _imeClient.performAction(action),
     );
     _documentImeClient = DocumentImeInputClient(
       selection: widget.editContext.composer.selectionNotifier,


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix performAction override for TextInputAction.newline (Resolves #1012) (#1017)" to stable