### PR TITLE
Implemented beginning of paragraph case for _insertBlockLevelContent

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1875,6 +1875,9 @@ class CommonEditorOperations {
   /// is converted into the given [blockNode] and a new empty paragraph
   /// is inserted after the [blockNode].
   ///
+  /// If the selection extent sits at the beginning of a non-empty paragraph,
+  /// the [blockNode] is inserted as a new node before that paragraph.
+  ///
   /// If the selection extent sits at the end of a paragraph, the [blockNode]
   /// is inserted as a new node after that paragraph, and then a new
   /// empty paragraph is inserted after the [blockNode].
@@ -1904,6 +1907,7 @@ class CommonEditorOperations {
     editor.executeCommand(
       EditorCommandFunction((document, transaction) {
         final paragraphPosition = composer.selection!.extent.nodePosition as TextNodePosition;
+        final beginningOfParagraph = node.beginningPosition;
         final endOfParagraph = node.endPosition;
 
         DocumentSelection newSelection;
@@ -1919,6 +1923,17 @@ class CommonEditorOperations {
             position: DocumentPosition(
               nodeId: emptyParagraph.id,
               nodePosition: emptyParagraph.beginningPosition,
+            ),
+          );
+        } else if (paragraphPosition.offset == beginningOfParagraph.offset) {
+          // Insert block item before the paragraph.
+          transaction.insertNodeBefore(existingNode: node, newNode: blockNode);
+
+          // Place the selection at the beginning of the paragraph.
+          newSelection = DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: node.id,
+              nodePosition: node.beginningPosition,
             ),
           );
         } else if (paragraphPosition.offset == endOfParagraph.offset) {

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -17,6 +17,45 @@ import 'document_test_tools.dart';
 void main() {
   group('SuperEditor', () {
     group('inserts an image', () {
+      testWidgetsOnAllPlatforms('when the selection sits at the beginning of a non-empty paragraph', (tester) async {
+        // Pump a widget with an arbitrary size for the images.
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .withAddedComponents(
+          [const FakeImageComponentBuilder(size: Size(100, 100))],
+        ).pump();
+
+        // Place caret at the beginning of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 0);
+
+        // Insert the image at the current selection.
+        context.editContext.commonOps.insertImage('http://image.fake');
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that one node was inserted.
+        expect(doc.nodes.length, 2);
+
+        // Ensure that the image was added.
+        expect(doc.nodes[0], isA<ImageNode>());
+
+        // Ensure that the paragraph node content remains unchanged, but is moved down.
+        expect(doc.nodes[1], isA<ParagraphNode>());
+        expect((doc.nodes[1] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure the selection was placed at the beginning of the paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes[1].id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
       testWidgetsOnAllPlatforms('when the selection sits at the middle of a paragraph', (tester) async {
         // Pump a widget with an arbitrary size for the images.
         final context = await tester //
@@ -146,7 +185,43 @@ void main() {
       });
     });
 
-    group('inserts an horizontal rule', () {
+    group('inserts a horizontal rule', () {
+      testWidgetsOnAllPlatforms('when the selection sits at the beginning of a non-empty paragraph', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .pump();
+
+        // Place caret at the beginning of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.editor.document.nodes.first.id, 0);
+
+        // Insert the horizontal rule at the current selection.
+        context.editContext.commonOps.insertHorizontalRule();
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that one node was inserted.
+        expect(doc.nodes.length, 2);
+
+        // Ensure that the horizontal rule was added.
+        expect(doc.nodes[0], isA<HorizontalRuleNode>());
+
+        // Ensure that the paragraph node content remains unchanged, but is moved down.
+        expect(doc.nodes[1], isA<ParagraphNode>());
+        expect((doc.nodes[1] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure the selection was placed at the beginning of the paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes[1].id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
       testWidgetsOnAllPlatforms('when the selection sits at the middle of a paragraph', (tester) async {
         final context = await tester //
             .createDocument()


### PR DESCRIPTION
The recent work on #1019 fixed image and horizontal rule insertion in the middle of a non-empty paragraph node. Both images and horizontal rules call `_insertBlockLevelContent`, which handles the following cases:
- Empty paragraph
- Selection at the end of a non-empty paragraph
- Selection in the middle of a non-empty paragraph

This PR adds the following case to the `_insertBlockLevelContent` function:
- Selection at the beginning of a non-empty paragraph

Before this PR, adding a horizontal rule or image when the selection is at the beginning of a non-empty paragraph would end up using the *Selection in the middle of a non-empty paragraph* case, which would end up adding an extra empty paragraph node above the original paragraph node. 

Now, the horizontal rule or image node is inserted before the paragraph node, no additional empty paragraph nodes are inserted, and selection remains at the beginning of the paragraph node.

#### Here's the behavior before this PR. Note the additional empty paragraph nodes inserted above the paragraph node:

https://user-images.githubusercontent.com/6467808/220417525-abf11a78-779a-4070-ba0f-2790fcba7bd4.mov

#### Here's the behavior after this PR:

https://user-images.githubusercontent.com/6467808/220417643-d3a101b1-e2b0-49d6-aa56-b37ec7d51287.MP4


