### PR TITLE
Added reference to old DocumentNode within NodeRemovedEvent (Resolves #1181)

### DIFF
--- a/super_editor/example/analysis_options.yaml
+++ b/super_editor/example/analysis_options.yaml
@@ -1,5 +1,3 @@
-include: package:flutter_lints/flutter.yaml
-
 linter:
   rules:
     avoid_print: false

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -168,10 +168,12 @@ class NodeMovedEvent implements NodeDocumentChange {
 
 /// A [DocumentNode] was removed from the [Document].
 class NodeRemovedEvent implements NodeDocumentChange {
-  const NodeRemovedEvent(this.nodeId);
+  const NodeRemovedEvent(this.nodeId, this.removedNode);
 
   @override
   final String nodeId;
+
+  final DocumentNode removedNode;
 
   @override
   bool operator ==(Object other) =>

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -328,7 +328,7 @@ class ReplaceNodeCommand extends EditCommand {
 
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(existingNodeId),
+        NodeRemovedEvent(existingNodeId, oldNode),
       ),
       DocumentEdit(
         NodeInsertedEvent(newNode.id, document.getNodeIndexById(newNode.id)),
@@ -379,7 +379,7 @@ class ReplaceNodeWithEmptyParagraphWithCaretCommand implements EditCommand {
 
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(oldNode.id),
+        NodeRemovedEvent(oldNode.id, oldNode),
       ),
       DocumentEdit(
         NodeInsertedEvent(newNode.id, document.getNodeIndexById(newNode.id)),
@@ -525,7 +525,7 @@ class DeleteSelectionCommand implements EditCommand {
     document.deleteNode(endNodeAfterDeletion);
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(endNodeAfterDeletion.id),
+        NodeRemovedEvent(endNodeAfterDeletion.id, endNodeAfterDeletion),
       )
     ]);
     _log.log('DeleteSelectionCommand', ' - done with selection deletion');
@@ -605,8 +605,9 @@ class DeleteSelectionCommand implements EditCommand {
     final changes = <EditEvent>[];
     for (int i = endIndex - 1; i > startIndex; --i) {
       _log.log('_deleteNodesBetweenFirstAndLast', ' - deleting node $i: ${document.getNodeAt(i)?.id}');
+      final removedNode = document.getNodeAt(i)!;
       changes.add(DocumentEdit(
-        NodeRemovedEvent(document.getNodeAt(i)!.id),
+        NodeRemovedEvent(removedNode.id, removedNode),
       ));
       document.deleteNodeAt(i);
     }
@@ -639,7 +640,7 @@ class DeleteSelectionCommand implements EditCommand {
 
         return [
           DocumentEdit(
-            NodeRemovedEvent(node.id),
+            NodeRemovedEvent(node.id, node),
           )
         ];
       } else {
@@ -685,7 +686,7 @@ class DeleteSelectionCommand implements EditCommand {
 
         return [
           DocumentEdit(
-            NodeRemovedEvent(node.id),
+            NodeRemovedEvent(node.id, node),
           )
         ];
       } else {
@@ -729,7 +730,7 @@ class DeleteSelectionCommand implements EditCommand {
 
       return [
         DocumentEdit(
-          NodeRemovedEvent(node.id),
+          NodeRemovedEvent(node.id, node),
         ),
         DocumentEdit(
           NodeInsertedEvent(newNode.id, document.getNodeIndexById(newNode.id)),
@@ -741,7 +742,7 @@ class DeleteSelectionCommand implements EditCommand {
 
       return [
         DocumentEdit(
-          NodeRemovedEvent(node.id),
+          NodeRemovedEvent(node.id, node),
         )
       ];
     }
@@ -779,7 +780,7 @@ class DeleteNodeCommand implements EditCommand {
     _log.log('DeleteNodeCommand', ' - done with node deletion');
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(node.id),
+        NodeRemovedEvent(node.id, node),
       )
     ]);
   }

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -300,7 +300,7 @@ class CombineParagraphsCommand implements EditCommand {
 
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(secondNode.id),
+        NodeRemovedEvent(secondNode.id, secondNode),
       ),
       DocumentEdit(
         NodeChangeEvent(nodeAbove.id),
@@ -516,7 +516,7 @@ class DeleteParagraphCommand implements EditCommand {
 
     executor.logChanges([
       DocumentEdit(
-        NodeRemovedEvent(node.id),
+        NodeRemovedEvent(node.id, node),
       )
     ]);
   }

--- a/super_editor/test/super_editor/infrastructure/editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/editor_test.dart
@@ -544,6 +544,30 @@ void main() {
           ],
         );
       });
+
+      test('reports the node that was removed', () {
+        DocumentNode? removedNode;
+        final editorPieces = _createStandardEditor(
+          initialDocument: longTextDoc(),
+          additionalReactions: [
+            FunctionalEditReaction((editorContext, requestDispatcher, changeList) {
+              expect(changeList.length, 1);
+
+              final event = changeList.first as DocumentEdit;
+              final change = event.change as NodeRemovedEvent;
+              removedNode = change.removedNode;
+            }),
+          ],
+        );
+
+        final nodeToRemove = editorPieces.document.getNodeById("2")!;
+
+        editorPieces.editor.execute([
+          DeleteNodeRequest(nodeId: nodeToRemove.id),
+        ]);
+
+        expect(removedNode, nodeToRemove);
+      });
     });
   });
 }
@@ -552,6 +576,7 @@ void main() {
 StandardEditorPieces _createStandardEditor({
   MutableDocument? initialDocument,
   DocumentSelection? initialSelection,
+  List<EditReaction> additionalReactions = const [],
 }) {
   final document = initialDocument ?? singleParagraphEmptyDoc();
 
@@ -563,6 +588,7 @@ StandardEditorPieces _createStandardEditor({
     },
     requestHandlers: defaultRequestHandlers,
     reactionPipeline: [
+      ...additionalReactions,
       const LinkifyReaction(),
       const UnorderedListItemConversionReaction(),
       const OrderedListItemConversionReaction(),


### PR DESCRIPTION
Added reference to old DocumentNode within NodeRemovedEvent (Resolves #1181)

This change was made so that editor reactions can base their decisions on content in a removed node.

This addition isn't ideal because we're passing a reference to a now-deleted, mutable `DocumentNode`, but it's unclear what else we should do. We'll probably revisit issues like this later.