### PR TITLE
Cherry Pick: Don't extend links to new, empty paragraphs (Resolves #1276) (#1297)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1538,8 +1538,8 @@ class CommonEditorOperations {
   /// If the current selection is not collapsed then the current selection
   /// is first deleted, then the aforementioned operation takes place.
   ///
-  /// Returns [true] if a new node was inserted or a node was split into two.
-  /// Returns [false] if there was no selection.
+  /// Returns `true` if a new node was inserted or a node was split into two.
+  /// Returns `false` if there was no selection.
   bool insertBlockLevelNewline() {
     editorOpsLog.fine("Inserting block-level newline");
     if (composer.selection == null) {

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -125,6 +125,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
           splitPosition: request.splitPosition,
           newNodeId: request.newNodeId,
           replicateExistingMetadata: request.replicateExistingMetadata,
+          attributionsToExtendToNewParagraph: request.attributionsToExtendToNewParagraph,
         )
       : null,
   (request) => request is ConvertParagraphToTaskRequest


### PR DESCRIPTION
Cherry Pick: Don't extend links to new, empty paragraphs (Resolves #1276) (#1297)