### PR TITLE
[SuperEditor][Android] Fix text input after a new line insertion (Resolves #1081)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -199,24 +199,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
 
     late List<TextEditingDelta> allowedDeltas;
 
-    if (hasTextDeltas) {
-      // The delta list includes deltas which modify the document's content.
-      //
-      // After these deltas are applied, non-text deltas in the same list might point to invalid offsets.
-      //
-      // For example, given we have the following text, where | represents the caret:
-      // "Before the line break |new line"
-      //
-      // Adding a new line causes the OS editing text to be "Before the line break \n|new line".
-      // However, with this insertion we split the paragraph into two, and now our editing text is: "|new line".
-      //
-      // If the OS sends a non-text delta in the same list as the insertion delta, placing the selection at
-      // "Before the line break \n|new line", the OS selection offset (23) can't be mapped to a
-      // document position.
-      //
-      // Ignore non-text deltas.
-      allowedDeltas = textEditingDeltas.where((e) => e is! TextEditingDeltaNonTextUpdate).toList();
-    } else if (!_allowNonTextDeltas) {
+    if (!_allowNonTextDeltas) {
       // After we call setEditingState(), we ignore non-text deltas until the end of the current frame.
       //
       // This is because, in some platforms, we get a TextEditingDeltaNonTextUpdate after this call.

--- a/super_editor/test/src/infrastructure/text_diff_test.dart
+++ b/super_editor/test/src/infrastructure/text_diff_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/default_editor/document_ime/document_delta_editing.dart';
+
+void main() {
+  group('text diff', () {
+    group('detects deletions', () {
+      test('at the start', () {
+        final textDiff = computeDiff('Before the line break \nnew line', 'new line');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 0, end: 23),
+            )
+          ],
+        );
+      });
+
+      test('at the middle', () {
+        final textDiff = computeDiff('Before we get the line break', 'Before we get line break');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 14, end: 18),
+            )
+          ],
+        );
+      });
+
+      test('at the middle with intersecting content', () {
+        final textDiff = computeDiff('Before a new line is found in a new document', 'Before a new document');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 6, end: 29),
+            )
+          ],
+        );
+      });
+
+      test('at the end', () {
+        final textDiff = computeDiff('Before the line break', 'Before the');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 10, end: 21),
+            )
+          ],
+        );
+      });
+    });
+
+    group('detects insertions', () {
+      test('at the start', () {
+        final textDiff = computeDiff('new line', 'Before the line break \nnew line');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 0, end: 23),
+            )
+          ],
+        );
+      });
+
+      test('at the middle', () {
+        final textDiff = computeDiff('Before we get line break', 'Before we get the line break');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 14, end: 18),
+            )
+          ],
+        );
+      });
+
+      test('at the end', () {
+        final textDiff = computeDiff('Before the', 'Before the line break');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 10, end: 21),
+            )
+          ],
+        );
+      });
+
+      test('and keeps longest sequence', () {
+        final textDiff = computeDiff('Paragraph two', 'Paragraph oneParagraph two');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 0, end: 13),
+            )
+          ],
+        );
+      });
+    });
+
+    group('detects replacements', () {
+      test('at the start', () {
+        final textDiff = computeDiff('A line', 'Other line');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 0, end: 1),
+            ),
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 0, end: 5),
+            )
+          ],
+        );
+      });
+
+      test('at the middle', () {
+        final textDiff = computeDiff('A prefix', 'A sufix');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 2, end: 5),
+            ),
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 2, end: 4),
+            )
+          ],
+        );
+      });
+
+      test('at the end', () {
+        final textDiff = computeDiff('A text', 'A string');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 2, end: 6),
+            ),
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 2, end: 8),
+            )
+          ],
+        );
+      });
+
+      test('of the whole content', () {
+        final textDiff = computeDiff('A text', 'Other string');
+
+        expect(
+          textDiff,
+          [
+            TextDiffOperation(
+              operation: TextDiffOperationKind.deletion,
+              range: const TextRange(start: 0, end: 6),
+            ),
+            TextDiffOperation(
+              operation: TextDiffOperationKind.insertion,
+              range: const TextRange(start: 0, end: 12),
+            )
+          ],
+        );
+      });
+    });
+    group('returns no difference', () {
+      test('to equal strings', () {
+        final textDiff = computeDiff('The text is the same', 'The text is the same');
+
+        expect(textDiff, []);
+      });
+    });
+  });
+}


### PR DESCRIPTION
[SuperEditor][Android] Fix text input after a new line insertion. Resolves #1081 

On Android, placing the caret at the middle of a line and pressing the new line button causes the text input to crash with the exception:

```
Couldn't map an IME position to a document position
```

This is another issue when we get multiple deltas in one batch. 

In this case, we get an insertion delta followed by a non-text delta. The selection offset of the non-text delta becomes invalid after the insertion delta is applied.

For example, we have the following text, where | means the caret:

```
Before the line break |new line
```

After we add a line break we get an insertion delta of `\n` followed by a non-text delta, which has:

```
old text: Before the line break \nnew line
selection at offset: 23
```

The problem is that when we get the `\n`, we split the paragraph into two and our editing text changes to `new line`. With this new text, 23 is an invalid offset.

I'm not sure what's the correct approach to handle this issue.

This PR changes the delta handling to ignore non-text deltas that are in the same batch of text deltas. Whenever we get a text delta, we are already sending back to the OS the new selection. So, in theory, it should be safe to ignore these non-text deltas.