### PR TITLE
Let the user add attributions without auto-merging with nearby attributions (Resolves #1198)

### DIFF
--- a/attributed_text/CHANGELOG.md
+++ b/attributed_text/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [X.Y.Z] - ???
+ * `AttributedText` now allows you to `addAttribution()` without auto-merging with preceding and following attributions (#1198)
+
 ## [0.2.2] - May, 2023
 Upgrade Dart constraints to explicitly include Dart 3. Make `markers` public on `AttributedSpans`.
 

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -151,8 +151,16 @@ class AttributedText {
 
   /// Adds the given [attribution] to all characters within the given
   /// [range], inclusive.
-  void addAttribution(Attribution attribution, SpanRange range) {
-    spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
+  ///
+  /// When [autoMerge] is `true`, the new attribution is merged with any
+  /// preceding or following attribution whose [Attribution.canMergeWith] returns
+  /// `true`.
+  void addAttribution(
+    Attribution attribution,
+    SpanRange range, {
+    bool autoMerge = true,
+  }) {
+    spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end, autoMerge: autoMerge);
     _notifyListeners();
   }
 
@@ -422,7 +430,12 @@ class CallbackAttributionVisitor implements AttributionVisitor {
   }
 
   @override
-  void visitAttributions(AttributedText fullText, int index, Set<Attribution> startingAttributions, Set<Attribution> endingAttributions) {
+  void visitAttributions(
+    AttributedText fullText,
+    int index,
+    Set<Attribution> startingAttributions,
+    Set<Attribution> endingAttributions,
+  ) {
     _onVisitAttributions(fullText, index, startingAttributions, endingAttributions);
   }
 

--- a/attributed_text/lib/src/test_tools.dart
+++ b/attributed_text/lib/src/test_tools.dart
@@ -7,6 +7,7 @@ class ExpectedSpans {
   static const bold = NamedAttribution('bold');
   static const italics = NamedAttribution('italics');
   static const strikethrough = NamedAttribution('strikethrough');
+  static const hashTag = NamedAttribution('hashTag');
 
   ExpectedSpans(
     List<String> spanTemplates,


### PR DESCRIPTION
Let the user add attributions without auto-merging with nearby attributions (Resolves #1198)

This change supports use-cases like hash tags where sometimes we want the attribution to expand, and other times we don't.

Example:
```
// We want to expand
#jo
#joh

// We don't want to expand
#john
#john#
```