### PR TITLE
Don't extend links to new, empty paragraphs (Resolves #1276)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1538,8 +1538,8 @@ class CommonEditorOperations {
   /// If the current selection is not collapsed then the current selection
   /// is first deleted, then the aforementioned operation takes place.
   ///
-  /// Returns [true] if a new node was inserted or a node was split into two.
-  /// Returns [false] if there was no selection.
+  /// Returns `true` if a new node was inserted or a node was split into two.
+  /// Returns `false` if there was no selection.
   bool insertBlockLevelNewline() {
     editorOpsLog.fine("Inserting block-level newline");
     if (composer.selection == null) {

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -125,6 +125,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
           splitPosition: request.splitPosition,
           newNodeId: request.newNodeId,
           replicateExistingMetadata: request.replicateExistingMetadata,
+          attributionsToExtendToNewParagraph: request.attributionsToExtendToNewParagraph,
         )
       : null,
   (request) => request is ConvertParagraphToTaskRequest

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -311,5 +311,87 @@ void main() {
         isFalse,
       );
     });
+
+    testWidgetsOnAllPlatforms('does not extend link to new paragraph', (tester) async {
+      await tester //
+          .createDocument()
+          .fromMarkdown("[www.google.com](www.google.com)")
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final doc = SuperEditorInspector.findDocument()!;
+
+      // Place the caret at "www.google.com|"
+      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+      // Create a new paragraph.
+      await tester.pressEnter();
+
+      // We had an issue where link attributions were extended to the beginning of
+      // an empty paragraph, but were removed after the user started typing. So, first,
+      // ensure that no link markers were added to the empty paragraph.
+      expect(doc.nodes.length, 2);
+      final newParagraphId = doc.nodes[1].id;
+      AttributedText newParagraphText = SuperEditorInspector.findTextInParagraph(newParagraphId);
+      expect(newParagraphText.spans.markers, isEmpty);
+
+      // Type some text.
+      await tester.typeImeText("New paragraph");
+
+      // Ensure the text we typed didn't re-introduce a link attribution.
+      newParagraphText = SuperEditorInspector.findTextInParagraph(newParagraphId);
+      expect(newParagraphText.text, "New paragraph");
+      expect(
+        newParagraphText.getAttributionSpansInRange(
+          attributionFilter: (a) => a is LinkAttribution,
+          range: SpanRange(start: 0, end: newParagraphText.text.length - 1),
+        ),
+        isEmpty,
+      );
+    });
+
+    testWidgetsOnAllPlatforms('does not extend link to new list item', (tester) async {
+      await tester //
+          .createDocument()
+          .fromMarkdown(" * [www.google.com](www.google.com)")
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final doc = SuperEditorInspector.findDocument()!;
+
+      // Ensure the Markdown correctly created a list item.
+      expect(doc.nodes.first, isA<ListItemNode>());
+
+      // Place the caret at "www.google.com|"
+      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+      // Create a new list item.
+      await tester.pressEnter();
+
+      // We had an issue where link attributions were extended to the beginning of
+      // an empty paragraph, but were removed after the user started typing. So, first,
+      // ensure that no link markers were added to the empty paragraph.
+      expect(doc.nodes.length, 2);
+      expect(doc.nodes[1], isA<ListItemNode>());
+      final newListItemId = doc.nodes[1].id;
+      AttributedText newListItemText = SuperEditorInspector.findTextInParagraph(newListItemId);
+      expect(newListItemText.spans.markers, isEmpty);
+
+      // Type some text.
+      await tester.typeImeText("New list item");
+
+      // Ensure the text we typed didn't re-introduce a link attribution.
+      newListItemText = SuperEditorInspector.findTextInParagraph(newListItemId);
+      expect(newListItemText.text, "New list item");
+      expect(
+        newListItemText.getAttributionSpansInRange(
+          attributionFilter: (a) => a is LinkAttribution,
+          range: SpanRange(start: 0, end: newListItemText.text.length - 1),
+        ),
+        isEmpty,
+      );
+    });
+
+    // TODO: once it's easier to configure task components (#1295), add a test that checks link attributions when inserting a new task
   });
 }

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -321,7 +321,7 @@ void main() {
 
       final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret at "www.google.com|"
+      // Place the caret at "www.google.com|".
       await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
 
       // Create a new paragraph.
@@ -362,15 +362,15 @@ void main() {
       // Ensure the Markdown correctly created a list item.
       expect(doc.nodes.first, isA<ListItemNode>());
 
-      // Place the caret at "www.google.com|"
+      // Place the caret at "www.google.com|".
       await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
 
       // Create a new list item.
       await tester.pressEnter();
 
       // We had an issue where link attributions were extended to the beginning of
-      // an empty paragraph, but were removed after the user started typing. So, first,
-      // ensure that no link markers were added to the empty paragraph.
+      // an empty list item, but were removed after the user started typing. So, first,
+      // ensure that no link markers were added to the empty list item.
       expect(doc.nodes.length, 2);
       expect(doc.nodes[1], isA<ListItemNode>());
       final newListItemId = doc.nodes[1].id;


### PR DESCRIPTION
Don't extend links to new, empty paragraphs (Resolves #1276)

The problem: When the user places the caret at the end of a link, at the end of a paragraph, and the user presses ENTER, the newly created paragraph initially contains the same link attribution. This attribution is immediately removed when the user starts typing, but the attribution should not exist at all in the new empty paragraph.

The longer term solution is probably to move attribution expansion to `EditReaction`s: https://github.com/superlistapp/super_editor/issues/1296

As a temporary solution, I've added an attribution filter to the paragraph split request, which decides which attributions can extend from the end of one paragraph to the beginning of a new paragraph.