### PR TITLE
Fix ConcurrentModificationError in AttributedSpans.hasAttributionsWithin (with Unit-Test)

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -65,11 +65,14 @@ class AttributedSpans {
   }) {
     final attributionsToFind = Set.from(attributions);
     for (int i = start; i <= end; ++i) {
+      final foundOnCharacter = <Attribution>{};
       for (final attribution in attributionsToFind) {
         if (hasAttributionAt(i, attribution: attribution)) {
-          attributionsToFind.remove(attribution);
+          foundOnCharacter.add(attribution);
         }
-
+      }
+      if (foundOnCharacter.isNotEmpty) {
+        attributionsToFind.removeAll(foundOnCharacter);
         if (attributionsToFind.isEmpty) {
           return true;
         }

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -65,17 +65,15 @@ class AttributedSpans {
   }) {
     final attributionsToFind = Set.from(attributions);
     for (int i = start; i <= end; ++i) {
-      final foundOnCharacter = <Attribution>{};
+      final foundAttributions = <Attribution>{};
       for (final attribution in attributionsToFind) {
         if (hasAttributionAt(i, attribution: attribution)) {
-          foundOnCharacter.add(attribution);
+          foundAttributions.add(attribution);
         }
       }
-      if (foundOnCharacter.isNotEmpty) {
-        attributionsToFind.removeAll(foundOnCharacter);
-        if (attributionsToFind.isEmpty) {
-          return true;
-        }
+      attributionsToFind.removeAll(foundAttributions);
+      if (attributionsToFind.isEmpty) {
+        return true;
       }
     }
     return false;

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -537,6 +537,40 @@ void main() {
         ]).expectSpans(spans);
       });
 
+      test('looking for multiple', () {
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 8)
+          ..addAttribution(newAttribution: ExpectedSpans.italics, start: 1, end: 5)
+          ..addAttribution(newAttribution: ExpectedSpans.strikethrough, start: 5, end: 9);
+
+        ExpectedSpans([
+          'bbbbbbbbb_',
+          '_iiiii____',
+          '_____sssss',
+        ]).expectSpans(spans);
+
+        expect(spans.hasAttributionsWithin(attributions: {
+          ExpectedSpans.bold,
+          ExpectedSpans.italics,
+          ExpectedSpans.strikethrough,
+        }, start: 0, end: 9), true);
+
+        expect(spans.hasAttributionsWithin(attributions: {
+          ExpectedSpans.bold,
+          ExpectedSpans.italics,
+        }, start: 0, end: 9), true);
+
+        expect(spans.hasAttributionsWithin(attributions: {
+          ExpectedSpans.bold,
+          ExpectedSpans.italics,
+        }, start: 0, end: 4), true);
+
+        expect(spans.hasAttributionsWithin(attributions: {
+          ExpectedSpans.bold,
+          ExpectedSpans.strikethrough,
+        }, start: 0, end: 4), false);
+      });
+
       test('incompatible attributions cannot overlap', () {
         final spans = AttributedSpans();
 


### PR DESCRIPTION
(second pull request for this issue, this time with tests, closing the previous one https://github.com/superlistapp/super_editor/pull/1188)

Fixes Issue: https://github.com/superlistapp/super_editor/issues/1201

The method AttributedSpans.hasAttributionsWithin iterates over a Set of attributes it want's to check and removes removes entries from this Set while iterating. This throws an exception (ConcurrentModificationError) as the iterator cannot be used after removing entries from the underlying it. This is a simple algorithmic bug / invalid usage of a set and it's iterator which will be fixed by this pull request

