### PR TITLE
Use dart test for attributed_text

### DIFF
--- a/flutter_test_registry/flutter_test_repo_test.bat
+++ b/flutter_test_registry/flutter_test_repo_test.bat
@@ -1,5 +1,5 @@
 PUSHD attributed_text
-CALL flutter test || GOTO :END
+CALL dart test || GOTO :END
 POPD
 
 PUSHD super_editor

--- a/flutter_test_registry/flutter_test_repo_test.sh
+++ b/flutter_test_registry/flutter_test_repo_test.sh
@@ -1,5 +1,5 @@
 set -e
 
-(cd ./attributed_text; flutter test)
+(cd ./attributed_text; dart test)
 (cd ./super_editor; flutter test)
 (cd ./super_text_layout; flutter test)


### PR DESCRIPTION
This package does not have a dependency on `flutter_test` and so there is no guarantee that the version of `test_api` from the pub solve is compatible with the `flutter test` command.

See https://github.com/flutter/flutter/issues/91107