### PR TITLE
Cherry-pick "[SuperEditor] Fix toggling attributions on first insertion (Resolves #1007) (#1043)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -343,6 +343,8 @@ class SuperEditorState extends State<SuperEditor> {
 
   @override
   void dispose() {
+    _composer.removeListener(_updateComposerPreferencesAtSelection);
+
     if (widget.composer == null) {
       _composer.dispose();
     }
@@ -414,6 +416,25 @@ class SuperEditorState extends State<SuperEditor> {
     if (_composer.selection?.extent == _previousSelectionExtent) {
       return;
     }
+
+    final selectionExtent = _composer.selection?.extent;
+    if (selectionExtent != null &&
+        selectionExtent.nodePosition is TextNodePosition &&
+        _previousSelectionExtent != null &&
+        _previousSelectionExtent!.nodePosition is TextNodePosition) {
+      // The current and previous selections are text positions. Check for the situation where the two
+      // selections are functionally equivalent, but the affinity changed.
+      final selectedNodePosition = selectionExtent.nodePosition as TextNodePosition;
+      final previousSelectedNodePosition = _previousSelectionExtent!.nodePosition as TextNodePosition;
+
+      if (selectionExtent.nodeId == _previousSelectionExtent!.nodeId &&
+          selectedNodePosition.offset == previousSelectedNodePosition.offset) {
+        // The text selection changed, but only the affinity is different. An affinity change doesn't alter
+        // the selection from the user's perspective, so don't alter any preferences. Return.
+        return;
+      }
+    }
+
     _previousSelectionExtent = _composer.selection?.extent;
 
     _composer.preferences.clearStyles();


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix toggling attributions on first insertion (Resolves #1007) (#1043)" to stable