### PR TITLE
[SuperEditor][Mobile] Fix task and list item splitting on ENTER (Resolves #1157)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1674,7 +1674,7 @@ class CommonEditorOperations {
 
       editor.execute([
         SplitExistingTaskRequest(
-          nodeId: extentNode.id,
+          existingNodeId: extentNode.id,
           splitOffset: splitOffset,
           newNodeId: newNodeId,
         ),

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -14,6 +14,7 @@ import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/super_editor.dart';
 
 import 'attributions.dart';
 import 'horizontal_rule.dart';
@@ -1668,6 +1669,26 @@ class CommonEditorOperations {
           ),
         ]);
       }
+    } else if (extentNode is TaskNode) {
+      final splitOffset = (composer.selection!.extent.nodePosition as TextNodePosition).offset;
+
+      editor.execute([
+        SplitExistingTaskRequest(
+          nodeId: extentNode.id,
+          splitOffset: splitOffset,
+          newNodeId: newNodeId,
+        ),
+        ChangeSelectionRequest(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: newNodeId,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+          SelectionChangeType.insertContent,
+          SelectionReason.userInteraction,
+        ),
+      ]);
     } else {
       // We don't know how to handle this type of node position. Do nothing.
       editorOpsLog.fine("Can't insert new block-level inline because we don't recognize the selected content type.");

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -130,7 +130,7 @@ final defaultRequestHandlers = [
       : null,
   (request) => request is SplitExistingTaskRequest
       ? SplitExistingTaskCommand(
-          nodeId: request.nodeId,
+          nodeId: request.existingNodeId,
           splitOffset: request.splitOffset,
           newNodeId: request.newNodeId,
         )

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -132,6 +132,7 @@ final defaultRequestHandlers = [
       ? SplitExistingTaskCommand(
           nodeId: request.nodeId,
           splitOffset: request.splitOffset,
+          newNodeId: request.newNodeId,
         )
       : null,
   (request) => request is SplitListItemRequest

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -7,9 +7,11 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
@@ -478,7 +480,40 @@ class TextDeltasDocumentEditor {
 
     final newNodeId = Editor.createNodeId();
 
-    if (extentNode is ParagraphNode) {
+    if (extentNode is ListItemNode) {
+      if (extentNode.text.text.isEmpty) {
+        // The list item is empty. Convert it to a paragraph.
+        editorOpsLog.finer(
+            "The current node is an empty list item. Converting it to a paragraph instead of inserting block-level newline.");
+        editor.execute([
+          ConvertTextNodeToParagraphRequest(nodeId: extentNode.id),
+        ]);
+        return;
+      }
+
+      // Split the list item into two.
+      editorOpsLog.finer("Splitting list item in two.");
+      editor.execute([
+        SplitListItemRequest(
+          nodeId: extentNode.id,
+          splitPosition: caretPosition.nodePosition as TextNodePosition,
+          newNodeId: newNodeId,
+        ),
+        ChangeSelectionRequest(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: newNodeId,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+          SelectionChangeType.insertContent,
+          SelectionReason.userInteraction,
+        ),
+      ]);
+      final newListItemNode = document.getNodeById(newNodeId)!;
+
+      _updateImeRangeMappingAfterNodeSplit(originNode: extentNode, newNode: newListItemNode);
+    } else if (extentNode is ParagraphNode) {
       // Split the paragraph into two. This includes headers, blockquotes, and
       // any other block-level paragraph.
       final currentExtentPosition = caretPosition.nodePosition as TextNodePosition;
@@ -508,30 +543,7 @@ class TextDeltasDocumentEditor {
         ),
       ]);
 
-      final newImeValue = _nextImeValue!;
-      final imeNewlineIndex = newImeValue.text.indexOf("\n");
-      final topImeToDocTextRange = TextRange(start: 0, end: imeNewlineIndex);
-      final bottomImeToDocTextRange = TextRange(start: imeNewlineIndex + 1, end: newImeValue.text.length);
-
-      // Update mapping from Document nodes to IME ranges.
-      _serializedDoc.docTextNodesToImeRanges[extentNode.id] = topImeToDocTextRange;
-      _serializedDoc.docTextNodesToImeRanges[newTextNode.id] = bottomImeToDocTextRange;
-
-      // Remove old mapping from IME TextRange to Document node.
-      late final MapEntry<TextRange, String> oldImeToDoc;
-      for (final entry in _serializedDoc.imeRangesToDocTextNodes.entries) {
-        if (entry.value != extentNode.id) {
-          continue;
-        }
-
-        oldImeToDoc = entry;
-        break;
-      }
-      _serializedDoc.imeRangesToDocTextNodes.remove(oldImeToDoc.key);
-
-      // Update and add mapping from IME TextRanges to Document nodes.
-      _serializedDoc.imeRangesToDocTextNodes[topImeToDocTextRange] = extentNode.id;
-      _serializedDoc.imeRangesToDocTextNodes[bottomImeToDocTextRange] = newTextNode.id;
+      _updateImeRangeMappingAfterNodeSplit(originNode: extentNode, newNode: newTextNode);
     } else if (caretPosition.nodePosition is UpstreamDownstreamNodePosition) {
       final extentPosition = caretPosition.nodePosition as UpstreamDownstreamNodePosition;
       if (extentPosition.affinity == TextAffinity.downstream) {
@@ -561,6 +573,29 @@ class TextDeltasDocumentEditor {
           ),
         ]);
       }
+    } else if (extentNode is TaskNode) {
+      final splitOffset = (caretPosition.nodePosition as TextNodePosition).offset;
+
+      editor.execute([
+        SplitExistingTaskRequest(
+          nodeId: extentNode.id,
+          splitOffset: splitOffset,
+          newNodeId: newNodeId,
+        ),
+        ChangeSelectionRequest(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: newNodeId,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+          SelectionChangeType.insertContent,
+          SelectionReason.userInteraction,
+        ),
+      ]);
+      final newTaskNode = document.getNodeById(newNodeId)!;
+
+      _updateImeRangeMappingAfterNodeSplit(originNode: extentNode, newNode: newTaskNode);
     } else {
       // We don't know how to handle this type of node position. Do nothing.
       editorOpsLog.fine("Can't insert new block-level inline because we don't recognize the selected content type.");
@@ -573,5 +608,36 @@ class TextDeltasDocumentEditor {
       commonOps.deleteSelection();
     }
     commonOps.insertBlockLevelNewline();
+  }
+
+  /// Updates mappings from Document nodes to IME ranges and IME ranges to Document nodes.
+  void _updateImeRangeMappingAfterNodeSplit({
+    required DocumentNode originNode,
+    required DocumentNode newNode,
+  }) {
+    final newImeValue = _nextImeValue!;
+    final imeNewlineIndex = newImeValue.text.indexOf("\n");
+    final topImeToDocTextRange = TextRange(start: 0, end: imeNewlineIndex);
+    final bottomImeToDocTextRange = TextRange(start: imeNewlineIndex + 1, end: newImeValue.text.length);
+
+    // Update mapping from Document nodes to IME ranges.
+    _serializedDoc.docTextNodesToImeRanges[originNode.id] = topImeToDocTextRange;
+    _serializedDoc.docTextNodesToImeRanges[newNode.id] = bottomImeToDocTextRange;
+
+    // Remove old mapping from IME TextRange to Document node.
+    late final MapEntry<TextRange, String> oldImeToDoc;
+    for (final entry in _serializedDoc.imeRangesToDocTextNodes.entries) {
+      if (entry.value != originNode.id) {
+        continue;
+      }
+
+      oldImeToDoc = entry;
+      break;
+    }
+    _serializedDoc.imeRangesToDocTextNodes.remove(oldImeToDoc.key);
+
+    // Update and add mapping from IME TextRanges to Document nodes.
+    _serializedDoc.imeRangesToDocTextNodes[topImeToDocTextRange] = originNode.id;
+    _serializedDoc.imeRangesToDocTextNodes[bottomImeToDocTextRange] = newNode.id;
   }
 }

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -578,7 +578,7 @@ class TextDeltasDocumentEditor {
 
       editor.execute([
         SplitExistingTaskRequest(
-          nodeId: extentNode.id,
+          existingNodeId: extentNode.id,
           splitOffset: splitOffset,
           newNodeId: newNodeId,
         ),

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -298,7 +298,7 @@ ExecutionInstruction enterToInsertNewTask({
 
   editContext.editor.execute([
     SplitExistingTaskRequest(
-      nodeId: node.id,
+      existingNodeId: node.id,
       splitOffset: splitOffset,
     ),
   ]);
@@ -401,12 +401,12 @@ class ConvertParagraphToTaskCommand implements EditCommand {
 
 class SplitExistingTaskRequest implements EditRequest {
   const SplitExistingTaskRequest({
-    required this.nodeId,
+    required this.existingNodeId,
     required this.splitOffset,
     this.newNodeId,
   });
 
-  final String nodeId;
+  final String existingNodeId;
   final int splitOffset;
   final String? newNodeId;
 }

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -403,20 +403,24 @@ class SplitExistingTaskRequest implements EditRequest {
   const SplitExistingTaskRequest({
     required this.nodeId,
     required this.splitOffset,
+    this.newNodeId,
   });
 
   final String nodeId;
   final int splitOffset;
+  final String? newNodeId;
 }
 
 class SplitExistingTaskCommand implements EditCommand {
   const SplitExistingTaskCommand({
     required this.nodeId,
     required this.splitOffset,
+    this.newNodeId,
   });
 
   final String nodeId;
   final int splitOffset;
+  final String? newNodeId;
 
   @override
   void execute(EditContext editContext, CommandExecutor executor) {
@@ -441,7 +445,7 @@ class SplitExistingTaskCommand implements EditCommand {
     }
 
     final newTaskNode = TaskNode(
-      id: Editor.createNodeId(),
+      id: newNodeId ?? Editor.createNodeId(),
       text: node.text.copyText(splitOffset),
       isComplete: false,
     );

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -161,6 +161,221 @@ void main() {
         // Ensure the caret is being displayed at the correct position.
         expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
       });
+
+      testWidgetsOnDesktop("inserts new item on ENTER at end of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // Press enter to create a new list item.
+        await tester.pressEnter();
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAndroid("inserts new item on ENTER at end of existing item with mobile keyboard (on Android)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText("\n");
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("inserts new item on ENTER at end of existing item with mobile keyboard (on iOS)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnDesktop("splits list item into two on ENTER in middle of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // Press enter to split the existing item into two.
+        await tester.pressEnter();
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAndroid(
+          "splits list item into two on ENTER in middle of existing item with mobile keyboard (on Android)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText("\n");
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("splits list item into two on ENTER in middle of existing item with mobile keyboard (on iOS)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
     });
 
     group('ordered list', () {
@@ -221,6 +436,221 @@ void main() {
 
         // Ensure the caret is being displayed at the correct position.
         expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
+      });
+
+      testWidgetsOnDesktop("inserts new item on ENTER at end of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // Press enter to create a new list item.
+        await tester.pressEnter();
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAndroid("inserts new item on ENTER at end of existing item with mobile keyboard (on Android)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText("\n");
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("inserts new item on ENTER at end of existing item with mobile keyboard (on iOS)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. Item 1')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodes.length, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnDesktop("splits list item into two on ENTER in middle of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // Press enter to split the existing item into two.
+        await tester.pressEnter();
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAndroid(
+          "splits list item into two on ENTER in middle of existing item with mobile keyboard (on Android)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText("\n");
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("splits list item into two on ENTER in middle of existing item with mobile keyboard (on iOS)",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. List Item')
+            .pump();
+
+        final document = context.editContext.document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodes.length, 2);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).text.text, "List ");
+        expect(document.nodes.last, isA<ListItemNode>());
+        expect((document.nodes.last as ListItemNode).text.text, "Item");
+        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
       });
     });
   });

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -162,7 +162,7 @@ void main() {
         expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
       });
 
-      testWidgetsOnDesktop("inserts new item on ENTER at end of existing item", (tester) async {
+      testWidgetsOnAllPlatforms("inserts new item on ENTER at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('* Item 1')
@@ -199,8 +199,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAndroid("inserts new item on ENTER at end of existing item with mobile keyboard (on Android)",
-          (tester) async {
+      testWidgetsOnAndroid("inserts new item upon new line insertion at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('* Item 1')
@@ -237,8 +236,7 @@ void main() {
         );
       });
 
-      testWidgetsOnIos("inserts new item on ENTER at end of existing item with mobile keyboard (on iOS)",
-          (tester) async {
+      testWidgetsOnMobile("inserts new item upon new line input action at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('* Item 1')
@@ -275,7 +273,7 @@ void main() {
         );
       });
 
-      testWidgetsOnDesktop("splits list item into two on ENTER in middle of existing item", (tester) async {
+      testWidgetsOnAllPlatforms("splits list item into two on ENTER in middle of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('* List Item')
@@ -308,8 +306,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAndroid(
-          "splits list item into two on ENTER in middle of existing item with mobile keyboard (on Android)",
+      testWidgetsOnAndroid("splits list item into two upon new line insertion in middle of existing item",
           (tester) async {
         final context = await tester //
             .createDocument()
@@ -343,7 +340,7 @@ void main() {
         );
       });
 
-      testWidgetsOnIos("splits list item into two on ENTER in middle of existing item with mobile keyboard (on iOS)",
+      testWidgetsOnMobile("splits list item into two upon new line input action in middle of existing item",
           (tester) async {
         final context = await tester //
             .createDocument()
@@ -438,7 +435,7 @@ void main() {
         expect(SuperEditorInspector.findCaretOffsetInDocument(), offsetMoreOrLessEquals(computedOffsetAfterUnindent));
       });
 
-      testWidgetsOnDesktop("inserts new item on ENTER at end of existing item", (tester) async {
+      testWidgetsOnAllPlatforms("inserts new item on ENTER at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('1. Item 1')
@@ -475,8 +472,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAndroid("inserts new item on ENTER at end of existing item with mobile keyboard (on Android)",
-          (tester) async {
+      testWidgetsOnAndroid("inserts new item upon new line insertion at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('1. Item 1')
@@ -513,8 +509,7 @@ void main() {
         );
       });
 
-      testWidgetsOnIos("inserts new item on ENTER at end of existing item with mobile keyboard (on iOS)",
-          (tester) async {
+      testWidgetsOnMobile("inserts new item upon new line input action at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('1. Item 1')
@@ -551,7 +546,7 @@ void main() {
         );
       });
 
-      testWidgetsOnDesktop("splits list item into two on ENTER in middle of existing item", (tester) async {
+      testWidgetsOnAllPlatforms("splits list item into two on ENTER in middle of existing item", (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown('1. List Item')
@@ -584,8 +579,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAndroid(
-          "splits list item into two on ENTER in middle of existing item with mobile keyboard (on Android)",
+      testWidgetsOnAndroid("splits list item into two upon new line insertion in middle of existing item",
           (tester) async {
         final context = await tester //
             .createDocument()
@@ -619,7 +613,7 @@ void main() {
         );
       });
 
-      testWidgetsOnIos("splits list item into two on ENTER in middle of existing item with mobile keyboard (on iOS)",
+      testWidgetsOnMobile("splits list item into two upon new line input action in middle of existing item",
           (tester) async {
         final context = await tester //
             .createDocument()

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -134,7 +134,7 @@ void main() {
       expect((document.nodes.first as TaskNode).text.text, "This will be a task");
     });
 
-    testWidgetsOnAllPlatforms("inserts new task on ENTER at end of existing task", (tester) async {
+    testWidgetsOnDesktop("inserts new task on ENTER at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -182,7 +182,104 @@ void main() {
       );
     });
 
-    testWidgetsOnAllPlatforms("splits task into two on ENTER in middle of existing task", (tester) async {
+    testWidgetsOnAndroid("inserts new task on ENTER at end of existing task with mobile keyboard (on Android)",
+        (tester) async {
+      final document = MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      );
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+      final task = document.getNodeAt(0) as TaskNode;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at the end of the task.
+      await tester.placeCaretInParagraph("1", task.text.text.length);
+
+      // On Android, pressing ENTER generates a "\n" insertion.
+      await tester.typeImeText("\n");
+
+      // Ensure that a new, empty task was created.
+      expect(document.nodes.length, 2);
+      expect(document.nodes.first, isA<TaskNode>());
+      expect((document.nodes.first as TaskNode).text.text, "This is a task");
+      expect(document.nodes.last, isA<TaskNode>());
+      expect((document.nodes.last as TaskNode).text.text, "");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnIos("inserts new task on ENTER at end of existing task with mobile keyboard (on iOS)", (tester) async {
+      final document = MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      );
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+      final task = document.getNodeAt(0) as TaskNode;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at the end of the task.
+      await tester.placeCaretInParagraph("1", task.text.text.length);
+
+      // On iOS, pressing ENTER generates a newline action.
+      await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+      // Ensure that a new, empty task was created.
+      expect(document.nodes.length, 2);
+      expect(document.nodes.first, isA<TaskNode>());
+      expect((document.nodes.first as TaskNode).text.text, "This is a task");
+      expect(document.nodes.last, isA<TaskNode>());
+      expect((document.nodes.last as TaskNode).text.text, "");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnDesktop("splits task into two on ENTER in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -210,6 +307,100 @@ void main() {
 
       // Press enter to split the existing task into two.
       await tester.pressEnter();
+
+      // Ensure that a new task was created with part of the previous task.
+      expect(document.nodes.length, 2);
+      expect(document.nodes.first, isA<TaskNode>());
+      expect((document.nodes.first as TaskNode).text.text, "This is ");
+      expect(document.nodes.last, isA<TaskNode>());
+      expect((document.nodes.last as TaskNode).text.text, "a task");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnAndroid("splits task into two on ENTER in middle of existing task with mobile keyboard (on Android)",
+        (tester) async {
+      final document = MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      );
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at "This is |a task"
+      await tester.placeCaretInParagraph("1", 8);
+
+      // On Android, pressing ENTER generates a "\n" insertion.
+      await tester.typeImeText("\n");
+
+      // Ensure that a new task was created with part of the previous task.
+      expect(document.nodes.length, 2);
+      expect(document.nodes.first, isA<TaskNode>());
+      expect((document.nodes.first as TaskNode).text.text, "This is ");
+      expect(document.nodes.last, isA<TaskNode>());
+      expect((document.nodes.last as TaskNode).text.text, "a task");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: document.nodes.last.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnIos("splits task into two on ENTER in middle of existing task with mobile keyboard (on iOS)",
+        (tester) async {
+      final document = MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+        ],
+      );
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at "This is |a task"
+      await tester.placeCaretInParagraph("1", 8);
+
+      // On iOS, pressing ENTER generates a newline action.
+      await tester.testTextInput.receiveAction(TextInputAction.newline);
 
       // Ensure that a new task was created with part of the previous task.
       expect(document.nodes.length, 2);

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -134,7 +134,7 @@ void main() {
       expect((document.nodes.first as TaskNode).text.text, "This will be a task");
     });
 
-    testWidgetsOnDesktop("inserts new task on ENTER at end of existing task", (tester) async {
+    testWidgetsOnAllPlatforms("inserts new task on ENTER at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -182,8 +182,7 @@ void main() {
       );
     });
 
-    testWidgetsOnAndroid("inserts new task on ENTER at end of existing task with mobile keyboard (on Android)",
-        (tester) async {
+    testWidgetsOnAndroid("inserts new task upon new line insertion at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -231,7 +230,7 @@ void main() {
       );
     });
 
-    testWidgetsOnIos("inserts new task on ENTER at end of existing task with mobile keyboard (on iOS)", (tester) async {
+    testWidgetsOnMobile("inserts new task upon new line input action at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -279,7 +278,7 @@ void main() {
       );
     });
 
-    testWidgetsOnDesktop("splits task into two on ENTER in middle of existing task", (tester) async {
+    testWidgetsOnAllPlatforms("splits task into two on ENTER in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -325,8 +324,7 @@ void main() {
       );
     });
 
-    testWidgetsOnAndroid("splits task into two on ENTER in middle of existing task with mobile keyboard (on Android)",
-        (tester) async {
+    testWidgetsOnAndroid("splits task into two upon new line insertion in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
@@ -372,8 +370,7 @@ void main() {
       );
     });
 
-    testWidgetsOnIos("splits task into two on ENTER in middle of existing task with mobile keyboard (on iOS)",
-        (tester) async {
+    testWidgetsOnMobile("splits task into two upon new line input action in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),


### PR DESCRIPTION
[SuperEditor][Mobile] Fix task and list item splitting on ENTER. Resolves #1157 

On mobile, pressing ENTER on a task doesn't split the task. The cause is that we weren't handling the `TaskNode` in `insertBlockLevelNewline` and `_insertNewlineInDeltas`.

After the fix, I found the same issue reported in https://github.com/superlistapp/super_editor/issues/1081, so I applied the same solution.

During the tests, I noticed that the list item splitting wasn't working on Android. I also fixed that.

There are 3 ways that the ENTER key is reported:
- On Desktop we receive key presses.
- On Android we receive an insertion delta of `\n`.
- On iOS we receive a `newline` input action.

Because of that I added 3 tests for each case. Maybe we could add another `pressEnter` method that generates different signals for each platform.