### PR TITLE
Exposed scroll control through SuperEditorContext (Resolves #1288)

### DIFF
--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -1,4 +1,5 @@
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
+import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 
 import 'document.dart';
 import 'document_composer.dart';
@@ -22,6 +23,7 @@ class SuperEditorContext {
     required this.document,
     required DocumentLayout Function() getDocumentLayout,
     required this.composer,
+    required this.scroller,
     required this.commonOps,
   }) : _getDocumentLayout = getDocumentLayout;
 
@@ -40,6 +42,10 @@ class SuperEditorContext {
   /// The [DocumentComposer] that maintains selection and attributions to work
   /// in conjunction with the [editor] to apply changes to the document.
   final DocumentComposer composer;
+
+  /// The [DocumentScroller] that provides status and control over [SuperEditor]
+  /// scrolling.
+  final DocumentScroller scroller;
 
   /// Common operations that can be executed to apply common, complex changes to
   /// the document.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -18,6 +18,7 @@ import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
+import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/selection_leader_document_layer.dart';
@@ -296,6 +297,7 @@ class SuperEditorState extends State<SuperEditor> {
 
   late DocumentComposer _composer;
 
+  late DocumentScroller _scroller;
   late ScrollController _scrollController;
   late AutoScrollController _autoScrollController;
 
@@ -396,11 +398,14 @@ class SuperEditorState extends State<SuperEditor> {
   }
 
   void _createEditContext() {
+    _scroller = DocumentScroller();
+
     editContext = SuperEditorContext(
       editor: widget.editor,
       document: widget.document,
       composer: _composer,
       getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
+      scroller: _scroller,
       commonOps: CommonEditorOperations(
         editor: widget.editor,
         document: widget.document,
@@ -503,6 +508,7 @@ class SuperEditorState extends State<SuperEditor> {
             gestureBuilder: _buildGestureInteractor,
             scrollController: _scrollController,
             autoScrollController: _autoScrollController,
+            scroller: _scroller,
             presenter: presenter,
             componentBuilders: widget.componentBuilders,
             underlays: [

--- a/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
@@ -4,6 +4,7 @@ import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/layout_single_column/_layout.dart';
 import 'package:super_editor/src/default_editor/layout_single_column/_presenter.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
+import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/viewport_size_reporting.dart';
 
 /// A scaffold that combines pieces to create a scrolling single-column document, with
@@ -19,6 +20,7 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
     required this.gestureBuilder,
     this.scrollController,
     required this.autoScrollController,
+    required this.scroller,
     required this.presenter,
     required this.componentBuilders,
     this.underlays = const [],
@@ -43,6 +45,11 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
 
   /// Controls auto-scrolling of the document's viewport.
   final AutoScrollController autoScrollController;
+
+  /// A [DocumentScroller], to which this scrollable attaches itself, so
+  /// that external actors, such as keyboard handlers, can query and change
+  /// the scroll offset.
+  final DocumentScroller? scroller;
 
   /// Presenter that computes styles for a single-column layout, e.g., component padding,
   /// text styles, selection.
@@ -90,6 +97,7 @@ class _DocumentScaffoldState extends State<DocumentScaffold> {
         autoScroller: widget.autoScrollController,
         scrollController: widget.scrollController,
         scrollingMinimapId: widget.debugPaint.scrollingMinimapId,
+        scroller: widget.scroller,
         showDebugPaint: widget.debugPaint.scrolling,
         child: child,
       ),

--- a/super_editor/lib/src/infrastructure/documents/document_scroller.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scroller.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+
+/// Scrolling status and controls for a document experience.
+///
+/// Depending on the surrounding widget tree, a [DocumentScroller] might be attached
+/// to a descendant `Scrollable`, which was added by the document experience widget
+/// (like `SuperEditor` or `SuperReader`). Or, a [DocumentScroller] might be attached
+/// to an ancestor `Scrollable`, if the document experience chooses to use an
+/// ancestor `Scrollable`.
+class DocumentScroller {
+  /// The height of a vertically scrolling viewport, or the width of a horizontally
+  /// scrolling viewport.
+  double get viewportDimension => _scrollPosition!.viewportDimension;
+
+  /// The smallest possible scrolling offset, which is usually zero.
+  double get minScrollExtent => _scrollPosition!.minScrollExtent;
+
+  /// The maximum possible scrolling offset, at which point the end of the scrolling
+  /// content is visible in the viewport.
+  double get maxScrollExtent => _scrollPosition!.maxScrollExtent;
+
+  /// The current scroll offset in the viewport, which is represented by the number
+  /// of pixels between the top-left corner of the viewport, and the top-left corner
+  /// of the content that sits inside the viewport.
+  double get scrollOffset => _scrollPosition!.pixels;
+
+  /// Immediately moves the [scrollOffset] to [newScrollOffset].
+  void jumpTo(double newScrollOffset) {
+    _scrollPosition!.jumpTo(newScrollOffset);
+  }
+
+  /// Animates [scrollOffset] from its current offset to [to], over the given [duration]
+  /// of time, following the given animation [curve].
+  void animateTo(
+    double to, {
+    required Duration duration,
+    Curve curve = Curves.easeInOut,
+  }) {
+    _scrollPosition!.animateTo(to, duration: duration, curve: curve);
+  }
+
+  ScrollPosition? _scrollPosition;
+
+  void attach(ScrollPosition scrollPosition) {
+    _scrollPosition = scrollPosition;
+  }
+
+  void detach() {
+    _scrollPosition = null;
+  }
+}

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -343,6 +343,7 @@ class SuperReaderState extends State<SuperReader> {
         gestureBuilder: _buildGestureInteractor,
         scrollController: _scrollController,
         autoScrollController: _autoScrollController,
+        // TODO: Finish integrating the DocumentScroller in SuperReader (https://github.com/superlistapp/super_editor/issues/1306)
         scroller: _scroller,
         presenter: _docLayoutPresenter!,
         componentBuilders: widget.componentBuilders,

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -23,6 +23,7 @@ import 'package:super_editor/src/default_editor/unknown_component.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/document_gestures_interaction_overrides.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
+import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/selection_leader_document_layer.dart';
 
@@ -191,6 +192,7 @@ class SuperReaderState extends State<SuperReader> {
 
   ContentTapDelegate? _contentTapDelegate;
 
+  late DocumentScroller _scroller;
   late ScrollController _scrollController;
   late AutoScrollController _autoScrollController;
 
@@ -216,6 +218,7 @@ class SuperReaderState extends State<SuperReader> {
 
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
 
+    _scroller = DocumentScroller();
     _scrollController = widget.scrollController ?? ScrollController();
     _autoScrollController = AutoScrollController();
 
@@ -340,6 +343,7 @@ class SuperReaderState extends State<SuperReader> {
         gestureBuilder: _buildGestureInteractor,
         scrollController: _scrollController,
         autoScrollController: _autoScrollController,
+        scroller: _scroller,
         presenter: _docLayoutPresenter!,
         componentBuilders: widget.componentBuilders,
         underlays: [

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -57,6 +57,7 @@ export 'src/infrastructure/_logging.dart';
 export 'src/infrastructure/attributed_text_styles.dart';
 export 'src/infrastructure/attribution_layout_bounds.dart';
 export 'src/infrastructure/composable_text.dart';
+export 'src/infrastructure/documents/document_scroller.dart';
 export 'src/infrastructure/focus.dart';
 export 'src/infrastructure/ime_input_owner.dart';
 export 'src/infrastructure/keyboard.dart';

--- a/super_editor/test/src/_document_test_tools.dart
+++ b/super_editor/test/src/_document_test_tools.dart
@@ -1,16 +1,14 @@
+import 'package:flutter/src/animation/curves.dart';
+import 'package:flutter/src/widgets/scroll_position.dart';
 import 'package:mockito/mockito.dart';
 import 'package:super_editor/super_editor.dart';
-
-/// Fake [DocumentLayout], intended for tests that interact with
-/// a logical [DocumentLayout] but do not depend upon a real
-/// widget tree with a real [DocumentLayout] implementation.
-class FakeDocumentLayout with Mock implements DocumentLayout {}
 
 SuperEditorContext createEditContext({
   required MutableDocument document,
   Editor? documentEditor,
   DocumentLayout? documentLayout,
   MutableDocumentComposer? documentComposer,
+  DocumentScroller? scroller,
   CommonEditorOperations? commonOps,
 }) {
   final composer = documentComposer ?? MutableDocumentComposer();
@@ -22,6 +20,7 @@ SuperEditorContext createEditContext({
     document: document,
     getDocumentLayout: layoutResolver,
     composer: composer,
+    scroller: scroller ?? FakeSuperEditorScroller(),
     commonOps: commonOps ??
         CommonEditorOperations(
           editor: editor,
@@ -30,6 +29,40 @@ SuperEditorContext createEditContext({
           documentLayoutResolver: layoutResolver,
         ),
   );
+}
+
+/// Fake [DocumentLayout], intended for tests that interact with
+/// a logical [DocumentLayout] but do not depend upon a real
+/// widget tree with a real [DocumentLayout] implementation.
+class FakeDocumentLayout with Mock implements DocumentLayout {}
+
+/// Fake [SuperEditorScroll], intended for tests that interact
+/// with logical resources but do not depend upon a real widget
+/// tree with a real `Scrollable`.
+class FakeSuperEditorScroller implements DocumentScroller {
+  @override
+  double get viewportDimension => throw UnimplementedError();
+
+  @override
+  double get minScrollExtent => throw UnimplementedError();
+
+  @override
+  double get maxScrollExtent => throw UnimplementedError();
+
+  @override
+  double get scrollOffset => throw UnimplementedError();
+
+  @override
+  void jumpTo(double newScrollOffset) => throw UnimplementedError();
+
+  @override
+  void animateTo(double to, {required Duration duration, Curve curve = Curves.easeInOut}) => throw UnimplementedError();
+
+  @override
+  void attach(ScrollPosition scrollPosition) => throw UnimplementedError();
+
+  @override
+  void detach() => throw UnimplementedError();
 }
 
 MutableDocument createExampleDocument() {

--- a/super_editor/test/src/default_editor/document_input_ime_test.dart
+++ b/super_editor/test/src/default_editor/document_input_ime_test.dart
@@ -916,7 +916,7 @@ Paragraph two
         final selection = SuperEditorInspector.findDocumentSelection()!;
         final base = (selection.base.nodePosition as TextNodePosition).offset;
         final extent = (selection.extent.nodePosition as TextNodePosition).offset;
-        final affinity = context.editContext.document.getAffinityForSelection(selection);
+        final affinity = context.findEditContext().document.getAffinityForSelection(selection);
 
         // Ensure we sent the same base, extent and affinity to the platform.
         expect(selectionBase, base);

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -545,7 +545,9 @@ void main() {
                 ),
               );
 
+              print("Verifying results on composer (${editContext.composer.hashCode})");
               expect(result, ExecutionInstruction.haltExecution);
+              expect(editContext.composer.selection, isNotNull);
               expect(
                 editContext.composer.selection!.base,
                 const DocumentPosition(
@@ -562,6 +564,7 @@ void main() {
               );
             },
           );
+
           testOnMac(
             'it selects all when CMD+A is pressed with a two-node document',
             () {

--- a/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
+++ b/super_editor/test/src/default_editor/document_keyboard_actions_test.dart
@@ -545,7 +545,6 @@ void main() {
                 ),
               );
 
-              print("Verifying results on composer (${editContext.composer.hashCode})");
               expect(result, ExecutionInstruction.haltExecution);
               expect(editContext.composer.selection, isNotNull);
               expect(

--- a/super_editor/test/src/default_editor/list_items_test.dart
+++ b/super_editor/test/src/default_editor/list_items_test.dart
@@ -30,7 +30,7 @@ void main() {
         await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
 
         // Convert the list item to a paragraph.
-        testContext.editContext.commonOps.convertToParagraph(
+        testContext.findEditContext().commonOps.convertToParagraph(
           newMetadata: {
             'blockType': const NamedAttribution("paragraph"),
           },
@@ -43,10 +43,10 @@ void main() {
         expect(richText.text.style!.color, Colors.red);
 
         // Convert the paragraph back to an unordered list item.
-        testContext.editContext.commonOps.convertToListItem(
-          ListItemType.unordered,
-          (doc.nodes.first as ParagraphNode).text,
-        );
+        testContext.findEditContext().commonOps.convertToListItem(
+              ListItemType.unordered,
+              (doc.nodes.first as ParagraphNode).text,
+            );
         await tester.pumpAndSettle();
 
         // Ensure that the textStyle for a list item was applied.
@@ -74,7 +74,7 @@ void main() {
         await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
 
         // Convert the list item to a paragraph.
-        testContext.editContext.commonOps.convertToParagraph(
+        testContext.findEditContext().commonOps.convertToParagraph(
           newMetadata: {
             'blockType': const NamedAttribution("paragraph"),
           },
@@ -87,10 +87,10 @@ void main() {
         expect(richText.text.style!.color, Colors.red);
 
         // Convert the paragraph back to an ordered list item.
-        testContext.editContext.commonOps.convertToListItem(
-          ListItemType.ordered,
-          (doc.nodes.first as ParagraphNode).text,
-        );
+        testContext.findEditContext().commonOps.convertToListItem(
+              ListItemType.ordered,
+              (doc.nodes.first as ParagraphNode).text,
+            );
         await tester.pumpAndSettle();
 
         // Ensure that the textStyle for a list item was applied.
@@ -168,7 +168,7 @@ void main() {
             .fromMarkdown('* Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -205,7 +205,7 @@ void main() {
             .fromMarkdown('* Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -242,7 +242,7 @@ void main() {
             .fromMarkdown('* Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -279,7 +279,7 @@ void main() {
             .fromMarkdown('* List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);
@@ -313,7 +313,7 @@ void main() {
             .fromMarkdown('* List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);
@@ -347,7 +347,7 @@ void main() {
             .fromMarkdown('* List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);
@@ -441,7 +441,7 @@ void main() {
             .fromMarkdown('1. Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -478,7 +478,7 @@ void main() {
             .fromMarkdown('1. Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -515,7 +515,7 @@ void main() {
             .fromMarkdown('1. Item 1')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
@@ -552,7 +552,7 @@ void main() {
             .fromMarkdown('1. List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);
@@ -586,7 +586,7 @@ void main() {
             .fromMarkdown('1. List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);
@@ -620,7 +620,7 @@ void main() {
             .fromMarkdown('1. List Item')
             .pump();
 
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
         await tester.placeCaretInParagraph(document.nodes.first.id, 5);

--- a/super_editor/test/src/default_editor/super_editor_test.dart
+++ b/super_editor/test/src/default_editor/super_editor_test.dart
@@ -53,7 +53,7 @@ void main() {
     group("stylesheet", () {
       testWidgets("change causes presentation to run again", (tester) async {
         // Configure and render a document.
-        final testDocument = await tester //
+        final testDocumentContext = await tester //
             .createDocument()
             .withSingleParagraph()
             .useStylesheet(_stylesheet1)
@@ -64,7 +64,7 @@ void main() {
 
         // Configure and render a document with a different stylesheet.
         await tester //
-            .updateDocument(testDocument)
+            .updateDocument(testDocumentContext.configuration)
             .useStylesheet(_stylesheet2)
             .pump();
 

--- a/super_editor/test/src/default_editor/text_test.dart
+++ b/super_editor/test/src/default_editor/text_test.dart
@@ -416,6 +416,7 @@ SuperEditorContext _createEditContext() {
     document: document,
     getDocumentLayout: () => fakeLayout,
     composer: composer,
+    scroller: FakeSuperEditorScroller(),
     commonOps: CommonEditorOperations(
       editor: documentEditor,
       document: document,

--- a/super_editor/test/super_editor/components/horizontal_rule_test.dart
+++ b/super_editor/test/super_editor/components/horizontal_rule_test.dart
@@ -22,7 +22,7 @@ Paragraph 2
           .withInputSource(TextInputSource.ime)
           .pump();
 
-      final document = testContext.editContext.document;
+      final document = testContext.findEditContext().document;
 
       // Place the caret at the end of the horizontal rule, by first placing the caret in the paragraph after the
       // horizontal rule, and then pressing the left arrow to move it up.
@@ -61,7 +61,7 @@ Paragraph 2
           .withInputSource(TextInputSource.ime)
           .pump();
 
-      final document = testContext.editContext.document;
+      final document = testContext.findEditContext().document;
 
       // Place the caret at the beginning of the horizontal rule, by first placing the caret in the paragraph before the
       // horizontal rule, and then pressing the right arrow to move it down.

--- a/super_editor/test/super_editor/document_test_tools.dart
+++ b/super_editor/test/super_editor/document_test_tools.dart
@@ -21,74 +21,74 @@ extension DocumentTester on WidgetTester {
     return TestDocumentSelector(this);
   }
 
-  /// Pumps a new [SuperEditor] using the existing [context].
+  /// Pumps a new [SuperEditor] using an existing [configuration].
   ///
   /// Use this method to simulate a [SuperEditor] whose widget tree changes.
-  TestDocumentConfigurator updateDocument(TestDocumentContext context) {
-    return TestDocumentConfigurator._fromExistingContext(this, context);
+  TestSuperEditorConfigurator updateDocument(SuperEditorTestConfiguration configuration) {
+    return TestSuperEditorConfigurator._fromExistingConfiguration(this, configuration);
   }
 }
 
 /// Selects a [Document] configuration when composing a [SuperEditor]
 /// widget in a test.
 ///
-/// Each document selection returns a [TestDocumentConfigurator], which
+/// Each document selection returns a [TestSuperEditorConfigurator], which
 /// is used to complete the configuration, and to pump the [SuperEditor].
 class TestDocumentSelector {
   const TestDocumentSelector(this._widgetTester);
 
   final WidgetTester _widgetTester;
 
-  TestDocumentConfigurator withCustomContent(MutableDocument document) {
-    return TestDocumentConfigurator._(_widgetTester, document);
+  TestSuperEditorConfigurator withCustomContent(MutableDocument document) {
+    return TestSuperEditorConfigurator._(_widgetTester, document);
   }
 
   /// Configures the editor with a [Document] that's parsed from the
   /// given [markdown].
-  TestDocumentConfigurator fromMarkdown(String markdown) {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator fromMarkdown(String markdown) {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       deserializeMarkdownToDocument(markdown),
     );
   }
 
-  TestDocumentConfigurator withSingleEmptyParagraph() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withSingleEmptyParagraph() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       singleParagraphEmptyDoc(),
     );
   }
 
-  TestDocumentConfigurator withSingleParagraph() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withSingleParagraph() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       singleParagraphDoc(),
     );
   }
 
-  TestDocumentConfigurator withSingleParagraphAndLink() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withSingleParagraphAndLink() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       singleParagraphWithLinkDoc(),
     );
   }
 
-  TestDocumentConfigurator withTwoEmptyParagraphs() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withTwoEmptyParagraphs() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       twoParagraphEmptyDoc(),
     );
   }
 
-  TestDocumentConfigurator withLongTextContent() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withLongTextContent() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       longTextDoc(),
     );
   }
 
-  TestDocumentConfigurator withLongDoc() {
-    return TestDocumentConfigurator._(
+  TestSuperEditorConfigurator withLongDoc() {
+    return TestSuperEditorConfigurator._(
       _widgetTester,
       longDoc(),
     );
@@ -96,214 +96,188 @@ class TestDocumentSelector {
 }
 
 /// Builder that configures and pumps a [SuperEditor] widget.
-class TestDocumentConfigurator {
-  TestDocumentConfigurator._fromExistingContext(this._widgetTester, this._existingContext) : _document = null;
+class TestSuperEditorConfigurator {
+  TestSuperEditorConfigurator._fromExistingConfiguration(this._widgetTester, this._config);
 
-  TestDocumentConfigurator._(this._widgetTester, this._document) : _existingContext = null;
+  TestSuperEditorConfigurator._(this._widgetTester, MutableDocument document)
+      : _config = SuperEditorTestConfiguration(document);
 
   final WidgetTester _widgetTester;
-  final MutableDocument? _document;
-  final TestDocumentContext? _existingContext;
-  final _addedRequestHandlers = <EditRequestHandler>[];
-  final _addedReactions = <EditReaction>[];
-  DocumentGestureMode? _gestureMode;
-  TextInputSource? _inputSource;
-  SuperEditorSelectionPolicies? _selectionPolicies;
-  SoftwareKeyboardController? _softwareKeyboardController;
-  SuperEditorImePolicies? _imePolicies;
-  SuperEditorImeConfiguration? _imeConfiguration;
-  DeltaTextInputClientDecorator? _imeOverrides;
-  final _prependedKeyboardActions = <DocumentKeyboardAction>[];
-  final _appendedKeyboardActions = <DocumentKeyboardAction>[];
-  ThemeData? _appTheme;
-  Stylesheet? _stylesheet;
-  final _addedComponents = <ComponentBuilder>[];
-  bool _autoFocus = false;
-  ui.Size? _editorSize;
-  List<ComponentBuilder>? _componentBuilders;
-  WidgetTreeBuilder? _widgetTreeBuilder;
-  ScrollController? _scrollController;
-  FocusNode? _focusNode;
-  DocumentSelection? _selection;
-  WidgetBuilder? _androidToolbarBuilder;
-  WidgetBuilder? _iOSToolbarBuilder;
-  Key? _key;
+  final SuperEditorTestConfiguration _config;
 
-  final _plugins = <SuperEditorPlugin>{};
-
-  TestDocumentConfigurator withAddedRequestHandlers(List<EditRequestHandler> addedRequestHandlers) {
-    _addedRequestHandlers.addAll(addedRequestHandlers);
+  TestSuperEditorConfigurator withAddedRequestHandlers(List<EditRequestHandler> addedRequestHandlers) {
+    _config.addedRequestHandlers.addAll(addedRequestHandlers);
     return this;
   }
 
-  TestDocumentConfigurator withAddedReactions(List<EditReaction> addedReactions) {
-    _addedReactions.addAll(addedReactions);
+  TestSuperEditorConfigurator withAddedReactions(List<EditReaction> addedReactions) {
+    _config.addedReactions.addAll(addedReactions);
     return this;
   }
 
   /// Configures the [SuperEditor] for standard desktop interactions,
   /// e.g., mouse and keyboard input.
-  TestDocumentConfigurator forDesktop({
+  TestSuperEditorConfigurator forDesktop({
     TextInputSource inputSource = TextInputSource.ime,
   }) {
-    _inputSource = inputSource;
-    _gestureMode = DocumentGestureMode.mouse;
+    _config.inputSource = inputSource;
+    _config.gestureMode = DocumentGestureMode.mouse;
     return this;
   }
 
   /// Configures the [SuperEditor] for standard Android interactions,
   /// e.g., touch gestures and IME input.
-  TestDocumentConfigurator forAndroid() {
-    _gestureMode = DocumentGestureMode.android;
-    _inputSource = TextInputSource.ime;
+  TestSuperEditorConfigurator forAndroid() {
+    _config.gestureMode = DocumentGestureMode.android;
+    _config.inputSource = TextInputSource.ime;
     return this;
   }
 
   /// Configures the [SuperEditor] for standard iOS interactions,
   /// e.g., touch gestures and IME input.
-  TestDocumentConfigurator forIOS() {
-    _gestureMode = DocumentGestureMode.iOS;
-    _inputSource = TextInputSource.ime;
+  TestSuperEditorConfigurator forIOS() {
+    _config.gestureMode = DocumentGestureMode.iOS;
+    _config.inputSource = TextInputSource.ime;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [inputSource].
-  TestDocumentConfigurator withInputSource(TextInputSource inputSource) {
-    _inputSource = inputSource;
+  TestSuperEditorConfigurator withInputSource(TextInputSource inputSource) {
+    _config.inputSource = inputSource;
     return this;
   }
 
   /// Configures the [SuperEditor] with the given selection [policies], which dictate the interactions
   /// between selection and other details, such as focus change.
-  TestDocumentConfigurator withSelectionPolicies(SuperEditorSelectionPolicies policies) {
-    _selectionPolicies = policies;
+  TestSuperEditorConfigurator withSelectionPolicies(SuperEditorSelectionPolicies policies) {
+    _config.selectionPolicies = policies;
     return this;
   }
 
   /// Configures the [SuperEditor]'s [SoftwareKeyboardController].
-  TestDocumentConfigurator withSoftwareKeyboardController(SoftwareKeyboardController controller) {
-    _softwareKeyboardController = controller;
+  TestSuperEditorConfigurator withSoftwareKeyboardController(SoftwareKeyboardController controller) {
+    _config.softwareKeyboardController = controller;
     return this;
   }
 
   /// Configures the [SuperEditor] with the given IME [policies], which dictate the interactions
   /// between focus, selection, and the platform IME, including software keyborads on mobile.
-  TestDocumentConfigurator withImePolicies(SuperEditorImePolicies policies) {
-    _imePolicies = policies;
+  TestSuperEditorConfigurator withImePolicies(SuperEditorImePolicies policies) {
+    _config.imePolicies = policies;
     return this;
   }
 
   /// Configures the way in which the user interacts with the IME, e.g., brightness, autocorrection, etc.
-  TestDocumentConfigurator withImeConfiguration(SuperEditorImeConfiguration configuration) {
-    _imeConfiguration = configuration;
+  TestSuperEditorConfigurator withImeConfiguration(SuperEditorImeConfiguration configuration) {
+    _config.imeConfiguration = configuration;
     return this;
   }
 
   /// Configures the [SuperEditor] to intercept and override desired IME signals, as
   /// determined by the given [imeOverrides].
-  TestDocumentConfigurator withImeOverrides(DeltaTextInputClientDecorator imeOverrides) {
-    _imeOverrides = imeOverrides;
+  TestSuperEditorConfigurator withImeOverrides(DeltaTextInputClientDecorator imeOverrides) {
+    _config.imeOverrides = imeOverrides;
     return this;
   }
 
-  TestDocumentConfigurator withAddedKeyboardActions({
+  TestSuperEditorConfigurator withAddedKeyboardActions({
     List<DocumentKeyboardAction> prepend = const [],
     List<DocumentKeyboardAction> append = const [],
   }) {
-    _prependedKeyboardActions.addAll(prepend);
-    _appendedKeyboardActions.addAll(append);
+    _config.prependedKeyboardActions.addAll(prepend);
+    _config.appendedKeyboardActions.addAll(append);
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [gestureMode].
-  TestDocumentConfigurator withGestureMode(DocumentGestureMode gestureMode) {
-    _gestureMode = gestureMode;
+  TestSuperEditorConfigurator withGestureMode(DocumentGestureMode gestureMode) {
+    _config.gestureMode = gestureMode;
     return this;
   }
 
   /// Configures the [SuperEditor] to constrain its maxHeight and maxWidth using the given [size].
-  TestDocumentConfigurator withEditorSize(ui.Size? size) {
-    _editorSize = size;
+  TestSuperEditorConfigurator withEditorSize(ui.Size? size) {
+    _config.editorSize = size;
     return this;
   }
 
   /// Configures the [SuperEditor] to use only the given [componentBuilders]
-  TestDocumentConfigurator withComponentBuilders(List<ComponentBuilder>? componentBuilders) {
-    _componentBuilders = componentBuilders;
+  TestSuperEditorConfigurator withComponentBuilders(List<ComponentBuilder>? componentBuilders) {
+    _config.componentBuilders = componentBuilders;
     return this;
   }
 
   /// Configures the [SuperEditor] to use a custom widget tree above [SuperEditor].
-  TestDocumentConfigurator withCustomWidgetTreeBuilder(WidgetTreeBuilder? builder) {
-    _widgetTreeBuilder = builder;
+  TestSuperEditorConfigurator withCustomWidgetTreeBuilder(WidgetTreeBuilder? builder) {
+    _config.widgetTreeBuilder = builder;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [scrollController]
-  TestDocumentConfigurator withScrollController(ScrollController? scrollController) {
-    _scrollController = scrollController;
+  TestSuperEditorConfigurator withScrollController(ScrollController? scrollController) {
+    _config.scrollController = scrollController;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [focusNode]
-  TestDocumentConfigurator withFocusNode(FocusNode? focusNode) {
-    _focusNode = focusNode;
+  TestSuperEditorConfigurator withFocusNode(FocusNode? focusNode) {
+    _config.focusNode = focusNode;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [selection] as its initial selection.
-  TestDocumentConfigurator withSelection(DocumentSelection? selection) {
-    _selection = selection;
+  TestSuperEditorConfigurator withSelection(DocumentSelection? selection) {
+    _config.selection = selection;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [builder] as its android toolbar builder.
-  TestDocumentConfigurator withAndroidToolbarBuilder(WidgetBuilder? builder) {
-    _androidToolbarBuilder = builder;
+  TestSuperEditorConfigurator withAndroidToolbarBuilder(WidgetBuilder? builder) {
+    _config.androidToolbarBuilder = builder;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [builder] as its iOS toolbar builder.
-  TestDocumentConfigurator withiOSToolbarBuilder(WidgetBuilder? builder) {
-    _iOSToolbarBuilder = builder;
+  TestSuperEditorConfigurator withiOSToolbarBuilder(WidgetBuilder? builder) {
+    _config.iOSToolbarBuilder = builder;
     return this;
   }
 
   /// Configures the [ThemeData] used for the [MaterialApp] that wraps
   /// the [SuperEditor].
-  TestDocumentConfigurator useAppTheme(ThemeData theme) {
-    _appTheme = theme;
+  TestSuperEditorConfigurator useAppTheme(ThemeData theme) {
+    _config.appTheme = theme;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [stylesheet].
-  TestDocumentConfigurator useStylesheet(Stylesheet? stylesheet) {
-    _stylesheet = stylesheet;
+  TestSuperEditorConfigurator useStylesheet(Stylesheet? stylesheet) {
+    _config.stylesheet = stylesheet;
     return this;
   }
 
   /// Adds the given component builders to the list of component builders that are
   /// used to render the document layout in the pumped [SuperEditor].
-  TestDocumentConfigurator withAddedComponents(List<ComponentBuilder> newComponents) {
-    _addedComponents.addAll(newComponents);
+  TestSuperEditorConfigurator withAddedComponents(List<ComponentBuilder> newComponents) {
+    _config.addedComponents.addAll(newComponents);
     return this;
   }
 
   /// Configures the [SuperEditor] to auto-focus when first pumped, or not.
-  TestDocumentConfigurator autoFocus(bool autoFocus) {
-    _autoFocus = autoFocus;
+  TestSuperEditorConfigurator autoFocus(bool autoFocus) {
+    _config.autoFocus = autoFocus;
     return this;
   }
 
   /// Configures the [SuperEditor] to use the given [key].
-  TestDocumentConfigurator withKey(Key? key) {
-    _key = key;
+  TestSuperEditorConfigurator withKey(Key? key) {
+    _config.key = key;
     return this;
   }
 
   /// Applies the given [plugin] to the pumped [SuperEditor].
-  TestDocumentConfigurator withPlugin(SuperEditorPlugin plugin) {
-    _plugins.add(plugin);
+  TestSuperEditorConfigurator withPlugin(SuperEditorPlugin plugin) {
+    _config.plugins.add(plugin);
     return this;
   }
 
@@ -322,11 +296,8 @@ class TestDocumentConfigurator {
   }
 
   /// Builds a Super Editor experience based on chosen configurations and
-  /// returns a [TestDocumentContext] and the associated [Widget], which
-  /// presents the Super Editor UI.
-  ///
-  /// The returned [Widget] includes more than just a [SuperEditor] widget.
-  /// It includes everything needed to pump a full UI in a widget test.
+  /// returns a [ConfiguredSuperEditorWidget], which includes the associated
+  /// Super Editor [Widget].
   ///
   /// If you want to immediately pump this UI into a [WidgetTester], use
   /// [pump], which does that for you.
@@ -356,49 +327,55 @@ class TestDocumentConfigurator {
   /// A [TestDocumentContext] is useful as a return value for clients, so that
   /// those clients can access important pieces within a [SuperEditor] widget.
   TestDocumentContext _createTestDocumentContext() {
-    assert(_document != null || _existingContext != null);
+    // if (_config.document == null) {
+    //   return _existingContext!;
+    // }
 
-    if (_document == null) {
-      return _existingContext!;
-    }
+    // Only assign if non-null in case we're updating an existing configuration
+    // from a previous widget pump.
+    _config.layoutKey ??= GlobalKey();
 
-    final layoutKey = GlobalKey();
-    final focusNode = _focusNode ?? FocusNode();
-    final composer = MutableDocumentComposer(initialSelection: _selection);
-    final editor = createDefaultDocumentEditor(document: _document!, composer: composer)
-      ..requestHandlers.insertAll(0, _addedRequestHandlers)
-      ..reactionPipeline.insertAll(0, _addedReactions);
+    final layoutKey = _config.layoutKey!;
+    final focusNode = _config.focusNode ?? FocusNode();
+    final composer = MutableDocumentComposer(initialSelection: _config.selection);
+    final editor = createDefaultDocumentEditor(document: _config.document, composer: composer)
+      ..requestHandlers.insertAll(0, _config.addedRequestHandlers)
+      ..reactionPipeline.insertAll(0, _config.addedReactions);
 
-    // ignore: prefer_function_declarations_over_variables
-    final layoutResolver = () => layoutKey.currentState as DocumentLayout;
-    final commonOps = CommonEditorOperations(
-      editor: editor,
-      document: _document!,
-      documentLayoutResolver: layoutResolver,
-      composer: composer,
-    );
-    final editContext = SuperEditorContext(
-      editor: editor,
-      document: _document!,
-      getDocumentLayout: layoutResolver,
-      composer: composer,
-      commonOps: commonOps,
-    );
+    // // ignore: prefer_function_declarations_over_variables
+    // final layoutResolver = () => layoutKey.currentState as DocumentLayout;
+    // final commonOps = CommonEditorOperations(
+    //   editor: editor,
+    //   document: _document!,
+    //   documentLayoutResolver: layoutResolver,
+    //   composer: composer,
+    // );
+    // final editContext = SuperEditorContext(
+    //   editor: editor,
+    //   document: _document!,
+    //   getDocumentLayout: layoutResolver,
+    //   composer: composer,
+    //   commonOps: commonOps,
+    // );
 
     return TestDocumentContext._(
       focusNode: focusNode,
       layoutKey: layoutKey,
-      editContext: editContext,
+      document: _config.document,
+      composer: composer,
+      editor: editor,
+      // editContext: editContext,
+      configuration: _config,
     );
   }
 
   /// Builds a complete screen experience, which includes the given [superEditor].
   Widget _buildWidgetTree(Widget superEditor) {
-    if (_widgetTreeBuilder != null) {
-      return _widgetTreeBuilder!(superEditor);
+    if (_config.widgetTreeBuilder != null) {
+      return _config.widgetTreeBuilder!(superEditor);
     }
     return MaterialApp(
-      theme: _appTheme,
+      theme: _config.appTheme,
       home: Scaffold(
         body: superEditor,
       ),
@@ -409,11 +386,11 @@ class TestDocumentConfigurator {
   /// Constrains the width and height of the given [superEditor], based on configurations
   /// in this class.
   Widget _buildConstrainedContent(Widget superEditor) {
-    if (_editorSize != null) {
+    if (_config.editorSize != null) {
       return ConstrainedBox(
         constraints: BoxConstraints(
-          maxWidth: _editorSize!.width,
-          maxHeight: _editorSize!.height,
+          maxWidth: _config.editorSize!.width,
+          maxHeight: _config.editorSize!.height,
         ),
         child: superEditor,
       );
@@ -425,36 +402,71 @@ class TestDocumentConfigurator {
   /// [testDocumentContext], as well as other configurations in this class.
   Widget _buildSuperEditor(TestDocumentContext testDocumentContext) {
     return SuperEditor(
-      key: _key,
-      documentLayoutKey: testDocumentContext.layoutKey,
-      editor: testDocumentContext.editContext.editor,
-      document: testDocumentContext.editContext.document,
-      composer: testDocumentContext.editContext.composer,
+      key: _config.key,
       focusNode: testDocumentContext.focusNode,
-      inputSource: _inputSource,
-      selectionPolicies: _selectionPolicies ?? const SuperEditorSelectionPolicies(),
-      softwareKeyboardController: _softwareKeyboardController,
-      imePolicies: _imePolicies ?? const SuperEditorImePolicies(),
-      imeConfiguration: _imeConfiguration ?? const SuperEditorImeConfiguration(),
-      imeOverrides: _imeOverrides,
+      editor: testDocumentContext.editor,
+      document: testDocumentContext.document,
+      composer: testDocumentContext.composer,
+      documentLayoutKey: testDocumentContext.layoutKey,
+      inputSource: _config.inputSource,
+      selectionPolicies: _config.selectionPolicies ?? const SuperEditorSelectionPolicies(),
+      softwareKeyboardController: _config.softwareKeyboardController,
+      imePolicies: _config.imePolicies ?? const SuperEditorImePolicies(),
+      imeConfiguration: _config.imeConfiguration ?? const SuperEditorImeConfiguration(),
+      imeOverrides: _config.imeOverrides,
       keyboardActions: [
-        ..._prependedKeyboardActions,
+        ..._config.prependedKeyboardActions,
         ...defaultKeyboardActions,
-        ..._appendedKeyboardActions,
+        ..._config.appendedKeyboardActions,
       ],
-      gestureMode: _gestureMode,
-      androidToolbarBuilder: _androidToolbarBuilder,
-      iOSToolbarBuilder: _iOSToolbarBuilder,
-      stylesheet: _stylesheet,
+      gestureMode: _config.gestureMode,
+      androidToolbarBuilder: _config.androidToolbarBuilder,
+      iOSToolbarBuilder: _config.iOSToolbarBuilder,
+      stylesheet: _config.stylesheet,
       componentBuilders: [
-        ..._addedComponents,
-        ...(_componentBuilders ?? defaultComponentBuilders),
+        ..._config.addedComponents,
+        ...(_config.componentBuilders ?? defaultComponentBuilders),
       ],
-      autofocus: _autoFocus,
-      scrollController: _scrollController,
-      plugins: _plugins,
+      autofocus: _config.autoFocus,
+      scrollController: _config.scrollController,
+      plugins: _config.plugins,
     );
   }
+}
+
+class SuperEditorTestConfiguration {
+  SuperEditorTestConfiguration(this.document);
+
+  ThemeData? appTheme;
+  Key? key;
+  FocusNode? focusNode;
+  bool autoFocus = false;
+  ui.Size? editorSize;
+  final MutableDocument document;
+  final addedRequestHandlers = <EditRequestHandler>[];
+  final addedReactions = <EditReaction>[];
+  GlobalKey? layoutKey;
+  List<ComponentBuilder>? componentBuilders;
+  Stylesheet? stylesheet;
+  ScrollController? scrollController;
+  DocumentGestureMode? gestureMode;
+  TextInputSource? inputSource;
+  SuperEditorSelectionPolicies? selectionPolicies;
+  SoftwareKeyboardController? softwareKeyboardController;
+  SuperEditorImePolicies? imePolicies;
+  SuperEditorImeConfiguration? imeConfiguration;
+  DeltaTextInputClientDecorator? imeOverrides;
+  final prependedKeyboardActions = <DocumentKeyboardAction>[];
+  final appendedKeyboardActions = <DocumentKeyboardAction>[];
+  final addedComponents = <ComponentBuilder>[];
+  WidgetBuilder? androidToolbarBuilder;
+  WidgetBuilder? iOSToolbarBuilder;
+
+  DocumentSelection? selection;
+
+  final plugins = <SuperEditorPlugin>{};
+
+  WidgetTreeBuilder? widgetTreeBuilder;
 }
 
 /// Must return a widget tree containing the given [superEditor]
@@ -464,12 +476,24 @@ class TestDocumentContext {
   const TestDocumentContext._({
     required this.focusNode,
     required this.layoutKey,
-    required this.editContext,
+    required this.document,
+    required this.composer,
+    required this.editor,
+    // required this.editContext,
+    required this.configuration,
   });
 
   final FocusNode focusNode;
   final GlobalKey layoutKey;
-  final SuperEditorContext editContext;
+  // TODO: remove these document, editor, composer references
+  final MutableDocument document;
+  final MutableDocumentComposer composer;
+  final Editor editor;
+  // final SuperEditorContext editContext;
+  SuperEditorContext findEditContext() =>
+      ((find.byType(SuperEditor).evaluate().first as StatefulElement).state as SuperEditorState).editContext;
+
+  final SuperEditorTestConfiguration configuration;
 }
 
 class ConfiguredSuperEditorWidget {

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -212,8 +212,8 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final doc = context.editContext.document;
-        final composer = context.editContext.composer;
+        final doc = context.findEditContext().document;
+        final composer = context.findEditContext().composer;
 
         // Place the caret at the end of the paragraph.
         await tester.placeCaretInParagraph(doc.nodes.first.id, 19);

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -23,10 +23,10 @@ void main() {
         ).pump();
 
         // Place caret at the beginning of the paragraph.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 0);
 
         // Insert the image at the current selection.
-        context.editContext.commonOps.insertImage('http://image.fake');
+        context.findEditContext().commonOps.insertImage('http://image.fake');
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -62,10 +62,10 @@ void main() {
         ).pump();
 
         // Place caret at "Before the image| after the image".
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 16);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 16);
 
         // Insert the image at the current selection.
-        context.editContext.commonOps.insertImage('http://image.fake');
+        context.findEditContext().commonOps.insertImage('http://image.fake');
         await tester.pump();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -106,10 +106,10 @@ void main() {
         ).pump();
 
         // Place caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 15);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 15);
 
         // Insert the image at the current selection.
-        context.editContext.commonOps.insertImage('http://image.fake');
+        context.findEditContext().commonOps.insertImage('http://image.fake');
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -154,11 +154,11 @@ Second paragraph"""). //
         // Place caret at the end of the first paragraph by selecting the second paragraph and pressing left.
         //
         // This results in an upstream text affinity.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.last.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.last.id, 0);
         await tester.pressLeftArrow();
 
         // Insert the image at the current selection.
-        context.editContext.commonOps.insertImage('http://image.fake');
+        context.findEditContext().commonOps.insertImage('http://image.fake');
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -202,7 +202,7 @@ Second paragraph"""). //
         await tester.placeCaretInParagraph("1", 0);
 
         // Insert the image at the current selection.
-        context.editContext.commonOps.insertImage('http://image.fake');
+        context.findEditContext().commonOps.insertImage('http://image.fake');
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -238,10 +238,10 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at the beginning of the paragraph.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 0);
 
         // Insert the horizontal rule at the current selection.
-        context.editContext.commonOps.insertHorizontalRule();
+        context.findEditContext().commonOps.insertHorizontalRule();
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -274,10 +274,10 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at "Before the hr| after the hr".
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 13);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 13);
 
         // Insert the horizontal rule at the current selection.
-        context.editContext.commonOps.insertHorizontalRule();
+        context.findEditContext().commonOps.insertHorizontalRule();
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -315,10 +315,10 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.first.id, 15);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 15);
 
         // Insert the horizontal rule at the current selection.
-        context.editContext.commonOps.insertHorizontalRule();
+        context.findEditContext().commonOps.insertHorizontalRule();
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -360,11 +360,11 @@ Second paragraph"""). //
         // Place caret at the end of the first paragraph by selecting the second paragraph and pressing left.
         //
         // This results in an upstream text affinity.
-        await tester.placeCaretInParagraph(context.editContext.document.nodes.last.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.last.id, 0);
         await tester.pressLeftArrow();
 
         // Insert the horizontal rule at the current selection.
-        context.editContext.commonOps.insertHorizontalRule();
+        context.findEditContext().commonOps.insertHorizontalRule();
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -405,7 +405,7 @@ Second paragraph"""). //
         await tester.placeCaretInParagraph("1", 0);
 
         // Insert the horizontal rule at the current selection.
-        context.editContext.commonOps.insertHorizontalRule();
+        context.findEditContext().commonOps.insertHorizontalRule();
         await tester.pumpAndSettle();
 
         final doc = SuperEditorInspector.findDocument()!;
@@ -477,7 +477,7 @@ Second paragraph"""). //
         await tester.pressEnter();
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
-        final doc = testContext.editContext.document;
+        final doc = testContext.findEditContext().document;
         expect(doc.nodes.length, 3);
         expect(doc.nodes[1], isA<ParagraphNode>());
         expect((doc.nodes[1] as ParagraphNode).text.text, '');
@@ -485,7 +485,7 @@ Second paragraph"""). //
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.editContext.document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.nodes[1].id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -536,7 +536,7 @@ Second paragraph"""). //
         await tester.typeImeText('\n');
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
-        final doc = testContext.editContext.document;
+        final doc = testContext.findEditContext().document;
         expect(doc.nodes.length, 3);
         expect(doc.nodes[1], isA<ParagraphNode>());
         expect((doc.nodes[1] as ParagraphNode).text.text, '');
@@ -544,7 +544,7 @@ Second paragraph"""). //
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.editContext.document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.nodes[1].id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -596,7 +596,7 @@ Second paragraph"""). //
         await tester.pump();
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
-        final doc = testContext.editContext.document;
+        final doc = testContext.findEditContext().document;
         expect(doc.nodes.length, 3);
         expect(doc.nodes[1], isA<ParagraphNode>());
         expect((doc.nodes[1] as ParagraphNode).text.text, '');
@@ -604,7 +604,7 @@ Second paragraph"""). //
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.editContext.document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.nodes[1].id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -32,7 +32,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -61,7 +61,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -90,7 +90,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -119,7 +119,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -148,7 +148,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -173,7 +173,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.last.id,
+            nodeId: testContext.findEditContext().document.nodes.last.id,
             nodePosition: const TextNodePosition(offset: 14),
           ),
         ),
@@ -197,7 +197,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.editContext.document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.nodes.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -514,7 +514,7 @@ spans multiple lines.''',
             // when/how to activate interaction mode on mobile. Rather than
             // add buttons in our test just for this purpose, we'll explicitly
             // activate interaction mode.
-            context.editContext.editor.execute([
+            context.findEditContext().editor.execute([
               const ChangeInteractionModeRequest(isInteractionModeDesired: true),
             ]);
           } else if (defaultTargetPlatform == TargetPlatform.macOS) {
@@ -526,7 +526,7 @@ spans multiple lines.''',
           }
 
           // Ensure that interaction mode is "on".
-          expect(context.editContext.composer.isInInteractionMode.value, isTrue);
+          expect(context.findEditContext().composer.isInInteractionMode.value, isTrue);
 
           // Tap on the link.
           await tester.tapInParagraph("1", 27);
@@ -552,7 +552,7 @@ spans multiple lines.''',
               .pump();
 
           // Ensure that interaction mode is "off".
-          expect(context.editContext.composer.isInInteractionMode.value, isFalse);
+          expect(context.findEditContext().composer.isInInteractionMode.value, isFalse);
 
           // Tap on the link.
           await tester.tapInParagraph("1", 27);

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -311,7 +311,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor to open the IME.
-        final nodeId = testContext.editContext.document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -361,7 +361,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.editContext.document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -436,7 +436,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor to open the IME.
-        final nodeId = testContext.editContext.document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -491,7 +491,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.editContext.document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -560,7 +560,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.editContext.document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -647,7 +647,7 @@ void main() {
         expect(find.byKey(firstPageKey), findsNothing);
 
         // Place the caret in Super Editor.
-        final nodeId = superEditorAndContext.context.editContext.document.nodes.first.id;
+        final nodeId = superEditorAndContext.context.findEditContext().document.nodes.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -747,7 +747,7 @@ Future<String> _pumpSingleLineWithCaret(
       .withInputSource(inputSource)
       .pump();
 
-  final nodeId = testContext.editContext.document.nodes.first.id;
+  final nodeId = testContext.findEditContext().document.nodes.first.id;
 
   await tester.placeCaretInParagraph(nodeId, offset);
 
@@ -765,7 +765,7 @@ Future<String> _pumpDoubleLineWithCaret(WidgetTester tester,
       .fromMarkdown("This is the first paragraph.\nThis is the second paragraph.")
       .pump();
 
-  final nodeId = testContext.editContext.document.nodes.first.id;
+  final nodeId = testContext.findEditContext().document.nodes.first.id;
 
   await tester.placeCaretInParagraph(nodeId, offset);
 

--- a/super_editor/test/super_editor/supereditor_mobile_handles_test.dart
+++ b/super_editor/test/super_editor/supereditor_mobile_handles_test.dart
@@ -13,7 +13,7 @@ void main() {
           .fromMarkdown("This is some text to select.") //
           .useAppTheme(ThemeData(primaryColor: Colors.red)) //
           .pump();
-      final nodeId = testContext.editContext.document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.nodes.first.id;
 
       await tester.placeCaretInParagraph(nodeId, 15);
 
@@ -29,7 +29,7 @@ void main() {
           .fromMarkdown("This is some text to select.") //
           .useAppTheme(ThemeData(primaryColor: Colors.red)) //
           .pump();
-      final nodeId = testContext.editContext.document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.nodes.first.id;
 
       await tester.doubleTapInParagraph(nodeId, 15);
 
@@ -45,7 +45,7 @@ void main() {
           .fromMarkdown("This is some text to select.") //
           .useAppTheme(ThemeData(primaryColor: Colors.red)) //
           .pump();
-      final nodeId = testContext.editContext.document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.nodes.first.id;
 
       await tester.placeCaretInParagraph(nodeId, 15);
 
@@ -61,7 +61,7 @@ void main() {
           .fromMarkdown("This is some text to select.") //
           .useAppTheme(ThemeData(primaryColor: Colors.red)) //
           .pump();
-      final nodeId = testContext.editContext.document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.nodes.first.id;
 
       await tester.doubleTapInParagraph(nodeId, 15);
 

--- a/super_editor/test/super_editor/supereditor_popover_focus_test.dart
+++ b/super_editor/test/super_editor/supereditor_popover_focus_test.dart
@@ -30,7 +30,7 @@ void main() {
           nodePosition: TextNodePosition(offset: 20),
         ),
       );
-      editContext.editContext.editor.execute([
+      editContext.findEditContext().editor.execute([
         const ChangeSelectionRequest(
           documentSelection,
           SelectionChangeType.expandSelection,
@@ -72,7 +72,7 @@ void main() {
           nodePosition: TextNodePosition(offset: 20),
         ),
       );
-      editContext.editContext.editor.execute([
+      editContext.findEditContext().editor.execute([
         const ChangeSelectionRequest(
           documentSelection,
           SelectionChangeType.expandSelection,

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -144,7 +144,7 @@ void main() {
 
       // Place the caret at the end of the document, which causes the editor to
       // scroll to the bottom.
-      docContext.editContext.editor.execute([
+      docContext.findEditContext().editor.execute([
         ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -208,7 +208,7 @@ void main() {
 
       // Place the caret at the end of the document, which should cause the
       // editor to scroll to the bottom.
-      docContext.editContext.editor.execute([
+      docContext.findEditContext().editor.execute([
         ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -252,7 +252,7 @@ void main() {
 
       // Place the caret at the last paragraph, simulating an event that wasn't initiated by the user.
       // This paragraph is outside the viewport.
-      docContext.editContext.editor.execute([
+      docContext.findEditContext().editor.execute([
         const ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -288,7 +288,7 @@ void main() {
       // We pretend it was initiated by the user because that's what causes an auto-scroll.
       // But the auto-scroll should be smart enough to see that the selection hasn't changed
       // and therefore it shouldn't auto-scroll.
-      docContext.editContext.editor.execute([
+      docContext.findEditContext().editor.execute([
         const ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -70,7 +70,7 @@ void main() {
           .createDocument() //
           .fromMarkdown("This is paragraph one.\nThis is paragraph two.") //
           .pump();
-      final nodeId = testContext.editContext.document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.nodes.first.id;
 
       /// Triple tap on the first line in the paragraph node.
       await tester.tripleTapInParagraph(nodeId, 10);
@@ -101,7 +101,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.editContext.document.nodes.first.id;
+      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -128,7 +128,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.editContext.document.nodes.last.id;
+      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -160,7 +160,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.editContext.document.nodes.last.id;
+      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -192,7 +192,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.editContext.document.nodes.first.id;
+      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -219,8 +219,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.editContext.document.nodes.first.id;
-      final secondParagraphId = testContext.editContext.document.nodes.last.id;
+      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
+      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -250,8 +250,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.editContext.document.nodes.first.id;
-      final secondParagraphId = testContext.editContext.document.nodes.last.id;
+      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
+      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -847,7 +847,7 @@ Second Paragraph
       expect(SuperEditorInspector.findDocumentSelection(), isNull);
 
       // Delete the selected node.
-      context.editContext.editor.execute([
+      context.findEditContext().editor.execute([
         DeleteNodeRequest(nodeId: "1"),
       ]);
 
@@ -933,8 +933,8 @@ Second Paragraph
           .autoFocus(true)
           .pump();
 
-      final doc = context.editContext.document;
-      final composer = context.editContext.composer;
+      final doc = context.findEditContext().document;
+      final composer = context.findEditContext().composer;
 
       int selectionNotificationCount = 0;
       composer.selectionNotifier.addListener(() {
@@ -957,7 +957,7 @@ Second Paragraph
       );
 
       // Send a selection change, using the existing selection.
-      context.editContext.editor.execute([
+      context.findEditContext().editor.execute([
         ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(

--- a/super_editor/test/super_editor/supereditor_smoke_test.dart
+++ b/super_editor/test/super_editor/supereditor_smoke_test.dart
@@ -58,7 +58,7 @@ void main() {
 
       // Ensure that we've created the document that we think we have.
       expect(
-        testDocContext.editContext.document,
+        testDocContext.findEditContext().document,
         documentEquivalentTo(_expectedDocument),
       );
     });

--- a/super_editor/test/super_editor/supereditor_software_keyboard_toolbar_test.dart
+++ b/super_editor/test/super_editor/supereditor_software_keyboard_toolbar_test.dart
@@ -25,10 +25,10 @@ void main() {
 
       // Convert the empty paragraph into a horizontal rule.
       final toolbarOps = KeyboardEditingToolbarOperations(
-        editor: context.editContext.editor,
-        document: context.editContext.document,
-        composer: context.editContext.composer,
-        commonOps: context.editContext.commonOps,
+        editor: context.findEditContext().editor,
+        document: context.findEditContext().document,
+        composer: context.findEditContext().composer,
+        commonOps: context.findEditContext().commonOps,
       );
       toolbarOps.convertToHr();
       await tester.pump();

--- a/super_editor/test/super_editor/supereditor_style_test.dart
+++ b/super_editor/test/super_editor/supereditor_style_test.dart
@@ -20,7 +20,7 @@ void main() {
       await tester.doubleTapInParagraph('1', 0);
 
       // Apply italic to the word.
-      testContext.editContext.commonOps.toggleAttributionsOnSelection({italicsAttribution});
+      testContext.findEditContext().commonOps.toggleAttributionsOnSelection({italicsAttribution});
       await tester.pump();
 
       // Ensure italic was applied.
@@ -37,7 +37,7 @@ void main() {
           .useStylesheet(_stylesheet)
           .pump();
 
-      final doc = testContext.editContext.document;
+      final doc = testContext.findEditContext().document;
 
       final firstParagraphId = doc.nodes[0].id;
       final secondParagraphId = doc.nodes[1].id;
@@ -46,7 +46,7 @@ void main() {
       expect(SuperEditorInspector.findParagraphStyle(firstParagraphId)!.color, Colors.red);
 
       // Remove the second paragraph.
-      testContext.editContext.editor.execute([
+      testContext.findEditContext().editor.execute([
         DeleteNodeRequest(nodeId: secondParagraphId),
       ]);
       await tester.pump();
@@ -195,7 +195,7 @@ A paragraph
 
       // Move the 2nd node to the end of the document. This should impact nodes 2, 3, and 4,
       // but not node 1.
-      testContext.editContext.editor.execute([
+      testContext.findEditContext().editor.execute([
         const MoveNodeRequest(nodeId: "2", newIndex: 3),
       ]);
       await tester.pumpAndSettle();

--- a/super_editor/test/super_editor/text_entry/keyboard_selection_and_deletion_test.dart
+++ b/super_editor/test/super_editor/text_entry/keyboard_selection_and_deletion_test.dart
@@ -31,7 +31,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem  dolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -60,7 +60,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem dolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -89,7 +89,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text, startsWith("Lorem ipsum  sit amet"));
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -118,7 +118,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem ipsum sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -145,7 +145,7 @@ void main() {
         await tester.pressCtlBackspace();
 
         // Ensure that a character was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem ipsu dolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -174,7 +174,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
         // Ensure that a character was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem ipsumdolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -203,7 +203,7 @@ void main() {
         await tester.pressCtlBackspace();
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem  dolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -230,7 +230,7 @@ void main() {
         await tester.pressCtlBackspace();
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem dolor sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -259,7 +259,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text, startsWith("Lorem ipsum  sit amet"));
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -288,7 +288,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
         // Ensure that the whole word was deleted.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text.startsWith("Lorem ipsum sit amet"), isTrue);
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -315,7 +315,7 @@ void main() {
         await tester.pressAltBackspace();
 
         // Ensure that nothing changed.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text, startsWith("Lorem ipsu dolor sit amet"));
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -344,7 +344,7 @@ void main() {
         await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
         // Ensure that nothing changed.
-        final paragraphNode = testContext.editContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
         expect(paragraphNode.text.text, startsWith("Lorem ipsumdolor sit amet"));
         expect(
           SuperEditorInspector.findDocumentSelection(),
@@ -367,7 +367,7 @@ void main() {
             .withInputSource(_inputSourceVariant.currentValue!)
             .pump();
 
-        final node = testContext.editContext.document.nodes.first;
+        final node = testContext.findEditContext().document.nodes.first;
 
         // Place caret at "A| header"
         await tester.placeCaretInParagraph(node.id, 1);
@@ -393,7 +393,7 @@ void main() {
             .withInputSource(_inputSourceVariant.currentValue!)
             .pump();
 
-        final node = testContext.editContext.document.nodes.first;
+        final node = testContext.findEditContext().document.nodes.first;
 
         // Place caret at the start of the header.
         await tester.placeCaretInParagraph(node.id, 0);

--- a/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
+++ b/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
@@ -26,7 +26,7 @@ void main() {
           await tester.typeImeText(headerVariant.$1);
 
           // Ensure that the paragraph is now a header, and it's content is empty.
-          final document = context.editContext.document;
+          final document = context.findEditContext().document;
           final paragraph = document.nodes.first as ParagraphNode;
 
           expect(paragraph.metadata['blockType'], headerVariant.$2);
@@ -47,7 +47,7 @@ void main() {
         await tester.typeImeText("####### ");
 
         // Ensure that the paragraph hasn't changed.
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
         final paragraph = document.nodes.first as ParagraphNode;
 
         expect(paragraph.metadata['blockType'], paragraphAttribution);
@@ -67,7 +67,7 @@ void main() {
         final unorderedListItemPattern = _unorderedListVariant.currentValue!;
         await tester.typeImeText(unorderedListItemPattern);
 
-        final listItemNode = context.editContext.document.nodes.first;
+        final listItemNode = context.findEditContext().document.nodes.first;
         expect(listItemNode, isA<ListItemNode>());
         expect((listItemNode as ListItemNode).type, ListItemType.unordered);
         expect(listItemNode.text.text.isEmpty, isTrue);
@@ -83,7 +83,7 @@ void main() {
 
         await tester.typeImeText("1 ");
 
-        final paragraphNode = context.editContext.document.nodes.first;
+        final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, "1 ");
       });
@@ -98,7 +98,7 @@ void main() {
 
         await tester.typeImeText(" 1 ");
 
-        final paragraphNode = context.editContext.document.nodes.first;
+        final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, " 1 ");
       });
@@ -116,7 +116,7 @@ void main() {
         final orderedListItemPattern = _orderedListVariant.currentValue!;
         await tester.typeImeText(orderedListItemPattern);
 
-        final listItemNode = context.editContext.document.nodes.first;
+        final listItemNode = context.findEditContext().document.nodes.first;
         expect(listItemNode, isA<ListItemNode>());
         expect((listItemNode as ListItemNode).type, ListItemType.ordered);
         expect(listItemNode.text.text.isEmpty, isTrue);
@@ -132,7 +132,7 @@ void main() {
 
         await tester.typeImeText("1 ");
 
-        final paragraphNode = context.editContext.document.nodes.first;
+        final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, "1 ");
       });
@@ -147,7 +147,7 @@ void main() {
 
         await tester.typeImeText(" 1 ");
 
-        final paragraphNode = context.editContext.document.nodes.first;
+        final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, " 1 ");
       });
@@ -165,7 +165,7 @@ void main() {
         await tester.typeImeText("--- ");
 
         // Ensure that we now have two nodes, and the first one is an HR.
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
         expect(document.nodes.length, 2);
 
         expect(document.nodes.first, isA<HorizontalRuleNode>());
@@ -184,7 +184,7 @@ void main() {
         final nonHrInput = _nonHrVariant.currentValue!;
         await tester.typeImeText(nonHrInput);
 
-        final paragraphNode = context.editContext.document.nodes.first;
+        final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, nonHrInput);
       }, variant: _nonHrVariant);
@@ -202,7 +202,7 @@ void main() {
         await tester.typeImeText("> ");
 
         // Ensure that the paragraph is now a blockquote, and it's content is empty.
-        final document = context.editContext.document;
+        final document = context.findEditContext().document;
         final paragraph = document.nodes.first as ParagraphNode;
 
         expect(paragraph.metadata['blockType'], blockquoteAttribution);
@@ -217,7 +217,7 @@ void main() {
             .fromMarkdown("# My Header")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final headerNode = context.editContext.document.nodes.first;
+        final headerNode = context.findEditContext().document.nodes.first;
 
         await tester.placeCaretInParagraph(headerNode.id, 0);
 
@@ -253,7 +253,7 @@ void main() {
             .fromMarkdown("> My Blockquote")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final blockquoteNode = context.editContext.document.nodes.first;
+        final blockquoteNode = context.findEditContext().document.nodes.first;
 
         await tester.placeCaretInParagraph(blockquoteNode.id, 0);
 
@@ -289,7 +289,7 @@ void main() {
             .fromMarkdown("1. My list item")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final listItemNode = context.editContext.document.nodes.first;
+        final listItemNode = context.findEditContext().document.nodes.first;
 
         await tester.placeCaretInParagraph(listItemNode.id, 0);
 
@@ -315,7 +315,7 @@ void main() {
         );
 
         // Ensure that the list item became a paragraph.
-        final newNode = context.editContext.document.nodes.first;
+        final newNode = context.findEditContext().document.nodes.first;
         expect(newNode, isA<ParagraphNode>());
         expect(newNode.metadata["blockType"], paragraphAttribution);
         expect(SuperEditorInspector.findTextInParagraph(listItemNode.id).text, "My list item");

--- a/super_editor/test/super_editor/text_entry/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/stable_tags_test.dart
@@ -915,7 +915,7 @@ void main() {
         await tester.typeImeText("@john two @sally three");
 
         // Expand the selection "one @jo|hn two @sa|lly three"
-        (context.editContext.composer as MutableDocumentComposer).setSelectionWithReason(
+        (context.findEditContext().composer as MutableDocumentComposer).setSelectionWithReason(
           const DocumentSelection(
             base: DocumentPosition(
               nodeId: "1",
@@ -971,7 +971,7 @@ void main() {
         await tester.typeImeText("three @sally four");
 
         // Expand the selection to "one @jo|hn two\nthree @sa|lly three"
-        (context.editContext.composer as MutableDocumentComposer).setSelectionWithReason(
+        (context.findEditContext().composer as MutableDocumentComposer).setSelectionWithReason(
           const DocumentSelection(
             base: DocumentPosition(
               nodeId: "1",


### PR DESCRIPTION
Exposed scroll control through SuperEditorContext (Resolves #1288)

This PR exposes some chosen scrolling controls through `SuperEditorContext`, which can then be used by keyboard handlers and other similar actors.

I had to refactor a lot of test references because we now have a difference between the objects passed into a `SuperEditor` vs objects revealed by a `SuperEditor`. That said, none of the test changes were behavioral changes. It's just re-organization.