### PR TITLE
Cherry-pick "[SuperEditor][Android] Fix IME mappings on text replacements (Resolves #1217) (#1225)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -189,6 +189,16 @@ class TextDeltasDocumentEditor {
 
     // Update the local IME value that changes with each delta.
     _previousImeValue = delta.apply(_previousImeValue);
+
+    // Update the IME to document serialization based on the replacement changes.
+    // It's possible that the replacement text have a different length from the replaced text.
+    // Therefore, we need to update our mapping from the IME positions to document positions.
+    _serializedDoc = DocumentImeSerializer(
+      document,
+      selection.value!,
+      composingRegion.value,
+      _serializedDoc.didPrependPlaceholder ? PrependedCharacterPolicy.include : PrependedCharacterPolicy.exclude,
+    )..imeText = _previousImeValue.text;
   }
 
   void _applyDeletion(TextEditingDeltaDeletion delta) {

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -573,6 +573,102 @@ Paragraph two
       });
     });
 
+    group('on Samsung M51 (Android 12 SP1A)', () {
+      testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the start of the paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Start typing the word "Anonymous" with typos.
+        await tester.typeImeText('Anonimoi');
+
+        // Simulate the user accepting a suggestion.
+        // The IME replaces the word and inserts a space after it.
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: 'Anonimoi',
+            selection: TextSelection.collapsed(
+              offset: 8,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: 0, end: 8),
+          ),
+          TextEditingDeltaReplacement(
+            oldText: 'Anonimoi',
+            replacementText: 'Anonymous',
+            replacedRange: TextRange(start: 0, end: 8),
+            selection: TextSelection.collapsed(offset: 9, affinity: TextAffinity.downstream),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          TextEditingDeltaInsertion(
+            oldText: 'Anonymous',
+            textInserted: ' ',
+            insertionOffset: 9,
+            selection: TextSelection.collapsed(
+              offset: 10,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: -1, end: -1),
+          )
+        ], getter: imeClientGetter);
+
+        expect(
+          SuperEditorInspector.findTextInParagraph('1').text,
+          'Anonymous ',
+        );
+      });
+    });
+
+    group('on Samsung M51 (Android 12 SP1A) with GBoard', () {
+      testWidgetsOnAndroid('applies keyboard suggestions', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the start of the paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Start typing the word "Anonymous" with typos.
+        await tester.typeImeText('Anonimoi');
+
+        // Simulate the user accepting a suggestion.
+        // The IME deletes the substring "imoi" and inserts "ymous ".
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaDeletion(
+            oldText: 'Anonimoi',
+            deletedRange: TextRange(start: 4, end: 8),
+            selection: TextSelection.collapsed(
+              offset: 4,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          TextEditingDeltaInsertion(
+            oldText: 'Anon',
+            textInserted: 'ymous ',
+            insertionOffset: 4,
+            selection: TextSelection.collapsed(
+              offset: 10,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        expect(
+          SuperEditorInspector.findTextInParagraph('1').text,
+          'Anonymous ',
+        );
+      });
+    });
+
     group('text serialization and selected content', () {
       test('within a single node is reported as a TextEditingValue', () {
         const text = "This is a paragraph of text.";


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor][Android] Fix IME mappings on text replacements (Resolves #1217) (#1225)" to stable.