### PR TITLE
[SuperTextField] Fix ImeAttributedTextEditingController not removing inner controller listener (Resolves #1227)

### DIFF
--- a/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/infrastructure/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -46,6 +46,8 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
   @override
   void dispose() {
+    _realController.removeListener(_onInnerControllerChange);
+
     if (_disposeClientController) {
       _realController.dispose();
     }

--- a/super_editor/test/super_textfield/ime_attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/ime_attributed_text_editing_controller_test.dart
@@ -402,7 +402,7 @@ void main() {
     });
   });
 
-  testWidgetsOnAllPlatforms('allows reusing inner controller', (tester) async {
+  testWidgetsOnAllPlatforms('allows reusing inner controller after disposal', (tester) async {
     final innerController = AttributedTextEditingController(
       text: AttributedText(
         text: 'some text',
@@ -416,7 +416,7 @@ void main() {
 
     late ImeAttributedTextEditingController controllerB;
 
-    final rebuildNotifier = ValueNotifier<bool>(true);
+    final useControllerA = ValueNotifier<bool>(true);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -424,7 +424,7 @@ void main() {
           body: SizedBox(
             width: 300,
             child: ValueListenableBuilder(
-              valueListenable: rebuildNotifier,
+              valueListenable: useControllerA,
               builder: (context, shouldUseTextFieldA, _) {
                 return shouldUseTextFieldA //
                     ? SuperTextField(
@@ -449,12 +449,10 @@ void main() {
       disposeClientController: false,
     );
     controllerA.dispose();
-    rebuildNotifier.value = false;
-    await tester.pump();
+    useControllerA.value = false;
 
     // Change the text of the inner controller to notify the listeners.
     innerController.text = AttributedText(text: 'New text');
-    await tester.pump();
 
     // Reaching this point means that disposing the old controller didn't cause a crash.
   });


### PR DESCRIPTION
[SuperTextField] Fix ImeAttributedTextEditingController not removing inner controller listener. Resolves #1227 

In `ImeAttributedTextEditingController` we are adding a listener to the inner controller, but we aren't removing it upon disposal. This causes a crash if the inner controller is reused in a new `ImeAttributedTextEditingController`.

This PR changes `ImeAttributedTextEditingController` to remove the listener when `dispose` is called.

I'm not sure if we need a test for this, but I added anyway.