### PR TITLE
[SuperReader] Fix setState() called after dispose (Resolves #1029)

### DIFF
--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -248,6 +248,13 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
       });
     }
   }
+  
+  @override
+  void setState(VoidCallback fn) {
+    if (mounted) {
+      super.setState(fn);
+    }
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
[SuperReader] Fix setState() called after dispose Resolves #1029 

This PR checks Whether this State object is currently in a tree. and setsState() only executes only when the state is mounted