### PR TITLE
[SuperTextField] Allow changing keyboard appearance while detached from IME (Resolves #1205)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -125,12 +125,14 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
     TextInputType textInputType = TextInputType.text,
     Brightness keyboardAppearance = Brightness.light,
   }) {
+    // Change the keyboard appearance even if we are detached from the IME.
+    // In the next time we attach to the IME, the keyboard appearance is used.
+    _keyboardAppearance = keyboardAppearance;
+
     if (!isAttachedToIme) {
       // We're not attached to the IME, so there is nothing to update.
       return;
     }
-
-    _keyboardAppearance = keyboardAppearance;
 
     // Close the current connection.
     _inputConnection?.close();

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -245,6 +245,47 @@ void main() {
         // Ensure the given keyboardAppearance was applied.
         expect(keyboardAppearance, 'Brightness.dark');
       });
+
+      testWidgetsOnIos('updates keyboard appearance when not attached to IME', (tester) async {
+        final controller = ImeAttributedTextEditingController(
+          keyboardAppearance: Brightness.light,
+        );
+
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: SuperTextField(
+              textController: controller,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Holds the keyboard appearance sent to the platform.
+        String? keyboardAppearance;
+
+        // Intercept the setClient message sent to the platform.
+        tester
+            .interceptChannel(SystemChannels.textInput.name) //
+            .interceptMethod(
+          'TextInput.setClient',
+          (methodCall) {
+            final params = methodCall.arguments[1] as Map;
+            keyboardAppearance = params['keyboardAppearance'];
+            return null;
+          },
+        );
+
+        // Change the keyboard appearance from light to dark while detached from IME.
+        controller.updateTextInputConfiguration(
+          keyboardAppearance: Brightness.dark,
+        );
+
+        // Tap the text field to show the software keyboard.
+        await tester.placeCaretInSuperTextField(0);
+
+        // Ensure the initial keyboardAppearance was dark.
+        expect(keyboardAppearance, 'Brightness.dark');
+      });
     });
 
     group("selection", () {


### PR DESCRIPTION
[SuperTextField] Allow changing keyboard appearance while detached from IME. Resolves #1205 

When detached from the IME, trying to update the keyboard appearance has no effect.

We were already caching the given `keyboardAppearance` in `updateTextInputConfiguration` and reusing it if we detach and reattach, but we weren't caching it if `updateTextInputConfiguration` is called while detached from the IME.

This PR changes `updateTextInputConfiguration` to always cache the given `keyboardAppearance`.