### PR TITLE
[SuperTextField][Mobile] Always compute the viewport height in the first frame (Resolves #939)

### DIFF
--- a/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
@@ -945,7 +945,7 @@ class _TextViewport extends SingleChildRenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderTextHeightLimiter(
+    return _RenderTextViewport(
       text: text,
       textKey: textKey,
       minLines: minLines,
@@ -956,7 +956,7 @@ class _TextViewport extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, covariant _RenderTextHeightLimiter renderObject) {
+  void updateRenderObject(BuildContext context, covariant _RenderTextViewport renderObject) {
     renderObject
       ..text = text
       ..textKey = textKey
@@ -967,8 +967,8 @@ class _TextViewport extends SingleChildRenderObjectWidget {
   }
 }
 
-class _RenderTextHeightLimiter extends RenderProxyBox {
-  _RenderTextHeightLimiter({
+class _RenderTextViewport extends RenderProxyBox {
+  _RenderTextViewport({
     required AttributedText text,
     required GlobalKey<ProseTextState> textKey,
     int? minLines,

--- a/super_editor/test/super_textfield/super_textfield_rendering_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_rendering_test.dart
@@ -47,21 +47,18 @@ void main() {
         minLines: 5,
       );
 
-      // Switch to display the SuperTextField.
-      // As our text has only one line, we should expand the text field height
-      // to acommodate 5 lines.
+      // Switch to display the SuperTextField, so we can inspect it on its first frame.
       showTextField.value = true;
-
-      // Pump exactly one frame to inspect if the text was rendered.
       await tester.pump();
 
       // Ensure the text is rendered in the first frame.
       expect(find.text('1', findRichText: true), findsOneWidget);
 
-      // Ensure the text field expanded to the height of maxLines.
+      // Ensure the text field expanded to the height of minLines.
       final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
       final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
-      expect(textFieldHeight, moreOrLessEquals(textHeight * 5));
+      final minLinesHeight = textHeight * 5;
+      expect(textFieldHeight, moreOrLessEquals(minLinesHeight));
     });
 
     testWidgetsOnMobile('shrinks to fit maxLines', (tester) async {
@@ -78,12 +75,8 @@ void main() {
         maxLines: 3,
       );
 
-      // Switch to display the SuperTextField.
-      // As our text has 6 lines, we should shrink the text field height
-      // to acommodate 3 lines only.
+      // Switch to display the SuperTextField, so we can inspect it on its first frame.
       showTextField.value = true;
-
-      // Pump exactly one frame to inspect if the text was rendered.
       await tester.pump();
 
       // Ensure the text is rendered in the first frame.
@@ -92,7 +85,8 @@ void main() {
       // Ensure the text field shrank to half of the text size.
       final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
       final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
-      expect(textFieldHeight, moreOrLessEquals(textHeight / 2));
+      final maxLinesHeight = textHeight / 2;
+      expect(textFieldHeight, moreOrLessEquals(maxLinesHeight));
     });
   });
 }

--- a/super_editor/test/super_textfield/super_textfield_rendering_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_rendering_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../test_tools.dart';
 
@@ -31,6 +32,68 @@ void main() {
       // Ensure the SuperTextField rendered the text.
       expect(find.text('Editing text', findRichText: true), findsOneWidget);
     });
+
+    testWidgetsOnMobile('expands to respect minLines', (tester) async {
+      // Indicates whether we should display the Text or the SuperTextField.
+      final showTextField = ValueNotifier<bool>(false);
+
+      // Pump the widget tree showing the Text widget.
+      await _pumpSwitchableTestApp(
+        tester,
+        controller: AttributedTextEditingController(
+          text: AttributedText('1'),
+        ),
+        showTextField: showTextField,
+        minLines: 5,
+      );
+
+      // Switch to display the SuperTextField.
+      // As our text has only one line, we should expand the text field height
+      // to acommodate 5 lines.
+      showTextField.value = true;
+
+      // Pump exactly one frame to inspect if the text was rendered.
+      await tester.pump();
+
+      // Ensure the text is rendered in the first frame.
+      expect(find.text('1', findRichText: true), findsOneWidget);
+
+      // Ensure the text field expanded to the height of maxLines.
+      final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
+      final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
+      expect(textFieldHeight, moreOrLessEquals(textHeight * 5));
+    });
+
+    testWidgetsOnMobile('shrinks to fit maxLines', (tester) async {
+      // Indicates whether we should display the Text or the SuperTextField.
+      final showTextField = ValueNotifier<bool>(false);
+
+      // Pump the widget tree showing the Text widget.
+      await _pumpSwitchableTestApp(
+        tester,
+        controller: AttributedTextEditingController(
+          text: AttributedText('1\n2\n3\n4\n5\n6'),
+        ),
+        showTextField: showTextField,
+        maxLines: 3,
+      );
+
+      // Switch to display the SuperTextField.
+      // As our text has 6 lines, we should shrink the text field height
+      // to acommodate 3 lines only.
+      showTextField.value = true;
+
+      // Pump exactly one frame to inspect if the text was rendered.
+      await tester.pump();
+
+      // Ensure the text is rendered in the first frame.
+      expect(find.text('1\n2\n3\n4\n5\n6', findRichText: true), findsOneWidget);
+
+      // Ensure the text field shrank to half of the text size.
+      final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
+      final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
+      expect(textFieldHeight, moreOrLessEquals(textHeight / 2));
+    });
   });
 }
 
@@ -40,6 +103,8 @@ Future<void> _pumpSwitchableTestApp(
   required AttributedTextEditingController controller,
   required ValueNotifier<bool> showTextField,
   double? lineHeight,
+  int? minLines,
+  int? maxLines,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -51,6 +116,8 @@ Future<void> _pumpSwitchableTestApp(
                 ? SuperTextField(
                     textController: controller,
                     lineHeight: lineHeight,
+                    minLines: minLines,
+                    maxLines: maxLines,
                   )
                 : const Text('');
           },


### PR DESCRIPTION
[SuperTextField][Mobile] Always compute the viewport height in the first frame. Resolves #939

Currently, there are cases where we compute the textfield size after the first frame. This causes some flickering when using it inside a scrollable.

This PR moves the existing viewport height computation to a new widget, which performs the computation during layout. With this change, we always size the viewport since the first frame.

The downside is that we perform layout twice. The first one is needed so the text layout is performed so we can access the text layout information and the second one uses the information retrieved from the first layout to size the viewport. We probably could introduce some caching to avoid performing two layouts in some situations.

