### PR TITLE
Cherry-pick "Fixes `flutter_test` deprecations (2) - Updates minimum version of `golden_toolkit` to remove reference to `addTime` method for other packages as well (#1214)" to stable

### DIFF
--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  golden_toolkit: ^0.11.0
+  golden_toolkit: ^0.13.0
 
 flutter:
 # no Flutter configuration

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -26,7 +26,7 @@ dependency_overrides:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.11.0
+  golden_toolkit: ^0.13.0
   args: ^2.3.1
 
 flutter:


### PR DESCRIPTION
This PR cherry-picks "Fixes `flutter_test` deprecations (2) - Updates minimum version of `golden_toolkit` to remove reference to `addTime` method for other packages as well (#1214)" to stable.