### PR TITLE
Switched SuperEditor from LayerLinks to LeaderLinks so we can add boundary behaviors (Resolves #669)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -459,40 +459,8 @@ class _EditorToolbarState extends State<EditorToolbar> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
+    return BuildInOrder(
       children: [
-        // Conditionally display the URL text field below
-        // the standard toolbar.
-        // if (_showUrlField)
-        // Positioned(
-        //   left: widget.anchor.value!.dx,
-        //   top: widget.anchor.value!.dy,
-        //   child: FractionalTranslation(
-        //     translation: const Offset(-0.5, 0.0),
-        //     child: _buildUrlField(),
-        //   ),
-        // ),
-        // _PositionedToolbar(
-        //   anchor: widget.anchor,
-        //   composer: widget.composer,
-        //   child: ValueListenableBuilder<DocumentSelection?>(
-        //     valueListenable: widget.composer.selectionNotifier,
-        //     builder: (context, selection, child) {
-        //       appLog.fine("Building toolbar. Selection: $selection");
-        //       if (selection == null) {
-        //         return const SizedBox();
-        //       }
-        //       if (selection.extent.nodePosition is! TextPosition) {
-        //         // The user selected non-text content. This toolbar is probably
-        //         // about to disappear. Until then, build nothing, because the
-        //         // toolbar needs to inspect selected text to build correctly.
-        //         return const SizedBox();
-        //       }
-        //
-        //       return _buildToolbar();
-        //     },
-        //   ),
-        // ),
         FollowerFadeOutBeyondBoundary(
           link: widget.anchor,
           boundary: _screenBoundary,
@@ -501,151 +469,141 @@ class _EditorToolbarState extends State<EditorToolbar> {
             aligner: _toolbarAligner,
             boundary: _screenBoundary,
             showWhenUnlinked: false,
-            child: _buildToolbar(),
+            child: _buildToolbars(),
           ),
         ),
-        // ValueListenableBuilder<DocumentSelection?>(
-        //   valueListenable: widget.composer.selectionNotifier,
-        //   builder: (context, selection, child) {
-        //     return FollowerFadeOutBeyondBoundary(
-        //       link: widget.anchor,
-        //       boundary: _screenBoundary,
-        //       child: Follower.withAligner(
-        //         link: widget.anchor,
-        //         aligner: _toolbarAligner,
-        //         boundary: _screenBoundary,
-        //         showWhenUnlinked: false,
-        //         child: _buildToolbar(),
-        //       ),
-        //     );
-        //   },
-        // ),
+      ],
+    );
+  }
+
+  Widget _buildToolbars() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildToolbar(),
+        if (_showUrlField) ...[
+          const SizedBox(height: 8),
+          _buildUrlField(),
+        ],
       ],
     );
   }
 
   Widget _buildToolbar() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        IntrinsicWidth(
-          child: Material(
-            shape: const StadiumBorder(),
-            elevation: 5,
-            clipBehavior: Clip.hardEdge,
-            child: SizedBox(
-              height: 40,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // Only allow the user to select a new type of text node if
-                  // the currently selected node can be converted.
-                  if (_isConvertibleNode()) ...[
-                    Tooltip(
-                      message: AppLocalizations.of(context)!.labelTextBlockType,
-                      child: DropdownButton<_TextType>(
-                        value: _getCurrentTextType(),
-                        items: _TextType.values
-                            .map((textType) => DropdownMenuItem<_TextType>(
-                                  value: textType,
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(left: 16.0),
-                                    child: Text(_getTextTypeName(textType)),
-                                  ),
-                                ))
-                            .toList(),
-                        icon: const Icon(Icons.arrow_drop_down),
-                        style: const TextStyle(
-                          color: Colors.black,
-                          fontSize: 12,
-                        ),
-                        underline: const SizedBox(),
-                        elevation: 0,
-                        itemHeight: 48,
-                        onChanged: _convertTextToNewType,
-                      ),
+    return IntrinsicWidth(
+      child: Material(
+        shape: const StadiumBorder(),
+        elevation: 5,
+        clipBehavior: Clip.hardEdge,
+        child: SizedBox(
+          height: 40,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Only allow the user to select a new type of text node if
+              // the currently selected node can be converted.
+              if (_isConvertibleNode()) ...[
+                Tooltip(
+                  message: AppLocalizations.of(context)!.labelTextBlockType,
+                  child: DropdownButton<_TextType>(
+                    value: _getCurrentTextType(),
+                    items: _TextType.values
+                        .map((textType) => DropdownMenuItem<_TextType>(
+                              value: textType,
+                              child: Padding(
+                                padding: const EdgeInsets.only(left: 16.0),
+                                child: Text(_getTextTypeName(textType)),
+                              ),
+                            ))
+                        .toList(),
+                    icon: const Icon(Icons.arrow_drop_down),
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 12,
                     ),
-                    _buildVerticalDivider(),
-                  ],
-                  Center(
-                    child: IconButton(
-                      onPressed: _toggleBold,
-                      icon: const Icon(Icons.format_bold),
-                      splashRadius: 16,
-                      tooltip: AppLocalizations.of(context)!.labelBold,
-                    ),
+                    underline: const SizedBox(),
+                    elevation: 0,
+                    itemHeight: 48,
+                    onChanged: _convertTextToNewType,
                   ),
-                  Center(
-                    child: IconButton(
-                      onPressed: _toggleItalics,
-                      icon: const Icon(Icons.format_italic),
-                      splashRadius: 16,
-                      tooltip: AppLocalizations.of(context)!.labelItalics,
-                    ),
-                  ),
-                  Center(
-                    child: IconButton(
-                      onPressed: _toggleStrikethrough,
-                      icon: const Icon(Icons.strikethrough_s),
-                      splashRadius: 16,
-                      tooltip: AppLocalizations.of(context)!.labelStrikethrough,
-                    ),
-                  ),
-                  Center(
-                    child: IconButton(
-                      onPressed: _areMultipleLinksSelected() ? null : _onLinkPressed,
-                      icon: const Icon(Icons.link),
-                      color: _isSingleLinkSelected() ? const Color(0xFF007AFF) : IconTheme.of(context).color,
-                      splashRadius: 16,
-                      tooltip: AppLocalizations.of(context)!.labelLink,
-                    ),
-                  ),
-                  // Only display alignment controls if the currently selected text
-                  // node respects alignment. List items, for example, do not.
-                  if (_isTextAlignable()) ...[
-                    _buildVerticalDivider(),
-                    Tooltip(
-                      message: AppLocalizations.of(context)!.labelTextAlignment,
-                      child: DropdownButton<TextAlign>(
-                        value: _getCurrentTextAlignment(),
-                        items: [TextAlign.left, TextAlign.center, TextAlign.right, TextAlign.justify]
-                            .map((textAlign) => DropdownMenuItem<TextAlign>(
-                                  value: textAlign,
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(left: 8.0),
-                                    child: Icon(_buildTextAlignIcon(textAlign)),
-                                  ),
-                                ))
-                            .toList(),
-                        icon: const Icon(Icons.arrow_drop_down),
-                        style: const TextStyle(
-                          color: Colors.black,
-                          fontSize: 12,
-                        ),
-                        underline: const SizedBox(),
-                        elevation: 0,
-                        itemHeight: 48,
-                        onChanged: _changeAlignment,
-                      ),
-                    ),
-                  ],
-                  _buildVerticalDivider(),
-                  Center(
-                    child: IconButton(
-                      onPressed: () {},
-                      icon: const Icon(Icons.more_vert),
-                      splashRadius: 16,
-                      tooltip: AppLocalizations.of(context)!.labelMoreOptions,
-                    ),
-                  ),
-                ],
+                ),
+                _buildVerticalDivider(),
+              ],
+              Center(
+                child: IconButton(
+                  onPressed: _toggleBold,
+                  icon: const Icon(Icons.format_bold),
+                  splashRadius: 16,
+                  tooltip: AppLocalizations.of(context)!.labelBold,
+                ),
               ),
-            ),
+              Center(
+                child: IconButton(
+                  onPressed: _toggleItalics,
+                  icon: const Icon(Icons.format_italic),
+                  splashRadius: 16,
+                  tooltip: AppLocalizations.of(context)!.labelItalics,
+                ),
+              ),
+              Center(
+                child: IconButton(
+                  onPressed: _toggleStrikethrough,
+                  icon: const Icon(Icons.strikethrough_s),
+                  splashRadius: 16,
+                  tooltip: AppLocalizations.of(context)!.labelStrikethrough,
+                ),
+              ),
+              Center(
+                child: IconButton(
+                  onPressed: _areMultipleLinksSelected() ? null : _onLinkPressed,
+                  icon: const Icon(Icons.link),
+                  color: _isSingleLinkSelected() ? const Color(0xFF007AFF) : IconTheme.of(context).color,
+                  splashRadius: 16,
+                  tooltip: AppLocalizations.of(context)!.labelLink,
+                ),
+              ),
+              // Only display alignment controls if the currently selected text
+              // node respects alignment. List items, for example, do not.
+              if (_isTextAlignable()) ...[
+                _buildVerticalDivider(),
+                Tooltip(
+                  message: AppLocalizations.of(context)!.labelTextAlignment,
+                  child: DropdownButton<TextAlign>(
+                    value: _getCurrentTextAlignment(),
+                    items: [TextAlign.left, TextAlign.center, TextAlign.right, TextAlign.justify]
+                        .map((textAlign) => DropdownMenuItem<TextAlign>(
+                              value: textAlign,
+                              child: Padding(
+                                padding: const EdgeInsets.only(left: 8.0),
+                                child: Icon(_buildTextAlignIcon(textAlign)),
+                              ),
+                            ))
+                        .toList(),
+                    icon: const Icon(Icons.arrow_drop_down),
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 12,
+                    ),
+                    underline: const SizedBox(),
+                    elevation: 0,
+                    itemHeight: 48,
+                    onChanged: _changeAlignment,
+                  ),
+                ),
+              ],
+              _buildVerticalDivider(),
+              Center(
+                child: IconButton(
+                  onPressed: () {},
+                  icon: const Icon(Icons.more_vert),
+                  splashRadius: 16,
+                  tooltip: AppLocalizations.of(context)!.labelMoreOptions,
+                ),
+              ),
+            ],
           ),
         ),
