### PR TITLE
[SuperEditor] Avoid restoring selection upon re-focus when selected nodes were deleted (Resolves #1074)

### DIFF
--- a/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
+++ b/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
@@ -8,6 +8,7 @@ class EditorSelectionAndFocusPolicy extends StatefulWidget {
   const EditorSelectionAndFocusPolicy({
     Key? key,
     required this.focusNode,
+    required this.document,
     required this.selection,
     required this.isDocumentLayoutAvailable,
     required this.getDocumentLayout,
@@ -30,6 +31,9 @@ class EditorSelectionAndFocusPolicy extends StatefulWidget {
   ///
   /// When focus is lost, this widget may clear the editor's selection.
   final FocusNode focusNode;
+
+  /// The editor's [Document].
+  final Document document;
 
   /// The document editor's current selection.
   final ValueNotifier<DocumentSelection?> selection;
@@ -109,6 +113,12 @@ class _EditorSelectionAndFocusPolicyState extends State<EditorSelectionAndFocusP
     // Ensure the editor has a selection when focused.
     if (!_wasFocused && widget.focusNode.hasFocus) {
       if (widget.restorePreviousSelectionOnGainFocus && _previousSelection != null) {
+        if (widget.document.getNodeById(_previousSelection!.base.nodeId) == null ||
+            widget.document.getNodeById(_previousSelection!.extent.nodeId) == null) {
+          editorPoliciesLog.info(
+              "[${widget.runtimeType}] - not restoring previous editor selection because one of the selected nodes was deleted");
+          return;
+        }
         // Restore the previous selection.
         editorPoliciesLog
             .info("[${widget.runtimeType}] - restoring previous editor selection because the editor re-gained focus");

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -548,6 +548,7 @@ class SuperEditorState extends State<SuperEditor> {
       focusNode: _focusNode,
       child: EditorSelectionAndFocusPolicy(
         focusNode: _focusNode,
+        document: widget.editor.document,
         selection: _composer.selectionNotifier,
         isDocumentLayoutAvailable: () => _docLayoutKey.currentContext != null,
         getDocumentLayout: () => editContext.documentLayout,


### PR DESCRIPTION
[SuperEditor] Avoid restoring selection upon re-focus when selected nodes were deleted. Resolves #1074

`EditorSelectionAndFocusPolicy` restores the previous selection when the editor re-gains focus. If the node at the selection base or extent was removed while the editor didn't have focus, restoring the selection causes the editor to crash, because we are applying a selection with an inexistent node.

This PR changes `EditorSelectionAndFocusPolicy` to check if the nodes at base and offset are still present before restoring the selection.