### PR TITLE
Cherry Pick: Use TapRegions in SuperTextField to support unfocusing when tapping or dragging outside (Resolves #1263) (#1310)

### DIFF
--- a/super_editor/example/lib/demos/supertextfield/_emojis_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_emojis_demo.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/supertextfield/demo_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
@@ -121,6 +122,7 @@ class _EmojisTextFieldDemoState extends State<EmojisTextFieldDemo> with TickerPr
                       );
                     },
                     hintBehavior: HintBehavior.displayHintUntilTextEntered,
+                    textStyleBuilder: demoTextStyleBuilder,
                     minLines: 1,
                     maxLines: 1,
                   ),

--- a/super_editor/example/lib/demos/supertextfield/_expanding_multi_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_expanding_multi_line_demo.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/supertextfield/demo_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
@@ -110,6 +111,7 @@ class _ExpandingMultiLineTextFieldDemoState extends State<ExpandingMultiLineText
                       );
                     },
                     hintBehavior: HintBehavior.displayHintUntilTextEntered,
+                    textStyleBuilder: demoTextStyleBuilder,
                     minLines: 1,
                     maxLines: 5,
                   ),

--- a/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
@@ -1,10 +1,8 @@
+import 'package:example/demos/supertextfield/demo_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
-
-const brandAttribution = NamedAttribution('brand');
-const flutterAttribution = NamedAttribution('flutter');
 
 class InteractiveTextFieldDemo extends StatefulWidget {
   @override
@@ -12,6 +10,8 @@ class InteractiveTextFieldDemo extends StatefulWidget {
 }
 
 class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
+  static const _tapRegionGroupId = "desktop";
+
   final _textFieldController = AttributedTextEditingController(
     text: AttributedText(
         text: 'Super Editor is an open source text editor for Flutter projects.',
@@ -118,78 +118,53 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () {
+    return TapRegion(
+      groupId: _tapRegionGroupId,
+      onTapOutside: (_) {
         // Remove focus from text field when the user taps anywhere else.
         _focusNode!.unfocus();
       },
       child: Center(
         child: SizedBox(
           width: 400,
-          child: GestureDetector(
-            onTap: () {
-              // no-op. Prevents unfocus from happening when text field is tapped.
-            },
-            child: SizedBox(
-              width: double.infinity,
-              child: SuperDesktopTextField(
-                textController: _textFieldController,
-                inputSource: TextInputSource.ime,
-                focusNode: _focusNode,
-                textStyleBuilder: _textStyleBuilder,
-                blinkTimingMode: BlinkTimingMode.timer,
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                decorationBuilder: (context, child) {
-                  return Container(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(4),
-                      border: Border.all(
-                        color: _focusNode!.hasFocus ? Colors.blue : Colors.grey.shade300,
-                        width: 1,
-                      ),
+          child: SizedBox(
+            width: double.infinity,
+            child: SuperDesktopTextField(
+              focusNode: _focusNode,
+              tapRegionGroupId: _tapRegionGroupId,
+              textController: _textFieldController,
+              inputSource: TextInputSource.ime,
+              textStyleBuilder: demoTextStyleBuilder,
+              blinkTimingMode: BlinkTimingMode.timer,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decorationBuilder: (context, child) {
+                return Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(4),
+                    border: Border.all(
+                      color: _focusNode!.hasFocus ? Colors.blue : Colors.grey.shade300,
+                      width: 1,
                     ),
-                    child: child,
-                  );
-                },
-                hintBuilder: (context) {
-                  return const Text(
-                    'enter some text',
-                    style: TextStyle(
-                      color: Colors.grey,
-                    ),
-                  );
-                },
-                hintBehavior: HintBehavior.displayHintUntilTextEntered,
-                minLines: 5,
-                maxLines: 5,
-                onRightClick: _onRightClick,
-              ),
+                  ),
+                  child: child,
+                );
+              },
+              hintBuilder: (context) {
+                return const Text(
+                  'enter some text',
+                  style: TextStyle(
+                    color: Colors.grey,
+                  ),
+                );
+              },
+              hintBehavior: HintBehavior.displayHintUntilTextEntered,
+              minLines: 5,
+              maxLines: 5,
+              onRightClick: _onRightClick,
             ),
           ),
         ),
       ),
     );
-  }
-
-  TextStyle _textStyleBuilder(Set<Attribution> attributions) {
-    TextStyle textStyle = const TextStyle(
-      color: Colors.black,
-      fontSize: 14,
-    );
-
-    if (attributions.contains(brandAttribution)) {
-      textStyle = textStyle.copyWith(
-        color: Colors.red,
-        fontWeight: FontWeight.bold,
-      );
-    }
-    if (attributions.contains(flutterAttribution)) {
-      textStyle = textStyle.copyWith(
-        color: Colors.blue,
-      );
-    }
-
-    return textStyle;
   }
 }

--- a/super_editor/example/lib/demos/supertextfield/_mobile_textfield_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_mobile_textfield_demo.dart
@@ -9,10 +9,14 @@ class MobileSuperTextFieldDemo extends StatefulWidget {
   const MobileSuperTextFieldDemo({
     Key? key,
     required this.initialText,
+    required this.textFieldFocusNode,
+    required this.textFieldTapRegionGroupId,
     required this.createTextField,
   }) : super(key: key);
 
   final AttributedText initialText;
+  final FocusNode textFieldFocusNode;
+  final String textFieldTapRegionGroupId;
   final Widget Function(MobileTextFieldDemoConfig) createTextField;
 
   @override
@@ -89,17 +93,15 @@ class _MobileSuperTextFieldDemoState extends State<MobileSuperTextFieldDemo> {
         children: [
           Expanded(
             child: Scaffold(
-              body: GestureDetector(
-                onTap: () {
-                  _screenFocusNode.requestFocus();
-                },
-                behavior: HitTestBehavior.translucent,
-                child: Focus(
-                  focusNode: _screenFocusNode,
-                  child: SafeArea(
-                    child: Center(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 48),
+              body: Focus(
+                focusNode: _screenFocusNode,
+                child: SafeArea(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 48),
+                      child: TapRegion(
+                        groupId: widget.textFieldTapRegionGroupId,
+                        onTapOutside: (_) => widget.textFieldFocusNode.unfocus(),
                         child: widget.createTextField(_createDemoConfig()),
                       ),
                     ),

--- a/super_editor/example/lib/demos/supertextfield/_single_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_single_line_demo.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/supertextfield/demo_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
@@ -110,6 +111,7 @@ class _SingleLineTextFieldDemoState extends State<SingleLineTextFieldDemo> with 
                       );
                     },
                     hintBehavior: HintBehavior.displayHintUntilTextEntered,
+                    textStyleBuilder: demoTextStyleBuilder,
                     minLines: 1,
                     maxLines: 1,
                   ),

--- a/super_editor/example/lib/demos/supertextfield/_static_multi_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_static_multi_line_demo.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/supertextfield/demo_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
@@ -109,6 +110,7 @@ class _StaticMultiLineTextFieldDemoState extends State<StaticMultiLineTextFieldD
                       );
                     },
                     hintBehavior: HintBehavior.displayHintUntilTextEntered,
+                    textStyleBuilder: demoTextStyleBuilder,
                     minLines: 5,
                     maxLines: 5,
                   ),

--- a/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
@@ -11,14 +11,22 @@ class SuperAndroidTextFieldDemo extends StatefulWidget {
 }
 
 class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
+  final String _tapRegionGroupId = "android";
+
+  late final FocusNode _focusNode;
+
   @override
   void initState() {
     super.initState();
     initLoggers(Level.FINER, {androidTextFieldLog, imeTextFieldLog});
+
+    _focusNode = FocusNode();
   }
 
   @override
   void dispose() {
+    _focusNode.dispose();
+
     deactivateLoggers({androidTextFieldLog, imeTextFieldLog});
     super.dispose();
   }
@@ -29,6 +37,8 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
       initialText: AttributedText(
           text:
               'This is a custom textfield implementation called SuperAndroidTextField. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.'),
+      textFieldFocusNode: _focusNode,
+      textFieldTapRegionGroupId: _tapRegionGroupId,
       createTextField: _buildTextField,
     );
   }
@@ -38,6 +48,8 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
     final lineHeight = genericTextStyle.fontSize! * (genericTextStyle.height ?? 1.0);
 
     return SuperAndroidTextField(
+      focusNode: _focusNode,
+      tapRegionGroupId: _tapRegionGroupId,
       textController: config.controller,
       textStyleBuilder: config.styleBuilder,
       hintBehavior: HintBehavior.displayHintUntilTextEntered,

--- a/super_editor/example/lib/demos/supertextfield/demo_text_styles.dart
+++ b/super_editor/example/lib/demos/supertextfield/demo_text_styles.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+TextStyle demoTextStyleBuilder(Set<Attribution> attributions) {
+  TextStyle textStyle = const TextStyle(
+    color: Colors.black,
+    fontSize: 14,
+  );
+
+  if (attributions.contains(brandAttribution)) {
+    textStyle = textStyle.copyWith(
+      color: Colors.red,
+      fontWeight: FontWeight.bold,
+    );
+  }
+  if (attributions.contains(flutterAttribution)) {
+    textStyle = textStyle.copyWith(
+      color: Colors.blue,
+    );
+  }
+
+  return textStyle;
+}
+
+const brandAttribution = NamedAttribution('brand');
+const flutterAttribution = NamedAttribution('flutter');

--- a/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
@@ -12,14 +12,22 @@ class SuperIOSTextFieldDemo extends StatefulWidget {
 }
 
 class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
+  final String _tapRegionGroupId = "iOS";
+
+  late final FocusNode _focusNode;
+
   @override
   void initState() {
     super.initState();
     initLoggers(Level.FINE, {iosTextFieldLog, imeTextFieldLog});
+
+    _focusNode = FocusNode();
   }
 
   @override
   void dispose() {
+    _focusNode.dispose();
+
     deactivateLoggers({iosTextFieldLog, imeTextFieldLog});
     super.dispose();
   }
@@ -30,6 +38,8 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
       initialText: AttributedText(
           text:
               'This is a custom textfield implementation called SuperIOSTextfield. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.'),
+      textFieldFocusNode: _focusNode,
+      textFieldTapRegionGroupId: _tapRegionGroupId,
       createTextField: _buildTextField,
     );
   }
@@ -39,6 +49,8 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
     final lineHeight = genericTextStyle.fontSize! * (genericTextStyle.height ?? 1.0);
 
     return SuperIOSTextField(
+      focusNode: _focusNode,
+      tapRegionGroupId: _tapRegionGroupId,
       textController: config.controller,
       textStyleBuilder: config.styleBuilder,
       hintBehavior: HintBehavior.displayHintUntilTextEntered,

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -35,6 +35,7 @@ class AndroidEditingOverlayControls extends StatefulWidget {
     required this.textContentKey,
     required this.textFieldLayerLink,
     required this.textContentLayerLink,
+    this.tapRegionGroupId,
     required this.handleColor,
     required this.popoverToolbarBuilder,
     this.showDebugPaint = false,
@@ -64,6 +65,10 @@ class AndroidEditingOverlayControls extends StatefulWidget {
   /// [GlobalKey] that references the widget that contains the text within
   /// the text field.
   final GlobalKey<ProseTextState> textContentKey;
+
+  /// A group ID that's assigned to a [TagRegion] around each widget added
+  /// by this overlay.
+  final String? tapRegionGroupId;
 
   /// The color of the selection handles.
   final Color handleColor;
@@ -542,10 +547,13 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
           opacity: widget.editingController.isToolbarVisible ? 1.0 : 0.0,
           duration: const Duration(milliseconds: 150),
           child: Builder(builder: (context) {
-            return widget.popoverToolbarBuilder(
-              context,
-              widget.editingController,
-              ToolbarConfig(focalPoint: textFieldGlobalOffset + toolbarTopAnchor),
+            return TapRegion(
+              groupId: widget.tapRegionGroupId,
+              child: widget.popoverToolbarBuilder(
+                context,
+                widget.editingController,
+                ToolbarConfig(focalPoint: textFieldGlobalOffset + toolbarTopAnchor),
+              ),
             );
           }),
         ),
@@ -694,9 +702,12 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
                         ? 0.0
                         : 1.0,
                     duration: const Duration(milliseconds: 150),
-                    child: AndroidSelectionHandle(
-                      handleType: handleType,
-                      color: widget.handleColor,
+                    child: TapRegion(
+                      groupId: widget.tapRegionGroupId,
+                      child: AndroidSelectionHandle(
+                        handleType: handleType,
+                        color: widget.handleColor,
+                      ),
                     ),
                   )
                 : const SizedBox(),

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -26,6 +26,7 @@ class SuperAndroidTextField extends StatefulWidget {
   const SuperAndroidTextField({
     Key? key,
     this.focusNode,
+    this.tapRegionGroupId,
     this.textController,
     this.textAlign = TextAlign.left,
     this.textStyleBuilder = defaultTextFieldStyleBuilder,
@@ -46,6 +47,9 @@ class SuperAndroidTextField extends StatefulWidget {
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
+
+  /// {@macro super_text_field_tap_region_group_id}
+  final String? tapRegionGroupId;
 
   /// Controller that owns the text content and text selection for
   /// this text field.
@@ -347,6 +351,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           textFieldKey: _textFieldKey,
           textContentLayerLink: _textContentLayerLink,
           textContentKey: _textContentKey,
+          tapRegionGroupId: widget.tapRegionGroupId,
           handleColor: widget.handlesColor,
           popoverToolbarBuilder: widget.popoverToolbarBuilder,
           showDebugPaint: widget.showDebugPaint,
@@ -467,54 +472,57 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   @override
   Widget build(BuildContext context) {
-    return NonReparentingFocus(
-      key: _textFieldKey,
-      focusNode: _focusNode,
-      onKey: _onKeyPressed,
-      child: CompositedTransformTarget(
-        link: _textFieldLayerLink,
-        child: AndroidTextFieldTouchInteractor(
-          focusNode: _focusNode,
-          textKey: _textContentKey,
-          textFieldLayerLink: _textFieldLayerLink,
-          textController: _textEditingController,
-          editingOverlayController: _editingOverlayController,
-          textScrollController: _textScrollController,
-          isMultiline: _isMultiline,
-          handleColor: widget.handlesColor,
-          showDebugPaint: widget.showDebugPaint,
-          child: TextScrollView(
-            key: _scrollKey,
-            textScrollController: _textScrollController,
+    return TapRegion(
+      groupId: widget.tapRegionGroupId,
+      child: NonReparentingFocus(
+        key: _textFieldKey,
+        focusNode: _focusNode,
+        onKey: _onKeyPressed,
+        child: CompositedTransformTarget(
+          link: _textFieldLayerLink,
+          child: AndroidTextFieldTouchInteractor(
+            focusNode: _focusNode,
             textKey: _textContentKey,
-            textEditingController: _textEditingController,
-            textAlign: widget.textAlign,
-            minLines: widget.minLines,
-            maxLines: widget.maxLines,
-            lineHeight: widget.lineHeight,
-            perLineAutoScrollDuration: const Duration(milliseconds: 100),
+            textFieldLayerLink: _textFieldLayerLink,
+            textController: _textEditingController,
+            editingOverlayController: _editingOverlayController,
+            textScrollController: _textScrollController,
+            isMultiline: _isMultiline,
+            handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
-            padding: widget.padding,
-            child: ListenableBuilder(
-              listenable: _textEditingController,
-              builder: (context, _) {
-                final isTextEmpty = _textEditingController.text.text.isEmpty;
-                final showHint = widget.hintBuilder != null &&
-                    ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
-                        (isTextEmpty &&
-                            !_focusNode.hasFocus &&
-                            widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+            child: TextScrollView(
+              key: _scrollKey,
+              textScrollController: _textScrollController,
+              textKey: _textContentKey,
+              textEditingController: _textEditingController,
+              textAlign: widget.textAlign,
+              minLines: widget.minLines,
+              maxLines: widget.maxLines,
+              lineHeight: widget.lineHeight,
+              perLineAutoScrollDuration: const Duration(milliseconds: 100),
+              showDebugPaint: widget.showDebugPaint,
+              padding: widget.padding,
+              child: ListenableBuilder(
+                listenable: _textEditingController,
+                builder: (context, _) {
+                  final isTextEmpty = _textEditingController.text.text.isEmpty;
+                  final showHint = widget.hintBuilder != null &&
+                      ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
+                          (isTextEmpty &&
+                              !_focusNode.hasFocus &&
+                              widget.hintBehavior == HintBehavior.displayHintUntilFocus));
 
-                return CompositedTransformTarget(
-                  link: _textContentLayerLink,
-                  child: Stack(
-                    children: [
-                      if (showHint) widget.hintBuilder!(context),
-                      _buildSelectableText(),
-                    ],
-                  ),
-                );
-              },
+                  return CompositedTransformTarget(
+                    link: _textContentLayerLink,
+                    child: Stack(
+                      children: [
+                        if (showHint) widget.hintBuilder!(context),
+                        _buildSelectableText(),
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         ),
@@ -548,7 +556,10 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 }
 
 Widget _defaultAndroidToolbarBuilder(
-    BuildContext context, AndroidEditingOverlayController controller, ToolbarConfig config) {
+  BuildContext context,
+  AndroidEditingOverlayController controller,
+  ToolbarConfig config,
+) {
   return AndroidTextEditingFloatingToolbar(
     onCutPressed: () {
       final textController = controller.textController;

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -33,6 +33,7 @@ class IOSEditingControls extends StatefulWidget {
     required this.textContentKey,
     required this.textFieldLayerLink,
     required this.textContentLayerLink,
+    this.tapRegionGroupId,
     required this.handleColor,
     required this.popoverToolbarBuilder,
     this.showDebugPaint = false,
@@ -62,6 +63,10 @@ class IOSEditingControls extends StatefulWidget {
   /// [GlobalKey] that references the widget that contains the field's
   /// text.
   final GlobalKey<ProseTextState> textContentKey;
+
+  /// A group ID for [TapRegion]s that surround each overlay widget, e.g.,
+  /// drag handles.
+  final String? tapRegionGroupId;
 
   /// The color of the selection handles.
   final Color handleColor;
@@ -381,9 +386,12 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
         child: AnimatedOpacity(
           opacity: widget.editingController.isToolbarVisible ? 1.0 : 0.0,
           duration: const Duration(milliseconds: 150),
-          child: Builder(builder: (context) {
-            return widget.popoverToolbarBuilder(context, widget.editingController);
-          }),
+          child: TapRegion(
+            groupId: widget.tapRegionGroupId,
+            child: Builder(builder: (context) {
+              return widget.popoverToolbarBuilder(context, widget.editingController);
+            }),
+          ),
         ),
       ),
     );
@@ -473,26 +481,29 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       offset: followerOffset,
       child: Transform.translate(
         offset: const Offset(-12, -5),
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onPanStart: onPanStart,
-          onPanUpdate: _onPanUpdate,
-          onPanEnd: _onPanEnd,
-          onPanCancel: _onPanCancel,
-          child: Container(
-            width: 24,
-            color: widget.showDebugPaint ? Colors.green : Colors.transparent,
-            child: showHandle
-                ? isUpstreamHandle
-                    ? IOSSelectionHandle.upstream(
-                        color: widget.handleColor,
-                        caretHeight: lineHeight,
-                      )
-                    : IOSSelectionHandle.downstream(
-                        color: widget.handleColor,
-                        caretHeight: lineHeight,
-                      )
-                : const SizedBox(),
+        child: TapRegion(
+          groupId: widget.tapRegionGroupId,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onPanStart: onPanStart,
+            onPanUpdate: _onPanUpdate,
+            onPanEnd: _onPanEnd,
+            onPanCancel: _onPanCancel,
+            child: Container(
+              width: 24,
+              color: widget.showDebugPaint ? Colors.green : Colors.transparent,
+              child: showHandle
+                  ? isUpstreamHandle
+                      ? IOSSelectionHandle.upstream(
+                          color: widget.handleColor,
+                          caretHeight: lineHeight,
+                        )
+                      : IOSSelectionHandle.downstream(
+                          color: widget.handleColor,
+                          caretHeight: lineHeight,
+                        )
+                  : const SizedBox(),
+            ),
           ),
         ),
       ),

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -30,6 +30,7 @@ class SuperIOSTextField extends StatefulWidget {
   const SuperIOSTextField({
     Key? key,
     this.focusNode,
+    this.tapRegionGroupId,
     this.textController,
     this.textStyleBuilder = defaultTextFieldStyleBuilder,
     this.textAlign = TextAlign.left,
@@ -50,6 +51,9 @@ class SuperIOSTextField extends StatefulWidget {
 
   /// [FocusNode] attached to this text field.
   final FocusNode? focusNode;
+
+  /// {@macro super_text_field_tap_region_group_id}
+  final String? tapRegionGroupId;
 
   /// Controller that owns the text content and text selection for
   /// this text field.
@@ -367,6 +371,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           textFieldKey: _textFieldKey,
           textContentLayerLink: _textContentLayerLink,
           textContentKey: _textContentKey,
+          tapRegionGroupId: widget.tapRegionGroupId,
           handleColor: widget.handlesColor,
           popoverToolbarBuilder: _defaultPopoverToolbarBuilder,
           showDebugPaint: widget.showDebugPaint,
@@ -468,62 +473,65 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
   @override
   Widget build(BuildContext context) {
-    return NonReparentingFocus(
-      key: _textFieldKey,
-      focusNode: _focusNode,
-      child: CompositedTransformTarget(
-        link: _textFieldLayerLink,
-        child: IOSTextFieldTouchInteractor(
-          focusNode: _focusNode,
-          selectableTextKey: _textContentKey,
-          textFieldLayerLink: _textFieldLayerLink,
-          textController: _textEditingController,
-          editingOverlayController: _editingOverlayController,
-          textScrollController: _textScrollController,
-          isMultiline: _isMultiline,
-          handleColor: widget.handlesColor,
-          showDebugPaint: widget.showDebugPaint,
-          child: TextScrollView(
-            key: _scrollKey,
+    return TapRegion(
+      groupId: widget.tapRegionGroupId,
+      child: NonReparentingFocus(
+        key: _textFieldKey,
+        focusNode: _focusNode,
+        child: CompositedTransformTarget(
+          link: _textFieldLayerLink,
+          child: IOSTextFieldTouchInteractor(
+            focusNode: _focusNode,
+            selectableTextKey: _textContentKey,
+            textFieldLayerLink: _textFieldLayerLink,
+            textController: _textEditingController,
+            editingOverlayController: _editingOverlayController,
             textScrollController: _textScrollController,
-            textKey: _textContentKey,
-            textEditingController: _textEditingController,
-            textAlign: widget.textAlign,
-            minLines: widget.minLines,
-            maxLines: widget.maxLines,
-            lineHeight: widget.lineHeight,
-            perLineAutoScrollDuration: const Duration(milliseconds: 100),
+            isMultiline: _isMultiline,
+            handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
-            padding: widget.padding,
-            child: ListenableBuilder(
-              listenable: _textEditingController,
-              builder: (context, _) {
-                final isTextEmpty = _textEditingController.text.text.isEmpty;
-                final showHint = widget.hintBuilder != null &&
-                    ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
-                        (isTextEmpty &&
-                            !_focusNode.hasFocus &&
-                            widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+            child: TextScrollView(
+              key: _scrollKey,
+              textScrollController: _textScrollController,
+              textKey: _textContentKey,
+              textEditingController: _textEditingController,
+              textAlign: widget.textAlign,
+              minLines: widget.minLines,
+              maxLines: widget.maxLines,
+              lineHeight: widget.lineHeight,
+              perLineAutoScrollDuration: const Duration(milliseconds: 100),
+              showDebugPaint: widget.showDebugPaint,
+              padding: widget.padding,
+              child: ListenableBuilder(
+                listenable: _textEditingController,
+                builder: (context, _) {
+                  final isTextEmpty = _textEditingController.text.text.isEmpty;
+                  final showHint = widget.hintBuilder != null &&
+                      ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
+                          (isTextEmpty &&
+                              !_focusNode.hasFocus &&
+                              widget.hintBehavior == HintBehavior.displayHintUntilFocus));
 
-                return CompositedTransformTarget(
-                  link: _textContentLayerLink,
-                  child: Stack(
-                    children: [
-                      if (showHint) widget.hintBuilder!(context),
-                      _buildSelectableText(),
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        right: 0,
-                        bottom: 0,
-                        child: IOSFloatingCursor(
-                          controller: _floatingCursorController,
+                  return CompositedTransformTarget(
+                    link: _textContentLayerLink,
+                    child: Stack(
+                      children: [
+                        if (showHint) widget.hintBuilder!(context),
+                        _buildSelectableText(),
+                        Positioned(
+                          left: 0,
+                          top: 0,
+                          right: 0,
+                          bottom: 0,
+                          child: IOSFloatingCursor(
+                            controller: _floatingCursorController,
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                );
-              },
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         ),

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -53,6 +53,7 @@ class SuperTextField extends StatefulWidget {
   const SuperTextField({
     Key? key,
     this.focusNode,
+    this.tapRegionGroupId,
     this.configuration,
     this.textController,
     this.textAlign = TextAlign.left,
@@ -73,6 +74,12 @@ class SuperTextField extends StatefulWidget {
   }) : super(key: key);
 
   final FocusNode? focusNode;
+
+  /// {@template super_text_field_tap_region_group_id}
+  /// An optional group ID for a tap region that surrounds this text field
+  /// and also surrounds any related widgets, such as drag handles and a toolbar.
+  /// {@endtemplate}
+  final String? tapRegionGroupId;
 
   /// The platform-style configuration for this text field, or `null` to
   /// automatically configure for the current platform.
@@ -295,6 +302,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
         return SuperDesktopTextField(
           key: _platformFieldKey,
           focusNode: widget.focusNode,
+          tapRegionGroupId: widget.tapRegionGroupId,
           textController: _controller,
           textAlign: widget.textAlign,
           textStyleBuilder: widget.textStyleBuilder,
@@ -321,6 +329,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           child: SuperAndroidTextField(
             key: _platformFieldKey,
             focusNode: widget.focusNode,
+            tapRegionGroupId: widget.tapRegionGroupId,
             textController: _controller,
             textAlign: widget.textAlign,
             textStyleBuilder: widget.textStyleBuilder,
@@ -345,6 +354,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           child: SuperIOSTextField(
             key: _platformFieldKey,
             focusNode: widget.focusNode,
+            tapRegionGroupId: widget.tapRegionGroupId,
             textController: _controller,
             textAlign: widget.textAlign,
             textStyleBuilder: widget.textStyleBuilder,


### PR DESCRIPTION
Cherry Pick: Use TapRegions in SuperTextField to support unfocusing when tapping or dragging outside (Resolves #1263) (#1310)