### PR TITLE
Update one floating cursor test for the M3 default transition

### DIFF
--- a/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
+++ b/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
@@ -128,6 +128,11 @@ void main() {
 
         // Ensure the caret has the default color.
         caret = tester.widget<BlinkingCaret>(_caretFinder());
+        // The default caret color is the theme's primary color. Currently
+        // this test will succeed for both Material2 and Material3.
+        // TODO(hansmuller) when the default for ThemeData.useMaterial3 is
+        // changed to true, change this test to check for the default
+        // M3 theme's primary color's value, Color(0xff6750a4).
         expect(caret.color, Theme.of(tester.firstElement(_caretFinder())).primaryColor);
       });
     });

--- a/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
+++ b/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
@@ -126,9 +126,9 @@ void main() {
         // Ensure the caret is displayed.
         expect(_caretFinder(), findsOneWidget);
 
-        // Ensure the caret is blue.
+        // Ensure the caret has the default color.
         caret = tester.widget<BlinkingCaret>(_caretFinder());
-        expect(caret.color, Colors.blue);
+        expect(caret.color, Theme.of(tester.firstElement(_caretFinder())).primaryColor);
       });
     });
   });


### PR DESCRIPTION
Prepare for the change to the default value of ThemeData.useMaterial3 coming in https://github.com/flutter/flutter/issues/127064. Currently the 'shows grey caret when far from text' test depends on the UI being configured for Material2. Changed the test so that it checks the theme's primary color; the cursor's default color. This works for M2 and M3.

