### PR TITLE
[SuperEditor] Fix text insertion when the caret sits at a horizontal rule (Resolves #1187)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1537,9 +1537,12 @@ class CommonEditorOperations {
   /// If the current selection is not collapsed then the current selection
   /// is first deleted, then the aforementioned operation takes place.
   ///
+  /// If [nodeId] is given, it is used as the new node id. Otherwise, a
+  /// new node id is generated.
+  ///
   /// Returns [true] if a new node was inserted or a node was split into two.
   /// Returns [false] if there was no selection.
-  bool insertBlockLevelNewline() {
+  bool insertBlockLevelNewline({String? nodeId}) {
     editorOpsLog.fine("Inserting block-level newline");
     if (composer.selection == null) {
       editorOpsLog.finer("Selection is null. Can't insert newline.");
@@ -1561,7 +1564,7 @@ class CommonEditorOperations {
       _deleteExpandedSelection();
     }
 
-    final newNodeId = Editor.createNodeId();
+    final newNodeId = nodeId ?? Editor.createNodeId();
 
     if (extentNode is ListItemNode) {
       if (extentNode.text.text.isEmpty) {

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1537,12 +1537,9 @@ class CommonEditorOperations {
   /// If the current selection is not collapsed then the current selection
   /// is first deleted, then the aforementioned operation takes place.
   ///
-  /// If [nodeId] is given, it is used as the new node id. Otherwise, a
-  /// new node id is generated.
-  ///
   /// Returns [true] if a new node was inserted or a node was split into two.
   /// Returns [false] if there was no selection.
-  bool insertBlockLevelNewline({String? nodeId}) {
+  bool insertBlockLevelNewline() {
     editorOpsLog.fine("Inserting block-level newline");
     if (composer.selection == null) {
       editorOpsLog.finer("Selection is null. Can't insert newline.");
@@ -1564,7 +1561,7 @@ class CommonEditorOperations {
       _deleteExpandedSelection();
     }
 
-    final newNodeId = nodeId ?? Editor.createNodeId();
+    final newNodeId = Editor.createNodeId();
 
     if (extentNode is ListItemNode) {
       if (extentNode.text.text.isEmpty) {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -271,6 +271,7 @@ class TextDeltasDocumentEditor {
     DocumentNode? insertionNode = document.getNodeById(insertionPosition.nodeId);
     if (insertionNode == null) {
       editorOpsLog.warning('Attempted to insert text using a non-existing node');
+      return false;
     }
 
     if (insertionPosition.nodePosition is UpstreamDownstreamNodePosition) {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -274,9 +274,11 @@ class TextDeltasDocumentEditor {
 
     if (extentNodePosition is UpstreamDownstreamNodePosition) {
       editorOpsLog.fine("The selected position is an UpstreamDownstreamPosition. Inserting new paragraph first.");
-      extentNodeId = Editor.createNodeId();
-      commonOps.insertBlockLevelNewline(nodeId: extentNodeId);
+      commonOps.insertBlockLevelNewline();
 
+      // After inserting a block level new line, the selection might change to another node.
+      // Therefore, we need to update the insertion position.
+      extentNodeId = selection.value!.extent.nodeId;
       final node = document.getNodeById(extentNodeId)!;
       extentNodePosition = node.endPosition;
       effectiveInsertionPosition = DocumentPosition(nodeId: extentNodeId, nodePosition: extentNodePosition);

--- a/super_editor/test/super_editor/components/horizontal_rule_test.dart
+++ b/super_editor/test/super_editor/components/horizontal_rule_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../../test_tools.dart';
+import '../document_test_tools.dart';
+
+void main() {
+  group('SuperEditor horizontal rule component', () {
+    testWidgetsOnAllPlatforms('inserts a paragraph when typing at the end', (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .fromMarkdown('''
+Paragraph 1
+
+---
+
+Paragraph 2
+''')
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final document = testContext.editContext.document;
+
+      // Place caret at the beginning of the last node.
+      await tester.placeCaretInParagraph(document.nodes.last.id, 0);
+
+      // Press left arrow to move the selection to the end of the horizontal rule.
+      await tester.pressLeftArrow();
+
+      // Type at the end of the horizontal rule
+      await tester.typeImeText('new paragraph');
+
+      // Ensure a new node was created.
+      expect(document.nodes.length, 4);
+
+      // The node should be inserted after the horizontal rule.
+      final insertedNode = document.nodes[2];
+
+      // Ensure the inserted node is a paragraph.
+      expect(insertedNode, isA<ParagraphNode>());
+
+      // Ensure the text was inserted at the new paragraph.
+      expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
+
+      // Ensure the caret sits at the end of the text.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: insertedNode.id,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnAllPlatforms('inserts a paragraph when typing at the beginning', (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .fromMarkdown('''
+Paragraph 1
+
+---
+
+Paragraph 2
+''')
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final document = testContext.editContext.document;
+
+      // Place caret at the end of the first node.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 11);
+
+      // Press right arrow to move the selection to the beginning of the horizontal rule.
+      await tester.pressRightArrow();
+
+      // Type at the beginning of the horizontal rule
+      await tester.typeImeText('new paragraph');
+
+      // Ensure a new node was created.
+      expect(document.nodes.length, 4);
+
+      // The node should be inserted before the horizontal rule.
+      final insertedNode = document.nodes[1];
+
+      // Ensure the inserted node is a paragraph.
+      expect(insertedNode, isA<ParagraphNode>());
+
+      // Ensure the text was inserted at the new paragraph.
+      expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
+
+      // Ensure the caret sits at the end of the text.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: insertedNode.id,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/super_editor/test/super_editor/components/horizontal_rule_test.dart
+++ b/super_editor/test/super_editor/components/horizontal_rule_test.dart
@@ -24,28 +24,19 @@ Paragraph 2
 
       final document = testContext.editContext.document;
 
-      // Place caret at the beginning of the last node.
+      // Place the caret at the end of the horizontal rule, by first placing the caret in the paragraph after the
+      // horizontal rule, and then pressing the left arrow to move it up.
       await tester.placeCaretInParagraph(document.nodes.last.id, 0);
-
-      // Press left arrow to move the selection to the end of the horizontal rule.
       await tester.pressLeftArrow();
 
       // Type at the end of the horizontal rule
       await tester.typeImeText('new paragraph');
 
-      // Ensure a new node was created.
+      // Ensure that the new text was inserted in a new paragraph after the horizontal rule.
       expect(document.nodes.length, 4);
-
-      // The node should be inserted after the horizontal rule.
       final insertedNode = document.nodes[2];
-
-      // Ensure the inserted node is a paragraph.
       expect(insertedNode, isA<ParagraphNode>());
-
-      // Ensure the text was inserted at the new paragraph.
       expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
-
-      // Ensure the caret sits at the end of the text.
       expect(
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
@@ -72,28 +63,19 @@ Paragraph 2
 
       final document = testContext.editContext.document;
 
-      // Place caret at the end of the first node.
+      // Place the caret at the beginning of the horizontal rule, by first placing the caret in the paragraph before the
+      // horizontal rule, and then pressing the right arrow to move it down.
       await tester.placeCaretInParagraph(document.nodes.first.id, 11);
-
-      // Press right arrow to move the selection to the beginning of the horizontal rule.
       await tester.pressRightArrow();
 
       // Type at the beginning of the horizontal rule
       await tester.typeImeText('new paragraph');
 
-      // Ensure a new node was created.
+      // Ensure that the new text was inserted in a new paragraph before the horizontal rule.
       expect(document.nodes.length, 4);
-
-      // The node should be inserted before the horizontal rule.
       final insertedNode = document.nodes[1];
-
-      // Ensure the inserted node is a paragraph.
       expect(insertedNode, isA<ParagraphNode>());
-
-      // Ensure the text was inserted at the new paragraph.
       expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
-
-      // Ensure the caret sits at the end of the text.
       expect(
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(


### PR DESCRIPTION
[SuperEditor] Fix text insertion when the caret sits at a horizontal rule. Resolves #1187

Typing text when a horizontal rule node has selection, introduces empty text nodes in the document. The issue is that we are inserting a new paragraph but not updating the insertion position before trying to insert the text.

This PR changes `_insertPlainText` to consider the end position of the new node to insert the text.



https://github.com/superlistapp/super_editor/assets/7597082/df5f983a-5e18-427c-861d-c22713b9a7ee


