### PR TITLE
chore: Relax http dependency constraint by including v1.x.x

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   attributed_text: ^0.2.2
   characters: ^1.2.0
   collection: ^1.15.0
-  http: ^0.13.1
+  http: ">=0.13.1 <2.0.0"
   linkify: ^4.0.0
   logging: ^1.0.1
   super_text_layout: ^0.1.6


### PR DESCRIPTION
`http` package has finally reached stable version.
There is no compatiblity issue between version `0.13.1` and `1.0.0`.