### PR TITLE
Prepare super_editor_markdown for v0.1.4+2 release

### DIFF
--- a/super_editor_markdown/CHANGELOG.md
+++ b/super_editor_markdown/CHANGELOG.md
@@ -1,8 +1,19 @@
+## [0.1.4+2] - May, 2022
+* Added support for paragraph "justify" alignment in Markdown serialization.
+
+## [0.1.4+1] - Nov, 2022
+* Added support for custom Markdown block syntax.
+* Fix: parsing empty markdown into a document.
+* Fix: serialization of paragraph alignment, text strikethrough and underline.
+
+## [0.1.4] - Nov, 2022
+* De-listed because we forgot to upgrade the super_editor dependency
+
 ## [0.1.3] - July, 2022
- * Updated `AttributedText` serialization to use new `AttributionVisitor` API.
- 
+* Updated `AttributedText` serialization to use new `AttributionVisitor` API.
+
 ## [0.1.2] - ~July, 2022~ (Removed from pub)
- * Updated `AttributedText` serialization to use new `AttributionVisitor` API.
+* Updated `AttributedText` serialization to use new `AttributionVisitor` API.
 
 ## [0.1.1] - June, 2022
- * BREAKING: changed super_editor_markdown to NOT append newlines after every line it serializes to avoid extra newlines at the end of a serialized document.
+* BREAKING: changed super_editor_markdown to NOT append newlines after every line it serializes to avoid extra newlines at the end of a serialized document.

--- a/super_editor_markdown/CHANGELOG.md
+++ b/super_editor_markdown/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.1.4+2] - May, 2022
+## [0.1.4+2] - May, 2023
 * Added support for paragraph "justify" alignment in Markdown serialization.
 
 ## [0.1.4+1] - Nov, 2022

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  super_editor: ^0.2.4
+  super_editor: ^0.2.4-dev.1
   logging: ^1.0.1
   markdown: ^4.0.0
 

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor_markdown
 description: Markdown (de)serialization for super_editor documents.
-version: 0.1.3
+version: 0.1.4+2
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  super_editor: ^0.2.2
+  super_editor: ^0.2.4
   logging: ^1.0.1
   markdown: ^4.0.0
 
@@ -26,11 +26,10 @@ dependency_overrides:
     path: ../attributed_text
 
 dev_dependencies:
-  # TODO: upgrade lints to 2.0.1 when we release super_editor 0.2.1
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.11.0
 
 flutter:
-  # no Flutter configuration
+# no Flutter configuration


### PR DESCRIPTION
Prepare super_editor_markdown for v0.1.4+2 release

This PR copies some changes that I think we only have on `stable`. This is probably because the last release was cut directly from `stable`, so we let `main` fall behind.

After bringing `main` up to date with `stable`, I updated the version number and added to the CHANGELOG.