### PR TITLE
Prepare for stable release

### DIFF
--- a/super_editor/CHANGELOG.md
+++ b/super_editor/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [0.2.4-dev.1] - May 08, 2023: 
+ * The same as v0.2.4+1, but compatible with Flutter `master`
+
+## [0.2.4] - May 08, 2023:
+ * FEATURE: `SuperEditor` includes a built-in concept of a "task"
+ * FEATURE: `SuperEditor` links open on tap, when in "interaction mode"
+ * FEATURE: `SuperEditor`, `SuperReader`, `SuperTextField` all respect `MediaQuery` text scale
+ * FEATURE: `SuperEditor` selection changes now include a "reason", to facilitate multi-user and server interactions
+ * FEATURE: `SuperEditor` supports GBoard spacebar caret movement, and other software keyboard gestures
+ * FEATURE: `SuperEditor` allows a selection even when the software keyboard is closed, and also lets apps open and close the keyboard at their discretion
+ * FEATURE: `SuperEditor` lets apps override what happens when the IME wants to a perform an action, like "done" or "newline"
+ * FEATURE: `SuperEditor` respects inherited `MediaQuery` `GestureSetting`s
+ * FEATURE: `SuperTextField` now exposes configuration for the caret style
+ * FEATURE: `SuperTextField` now exposes configuration for keyboard appearance
+ * FEATURE: `SuperDesktopTextField` now supports IME text entry, which adds support for compound characters
+ * FIX: `SuperEditor` don't scroll while dragging over an image
+ * FIX: `SuperEditor` partial improvements to iOS floating cursor display
+ * FIX: `SuperEditor` fix text styles when backspacing a list item into a preceding paragraph
+ * FIX: `SuperEditor` rebuilds layers when document layout or component layout changes, e.g., rebuilds caret when a list item animates its size
+ * FIX: `SuperTextField` when selection changes, don't auto-scroll if the new selection position is already visible
+ * FIX: `SuperTextField` popup toolbar on iOS shows the arrow pointing towards content, instead of pointing away from content
+ * FIX: `SuperTextField` don't change selection when two fingers move on trackpad
+ * FIX: `SuperTextField` handle numpad ENTER same as regular ENTER
+ * FIX: `SuperTextField` when user taps to stop scroll momentum, don't change the selection
+
+## [0.2.3-dev.1] - Nov 11, 2022: SuperReader, Bug Fixes (pre-release)
+ * The same as v0.2.3+1, but compatible with Flutter `master`
+
 ## [0.2.3+1] - Nov, 2022: Pub.dev listing updates
  * No functional changes
 

--- a/super_editor/README_RELEASING.md
+++ b/super_editor/README_RELEASING.md
@@ -1,9 +1,31 @@
 # Releasing Super Editor
+Super Editor maintains two active branches and releases: `main` and `stable`.
 
-Follow these steps to release new versions of Super Editor:
+The `main` branch tracks Flutter's `master` branch. The `stable` branch tracks Flutter's `stable` branch.
+
+New releases should be cut for both branches at the same time (unless other factors dictate otherwise).
+
+Releases based on `main` should end with `-dev.X`, e.g. `v0.2.1-dev.1`.
+
+Releases based on `stable` should use standard versioning, e.g., `v0.2.1`.
+
+To release `main`:
 
 1. Checkout the tip of the `main` branch
-2. Update the `CHANGELOG.md` to describe the important changes in this release
-3. Merge the `CHANGELOG.md` update into `main` and ensure you're at the new tip of `main`
-4. Follow official instructions to publish a new version to pub.dev: https://dart.dev/tools/pub/publishing#publishing-your-package
-5. Tag the commit that was published with the version, e.g., "v0.1.0", and push that tag to `origin`
+2. Increment the build version in the pubspec, e.g., `v0.2.1-dev.1` -> `v0.2.2-dev.1`
+3. Update the `CHANGELOG.md` to describe the important changes in this release. Take this opportunity to add descriptions for both the `-dev` release and the standard release.
+4. Use a PR to merge the `CHANGELOG.md` and version update into `main`.
+5. Pull the latest version of `main` from `origin`, which should now be ready to publish.
+6. Follow official instructions to publish a new version to pub.dev: https://dart.dev/tools/pub/publishing#publishing-your-package
+7. Tag the commit that was published with the version, e.g., "v0.2.2-dev.1", and push that tag to `origin`
+
+To release `stable`:
+
+1. Follow instructions above to release to `main`.
+2. Create a branch off of `stable` called something like `release-stable`.
+3. Cherry pick the commit from `main` with the `CHANGELOG.md` and build version change.
+4. Remove the `-dev.X` from the build version in the pubspec, e.g., `v0.2.2-dev.1` => `v0.2.2`.
+5. Use a PR to merge these changes into `stable`.
+6. Pull the latest version of `stable` from `origin`, which should now be ready to publish. 
+7. Follow official instructions to publish a new version to pub.dev: https://dart.dev/tools/pub/publishing#publishing-your-package
+8. Tag the commit that was published with the version, e.g., "v0.2.2", and push that tag to `origin`

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -305,7 +305,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: _brightness,
-      builder: (context, _) {
+      builder: (context) {
         return Theme(
           data: ThemeData(brightness: _brightness.value),
           child: Builder(
@@ -426,7 +426,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
           keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
           androidToolbarBuilder: (_) => ListenableBuilder(
             listenable: _brightness,
-            builder: (context, _) {
+            builder: (context) {
               return Theme(
                 data: ThemeData(brightness: _brightness.value),
                 child: AndroidTextEditingFloatingToolbar(
@@ -440,7 +440,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
           ),
           iOSToolbarBuilder: (_) => ListenableBuilder(
             listenable: _brightness,
-            builder: (context, _) {
+            builder: (context) {
               return Theme(
                 data: ThemeData(brightness: _brightness.value),
                 child: IOSTextEditingFloatingToolbar(

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor
 description: Configurable, composable, extensible text editor and document renderer for Flutter.
-version: 0.2.3+1
+version: 0.2.4
 homepage: https://github.com/superlistapp/super_editor
 
 screenshots:


### PR DESCRIPTION
Prepare for stable release.

This PR cherry picks the v0.2.4-dev.1 release commit from `main` and adjusts it for `stable`, where we'll release v0.2.4.