### PR TITLE
Make super_text_layout releasable again (Resolves #1083)

### DIFF
--- a/super_editor/test/super_editor/supereditor_text_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_text_layout_test.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/super_editor_test.dart';
-import 'package:super_text_layout/super_text_layout.dart';
+import 'package:super_text_layout/super_text_layout_inspector.dart';
 
 import '../test_tools.dart';
 import 'document_test_tools.dart';

--- a/super_text_layout/CHANGELOG.md
+++ b/super_text_layout/CHANGELOG.md
@@ -1,22 +1,22 @@
-## [0.1.4] - Oct, 2022
+## [0.1.5]
+Added support for font scaling (April, 2023)
+ 
+ * Bumped `attributed_text` dependency to `0.2.1`.
+ 
+## [0.1.4]
+Fixed a `NullPointerException` in `SuperTextLayout` (Oct, 2022)
 
-Fixed a `NullPointerException` in `SuperTextLayout`.
+## [0.1.3]
+Upgraded the dependency on `attributed_text` from `0.1.3` to `0.2.0` (July, 2022)
 
-## [0.1.3] - July, 2022
+## [0.1.2] - DEPRECATED
+Upgraded the dependency on `attributed_text` from `0.1.3` to `0.2.0` (July, 2022)
 
-Upgraded the dependency on `attributed_text` from `0.1.3` to `0.2.0`.
+## [0.1.1] - DEPRECATED
+Added `estimatedLineHeight` to `TextLayout`. The method is experimental - it may be removed later (July, 2022)
 
-## [0.1.2] - July, 2022 - DEPRECATED
-
-Upgraded the dependency on `attributed_text` from `0.1.3` to `0.2.0`.
-
-## [0.1.1] - July, 2022 - DEPRECATED
-
-Added `estimatedLineHeight` to `TextLayout`. The method is experimental - it may be removed later.
-
-## [0.1.0] - May, 2022
-
-The `super_text_layout` package is extracted from `super_editor`.
+## [0.1.0]
+The `super_text_layout` package is extracted from `super_editor` (May, 2022)
 
  * Introduces `SuperText` widget to render text with layers above and beneath the text
  * Introduces `SuperTextWithSelection` to easily paint text with traditional user selections, 

--- a/super_text_layout/lib/super_text_layout.dart
+++ b/super_text_layout/lib/super_text_layout.dart
@@ -4,4 +4,3 @@ export 'src/super_text_layout_with_selection.dart';
 export 'src/text_layout.dart';
 export 'src/text_selection_layer.dart';
 export 'src/infrastructure/blink_controller.dart';
-export 'src/super_text_inspector.dart';

--- a/super_text_layout/lib/super_text_layout_inspector.dart
+++ b/super_text_layout/lib/super_text_layout_inspector.dart
@@ -1,0 +1,1 @@
+export 'src/super_text_inspector.dart';

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -14,6 +14,10 @@ dependencies:
   attributed_text: ^0.2.1
   logging: ^1.0.1
 
+  # For inspector
+  flutter_test:
+    sdk: flutter
+
 #dependency_overrides:
 #  # Override to local mono-repo path so devs can test this repo
 #  # against changes that they're making to other mono-repo packages
@@ -22,8 +26,6 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  flutter_test:
-    sdk: flutter
   golden_toolkit: ^0.11.0
   args: ^2.3.1
 

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -18,11 +18,11 @@ dependencies:
   flutter_test:
     sdk: flutter
 
-#dependency_overrides:
-#  # Override to local mono-repo path so devs can test this repo
-#  # against changes that they're making to other mono-repo packages
-#  attributed_text:
-#    path: ../attributed_text
+dependency_overrides:
+  # Override to local mono-repo path so devs can test this repo
+  # against changes that they're making to other mono-repo packages
+  attributed_text:
+    path: ../attributed_text
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_text_layout
 description: Configurable, composable, extensible text display for Flutter.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
@@ -11,14 +11,14 @@ dependencies:
   flutter:
     sdk: flutter
 
-  attributed_text: ^0.2.0
+  attributed_text: ^0.2.1
   logging: ^1.0.1
 
-dependency_overrides:
-  # Override to local mono-repo path so devs can test this repo
-  # against changes that they're making to other mono-repo packages
-  attributed_text:
-    path: ../attributed_text
+#dependency_overrides:
+#  # Override to local mono-repo path so devs can test this repo
+#  # against changes that they're making to other mono-repo packages
+#  attributed_text:
+#    path: ../attributed_text
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Make super_text_layout releasable again (Resolves #1083)

I added `flutter_test` to the regular package deps. I'd prefer not to, but we ship an "inspector", which uses test inspection APIs.

I also released v0.1.5 of `super_text_layout` with the code from this PR.