### PR TITLE
[SuperEditor] Moves caret on downstream when right arrow's pressed while block is selected (Resolves #1247)

### DIFF
--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -46,9 +46,9 @@ abstract class BlockNode extends DocumentNode {
     }
 
     if (position1.affinity == TextAffinity.downstream || position2.affinity == TextAffinity.downstream) {
-      return const UpstreamDownstreamNodePosition.upstream();
-    } else {
       return const UpstreamDownstreamNodePosition.downstream();
+    } else {
+      return const UpstreamDownstreamNodePosition.upstream();
     }
   }
 

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -278,7 +278,8 @@ void main() {
         expect(composer.selection!.extent.nodePosition, const UpstreamDownstreamNodePosition.upstream());
       });
 
-      testWidgets("right arrow moves caret to downstream edge of the selection made on a block node", (tester) async {
+      testWidgets("right arrow collapses the expanded selection around block node to a caret on the downstream edge",
+          (tester) async {
         await tester
             .createDocument()
             .withCustomContent(paragraphThenHrThenParagraphDoc())

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -277,6 +277,26 @@ void main() {
       });
     });
 
+    group("selection", () {
+      testWidgets("keeps caret downstream when right arrow is pressed while a block is selected", (tester) async {
+        final document = paragraphThenHrThenParagraphDoc();
+        final composer = MutableDocumentComposer(
+          initialSelection: const DocumentSelection(
+            base: DocumentPosition(nodeId: "2", nodePosition: UpstreamDownstreamNodePosition.upstream()),
+            extent: DocumentPosition(nodeId: "2", nodePosition: UpstreamDownstreamNodePosition.downstream()),
+          ),
+        );
+        await tester.pumpWidget(_buildHardwareKeyboardEditor(document, composer));
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        expect(composer.selection!.isCollapsed, true);
+        expect(composer.selection!.extent.nodeId, "2");
+        expect(composer.selection!.extent.nodePosition, const UpstreamDownstreamNodePosition.downstream());
+      });
+    });
+
     group("deletion", () {
       testWidgets("backspace moves caret to node above when caret is on upstream edge", (tester) async {
         final document = paragraphThenHrThenParagraphDoc();

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -285,19 +285,17 @@ void main() {
             .withEditorSize(const Size(300, 300))
             .pump();
 
-        final document = SuperEditorInspector.findDocument()!;
-        final hrNode = document.getNodeById("2") as HorizontalRuleNode;
-
-        await tester.tapAtDocumentPosition(DocumentPosition(
-          nodeId: hrNode.id,
-          nodePosition: hrNode.beginningPosition,
+        await tester.tapAtDocumentPosition(const DocumentPosition(
+          nodeId: "2",
+          nodePosition: UpstreamDownstreamNodePosition.upstream(),
         ));
+        // Wait till the tap event is complete and the latest selection is available.
         await tester.pumpAndSettle();
 
         final testerGesture = await tester.startDocumentDragFromPosition(
-          from: DocumentPosition(
-            nodeId: hrNode.id,
-            nodePosition: hrNode.beginningPosition,
+          from: const DocumentPosition(
+            nodeId: "2",
+            nodePosition: UpstreamDownstreamNodePosition.upstream(),
           ),
         );
 
@@ -310,14 +308,14 @@ void main() {
 
         expect(
           SuperEditorInspector.findDocumentSelection(),
-          DocumentSelection(
+          const DocumentSelection(
             base: DocumentPosition(
-              nodeId: hrNode.id,
-              nodePosition: hrNode.beginningPosition,
+              nodeId: "2",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
             ),
             extent: DocumentPosition(
-              nodeId: hrNode.id,
-              nodePosition: hrNode.endPosition,
+              nodeId: "2",
+              nodePosition: UpstreamDownstreamNodePosition.downstream(),
             ),
           ),
         );
@@ -328,7 +326,7 @@ void main() {
         final selection = SuperEditorInspector.findDocumentSelection();
 
         expect(selection!.isCollapsed, true);
-        expect(selection.extent.nodeId, hrNode.id);
+        expect(selection.extent.nodeId, "2");
         expect(selection.extent.nodePosition, const UpstreamDownstreamNodePosition.downstream());
       });
     });

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -285,26 +285,13 @@ void main() {
             .withEditorSize(const Size(300, 300))
             .pump();
 
-        await tester.tapAtDocumentPosition(const DocumentPosition(
-          nodeId: "2",
-          nodePosition: UpstreamDownstreamNodePosition.upstream(),
-        ));
-        // Wait till the tap event is complete and the latest selection is available.
-        await tester.pumpAndSettle();
-
-        final testerGesture = await tester.startDocumentDragFromPosition(
-          from: const DocumentPosition(
+        for (var i = 0; i < 2; i++) {
+          await tester.tapAtDocumentPosition(const DocumentPosition(
             nodeId: "2",
             nodePosition: UpstreamDownstreamNodePosition.upstream(),
-          ),
-        );
-
-        // Move by sufficient distance to select the hr.
-        await testerGesture.moveBy(const Offset(300, 0));
-        await tester.pump();
-
-        await tester.endDocumentDragGesture(testerGesture);
-        await tester.pump();
+          ));
+          await tester.pump(kTapMinTime + const Duration(milliseconds: 1));
+        }
 
         expect(
           SuperEditorInspector.findDocumentSelection(),

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -286,13 +286,18 @@ void main() {
             .withEditorSize(const Size(300, 300))
             .pump();
 
-        for (var i = 0; i < 2; i++) {
-          await tester.tapAtDocumentPosition(const DocumentPosition(
-            nodeId: "2",
-            nodePosition: UpstreamDownstreamNodePosition.upstream(),
-          ));
-          await tester.pump(kTapMinTime + const Duration(milliseconds: 1));
-        }
+        // TODO: Move this to Super Editor tooling.
+        await tester.tapAtDocumentPosition(const DocumentPosition(
+          nodeId: "2",
+          nodePosition: UpstreamDownstreamNodePosition.upstream(),
+        ));
+        await tester.pump(kTapMinTime + const Duration(milliseconds: 1));
+
+        await tester.tapAtDocumentPosition(const DocumentPosition(
+          nodeId: "2",
+          nodePosition: UpstreamDownstreamNodePosition.upstream(),
+        ));
+        await tester.pump(kTapMinTime + const Duration(milliseconds: 1));
 
         expect(
           SuperEditorInspector.findDocumentSelection(),

--- a/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
+++ b/super_editor/test/src/default_editor/upstream_downstream_selection_test.dart
@@ -275,10 +275,9 @@ void main() {
         expect(composer.selection!.extent.nodeId, "2");
         expect(composer.selection!.extent.nodePosition, const UpstreamDownstreamNodePosition.upstream());
       });
-    });
 
-    group("selection", () {
-      testWidgets("keeps caret downstream when right arrow is pressed while a block is selected", (tester) async {
+      testWidgets("right arrow moves caret to downstream edge of the non-collapsed selection on a block node",
+          (tester) async {
         final document = paragraphThenHrThenParagraphDoc();
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection(


### PR DESCRIPTION
Resolves #1247

**Description:**

The current implementation of the `selectDownstreamPosition` on the `BlockNode` returns the wrong `UpstreamDownstreamNodePosition` which results in a bug where the caret moves to upstream on the selected block when right arrow key is pressed, as seen in the video below

https://github.com/superlistapp/super_editor/assets/65209850/c084456d-6992-4e13-9c8c-b496322123bf

This affected the Nodes based on `BlockNode`, `ImageNode` and `HorizontalRuleNode`.

**Solution:**

Correct behaviour is to move the caret position on the downstream on the block. This PR resolves this by returning the `UpstreamDownstreamNodePosition` with appropriate `TextAffinity`, which moves the caret position on the downstream when right arrow key is pressed with the block selected.

https://github.com/superlistapp/super_editor/assets/65209850/77838d2c-bab1-41e4-93c6-37544ebe6238


Also adds Tests to ensure the behaviour remains consistent.