-        if (_showUrlField) //
-          _buildUrlField(),
-      ],
+      ),
     );
   }
 

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:example/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:overlord/follow_the_leader.dart';
 import 'package:super_editor/super_editor.dart';
 
 /// Small toolbar that is intended to display near some selected
@@ -15,20 +17,24 @@ import 'package:super_editor/super_editor.dart';
 class EditorToolbar extends StatefulWidget {
   const EditorToolbar({
     Key? key,
-    required this.anchor,
+    required this.editorViewportKey,
     required this.editorFocusNode,
     required this.editor,
     required this.document,
     required this.composer,
+    required this.anchor,
     required this.closeToolbar,
   }) : super(key: key);
 
-  /// [EditorToolbar] displays itself horizontally centered and
-  /// slightly above the given [anchor] value.
+  /// [GlobalKey] that should be attached to a widget that wraps the viewport
+  /// area, which keeps the toolbar from appearing outside of the editor area.
+  final GlobalKey editorViewportKey;
+
+  /// A [LeaderLink] that should be attached to the boundary of the toolbar
+  /// focal area, such as wrapped around the user's selection area.
   ///
-  /// [anchor] is a [ValueNotifier] so that [EditorToolbar] can
-  /// reposition itself as the [Offset] value changes.
-  final ValueNotifier<Offset?> anchor;
+  /// The toolbar is positioned relative to this anchor link.
+  final LeaderLink anchor;
 
   /// The [FocusNode] attached to the editor to which this toolbar applies.
   final FocusNode editorFocusNode;
@@ -56,6 +62,9 @@ class EditorToolbar extends StatefulWidget {
 }
 
 class _EditorToolbarState extends State<EditorToolbar> {
+  late final FollowerAligner _toolbarAligner;
+  late FollowerBoundary _screenBoundary;
+
   bool _showUrlField = false;
   late FocusNode _urlFocusNode;
   AttributedTextEditingController? _urlController;
@@ -63,9 +72,22 @@ class _EditorToolbarState extends State<EditorToolbar> {
   @override
   void initState() {
     super.initState();
+
+    _toolbarAligner = CupertinoPopoverToolbarAligner(widget.editorViewportKey);
+
     _urlFocusNode = FocusNode();
     _urlController = SingleLineAttributedTextEditingController(_applyLink) //
       ..text = AttributedText(text: "https://");
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _screenBoundary = WidgetFollowerBoundary(
+      boundaryKey: widget.editorViewportKey,
+      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+    );
   }
 
   @override
@@ -441,153 +463,189 @@ class _EditorToolbarState extends State<EditorToolbar> {
       children: [
         // Conditionally display the URL text field below
         // the standard toolbar.
-        if (_showUrlField)
-          Positioned(
-            left: widget.anchor.value!.dx,
-            top: widget.anchor.value!.dy,
-            child: FractionalTranslation(
-              translation: const Offset(-0.5, 0.0),
-              child: _buildUrlField(),
-            ),
-          ),
-        _PositionedToolbar(
-          anchor: widget.anchor,
-          composer: widget.composer,
-          child: ValueListenableBuilder<DocumentSelection?>(
-            valueListenable: widget.composer.selectionNotifier,
-            builder: (context, selection, child) {
-              appLog.fine("Building toolbar. Selection: $selection");
-              if (selection == null) {
-                return const SizedBox();
-              }
-              if (selection.extent.nodePosition is! TextPosition) {
-                // The user selected non-text content. This toolbar is probably
-                // about to disappear. Until then, build nothing, because the
-                // toolbar needs to inspect selected text to build correctly.
-                return const SizedBox();
-              }
-
-              return _buildToolbar();
-            },
+        // if (_showUrlField)
+        // Positioned(
+        //   left: widget.anchor.value!.dx,
+        //   top: widget.anchor.value!.dy,
+        //   child: FractionalTranslation(
+        //     translation: const Offset(-0.5, 0.0),
+        //     child: _buildUrlField(),
+        //   ),
+        // ),
+        // _PositionedToolbar(
+        //   anchor: widget.anchor,
+        //   composer: widget.composer,
+        //   child: ValueListenableBuilder<DocumentSelection?>(
+        //     valueListenable: widget.composer.selectionNotifier,
+        //     builder: (context, selection, child) {
+        //       appLog.fine("Building toolbar. Selection: $selection");
+        //       if (selection == null) {
+        //         return const SizedBox();
+        //       }
+        //       if (selection.extent.nodePosition is! TextPosition) {
+        //         // The user selected non-text content. This toolbar is probably
+        //         // about to disappear. Until then, build nothing, because the
+        //         // toolbar needs to inspect selected text to build correctly.
+        //         return const SizedBox();
+        //       }
+        //
+        //       return _buildToolbar();
+        //     },
+        //   ),
+        // ),
+        FollowerFadeOutBeyondBoundary(
+          link: widget.anchor,
+          boundary: _screenBoundary,
+          child: Follower.withAligner(
+            link: widget.anchor,
+            aligner: _toolbarAligner,
+            boundary: _screenBoundary,
+            showWhenUnlinked: false,
+            child: _buildToolbar(),
           ),
         ),
+        // ValueListenableBuilder<DocumentSelection?>(
+        //   valueListenable: widget.composer.selectionNotifier,
+        //   builder: (context, selection, child) {
+        //     return FollowerFadeOutBeyondBoundary(
+        //       link: widget.anchor,
+        //       boundary: _screenBoundary,
+        //       child: Follower.withAligner(
+        //         link: widget.anchor,
+        //         aligner: _toolbarAligner,
+        //         boundary: _screenBoundary,
+        //         showWhenUnlinked: false,
+        //         child: _buildToolbar(),
+        //       ),
+        //     );
+        //   },
+        // ),
       ],
     );
   }
 
   Widget _buildToolbar() {
-    return Material(
-      shape: const StadiumBorder(),
-      elevation: 5,
-      clipBehavior: Clip.hardEdge,
-      child: SizedBox(
-        height: 40,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Only allow the user to select a new type of text node if
-            // the currently selected node can be converted.
-            if (_isConvertibleNode()) ...[
-              Tooltip(
-                message: AppLocalizations.of(context)!.labelTextBlockType,
-                child: DropdownButton<_TextType>(
-                  value: _getCurrentTextType(),
-                  items: _TextType.values
-                      .map((textType) => DropdownMenuItem<_TextType>(
-                            value: textType,
-                            child: Padding(
-                              padding: const EdgeInsets.only(left: 16.0),
-                              child: Text(_getTextTypeName(textType)),
-                            ),
-                          ))
-                      .toList(),
-                  icon: const Icon(Icons.arrow_drop_down),
-                  style: const TextStyle(
-                    color: Colors.black,
-                    fontSize: 12,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IntrinsicWidth(
+          child: Material(
+            shape: const StadiumBorder(),
+            elevation: 5,
+            clipBehavior: Clip.hardEdge,
+            child: SizedBox(
+              height: 40,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Only allow the user to select a new type of text node if
+                  // the currently selected node can be converted.
+                  if (_isConvertibleNode()) ...[
+                    Tooltip(
+                      message: AppLocalizations.of(context)!.labelTextBlockType,
+                      child: DropdownButton<_TextType>(
+                        value: _getCurrentTextType(),
+                        items: _TextType.values
+                            .map((textType) => DropdownMenuItem<_TextType>(
+                                  value: textType,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(left: 16.0),
+                                    child: Text(_getTextTypeName(textType)),
+                                  ),
+                                ))
+                            .toList(),
+                        icon: const Icon(Icons.arrow_drop_down),
+                        style: const TextStyle(
+                          color: Colors.black,
+                          fontSize: 12,
+                        ),
+                        underline: const SizedBox(),
+                        elevation: 0,
+                        itemHeight: 48,
+                        onChanged: _convertTextToNewType,
+                      ),
+                    ),
+                    _buildVerticalDivider(),
+                  ],
+                  Center(
+                    child: IconButton(
+                      onPressed: _toggleBold,
+                      icon: const Icon(Icons.format_bold),
+                      splashRadius: 16,
+                      tooltip: AppLocalizations.of(context)!.labelBold,
+                    ),
                   ),
-                  underline: const SizedBox(),
-                  elevation: 0,
-                  itemHeight: 48,
-                  onChanged: _convertTextToNewType,
-                ),
-              ),
-              _buildVerticalDivider(),
-            ],
-            Center(
-              child: IconButton(
-                onPressed: _toggleBold,
-                icon: const Icon(Icons.format_bold),
-                splashRadius: 16,
-                tooltip: AppLocalizations.of(context)!.labelBold,
-              ),
-            ),
-            Center(
-              child: IconButton(
-                onPressed: _toggleItalics,
-                icon: const Icon(Icons.format_italic),
-                splashRadius: 16,
-                tooltip: AppLocalizations.of(context)!.labelItalics,
-              ),
-            ),
-            Center(
-              child: IconButton(
-                onPressed: _toggleStrikethrough,
-                icon: const Icon(Icons.strikethrough_s),
-                splashRadius: 16,
-                tooltip: AppLocalizations.of(context)!.labelStrikethrough,
-              ),
-            ),
-            Center(
-              child: IconButton(
-                onPressed: _areMultipleLinksSelected() ? null : _onLinkPressed,
-                icon: const Icon(Icons.link),
-                color: _isSingleLinkSelected() ? const Color(0xFF007AFF) : IconTheme.of(context).color,
-                splashRadius: 16,
-                tooltip: AppLocalizations.of(context)!.labelLink,
-              ),
-            ),
-            // Only display alignment controls if the currently selected text
-            // node respects alignment. List items, for example, do not.
-            if (_isTextAlignable()) ...[
-              _buildVerticalDivider(),
-              Tooltip(
-                message: AppLocalizations.of(context)!.labelTextAlignment,
-                child: DropdownButton<TextAlign>(
-                  value: _getCurrentTextAlignment(),
-                  items: [TextAlign.left, TextAlign.center, TextAlign.right, TextAlign.justify]
-                      .map((textAlign) => DropdownMenuItem<TextAlign>(
-                            value: textAlign,
-                            child: Padding(
-                              padding: const EdgeInsets.only(left: 8.0),
-                              child: Icon(_buildTextAlignIcon(textAlign)),
-                            ),
-                          ))
-                      .toList(),
-                  icon: const Icon(Icons.arrow_drop_down),
-                  style: const TextStyle(
-                    color: Colors.black,
-                    fontSize: 12,
+                  Center(
+                    child: IconButton(
+                      onPressed: _toggleItalics,
+                      icon: const Icon(Icons.format_italic),
+                      splashRadius: 16,
+                      tooltip: AppLocalizations.of(context)!.labelItalics,
+                    ),
                   ),
-                  underline: const SizedBox(),
-                  elevation: 0,
-                  itemHeight: 48,
-                  onChanged: _changeAlignment,
-                ),
-              ),
-            ],
-            _buildVerticalDivider(),
-            Center(
-              child: IconButton(
-                onPressed: () {},
-                icon: const Icon(Icons.more_vert),
-                splashRadius: 16,
-                tooltip: AppLocalizations.of(context)!.labelMoreOptions,
+                  Center(
+                    child: IconButton(
+                      onPressed: _toggleStrikethrough,
+                      icon: const Icon(Icons.strikethrough_s),
+                      splashRadius: 16,
+                      tooltip: AppLocalizations.of(context)!.labelStrikethrough,
+                    ),
+                  ),
+                  Center(
+                    child: IconButton(
+                      onPressed: _areMultipleLinksSelected() ? null : _onLinkPressed,
+                      icon: const Icon(Icons.link),
+                      color: _isSingleLinkSelected() ? const Color(0xFF007AFF) : IconTheme.of(context).color,
+                      splashRadius: 16,
+                      tooltip: AppLocalizations.of(context)!.labelLink,
+                    ),
+                  ),
+                  // Only display alignment controls if the currently selected text
+                  // node respects alignment. List items, for example, do not.
+                  if (_isTextAlignable()) ...[
+                    _buildVerticalDivider(),
+                    Tooltip(
+                      message: AppLocalizations.of(context)!.labelTextAlignment,
+                      child: DropdownButton<TextAlign>(
+                        value: _getCurrentTextAlignment(),
+                        items: [TextAlign.left, TextAlign.center, TextAlign.right, TextAlign.justify]
+                            .map((textAlign) => DropdownMenuItem<TextAlign>(
+                                  value: textAlign,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(left: 8.0),
+                                    child: Icon(_buildTextAlignIcon(textAlign)),
+                                  ),
+                                ))
+                            .toList(),
+                        icon: const Icon(Icons.arrow_drop_down),
+                        style: const TextStyle(
+                          color: Colors.black,
+                          fontSize: 12,
+                        ),
+                        underline: const SizedBox(),
+                        elevation: 0,
+                        itemHeight: 48,
+                        onChanged: _changeAlignment,
+                      ),
+                    ),
+                  ],
+                  _buildVerticalDivider(),
+                  Center(
+                    child: IconButton(
+                      onPressed: () {},
+                      icon: const Icon(Icons.more_vert),
+                      splashRadius: 16,
+                      tooltip: AppLocalizations.of(context)!.labelMoreOptions,
+                    ),
+                  ),
+                ],
               ),
             ),
-          ],
+          ),
         ),
-      ),
+        if (_showUrlField) //
+          _buildUrlField(),
+      ],
     );
   }
 

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -29,11 +29,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
 
   late ScrollController _scrollController;
 
-  final SelectionLayerLinks _selectionLayerLinks = SelectionLayerLinks(
-    caretLink: LayerLink(),
-    upstreamLink: LayerLink(),
-    downstreamLink: LayerLink(),
-  );
+  final SelectionLayerLinks _selectionLayerLinks = SelectionLayerLinks();
 
   final _darkBackground = const Color(0xFF222222);
   final _lightBackground = Colors.white;

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -16,6 +16,7 @@ class ExampleEditor extends StatefulWidget {
 }
 
 class _ExampleEditorState extends State<ExampleEditor> {
+  final GlobalKey _viewportKey = GlobalKey();
   final GlobalKey _docLayoutKey = GlobalKey();
 
   late MutableDocument _doc;
@@ -27,6 +28,12 @@ class _ExampleEditorState extends State<ExampleEditor> {
   late FocusNode _editorFocusNode;
 
   late ScrollController _scrollController;
+
+  final SelectionLayerLinks _selectionLayerLinks = SelectionLayerLinks(
+    caretLink: LayerLink(),
+    upstreamLink: LayerLink(),
+    downstreamLink: LayerLink(),
+  );
 
   final _darkBackground = const Color(0xFF222222);
   final _lightBackground = Colors.white;
@@ -143,7 +150,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
       //       application overlay
       _textFormatBarOverlayEntry ??= OverlayEntry(builder: (context) {
         return EditorToolbar(
-          anchor: _textSelectionAnchor,
+          editorViewportKey: _viewportKey,
+          anchor: _selectionLayerLinks.expandedSelectionBoundsLink,
           editorFocusNode: _editorFocusNode,
           editor: _docEditor,
           document: _doc,
@@ -225,7 +233,6 @@ class _ExampleEditorState extends State<ExampleEditor> {
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         return TextInputSource.ime;
-      // return DocumentInputSource.keyboard;
     }
   }
 
@@ -403,65 +410,69 @@ class _ExampleEditorState extends State<ExampleEditor> {
       color: isLight ? _lightBackground : _darkBackground,
       child: SuperEditorDebugVisuals(
         config: _debugConfig ?? const SuperEditorDebugVisualsConfig(),
-        child: SuperEditor(
-          editor: _docEditor,
-          document: _doc,
-          composer: _composer,
-          focusNode: _editorFocusNode,
-          scrollController: _scrollController,
-          documentLayoutKey: _docLayoutKey,
-          documentOverlayBuilders: [
-            DefaultCaretOverlayBuilder(
-              caretStyle: const CaretStyle().copyWith(color: isLight ? Colors.black : Colors.redAccent),
-            ),
-          ],
-          selectionStyle: isLight
-              ? defaultSelectionStyle
-              : SelectionStyles(
-                  selectionColor: Colors.red.withOpacity(0.3),
-                ),
-          stylesheet: defaultStylesheet.copyWith(
-            addRulesAfter: [
-              if (!isLight) ..._darkModeStyles,
-              taskStyles,
+        child: KeyedSubtree(
+          key: _viewportKey,
+          child: SuperEditor(
+            editor: _docEditor,
+            document: _doc,
+            composer: _composer,
+            focusNode: _editorFocusNode,
+            scrollController: _scrollController,
+            documentLayoutKey: _docLayoutKey,
+            documentOverlayBuilders: [
+              DefaultCaretOverlayBuilder(
+                caretStyle: const CaretStyle().copyWith(color: isLight ? Colors.black : Colors.redAccent),
+              ),
             ],
+            selectionLayerLinks: _selectionLayerLinks,
+            selectionStyle: isLight
+                ? defaultSelectionStyle
+                : SelectionStyles(
+                    selectionColor: Colors.red.withOpacity(0.3),
+                  ),
+            stylesheet: defaultStylesheet.copyWith(
+              addRulesAfter: [
+                if (!isLight) ..._darkModeStyles,
+                taskStyles,
+              ],
+            ),
+            componentBuilders: [
+              TaskComponentBuilder(_docEditor),
+              ...defaultComponentBuilders,
+            ],
+            gestureMode: _gestureMode,
+            inputSource: _inputSource,
+            keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
+            androidToolbarBuilder: (_) => ListenableBuilder(
+              listenable: _brightness,
+              builder: (context, _) {
+                return Theme(
+                  data: ThemeData(brightness: _brightness.value),
+                  child: AndroidTextEditingFloatingToolbar(
+                    onCutPressed: _cut,
+                    onCopyPressed: _copy,
+                    onPastePressed: _paste,
+                    onSelectAllPressed: _selectAll,
+                  ),
+                );
+              },
+            ),
+            iOSToolbarBuilder: (_) => ListenableBuilder(
+              listenable: _brightness,
+              builder: (context, _) {
+                return Theme(
+                  data: ThemeData(brightness: _brightness.value),
+                  child: IOSTextEditingFloatingToolbar(
+                    onCutPressed: _cut,
+                    onCopyPressed: _copy,
+                    onPastePressed: _paste,
+                    focalPoint: _overlayController.toolbarTopAnchor!,
+                  ),
+                );
+              },
+            ),
+            overlayController: _overlayController,
           ),
-          componentBuilders: [
-            TaskComponentBuilder(_docEditor),
-            ...defaultComponentBuilders,
-          ],
-          gestureMode: _gestureMode,
-          inputSource: _inputSource,
-          keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
-          androidToolbarBuilder: (_) => ListenableBuilder(
-            listenable: _brightness,
-            builder: (context, _) {
-              return Theme(
-                data: ThemeData(brightness: _brightness.value),
-                child: AndroidTextEditingFloatingToolbar(
-                  onCutPressed: _cut,
-                  onCopyPressed: _copy,
-                  onPastePressed: _paste,
-                  onSelectAllPressed: _selectAll,
-                ),
-              );
-            },
-          ),
-          iOSToolbarBuilder: (_) => ListenableBuilder(
-            listenable: _brightness,
-            builder: (context, _) {
-              return Theme(
-                data: ThemeData(brightness: _brightness.value),
-                child: IOSTextEditingFloatingToolbar(
-                  onCutPressed: _cut,
-                  onCopyPressed: _copy,
-                  onPastePressed: _paste,
-                  focalPoint: _overlayController.toolbarTopAnchor!,
-                ),
-              );
-            },
-          ),
-          overlayController: _overlayController,
         ),
       ),
     );

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';
@@ -1339,8 +1340,8 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
       return const SizedBox();
     }
 
-    return CompositedTransformFollower(
-      link: widget.editingController.selectionLinks.caretLink!,
+    return Follower.withOffset(
+      link: widget.editingController.selectionLinks.caretLink,
       showWhenUnlinked: false,
       child: IgnorePointer(
         child: BlinkingCaret(
@@ -1381,7 +1382,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
   Widget _buildCollapsedHandle() {
     return _buildHandle(
       handleKey: _collapsedHandleKey,
-      handleLink: widget.editingController.selectionLinks.caretLink!,
+      handleLink: widget.editingController.selectionLinks.caretLink,
       leaderAnchor: Alignment.bottomCenter,
       followerAnchor: Alignment.topCenter,
       handleOffset: const Offset(-0.5, 5), // Chosen experimentally
@@ -1396,7 +1397,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
       // upstream-bounding (left side of a RTL line of text) handle touch target
       _buildHandle(
         handleKey: _upstreamHandleKey,
-        handleLink: widget.editingController.selectionLinks.upstreamLink!,
+        handleLink: widget.editingController.selectionLinks.upstreamLink,
         leaderAnchor: Alignment.bottomLeft,
         followerAnchor: Alignment.topRight,
         handleOffset: const Offset(0, 2), // Chosen experimentally
@@ -1407,7 +1408,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
       // downstream-bounding (right side of a RTL line of text) handle touch target
       _buildHandle(
         handleKey: _downstreamHandleKey,
-        handleLink: widget.editingController.selectionLinks.downstreamLink!,
+        handleLink: widget.editingController.selectionLinks.downstreamLink,
         leaderAnchor: Alignment.bottomRight,
         followerAnchor: Alignment.topLeft,
         handleOffset: const Offset(-1, 2), // Chosen experimentally
@@ -1420,7 +1421,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
 
   Widget _buildHandle({
     required Key handleKey,
-    required LayerLink handleLink,
+    required LeaderLink handleLink,
     required Alignment leaderAnchor,
     required Alignment followerAnchor,
     Offset? handleOffset,
@@ -1429,10 +1430,10 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
     required Color debugColor,
     required void Function(DragStartDetails) onPanStart,
   }) {
-    return CompositedTransformFollower(
+    return Follower.withOffset(
       key: handleKey,
       link: handleLink,
-      targetAnchor: leaderAnchor,
+      leaderAnchor: leaderAnchor,
       followerAnchor: followerAnchor,
       offset: handleOffset ?? Offset.zero,
       showWhenUnlinked: false,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -337,12 +337,13 @@ class SuperEditorState extends State<SuperEditor> {
 
     _docLayoutKey = widget.documentLayoutKey ?? GlobalKey();
 
+    _selectionLinks = widget.selectionLayerLinks ?? SelectionLayerLinks();
+
     widget.editor.context.put(
       Editor.layoutKey,
       DocumentLayoutEditable(() => _docLayoutKey.currentState as DocumentLayout),
     );
 
-    _createSelectionLayerLinks();
     _createEditContext();
     _createLayoutPresenter();
   }
@@ -360,7 +361,7 @@ class SuperEditorState extends State<SuperEditor> {
     }
 
     if (widget.selectionLayerLinks != oldWidget.selectionLayerLinks) {
-      _createSelectionLayerLinks();
+      _selectionLinks = widget.selectionLayerLinks ?? SelectionLayerLinks();
     }
 
     if (widget.editor != oldWidget.editor) {
@@ -404,15 +405,6 @@ class SuperEditorState extends State<SuperEditor> {
     }
 
     super.dispose();
-  }
-
-  void _createSelectionLayerLinks() {
-    _selectionLinks = widget.selectionLayerLinks ??
-        SelectionLayerLinks(
-          caretLink: LayerLink(),
-          upstreamLink: LayerLink(),
-          downstreamLink: LayerLink(),
-        );
   }
 
   void _createEditContext() {

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';
@@ -364,11 +365,11 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
   }) {
     const ballDiameter = 8.0;
 
-    late LayerLink handleLink;
+    late LeaderLink handleLink;
     late Widget handle;
     switch (handleType) {
       case HandleType.collapsed:
-        handleLink = widget.editingController.selectionLinks.caretLink!;
+        handleLink = widget.editingController.selectionLinks.caretLink;
         handle = ValueListenableBuilder<bool>(
           valueListenable: _isShowingFloatingCursor,
           builder: (context, isShowingFloatingCursor, child) {
@@ -381,7 +382,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
         );
         break;
       case HandleType.upstream:
-        handleLink = widget.editingController.selectionLinks.upstreamLink!;
+        handleLink = widget.editingController.selectionLinks.upstreamLink;
         handle = IOSSelectionHandle.upstream(
           color: widget.handleColor,
           handleType: handleType,
@@ -390,7 +391,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
         );
         break;
       case HandleType.downstream:
-        handleLink = widget.editingController.selectionLinks.downstreamLink!;
+        handleLink = widget.editingController.selectionLinks.downstreamLink;
         handle = IOSSelectionHandle.upstream(
           color: widget.handleColor,
           handleType: handleType,
@@ -411,13 +412,13 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
   Widget _buildHandle({
     required Key handleKey,
     required Widget handle,
-    required LayerLink handleLink,
+    required LeaderLink handleLink,
     required Color debugColor,
   }) {
-    return CompositedTransformFollower(
+    return Follower.withOffset(
       key: handleKey,
       link: handleLink,
-      targetAnchor: Alignment.center,
+      leaderAnchor: Alignment.center,
       followerAnchor: Alignment.center,
       showWhenUnlinked: false,
       child: IgnorePointer(

--- a/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
@@ -131,14 +131,14 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
     return IgnorePointer(
       child: Stack(
         children: [
-          if (_caret != null && widget.links.caretLink != null)
+          if (_caret != null)
             Positioned(
               top: _caret!.top,
               left: _caret!.left,
               width: 1,
               height: _caret!.height,
-              child: CompositedTransformTarget(
-                link: widget.links.caretLink!,
+              child: Leader(
+                link: widget.links.caretLink,
                 child: widget.showDebugLeaderBounds
                     ? DecoratedBox(
                         decoration: BoxDecoration(border: Border.all(width: 4, color: const Color(0xFFFF0000))),
@@ -146,14 +146,14 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_upstream != null && widget.links.upstreamLink != null)
+          if (_upstream != null)
             Positioned(
               top: _upstream!.top,
               left: _upstream!.left,
               width: 1,
               height: _upstream!.height,
-              child: CompositedTransformTarget(
-                link: widget.links.upstreamLink!,
+              child: Leader(
+                link: widget.links.upstreamLink,
                 child: widget.showDebugLeaderBounds
                     ? DecoratedBox(
                         decoration: BoxDecoration(border: Border.all(width: 4, color: const Color(0xFF00FF00))),
@@ -161,14 +161,14 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_downstream != null && widget.links.downstreamLink != null)
+          if (_downstream != null)
             Positioned(
               top: _downstream!.top,
               left: _downstream!.left,
               width: 1,
               height: _downstream!.height,
-              child: CompositedTransformTarget(
-                link: widget.links.downstreamLink!,
+              child: Leader(
+                link: widget.links.downstreamLink,
                 child: widget.showDebugLeaderBounds
                     ? DecoratedBox(
                         decoration: BoxDecoration(border: Border.all(width: 4, color: const Color(0xFF0000FF))),
@@ -198,25 +198,28 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
 /// visual selection locations, such as at the caret position.
 class SelectionLayerLinks {
   SelectionLayerLinks({
-    this.caretLink,
-    this.upstreamLink,
-    this.downstreamLink,
+    LeaderLink? caretLink,
+    LeaderLink? upstreamLink,
+    LeaderLink? downstreamLink,
     LeaderLink? expandedSelectionBoundsLink,
   }) {
+    this.caretLink = caretLink ?? LeaderLink();
+    this.upstreamLink = upstreamLink ?? LeaderLink();
+    this.downstreamLink = downstreamLink ?? LeaderLink();
     this.expandedSelectionBoundsLink = expandedSelectionBoundsLink ?? LeaderLink();
   }
 
   /// [LayerLink] that's connected to a rectangle at the collapsed selection caret
   /// position.
-  final LayerLink? caretLink;
+  late final LeaderLink caretLink;
 
   /// [LayerLink] that's connected to a rectangle at the expanded selection upstream
   /// position.
-  final LayerLink? upstreamLink;
+  late final LeaderLink upstreamLink;
 
   /// [LayerLink] that's connected to a rectangle at the expanded selection downstream
   /// position.
-  final LayerLink? downstreamLink;
+  late final LeaderLink downstreamLink;
 
   /// [LayerLink] that's connected to a rectangle that bounds the entire expanded
   /// selection, from the top of upstream to the bottom of downstream.

--- a/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
@@ -175,11 +176,11 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_expandedSelectionBounds != null && widget.links.expandedSelectionBoundsLink != null)
+          if (_expandedSelectionBounds != null)
             Positioned.fromRect(
               rect: _expandedSelectionBounds!,
-              child: CompositedTransformTarget(
-                link: widget.links.expandedSelectionBoundsLink!,
+              child: Leader(
+                link: widget.links.expandedSelectionBoundsLink,
                 child: widget.showDebugLeaderBounds
                     ? DecoratedBox(
                         decoration: BoxDecoration(border: Border.all(width: 4, color: const Color(0xFFFF00FF))),
@@ -196,12 +197,14 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
 /// A collection of [LayerLink]s that should be positioned near important
 /// visual selection locations, such as at the caret position.
 class SelectionLayerLinks {
-  const SelectionLayerLinks({
+  SelectionLayerLinks({
     this.caretLink,
     this.upstreamLink,
     this.downstreamLink,
-    this.expandedSelectionBoundsLink,
-  });
+    LeaderLink? expandedSelectionBoundsLink,
+  }) {
+    this.expandedSelectionBoundsLink = expandedSelectionBoundsLink ?? LeaderLink();
+  }
 
   /// [LayerLink] that's connected to a rectangle at the collapsed selection caret
   /// position.
@@ -217,5 +220,5 @@ class SelectionLayerLinks {
 
   /// [LayerLink] that's connected to a rectangle that bounds the entire expanded
   /// selection, from the top of upstream to the bottom of downstream.
-  final LayerLink? expandedSelectionBoundsLink;
+  late final LeaderLink expandedSelectionBoundsLink;
 }

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -204,11 +204,7 @@ class SuperReaderState extends State<SuperReader> {
 
   // Layer links that connect leader widgets near the user's selection
   // to carets, handles, and other things that want to follow the selection.
-  final _selectionLinks = SelectionLayerLinks(
-    caretLink: LayerLink(),
-    upstreamLink: LayerLink(),
-    downstreamLink: LayerLink(),
-  );
+  final _selectionLinks = SelectionLayerLinks();
 
   @override
   void initState() {

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -208,7 +208,6 @@ class SuperReaderState extends State<SuperReader> {
     caretLink: LayerLink(),
     upstreamLink: LayerLink(),
     downstreamLink: LayerLink(),
-    expandedSelectionBoundsLink: LayerLink(),
   );
 
   @override

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   attributed_text: ^0.2.2
   characters: ^1.2.0
   collection: ^1.15.0
+  follow_the_leader: ^0.0.4+3
   http: ">=0.13.1 <2.0.0"
   linkify: ^4.0.0
   logging: ^1.0.1


### PR DESCRIPTION
Switched SuperEditor from LayerLinks to LeaderLinks so we can add boundary behaviors (Resolves #669)

Initially, we were computing an (x,y) position for the toolbar on every frame. Then we recently switched to `LayerLink`s to avoid scheduling an extra frame for every selection change. The `LayerLink` followed an invisible widget in a document overlay. But `LayerLink`s can't avoid obstaces, so this PR switches up to use `LeaderLink`s from `follow_the_leader`, which can be configured to avoid screen boundaries.

Original problem:

![Screenshot 2023-08-15 at 11 46 22 AM](https://github.com/superlistapp/super_editor/assets/7259036/590271e8-3846-46ce-92a1-8401f0842fc2)

New behavior:


https://github.com/superlistapp/super_editor/assets/7259036/3f07fe3e-a97b-4025-a97e-83952fe43f0d

