### PR TITLE
Cherry-pick "Fixes `flutter_test` deprecations - Updates minimum version of `golden_toolkit` to remove reference to deprecated `addTime` method. (#1211)" to stable

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.11.0
+  golden_toolkit: ^0.13.0
   mockito: ^5.0.4
   super_editor_markdown:
     path: ../super_editor_markdown


### PR DESCRIPTION
This PR cherry-picks "Fixes `flutter_test` deprecations - Updates minimum version of `golden_toolkit` to remove reference to deprecated `addTime` method. (#1211)" to stable