### PR TITLE
[SuperEditor] Fix toggling attributions on first insertion (Resolves #1007)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -358,6 +358,8 @@ class SuperEditorState extends State<SuperEditor> {
   void dispose() {
     _contentTapDelegate?.dispose();
 
+    _composer.removeListener(_updateComposerPreferencesAtSelection);
+
     if (widget.composer == null) {
       _composer.dispose();
     }
@@ -434,6 +436,21 @@ class SuperEditorState extends State<SuperEditor> {
     if (_composer.selection?.extent == _previousSelectionExtent) {
       return;
     }
+
+    final selectedNodePosition = _composer.selection?.extent.nodePosition;
+    final previousSelectedNodePosition = _previousSelectionExtent?.nodePosition;
+
+    if (_composer.selection != null &&
+        _previousSelectionExtent != null &&
+        _composer.selection!.extent.nodeId == _previousSelectionExtent!.nodeId &&
+        (selectedNodePosition is TextNodePosition) &&
+        (previousSelectedNodePosition is TextNodePosition) &&
+        selectedNodePosition.offset == previousSelectedNodePosition.offset) {
+      // The selection changed, but the selected node and offset are the same.
+      // It might be the case that the OS sent us a selection with a different affinity.
+      return;
+    }
+
     _previousSelectionExtent = _composer.selection?.extent;
 
     _composer.preferences.clearStyles();

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -437,18 +437,22 @@ class SuperEditorState extends State<SuperEditor> {
       return;
     }
 
-    final selectedNodePosition = _composer.selection?.extent.nodePosition;
-    final previousSelectedNodePosition = _previousSelectionExtent?.nodePosition;
-
-    if (_composer.selection != null &&
+    final selectionExtent = _composer.selection?.extent;
+    if (selectionExtent != null &&
+        selectionExtent.nodePosition is TextNodePosition &&
         _previousSelectionExtent != null &&
-        _composer.selection!.extent.nodeId == _previousSelectionExtent!.nodeId &&
-        (selectedNodePosition is TextNodePosition) &&
-        (previousSelectedNodePosition is TextNodePosition) &&
-        selectedNodePosition.offset == previousSelectedNodePosition.offset) {
-      // The selection changed, but the selected node and offset are the same.
-      // It might be the case that the OS sent us a selection with a different affinity.
-      return;
+        _previousSelectionExtent!.nodePosition is TextNodePosition) {
+      // The current and previous selections are text positions. Check for the situation where the two
+      // selections are functionally equivalent, but the affinity changed.
+      final selectedNodePosition = selectionExtent.nodePosition as TextNodePosition;
+      final previousSelectedNodePosition = _previousSelectionExtent!.nodePosition as TextNodePosition;
+
+      if (selectionExtent.nodeId == _previousSelectionExtent!.nodeId &&
+          selectedNodePosition.offset == previousSelectedNodePosition.offset) {
+        // The text selection changed, but only the affinity is different. An affinity change doesn't alter
+        // the selection from the user's perspective, so don't alter any preferences. Return.
+        return;
+      }
     }
 
     _previousSelectionExtent = _composer.selection?.extent;

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -220,21 +220,18 @@ void main() {
 
         // Toggle the bold attribution.
         composer.preferences.toggleStyle(boldAttribution);
-        await tester.pumpAndSettle();
+        await tester.pump();
 
-        // Invert the selection affinity.
-        final newAffinity =
-            (composer.selection!.extent.nodePosition as TextNodePosition).affinity == TextAffinity.downstream //
-                ? TextAffinity.upstream
-                : TextAffinity.downstream;
+        // Ensure we have an upstream selection.
+        expect((composer.selection!.extent.nodePosition as TextNodePosition).affinity, TextAffinity.upstream);
 
         // Simulate the IME sending us a selection at the same offset
         // but with a different affinity.
         await tester.ime.sendDeltas(
           [
-            TextEditingDeltaNonTextUpdate(
+            const TextEditingDeltaNonTextUpdate(
               oldText: "This text should be",
-              selection: TextSelection.collapsed(offset: 19, affinity: newAffinity),
+              selection: TextSelection.collapsed(offset: 19, affinity: TextAffinity.downstream),
               composing: TextRange.empty,
             ),
           ],

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -1,6 +1,10 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/test/ime.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
 
@@ -197,6 +201,51 @@ void main() {
 
         // Ensure the bold attribution wasn't applied to the inserted text.
         expect(doc, equalsMarkdown("A very **bold** text"));
+      });
+    });
+
+    group("doesn't clear attributions", () {
+      testWidgetsOnAllPlatforms("when changing the selection affinity", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("This text should be")
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final doc = context.editContext.editor.document;
+        final composer = context.editContext.composer;
+
+        // Place the caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 19);
+
+        // Toggle the bold attribution.
+        composer.preferences.toggleStyle(boldAttribution);
+        await tester.pumpAndSettle();
+
+        // Invert the selection affinity.
+        final newAffinity =
+            (composer.selection!.extent.nodePosition as TextNodePosition).affinity == TextAffinity.downstream //
+                ? TextAffinity.upstream
+                : TextAffinity.downstream;
+
+        // Simulate the IME sending us a selection at the same offset
+        // but with a different affinity.
+        await tester.ime.sendDeltas(
+          [
+            TextEditingDeltaNonTextUpdate(
+              oldText: "This text should be",
+              selection: TextSelection.collapsed(offset: 19, affinity: newAffinity),
+              composing: TextRange.empty,
+            ),
+          ],
+          getter: imeClientGetter,
+        );
+
+        // Type text at the end of the paragraph.
+        await tester.typeImeText(" bold");
+
+        // Ensure the bold attribution is applied.
+        expect(doc, equalsMarkdown("This text should be** bold**"));
       });
     });
   });


### PR DESCRIPTION
[SuperEditor] Fix toggling attributions on first insertion. Resolves #1007

After placing the caret at the end of a paragraph for the first time and toggling an attribution, the attribution isn't preserved when the user types:

https://user-images.githubusercontent.com/20045287/214872670-374060f6-7c00-4c4b-8059-f34ed046ea35.mov

The cause is that, upon the first insertion, the IME is sending us a `TextEditingDeltaNonTextUpdate` changing only the selection affinity. As the selection changed, we clear the current attributions.

This PR changes the `_updateComposerPreferencesAtSelection`  method to avoid updating the attributions when the selection is at the same node and the same offset as the previous selection.

