### PR TITLE
Add a demo where the height of the content (e.g. task) can animate

### DIFF
--- a/super_editor/example/lib/demos/demo_animated_task_height.dart
+++ b/super_editor/example/lib/demos/demo_animated_task_height.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// Example of a task component whose height is animated.
+class AnimatedTaskHeightDemo extends StatefulWidget {
+  @override
+  _AnimatedTaskHeightDemoState createState() => _AnimatedTaskHeightDemoState();
+}
+
+class _AnimatedTaskHeightDemoState extends State<AnimatedTaskHeightDemo> {
+  late MutableDocument _doc;
+  late DocumentEditor _docEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = _createDocument();
+    _docEditor = DocumentEditor(document: _doc);
+  }
+
+  @override
+  void dispose() {
+    _doc.dispose();
+    super.dispose();
+  }
+
+  MutableDocument _createDocument() {
+    return MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: DocumentEditor.createNodeId(),
+          text: AttributedText(
+            text:
+                "Below are several tasks. These tasks will animate the appearance of a subtitle depending on whether they have selection. Try and find out:",
+          ),
+        ),
+        ...List.generate(
+          10,
+          (index) => TaskNode(
+            id: DocumentEditor.createNodeId(),
+            text: AttributedText(text: "Task ${index + 1}"),
+            isComplete: false,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor(
+      editor: _docEditor,
+      stylesheet: defaultStylesheet.copyWith(
+        documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
+      ),
+      // Add a new component builder that creates a task that animates its height,
+      // instead of creating the usual static kind.
+      componentBuilders: [
+        const AnimatedTaskComponentBuilder(),
+        TaskComponentBuilder(_docEditor),
+        ...defaultComponentBuilders,
+      ],
+    );
+  }
+}
+
+/// SuperEditor [ComponentBuilder] that builds a task that is animates the appearance of
+/// a subtitle depending on whether it has selection.
+class AnimatedTaskComponentBuilder implements ComponentBuilder {
+  const AnimatedTaskComponentBuilder();
+
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    // This builder can work with the standard task view model, so
+    // we'll defer to the standard task builder.
+    return null;
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! TaskComponentViewModel) {
+      return null;
+    }
+
+    return _AnimatedTaskComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
+class _AnimatedTaskComponent extends StatefulWidget {
+  const _AnimatedTaskComponent({
+    Key? key,
+    required this.viewModel,
+    this.showDebugPaint = false,
+  }) : super(key: key);
+
+  final TaskComponentViewModel viewModel;
+  final bool showDebugPaint;
+
+  @override
+  State<_AnimatedTaskComponent> createState() => _AnimatedTaskComponentState();
+}
+
+class _AnimatedTaskComponentState extends State<_AnimatedTaskComponent>
+    with ProxyDocumentComponent<_AnimatedTaskComponent>, ProxyTextComposable {
+  final _textKey = GlobalKey();
+
+  @override
+  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => _textKey;
+
+  @override
+  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 16, right: 4),
+              child: Checkbox(
+                value: widget.viewModel.isComplete,
+                onChanged: (newValue) {
+                  widget.viewModel.setComplete(newValue!);
+                },
+              ),
+            ),
+            Expanded(
+              child: TextComponent(
+                key: _textKey,
+                text: widget.viewModel.text,
+                textStyleBuilder: (attributions) {
+                  // Show a strikethrough across the entire task if it's complete.
+                  final style = widget.viewModel.textStyleBuilder(attributions);
+                  return widget.viewModel.isComplete
+                      ? style.copyWith(
+                          decoration: style.decoration == null
+                              ? TextDecoration.lineThrough
+                              : TextDecoration.combine([TextDecoration.lineThrough, style.decoration!]),
+                        )
+                      : style;
+                },
+                textSelection: widget.viewModel.selection,
+                selectionColor: widget.viewModel.selectionColor,
+                highlightWhenEmpty: widget.viewModel.highlightWhenEmpty,
+                showDebugPaint: widget.showDebugPaint,
+              ),
+            ),
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 56),
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 100),
+            child: widget.viewModel.selection != null
+                ? SizedBox(
+                    height: 20,
+                    child: Row(
+                      children: [
+                        Icon(Icons.label_important_outline, size: 16),
+                        const SizedBox(width: 4),
+                        Icon(Icons.timelapse_sharp, size: 16),
+                      ],
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:example/demos/components/demo_text_with_hint.dart';
 import 'package:example/demos/components/demo_unselectable_hr.dart';
 import 'package:example/demos/debugging/simple_deltas_input.dart';
+import 'package:example/demos/demo_animated_task_height.dart';
 import 'package:example/demos/demo_app_shortcuts.dart';
 import 'package:example/demos/demo_empty_document.dart';
 import 'package:example/demos/demo_markdown_serialization.dart';
@@ -254,6 +255,13 @@ final _menu = <_MenuGroup>[
         title: 'Empty Document',
         pageBuilder: (context) {
           return EmptyDocumentDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.description,
+        title: 'Animated task height demo',
+        pageBuilder: (context) {
+          return AnimatedTaskHeightDemo();
         },
       ),
     ],


### PR DESCRIPTION
This new demo has a custom task component that shows/hides content under the task title with a size animation, depending on whether the task has selection or not. 

In this demo it is a custom implementation of `TaskComponent`, but it could be other types of nodes, like an image nodes that animates from a placeholder to the actual image once it's fully loaded.

As described in #1022, the animation of the height of components will not trigger the caret offset to be recalculated, since it currently only reacts to changes to the selections or to the document content (i.e. nodes). Same applies for any other overlay builder that attempts to render something above the document.