### PR TITLE
[SuperTextField][Android] Fix emoji deletion (Resolves #1031)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -515,10 +515,12 @@ class AttributedTextEditingController with ChangeNotifier {
       return;
     }
 
+    final deleteFromOffset = getCharacterStartBounds(_text.text, selection.extentOffset);
+
     delete(
-      from: selection.extentOffset - 1,
+      from: deleteFromOffset,
       to: selection.extentOffset,
-      newSelection: TextSelection.collapsed(offset: selection.extentOffset - 1),
+      newSelection: TextSelection.collapsed(offset: deleteFromOffset),
       newComposingRegion: newComposingRegion,
     );
   }
@@ -537,9 +539,11 @@ class AttributedTextEditingController with ChangeNotifier {
       return;
     }
 
+    final deleteToOffset = getCharacterEndBounds(_text.text, selection.extentOffset);
+
     delete(
       from: selection.extentOffset,
-      to: selection.extentOffset + 1,
+      to: deleteToOffset,
       newSelection: TextSelection.collapsed(offset: selection.extentOffset),
       newComposingRegion: newComposingRegion,
     );

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -354,6 +354,22 @@ void main() {
       // Ensure text is deleted
       expect(controller.text.text, 'This is a');
     });
+
+    testWidgetsOnAndroid('deletes emojis with BACKSPACE (on Android)', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText(text: 'This is a text with an emoji 🐢'),
+      );
+      await _pumpScaffoldForBuggyKeyboards(tester, controller: controller);
+
+      // Place the caret at the end of the text field.
+      await tester.placeCaretInSuperTextField(controller.text.text.length);
+
+      // Press backspace to delete the previous character.
+      await tester.pressBackspace();
+
+      // Ensure the emoji is deleted.
+      expect(controller.text.text, 'This is a text with an emoji ');
+    });
   });
 }
 


### PR DESCRIPTION
[SuperTextField][Android] Fix emoji deletion. Resolves #1031

Using the Samsung keyboard, pressing the backspace button generates a key event instead of a deletion delta.

In the `deletePreviousCharacter` method, we aren't handling glyphs with multiple codepoints correctly.

This PR fixes the deletion of characters with multiple codepoints.