### PR TITLE
[SuperEditor] Fix image insertion bugs (Partially resolves #1209)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -575,6 +575,16 @@ class TextDeltasDocumentEditor {
               text: AttributedText(text: ''),
             ),
           ),
+          ChangeSelectionRequest(
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: newNodeId,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+            SelectionChangeType.insertContent,
+            SelectionReason.userInteraction,
+          ),
         ]);
       } else {
         // The caret sits on the upstream edge of block-level content. Insert

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -164,7 +164,7 @@ class InsertNodeAtCaretCommand extends EditCommand {
           nodePosition: selectedNode.beginningPosition,
         ),
       );
-    } else if (paragraphPosition == beginningOfParagraph) {
+    } else if (paragraphPosition.offset == beginningOfParagraph.offset) {
       // Insert block item after the paragraph.
       document.insertNodeAt(document.getNodeIndexById(selectedNode.id), newNode);
       executor.logChanges([
@@ -179,19 +179,26 @@ class InsertNodeAtCaretCommand extends EditCommand {
           nodePosition: selectedNode.beginningPosition,
         ),
       );
-    } else if (paragraphPosition == endOfParagraph) {
-      // Insert block item after the paragraph.
-      document.insertNodeAfter(existingNode: selectedNode, newNode: newNode);
+    } else if (paragraphPosition.offset == endOfParagraph.offset) {
+      final emptyParagraph = ParagraphNode(id: Editor.createNodeId(), text: AttributedText());
+
+      // Insert block item after the paragraph and insert a new empty paragraph.
+      document
+        ..insertNodeAfter(existingNode: selectedNode, newNode: newNode)
+        ..insertNodeAfter(existingNode: newNode, newNode: emptyParagraph);
       executor.logChanges([
         DocumentEdit(
           NodeInsertedEvent(newNode.id, document.getNodeIndexById(newNode.id)),
-        )
+        ),
+        DocumentEdit(
+          NodeInsertedEvent(emptyParagraph.id, document.getNodeIndexById(emptyParagraph.id)),
+        ),
       ]);
 
       newSelection = DocumentSelection.collapsed(
         position: DocumentPosition(
-          nodeId: selectedNodeId,
-          nodePosition: newNode.endPosition,
+          nodeId: emptyParagraph.id,
+          nodePosition: emptyParagraph.endPosition,
         ),
       );
     } else {

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -96,7 +96,51 @@ void main() {
         );
       });
 
-      testWidgetsOnAllPlatforms('when the selection sits at the end of a paragraph', (tester) async {
+      testWidgetsOnAllPlatforms('when a downstream selection sits at the end of a paragraph', (tester) async {
+        // Pump a widget with an arbitrary size for the images.
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .withAddedComponents(
+          [const FakeImageComponentBuilder(size: Size(100, 100))],
+        ).pump();
+
+        // Place caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 15);
+
+        // Insert the image at the current selection.
+        context.editContext.commonOps.insertImage('http://image.fake');
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node remains unchanged.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure that the image was added.
+        expect(doc.nodes[1], isA<ImageNode>());
+
+        // Ensure that an empty node was added after the image.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when an upstream selection sits at the end of a paragraph', (tester) async {
         // Pump a widget with an arbitrary size for the images.
         final context = await tester //
             .createDocument()
@@ -264,7 +308,48 @@ Second paragraph"""). //
         );
       });
 
-      testWidgetsOnAllPlatforms('when the selection sits at the end of a paragraph', (tester) async {
+      testWidgetsOnAllPlatforms('when a downstream selection sits at the end of a paragraph', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("First paragraph")
+            .pump();
+
+        // Place caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 15);
+
+        // Insert the horizontal rule at the current selection.
+        context.editContext.commonOps.insertHorizontalRule();
+        await tester.pumpAndSettle();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure that two nodes were inserted.
+        expect(doc.nodes.length, 3);
+
+        // Ensure that the first node remains unchanged.
+        expect(doc.nodes[0], isA<ParagraphNode>());
+        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure that the horizontal rule was added.
+        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+
+        // Ensure that an empty node was added at the end.
+        expect(doc.nodes[2], isA<ParagraphNode>());
+        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+
+        // Ensure the selection was placed at the beginning of the last paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: doc.nodes.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when an upstream selection sits at the end of a paragraph', (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown("""First paragraph
@@ -349,7 +434,7 @@ Second paragraph"""). //
     });
 
     group('inserts a paragraph', () {
-      testWidgetsOnDesktop('on ENTER at the end of an image', (tester) async {
+      testWidgetsOnDesktop('when the user presses ENTER at the end of an image', (tester) async {
         final testContext = await tester
             .createDocument()
             .withCustomContent(
@@ -407,7 +492,9 @@ Second paragraph"""). //
         );
       });
 
-      testWidgetsOnAndroid('upon new line insertion at the end of an image (on Android)', (tester) async {
+      testWidgetsOnAndroid(
+          'when the user presses the newline button on the software keyboard at the end of an image (on Android)',
+          (tester) async {
         final testContext = await tester
             .createDocument()
             .withCustomContent(
@@ -464,7 +551,9 @@ Second paragraph"""). //
         );
       });
 
-      testWidgetsOnMobile('upon new line input action at the end of an image', (tester) async {
+      testWidgetsOnIos(
+          'when the user presses the newline button on the software keyboard at the end of an image (on iOS)',
+          (tester) async {
         final testContext = await tester
             .createDocument()
             .withCustomContent(


### PR DESCRIPTION
[SuperEditor] Fix image insertion bugs. Partially resolves #1209

We have some issues related to images:

-  Inserting a paragraph when the caret sits after an image doesn't change the selection:

https://github.com/superlistapp/super_editor/assets/6467808/0c3cb5f3-dfb1-4dd6-add8-5e8ce7b6d0d5

The root cause is that we aren't executing a `ChangeSelectionRequest` after inserting the image.

This PR changes the image insertion to execute a `ChangeSelectionRequest`.

- Inserting an image when the caret sits at the end of a paragraph (with upstream affinity) throws an exception:

https://github.com/superlistapp/super_editor/assets/6467808/9965ccb2-d20c-4995-8755-defb9657af07

We are comparing the text positions as `paragraphPosition == endOfParagraph`, which returns `false` if the affinity is different. 

We already have tests for image insertion. However, in the tests, we are always producing downstream selections, and the issue only happens with upstream affinity. May we should have tests for both affinities?

This PR changes the comparison to only care about the offset, ignoring the affinity.

The other issue reported in the ticket is caused because the image component resizes itself after the image is loaded, and we aren't rebuilding the caret. I think this should be handled by refactoring the mobile widget tree to use the same layer structure as the desktop.
