### PR TITLE
Cherry-pick "[SuperEditor] Fix deletion of first character of a header with backspace (Resolves #1176) (#1179)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -529,6 +529,10 @@ ExecutionInstruction backspaceToClearParagraphBlockType({
   required SuperEditorContext editContext,
   required RawKeyEvent keyEvent,
 }) {
+  if (keyEvent is! RawKeyDownEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
   if (keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
     return ExecutionInstruction.continueExecution;
   }

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -77,10 +77,11 @@ void testWidgetsOnDesktop(
   String description,
   WidgetTesterCallback test, {
   bool skip = false,
+  TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgetsOnMac("$description (on MAC)", test, skip: skip);
-  testWidgetsOnWindows("$description (on Windows)", test, skip: skip);
-  testWidgetsOnLinux("$description (on Linux)", test, skip: skip);
+  testWidgetsOnMac("$description (on MAC)", test, skip: skip, variant: variant);
+  testWidgetsOnWindows("$description (on Windows)", test, skip: skip, variant: variant);
+  testWidgetsOnLinux("$description (on Linux)", test, skip: skip, variant: variant);
 }
 
 /// A widget test that runs a variant for every mobile platform, e.g.,


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix deletion of first character of a header with backspace (Resolves #1176) (#1179)" to stable