### PR TITLE
Cherry-pick "[SuperEditor] Fix text insertion when the caret sits at a horizontal rule (Resolves #1187) (#1196)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -278,23 +278,30 @@ class TextDeltasDocumentEditor {
   ) {
     editorOpsLog.fine('Attempting to insert "$text" at position: $insertionPosition');
 
-    final extentNodePosition = insertionPosition.nodePosition;
-    if (extentNodePosition is UpstreamDownstreamNodePosition) {
-      editorOpsLog.fine("The selected position is an UpstreamDownstreamPosition. Inserting new paragraph first.");
-      commonOps.insertBlockLevelNewline();
-    }
-
-    final extentNode = document.getNodeById(insertionPosition.nodeId)!;
-    if (extentNode is! TextNode || extentNodePosition is! TextNodePosition) {
-      editorOpsLog.fine(
-          "Couldn't insert text because Super Editor doesn't know how to handle a node of type: $extentNode, with position: $extentNodePosition");
+    DocumentNode? insertionNode = document.getNodeById(insertionPosition.nodeId);
+    if (insertionNode == null) {
+      editorOpsLog.warning('Attempted to insert text using a non-existing node');
       return false;
     }
 
-    final textNode = document.getNodeById(insertionPosition.nodeId) as TextNode;
+    if (insertionPosition.nodePosition is UpstreamDownstreamNodePosition) {
+      editorOpsLog.fine("The selected position is an UpstreamDownstreamPosition. Inserting new paragraph first.");
+      commonOps.insertBlockLevelNewline();
+
+      // After inserting a block level new line, the selection changes to another node.
+      // Therefore, we need to update the insertion position.
+      insertionNode = document.getNodeById(selection.value!.extent.nodeId)!;
+      insertionPosition = DocumentPosition(nodeId: insertionNode.id, nodePosition: insertionNode.endPosition);
+    }
+
+    if (insertionNode is! TextNode || insertionPosition.nodePosition is! TextNodePosition) {
+      editorOpsLog.fine(
+          "Couldn't insert text because Super Editor doesn't know how to handle a node of type: $insertionNode, with position: ${insertionPosition.nodePosition}");
+      return false;
+    }
 
     editorOpsLog.fine("Executing text insertion command.");
-    editorOpsLog.finer("Text before insertion: '${textNode.text.text}'");
+    editorOpsLog.finer("Text before insertion: '${insertionNode.text.text}'");
     editor.execute([
       InsertTextRequest(
         documentPosition: insertionPosition,
@@ -302,7 +309,7 @@ class TextDeltasDocumentEditor {
         attributions: composerPreferences.currentAttributions,
       ),
     ]);
-    editorOpsLog.finer("Text after insertion: '${textNode.text.text}'");
+    editorOpsLog.finer("Text after insertion: '${insertionNode.text.text}'");
 
     return true;
   }

--- a/super_editor/test/super_editor/components/horizontal_rule_test.dart
+++ b/super_editor/test/super_editor/components/horizontal_rule_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../../test_tools.dart';
+import '../document_test_tools.dart';
+
+void main() {
+  group('SuperEditor horizontal rule component', () {
+    testWidgetsOnAllPlatforms('inserts a paragraph when typing at the end', (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .fromMarkdown('''
+Paragraph 1
+
+---
+
+Paragraph 2
+''')
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final document = testContext.editContext.document;
+
+      // Place the caret at the end of the horizontal rule, by first placing the caret in the paragraph after the
+      // horizontal rule, and then pressing the left arrow to move it up.
+      await tester.placeCaretInParagraph(document.nodes.last.id, 0);
+      await tester.pressLeftArrow();
+
+      // Type at the end of the horizontal rule
+      await tester.typeImeText('new paragraph');
+
+      // Ensure that the new text was inserted in a new paragraph after the horizontal rule.
+      expect(document.nodes.length, 4);
+      final insertedNode = document.nodes[2];
+      expect(insertedNode, isA<ParagraphNode>());
+      expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: insertedNode.id,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnAllPlatforms('inserts a paragraph when typing at the beginning', (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .fromMarkdown('''
+Paragraph 1
+
+---
+
+Paragraph 2
+''')
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final document = testContext.editContext.document;
+
+      // Place the caret at the beginning of the horizontal rule, by first placing the caret in the paragraph before the
+      // horizontal rule, and then pressing the right arrow to move it down.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 11);
+      await tester.pressRightArrow();
+
+      // Type at the beginning of the horizontal rule
+      await tester.typeImeText('new paragraph');
+
+      // Ensure that the new text was inserted in a new paragraph before the horizontal rule.
+      expect(document.nodes.length, 4);
+      final insertedNode = document.nodes[1];
+      expect(insertedNode, isA<ParagraphNode>());
+      expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: insertedNode.id,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix text insertion when the caret sits at a horizontal rule (Resolves #1187) (#1196)" to stable.