### PR TITLE
[SuperEditor] Linkify URLs without www (Resolves #1178)

### DIFF
--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -548,6 +548,7 @@ class LinkifyReaction implements EditReaction {
           word,
           options: const LinkifyOptions(
             humanize: false,
+            looseUrl: true,
           ),
         );
         final int linkCount = extractedLinks.fold(0, (value, element) => element is UrlElement ? value + 1 : value);


### PR DESCRIPTION
[SuperEditor] Linkify URLs without www (Resolves #1178).

By default, the package used to extract URLs from the text doesn't recognize URLs without www.

This PR enables the option to allow "loose" URLs.