### PR TITLE
Moved IME upstream deletion in empty nodes to Editor requests instead of direct implementation, for the purpose of extensability (Resolves #1259)

### DIFF
--- a/super_editor/example/lib/demos/demo_empty_document.dart
+++ b/super_editor/example/lib/demos/demo_empty_document.dart
@@ -40,7 +40,6 @@ class _EmptyDocumentDemoState extends State<EmptyDocumentDemo> {
         document: _doc,
         composer: _composer,
         gestureMode: DocumentGestureMode.mouse,
-        inputSource: TextInputSource.keyboard,
       ),
     );
   }

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -40,6 +40,7 @@ Future<void> main() async {
     // editorScrollingLog,
     // editorGesturesLog,
     // editorImeLog,
+    // editorImeDeltasLog,
     // editorKeyLog,
     // editorOpsLog,
     // editorLayoutLog,

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:super_editor/src/core/editor.dart';
 
 import 'document_selection.dart';
 import 'document.dart';
@@ -11,6 +12,23 @@ import 'document.dart';
 /// this is passed around, instead of a direct reference to a
 /// [DocumentLayout].
 typedef DocumentLayoutResolver = DocumentLayout Function();
+
+/// An [Editable] that provides access to a [DocumentLayout] so that
+/// [EditCommand]s can make decisions based on the layout of the
+/// document in an editor.
+class DocumentLayoutEditable implements Editable {
+  const DocumentLayoutEditable(this._documentLayoutResolver);
+
+  final DocumentLayoutResolver _documentLayoutResolver;
+
+  DocumentLayout get documentLayout => _documentLayoutResolver();
+
+  @override
+  void onTransactionEnd(List<EditEvent> edits) {}
+
+  @override
+  void onTransactionStart() {}
+}
 
 /// Abstract representation of a document layout.
 ///

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
+import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
 import '../core/document_layout.dart';
@@ -288,6 +293,92 @@ class SelectableBox extends StatelessWidget {
           position: DecorationPosition.foreground,
           child: child,
         ),
+      ),
+    );
+  }
+}
+
+class DeleteUpstreamAtBeginningOfBlockNodeCommand implements EditCommand {
+  DeleteUpstreamAtBeginningOfBlockNodeCommand(this.node);
+
+  final DocumentNode node;
+
+  @override
+  void execute(EditContext context, CommandExecutor executor) {
+    final document = context.find<MutableDocument>(Editor.documentKey);
+    final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
+    final documentLayoutEditable = context.find<DocumentLayoutEditable>(Editor.layoutKey);
+
+    final deletionPosition = DocumentPosition(nodeId: node.id, nodePosition: node.beginningPosition);
+
+    final nodePosition = deletionPosition.nodePosition as UpstreamDownstreamNodePosition;
+    if (nodePosition.affinity == TextAffinity.downstream) {
+      // The caret is sitting on the downstream edge of block-level content. Delete the
+      // whole block by replacing it with an empty paragraph.
+      executor.executeCommand(
+        ReplaceNodeWithEmptyParagraphWithCaretCommand(nodeId: deletionPosition.nodeId),
+      );
+      return;
+    } else {
+      // The caret is sitting on the upstream edge of block-level content and
+      // the user is trying to delete upstream.
+      //  * If the node above is an empty paragraph, delete it.
+      //  * If the node above is non-selectable, delete it.
+      //  * Otherwise, move the caret up to the node above.
+      final nodeBefore = document.getNodeBefore(node);
+      if (nodeBefore == null) {
+        return;
+      }
+
+      if (nodeBefore is TextNode && nodeBefore.text.text.isEmpty) {
+        executor.executeCommand(
+          DeleteNodeCommand(nodeId: nodeBefore.id),
+        );
+        return;
+      }
+
+      final componentBefore = documentLayoutEditable.documentLayout.getComponentByNodeId(nodeBefore.id)!;
+      if (!componentBefore.isVisualSelectionSupported()) {
+        // The node/component above is not selectable. Delete it.
+        executor.executeCommand(
+          DeleteNodeCommand(nodeId: nodeBefore.id),
+        );
+        return;
+      }
+
+      moveSelectionToEndOfPrecedingNode(executor, document, composer);
+    }
+  }
+
+  void moveSelectionToEndOfPrecedingNode(
+    CommandExecutor executor,
+    MutableDocument document,
+    MutableDocumentComposer composer,
+  ) {
+    if (composer.selection == null) {
+      return;
+    }
+
+    final node = document.getNodeById(composer.selection!.extent.nodeId);
+    if (node == null) {
+      return;
+    }
+
+    final nodeBefore = document.getNodeBefore(node);
+    if (nodeBefore == null) {
+      return;
+    }
+
+    executor.executeCommand(
+      ChangeSelectionCommand(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: nodeBefore.id,
+            nodePosition: nodeBefore.endPosition,
+          ),
+        ),
+        SelectionChangeType.collapseSelection,
+        SelectionReason.userInteraction,
       ),
     );
   }

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -1,5 +1,6 @@
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/box_component.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
@@ -80,6 +81,15 @@ final defaultRequestHandlers = [
       : null,
   (request) => request is DeleteSelectionRequest //
       ? DeleteSelectionCommand(documentSelection: request.documentSelection)
+      : null,
+  (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
+      ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)
+      : null,
+  (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ParagraphNode
+      ? DeleteUpstreamAtBeginningOfParagraphCommand(request.node)
+      : null,
+  (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is BlockNode
+      ? DeleteUpstreamAtBeginningOfBlockNodeCommand(request.node)
       : null,
   (request) => request is DeleteNodeRequest //
       ? DeleteNodeCommand(nodeId: request.nodeId)

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -49,6 +49,11 @@ class TextDeltasDocumentEditor {
   void applyDeltas(List<TextEditingDelta> textEditingDeltas) {
     editorImeLog.info("Applying ${textEditingDeltas.length} IME deltas to document");
 
+    editorImeDeltasLog.fine("Incoming deltas:");
+    for (final delta in textEditingDeltas) {
+      editorImeDeltasLog.fine(delta);
+    }
+
     // Apply deltas to the document.
     editorImeLog.fine("Serializing document to perform IME operations");
     _serializedDoc = DocumentImeSerializer(
@@ -357,19 +362,17 @@ class TextDeltasDocumentEditor {
       final selectedNodeIndex = document.getNodeIndexById(
         selection.value!.extent.nodeId,
       );
-      if (selectedNodeIndex > 0) {
-        // The user is trying to delete upstream at the start of a node.
-        // This action requires intervention because the IME doesn't know
-        // that there's more content before this node. Instruct the editor
-        // to run a delete action upstream, which will take the desired
-        // "backspace" behavior at the start of this node.
-        editor.execute([
-          DeleteUpstreamAtBeginningOfNodeRequest(
-            document.getNodeAt(selectedNodeIndex)!,
-          ),
-        ]);
-        return;
-      }
+      // The user is trying to delete upstream at the start of a node.
+      // This action requires intervention because the IME doesn't know
+      // that there's more content before this node. Instruct the editor
+      // to run a delete action upstream, which will take the desired
+      // "backspace" behavior at the start of this node.
+      editor.execute([
+        DeleteUpstreamAtBeginningOfNodeRequest(
+          document.getNodeAt(selectedNodeIndex)!,
+        ),
+      ]);
+      return;
     }
 
     editorImeLog.fine("Running selection deletion operation");

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -363,9 +363,11 @@ class TextDeltasDocumentEditor {
         // that there's more content before this node. Instruct the editor
         // to run a delete action upstream, which will take the desired
         // "backspace" behavior at the start of this node.
-        final node = document.getNodeAt(selectedNodeIndex)!;
-        _deleteUpstream(DocumentPosition(nodeId: node.id, nodePosition: node.beginningPosition));
-        editorImeLog.fine("Deleted upstream. New selection: ${selection.value}");
+        editor.execute([
+          DeleteUpstreamAtBeginningOfNodeRequest(
+            document.getNodeAt(selectedNodeIndex)!,
+          ),
+        ]);
         return;
       }
     }
@@ -379,104 +381,6 @@ class TextDeltasDocumentEditor {
       ),
     ]);
     commonOps.deleteSelection();
-  }
-
-  /// Deletes a unit of content that comes before the [DocumentComposer]'s
-  /// selection extent, or deletes all selected content if the selection
-  /// is not collapsed.
-  ///
-  /// In the case of text editing, deletes the character that appears before
-  /// the caret.
-  ///
-  /// If the caret sits at the beginning of a content block, such as the
-  /// beginning of a text node, and the upstream node is not visually selectable,
-  /// then the upstream node is deleted and the caret is kept where it is.
-  ///
-  /// Returns [true] if content was deleted, or [false] if no upstream
-  /// content exists.
-  bool _deleteUpstream(DocumentPosition deletionPosition) {
-    final node = document.getNodeById(deletionPosition.nodeId)!;
-
-    if (deletionPosition.nodePosition is UpstreamDownstreamNodePosition) {
-      final nodePosition = deletionPosition.nodePosition as UpstreamDownstreamNodePosition;
-      if (nodePosition.affinity == TextAffinity.downstream) {
-        // The caret is sitting on the downstream edge of block-level content. Delete the
-        // whole block by replacing it with an empty paragraph.
-        commonOps.replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(deletionPosition.nodeId);
-
-        return true;
-      } else {
-        // The caret is sitting on the upstream edge of block-level content and
-        // the user is trying to delete upstream.
-        //  * If the node above is an empty paragraph, delete it.
-        //  * If the node above is non-selectable, delete it.
-        //  * Otherwise, move the caret up to the node above.
-        final nodeBefore = document.getNodeBefore(node);
-        if (nodeBefore == null) {
-          return false;
-        }
-
-        if (nodeBefore is TextNode && nodeBefore.text.text.isEmpty) {
-          editor.execute([
-            DeleteNodeRequest(nodeId: nodeBefore.id),
-          ]);
-          return true;
-        }
-
-        final componentBefore = documentLayoutResolver().getComponentByNodeId(nodeBefore.id)!;
-        if (!componentBefore.isVisualSelectionSupported()) {
-          // The node/component above is not selectable. Delete it.
-          commonOps.deleteNonSelectedNode(nodeBefore);
-          return true;
-        }
-
-        return commonOps.moveSelectionToEndOfPrecedingNode();
-      }
-    }
-
-    if (deletionPosition.nodePosition is TextNodePosition) {
-      final textPosition = deletionPosition.nodePosition as TextNodePosition;
-      if (textPosition.offset == 0) {
-        final nodeBefore = document.getNodeBefore(node);
-        if (nodeBefore == null) {
-          return false;
-        }
-
-        if (nodeBefore is TextNode) {
-          // The caret is at the beginning of one TextNode and is preceded by
-          // another TextNode. Merge the two TextNodes.
-          return commonOps.mergeTextNodeWithUpstreamTextNode();
-        }
-
-        final componentBefore = documentLayoutResolver().getComponentByNodeId(nodeBefore.id)!;
-        if (!componentBefore.isVisualSelectionSupported()) {
-          // The node/component above is not selectable. Delete it.
-          commonOps.deleteNonSelectedNode(nodeBefore);
-          return true;
-        }
-
-        if ((node as TextNode).text.text.isEmpty) {
-          // The caret is at the beginning of an empty TextNode and the preceding
-          // node is not a TextNode. Delete the current TextNode and move the
-          // selection up to the preceding node if exist.
-          if (commonOps.moveSelectionToEndOfPrecedingNode()) {
-            editor.execute([
-              DeleteNodeRequest(nodeId: node.id),
-            ]);
-          }
-          return true;
-        }
-
-        // The caret is at the beginning of a non-empty TextNode, and the
-        // preceding node is not a TextNode. Move the document selection to the
-        // preceding node.
-        return commonOps.moveSelectionToEndOfPrecedingNode();
-      } else {
-        return commonOps.deleteUpstreamCharacter();
-      }
-    }
-
-    return false;
   }
 
   void insertNewline() {

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -114,15 +114,12 @@ class DocumentImeSerializer {
     }
 
     // We want to prepend an arbitrary placeholder character whenever the
-    // user's selection is collapsed at the beginning of a node, and there's
-    // another node above the selected node. Without the arbitrary character,
-    // the IME would assume that there's no content before the current node and
-    // therefore it wouldn't report the backspace button.
+    // user's selection is collapsed at the beginning of a node. Without the
+    // arbitrary character, the IME would assume that there's no content
+    // before the current node and therefore it wouldn't report the backspace
+    // button.
     final selectedNode = _doc.getNode(selection.extent)!;
-    final selectedNodeIndex = _doc.getNodeIndexById(selectedNode.id);
-    return selectedNodeIndex > 0 &&
-        selection.isCollapsed &&
-        selection.extent.nodePosition == selectedNode.beginningPosition;
+    return selection.isCollapsed && selection.extent.nodePosition == selectedNode.beginningPosition;
   }
 
   bool get didPrependPlaceholder => _prependedPlaceholder.isNotEmpty;

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
@@ -27,7 +28,7 @@ class ListItemNode extends TextNode {
           text: text,
           metadata: metadata,
         ) {
-    putMetadataValue("blockType", const NamedAttribution("listItem"));
+    putMetadataValue("blockType", listItemAttribution);
   }
 
   ListItemNode.unordered({
@@ -42,7 +43,7 @@ class ListItemNode extends TextNode {
           text: text,
           metadata: metadata,
         ) {
-    putMetadataValue("blockType", const NamedAttribution("listItem"));
+    putMetadataValue("blockType", listItemAttribution);
   }
 
   ListItemNode({
@@ -59,7 +60,7 @@ class ListItemNode extends TextNode {
           metadata: metadata ?? {},
         ) {
     if (!hasMetadataValue("blockType")) {
-      putMetadataValue("blockType", const NamedAttribution("listItem"));
+      putMetadataValue("blockType", listItemAttribution);
     }
   }
 
@@ -91,6 +92,8 @@ class ListItemNode extends TextNode {
   @override
   int get hashCode => super.hashCode ^ type.hashCode ^ _indent.hashCode;
 }
+
+const listItemAttribution = NamedAttribution("listItem");
 
 enum ListItemType {
   ordered,
@@ -533,11 +536,15 @@ class ConvertListItemToParagraphCommand implements EditCommand {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId);
     final listItem = node as ListItemNode;
+    final newMetadata = Map<String, dynamic>.from(paragraphMetadata ?? {});
+    if (newMetadata["blockType"] == listItemAttribution) {
+      newMetadata["blockType"] = paragraphAttribution;
+    }
 
     final newParagraphNode = ParagraphNode(
       id: listItem.id,
       text: listItem.text,
-      metadata: paragraphMetadata ?? {},
+      metadata: newMetadata,
     );
     document.replaceNode(oldNode: listItem, newNode: newParagraphNode);
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -749,6 +749,24 @@ class DeleteSelectionCommand implements EditCommand {
   }
 }
 
+/// Request to handle a collapsed selection upstream deletion at the
+/// beginning of a [node].
+///
+/// When this request is submitted, the caret should be at the beginning of
+/// the given [node].
+///
+/// This request is likely to be handled differently based on the type of
+/// [node] where this upstream deletion takes place. For example, a paragraph
+/// might combine with the paragraph above it. A list item might convert
+/// to a regular paragraph.
+class DeleteUpstreamAtBeginningOfNodeRequest implements EditRequest {
+  DeleteUpstreamAtBeginningOfNodeRequest(this.node);
+
+  /// The [DocumentNode] where an upstream deletion should take
+  /// place at the beginning end of the node.
+  final DocumentNode node;
+}
+
 class DeleteNodeRequest implements EditRequest {
   DeleteNodeRequest({
     required this.nodeId,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -317,6 +317,11 @@ class SuperEditorState extends State<SuperEditor> {
 
     _docLayoutKey = widget.documentLayoutKey ?? GlobalKey();
 
+    widget.editor.context.put(
+      Editor.layoutKey,
+      DocumentLayoutEditable(() => _docLayoutKey.currentState as DocumentLayout),
+    );
+
     _createEditContext();
     _createLayoutPresenter();
   }
@@ -340,6 +345,13 @@ class SuperEditorState extends State<SuperEditor> {
     }
 
     if (widget.editor != oldWidget.editor) {
+      oldWidget.editor.context.remove(Editor.layoutKey);
+
+      widget.editor.context.put(
+        Editor.layoutKey,
+        DocumentLayoutEditable(() => _docLayoutKey.currentState as DocumentLayout),
+      );
+
       _createEditContext();
       _createLayoutPresenter();
     } else if (widget.selectionStyles != oldWidget.selectionStyles) {
@@ -358,6 +370,8 @@ class SuperEditorState extends State<SuperEditor> {
     _contentTapDelegate?.dispose();
 
     _composer.selectionNotifier.removeListener(_updateComposerPreferencesAtSelection);
+
+    widget.editor.context.remove(Editor.layoutKey);
 
     _focusNode.removeListener(_onFocusChange);
     if (widget.focusNode == null) {

--- a/super_editor/lib/src/infrastructure/_logging.dart
+++ b/super_editor/lib/src/infrastructure/_logging.dart
@@ -10,6 +10,7 @@ class LogNames {
   static const editorKeys = 'editor.keys';
   static const editorIme = 'editor.ime';
   static const editorImeConnection = 'editor.ime.connection';
+  static const editorImeDeltas = 'editor.ime.deltas';
   static const editorLayout = 'editor.layout';
   static const editorStyle = 'editor.style';
   static const editorDocument = 'editor.document';
@@ -46,6 +47,7 @@ final editorGesturesLog = logging.Logger(LogNames.editorGestures);
 final editorKeyLog = logging.Logger(LogNames.editorKeys);
 final editorImeLog = logging.Logger(LogNames.editorIme);
 final editorImeConnectionLog = logging.Logger(LogNames.editorImeConnection);
+final editorImeDeltasLog = logging.Logger(LogNames.editorImeDeltas);
 final editorLayoutLog = logging.Logger(LogNames.editorLayout);
 final editorStyleLog = logging.Logger(LogNames.editorStyle);
 final editorDocLog = logging.Logger(LogNames.editorDocument);

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -183,16 +183,16 @@ void main() {
       await tester.ime.sendDeltas(
         const [
           TextEditingDeltaNonTextUpdate(
-            oldText: '',
-            selection: TextSelection.collapsed(offset: 0),
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
             composing: TextRange(start: -1, end: -1),
           ),
           TextEditingDeltaInsertion(
-            oldText: '',
+            oldText: '. ',
             textInserted: 'Goi',
-            insertionOffset: 0,
-            selection: TextSelection.collapsed(offset: 3),
-            composing: TextRange(start: 0, end: 3),
+            insertionOffset: 2,
+            selection: TextSelection.collapsed(offset: 5),
+            composing: TextRange(start: 2, end: 5),
           )
         ],
         getter: imeClientGetter,
@@ -443,11 +443,11 @@ void main() {
         await tester.ime.sendDeltas(
           const [
             TextEditingDeltaInsertion(
-              oldText: '',
+              oldText: '. ',
               textInserted: 'Before the line break new line',
-              insertionOffset: 0,
-              selection: TextSelection.collapsed(offset: 30),
-              composing: TextRange(start: 0, end: 30),
+              insertionOffset: 2,
+              selection: TextSelection.collapsed(offset: 32),
+              composing: TextRange(start: 2, end: 32),
             )
           ],
           getter: imeClientGetter,


### PR DESCRIPTION
Moved IME upstream deletion in empty nodes to Editor requests instead of direct implementation, for the purpose of extensability (Resolves #1259)

This is a temporary PR so that Superlist can try this behavior on Flutter `stable`.