### PR TITLE
[SuperEditor] Fix deletion of first character of a header with backspace (Resolves #1176)

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -529,6 +529,10 @@ ExecutionInstruction backspaceToClearParagraphBlockType({
   required SuperEditorContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -77,10 +77,11 @@ void testWidgetsOnDesktop(
   String description,
   WidgetTesterCallback test, {
   bool skip = false,
+  TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgetsOnMac("$description (on MAC)", test, skip: skip);
-  testWidgetsOnWindows("$description (on Windows)", test, skip: skip);
-  testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
+  testWidgetsOnMac("$description (on MAC)", test, skip: skip, variant: variant);
+  testWidgetsOnWindows("$description (on Windows)", test, skip: skip, variant: variant);
+  testWidgetsOnLinux("$description (on Linux)", test, skip: skip, variant: variant);
 }
 
 /// A widget test that runs a variant for every mobile platform, e.g.,


### PR DESCRIPTION
[SuperEditor] Fix deletion of first character of a header with backspace (Resolves #1176)

When the caret is after the first character of a header, pressing deleting is causing the header to be converted to a paragraph.

The cause is that, after deleting the character, we are handling the backspace KeyUpEvent in `backspaceToClearParagraphBlockType`. As the first character was already removed when `backspaceToClearParagraphBlockType` the selection sits at the beginning of the text and thus the header metadata is cleared.

This PR changes `backspaceToClearParagraphBlockType` to ignore events other than `RawKeyDownEvent`.