### PR TITLE
[SuperEditor] Add chinese input test (Resolves #1230)

### DIFF
--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -685,15 +685,20 @@ Paragraph two
 
         // Simulate the user typing "a a a".
         await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
           TextEditingDeltaInsertion(
-            oldText: '',
+            oldText: '. ',
             textInserted: 'a',
-            insertionOffset: 0,
+            insertionOffset: 2,
             selection: TextSelection.collapsed(
-              offset: 1,
+              offset: 3,
               affinity: TextAffinity.upstream,
             ),
-            composing: TextRange(start: 0, end: 1),
+            composing: TextRange(start: 2, end: 3),
           ),
         ], getter: imeClientGetter);
         await tester.ime.sendDeltas(const [


### PR DESCRIPTION
[SuperEditor] Add chinese input test. Resolves #1230

Before #1245 was merged, when the user uses a chinese keyboard, typing a characterd after accepting a suggestion causes the whole text to be replaced by the last character typed.

Looking at the logs, the following is happening:

1. We receive the replacement delta
2. We send [0,3) as the composing region back to the IME.
3. We receive [-1,-1] as the new composing region (in the same frame)

It seems that, after step 3, the IME changes the composing region to the value we sent in step 2. As we had code to ignore non-text deltas in the same frame as we send the editing value to the IME, we don't clear the composing region after step 3.

Because of that, the whole text becomes part of the composing region, which is why the whole text is replaced.

Relevant logs: 

```console
flutter: (14.982) editor.ime > INFO: Applying delta: TextEditingDeltaReplacement#70159(oldText: a a a, textReplaced: a a a, replacementText: 呵呵呵, replacedRange: TextRange(start: 0, end: 5), selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.upstream, isDirectional: false), composing: TextRange(start: 0, end: 3))

flutter: (15.015) editor.ime > FINE: Sending forceful update to IME because our local TextEditingValue didn't change, but the IME may have:
flutter: (15.015) editor.ime > FINE: TextEditingValue(text: ┤呵呵呵├, selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 0, end: 3))

flutter: (15.017) editor.ime > FINE: TextEditingDeltaNonTextUpdate#e0ae5(oldText: 呵呵呵, selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.upstream, isDirectional: false), composing: TextRange(start: -1, end: -1))
flutter: (15.017) editor.ime > FINE: Ignoring this delta because it's a non-text update that came in right after we setEditingState()

flutter: (16.431) editor.ime > FINE: Received edit deltas from platform: 1 deltas
flutter: (16.435) editor.ime > FINE: TextEditingDeltaReplacement#9043f(oldText: 呵呵呵, textReplaced: 呵呵呵, replacementText: d, replacedRange: TextRange(start: 0, end: 3), selection: TextSelection.collapsed(offset: 1, affinity: TextAffinity.upstream, isDirectional: false), composing: TextRange(start: 0, end: 1))
```

This PR adds a test to ensure we are sending the composing region back to the IME after we receive the non-text delta in the same frame. I'm not sure this test is valuable enough though...