### PR TITLE
Adjusted cherry pick (main hash - 3ca24ada5f6e12e911f1770c25dbcc2cf371772e): Converted AttributedText to use optional position constructor parameters instead of named parameters, for brevity, and also added ability to create an AttributedText directly from a Markdown string (Resolves #488) (#1325)

### DIFF
--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -17,10 +17,11 @@ final _log = attributionsLog;
 // TODO: there is a mixture of mutable and immutable behavior in this class.
 //       Pick one or the other, or offer 2 classes: mutable and immutable (#113)
 class AttributedText {
-  AttributedText({
-    this.text = '',
+  AttributedText([
+    String? text,
     AttributedSpans? spans,
-  }) : spans = spans ?? AttributedSpans();
+  ])  : text = text ?? "",
+        spans = spans ?? AttributedSpans();
 
   void dispose() {
     _listeners.clear();
@@ -215,8 +216,8 @@ class AttributedText {
     _log.fine('offsets, start: $startCopyOffset, end: $endCopyOffset');
 
     return AttributedText(
-      text: text.substring(startOffset, endOffset),
-      spans: spans.copyAttributionRegion(startCopyOffset, endCopyOffset),
+      text.substring(startOffset, endOffset),
+      spans.copyAttributionRegion(startCopyOffset, endCopyOffset),
     );
   }
 
@@ -228,22 +229,22 @@ class AttributedText {
     if (other.text.isEmpty) {
       _log.fine('`other` has no text. Returning a direct copy of ourselves.');
       return AttributedText(
-        text: text,
-        spans: spans.copy(),
+        text,
+        spans.copy(),
       );
     }
     if (text.isEmpty) {
       _log.fine('our `text` is empty. Returning a direct copy of the `other` text.');
       return AttributedText(
-        text: other.text,
-        spans: other.spans.copy(),
+        other.text,
+        other.spans.copy(),
       );
     }
 
     final newSpans = spans.copy()..addAt(other: other.spans, index: text.length);
     return AttributedText(
-      text: text + other.text,
-      spans: newSpans,
+      text + other.text,
+      newSpans,
     );
   }
 
@@ -281,9 +282,7 @@ class AttributedText {
     _log.fine('endText: $endText');
 
     _log.fine('creating new attributed text for insertion');
-    final insertedText = AttributedText(
-      text: textToInsert,
-    );
+    final insertedText = AttributedText(textToInsert);
     final insertTextRange = SpanRange(start: 0, end: textToInsert.length - 1);
     for (dynamic attribution in applyAttributions) {
       insertedText.addAttribution(attribution, insertTextRange);
@@ -317,8 +316,8 @@ class AttributedText {
     _log.fine(contractedAttributions.toString());
 
     return AttributedText(
-      text: reducedText,
-      spans: contractedAttributions,
+      reducedText,
+      contractedAttributions,
     );
   }
 

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -5,8 +5,8 @@ void main() {
   group('Attributed Text', () {
     test('Bug 145 - insert character at beginning of styled text', () {
       final initialText = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
+        'abcdefghij',
+        AttributedSpans(
           attributions: [
             const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
@@ -30,7 +30,7 @@ void main() {
     group('span manipulation', () {
       test('combines overlapping spans when adding from left to right', () {
         // Note: span overlaps at the boundary had a bug that was filed in #582.
-        final text = AttributedText(text: '01234567');
+        final text = AttributedText('01234567');
         text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
         text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
 
@@ -47,7 +47,7 @@ void main() {
       });
 
       test('combines overlapping spans when adding from left to right', () {
-        final text = AttributedText(text: '01234567');
+        final text = AttributedText('01234567');
         text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
         text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
 
@@ -64,7 +64,7 @@ void main() {
       });
 
       test('automatically combines back-to-back spans after addition', () {
-        final text = AttributedText(text: 'ABCD');
+        final text = AttributedText('ABCD');
         text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 0, end: 1));
         text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 2, end: 3));
 
@@ -81,7 +81,7 @@ void main() {
       });
 
       test('keeps back-to-back spans separate when requested', () {
-        final text = AttributedText(text: '#john#sally');
+        final text = AttributedText('#john#sally');
         text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 0, end: 4));
         text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 5, end: 10), autoMerge: false);
 
@@ -112,7 +112,7 @@ void main() {
       });
 
       test('throws exception when compatible attributions overlap but auto-merge is false', () {
-        final text = AttributedText(text: '#john#sally');
+        final text = AttributedText('#john#sally');
         text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 0, end: 4));
 
         expect(
@@ -125,7 +125,7 @@ void main() {
     test('notifies listeners when style changes', () {
       bool listenerCalled = false;
 
-      final text = AttributedText(text: 'abcdefghij');
+      final text = AttributedText('abcdefghij');
       text.addListener(() {
         listenerCalled = true;
       });
@@ -139,8 +139,8 @@ void main() {
       test("equivalent AttributedText are equal", () {
         expect(
           AttributedText(
-            text: 'abcdefghij',
-            spans: AttributedSpans(
+            'abcdefghij',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
@@ -151,8 +151,8 @@ void main() {
           ),
           equals(
             AttributedText(
-              text: 'abcdefghij',
-              spans: AttributedSpans(
+              'abcdefghij',
+              AttributedSpans(
                 attributions: [
                   const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                   const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
@@ -168,8 +168,8 @@ void main() {
       test("different text are not equal", () {
         expect(
           AttributedText(
-                text: 'jihgfedcba',
-                spans: AttributedSpans(
+                'jihgfedcba',
+                AttributedSpans(
                   attributions: [
                     const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                     const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
@@ -179,8 +179,8 @@ void main() {
                 ),
               ) ==
               AttributedText(
-                text: 'abcdefghij',
-                spans: AttributedSpans(
+                'abcdefghij',
+                AttributedSpans(
                   attributions: [
                     const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                     const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
@@ -196,8 +196,8 @@ void main() {
       test("different spans are not equal", () {
         expect(
           AttributedText(
-                text: 'abcdefghij',
-                spans: AttributedSpans(
+                'abcdefghij',
+                AttributedSpans(
                   attributions: [
                     const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                     const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
@@ -207,8 +207,8 @@ void main() {
                 ),
               ) ==
               AttributedText(
-                text: 'abcdefghij',
-                spans: AttributedSpans(
+                'abcdefghij',
+                AttributedSpans(
                   attributions: [
                     const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
                     const SpanMarker(attribution: ExpectedSpans.bold, offset: 5, markerType: SpanMarkerType.end),
@@ -223,8 +223,8 @@ void main() {
     group('attribution queries', () {
       test('finds all bold text around a character', () {
         final attributedText = AttributedText(
-          text: 'Hello world',
-          spans: AttributedSpans(
+          'Hello world',
+          AttributedSpans(
             attributions: [
               SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
               SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
@@ -238,8 +238,8 @@ void main() {
 
       test('finds all bold and italics text around a character', () {
         final attributedText = AttributedText(
-          text: 'Hello world',
-          spans: AttributedSpans(
+          'Hello world',
+          AttributedSpans(
             attributions: [
               SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
               SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
@@ -259,8 +259,8 @@ void main() {
           'finds all bold, italic and strikethrough text within a word that also includes a span with only bold and italics',
           () {
         final attributedText = AttributedText(
-          text: 'Hello world',
-          spans: AttributedSpans(
+          'Hello world',
+          AttributedSpans(
             attributions: [
               SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
               SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.end),

--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -44,24 +44,23 @@ class _TextWithHintDemoState extends State<TextWithHintDemo> {
       nodes: [
         ParagraphNode(
           id: Editor.createNodeId(),
-          text: AttributedText(text: ''),
+          text: AttributedText(),
           metadata: {'blockType': header1Attribution},
         ),
         ParagraphNode(
           id: Editor.createNodeId(),
-          text: AttributedText(text: ''),
+          text: AttributedText(),
           metadata: {'blockType': header2Attribution},
         ),
         ParagraphNode(
           id: Editor.createNodeId(),
-          text: AttributedText(text: ''),
+          text: AttributedText(),
           metadata: {'blockType': header3Attribution},
         ),
         ParagraphNode(
           id: Editor.createNodeId(),
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
       ],
@@ -180,8 +179,8 @@ class HeaderWithHintComponentBuilder implements ComponentBuilder {
           : {},
       // This is the text displayed as a hint.
       hintText: AttributedText(
-        text: 'header goes here...',
-        spans: AttributedSpans(
+        'header goes here...',
+        AttributedSpans(
           attributions: [
             const SpanMarker(attribution: italicsAttribution, offset: 12, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: italicsAttribution, offset: 15, markerType: SpanMarkerType.end),

--- a/super_editor/example/lib/demos/components/demo_unselectable_hr.dart
+++ b/super_editor/example/lib/demos/components/demo_unselectable_hr.dart
@@ -34,16 +34,14 @@ class _UnselectableHrDemoState extends State<UnselectableHrDemo> {
         ParagraphNode(
           id: Editor.createNodeId(),
           text: AttributedText(
-            text:
-                "Below is a horizontal rule (HR). Normally in a SuperEditor, the user can tap to select an HR. In this case, you can't select the HR. You can only select around it. Try and find out:",
+            "Below is a horizontal rule (HR). Normally in a SuperEditor, the user can tap to select an HR. In this case, you can't select the HR. You can only select around it. Try and find out:",
           ),
         ),
         HorizontalRuleNode(id: Editor.createNodeId()),
         ParagraphNode(
           id: Editor.createNodeId(),
           text: AttributedText(
-            text:
-                "Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.",
+            "Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.",
           ),
         ),
       ],

--- a/super_editor/example/lib/demos/debugging/simple_deltas_input.dart
+++ b/super_editor/example/lib/demos/debugging/simple_deltas_input.dart
@@ -14,7 +14,7 @@ class SimpleDeltasInputDemo extends StatefulWidget {
 
 class _SimpleDeltasInputState extends State<SimpleDeltasInputDemo> with TextInputClient, DeltaTextInputClient {
   final _textGlobalKey = GlobalKey(debugLabel: "text_input");
-  AttributedText _text = AttributedText(text: "Hello, world!");
+  AttributedText _text = AttributedText("Hello, world!");
 
   @override
   void initState() {
@@ -149,7 +149,7 @@ class _SimpleDeltasInputState extends State<SimpleDeltasInputDemo> with TextInpu
 
       setState(() {
         _currentTextEditingValue = delta.apply(currentTextEditingValue!);
-        _text = AttributedText(text: _currentTextEditingValue!.text);
+        _text = AttributedText(_currentTextEditingValue!.text);
       });
     }
 

--- a/super_editor/example/lib/demos/demo_animated_task_height.dart
+++ b/super_editor/example/lib/demos/demo_animated_task_height.dart
@@ -32,15 +32,14 @@ class _AnimatedTaskHeightDemoState extends State<AnimatedTaskHeightDemo> {
         ParagraphNode(
           id: Editor.createNodeId(),
           text: AttributedText(
-            text:
-                "Below are several tasks. These tasks will animate the appearance of a subtitle depending on whether they have selection. Try and find out:",
+            "Below are several tasks. These tasks will animate the appearance of a subtitle depending on whether they have selection. Try and find out:",
           ),
         ),
         ...List.generate(
           10,
           (index) => TaskNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: "Task ${index + 1}"),
+            text: AttributedText("Task ${index + 1}"),
             isComplete: false,
           ),
         ),

--- a/super_editor/example/lib/demos/demo_app_shortcuts.dart
+++ b/super_editor/example/lib/demos/demo_app_shortcuts.dart
@@ -22,7 +22,7 @@ class _AppShortcutsDemoState extends State<AppShortcutsDemo> {
       nodes: [
         ParagraphNode(
           id: Editor.createNodeId(),
-          text: AttributedText(text: 'Random paragraph....'),
+          text: AttributedText('Random paragraph....'),
         ),
       ],
     );

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -22,7 +22,7 @@ class _AttributedTextDemoState extends State<AttributedTextDemo> {
 
   void _computeStyledText() {
     AttributedText text = AttributedText(
-      text: 'This is some text styled with AttributedText',
+      'This is some text styled with AttributedText',
     );
 
     for (final range in _boldRanges) {

--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -72,9 +72,7 @@ MutableDocument _createDocument1() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Document #1',
-        ),
+        text: AttributedText('Document #1'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -82,8 +80,7 @@ MutableDocument _createDocument1() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/demo_empty_document.dart
+++ b/super_editor/example/lib/demos/demo_empty_document.dart
@@ -48,7 +48,7 @@ class _EmptyDocumentDemoState extends State<EmptyDocumentDemo> {
 MutableDocument _createDocument1() {
   return MutableDocument(
     nodes: [
-      ParagraphNode(id: "1", text: AttributedText(text: "")),
+      ParagraphNode(id: "1", text: AttributedText()),
     ],
   );
 }

--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -106,9 +106,7 @@ MutableDocument _createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -117,27 +115,22 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is an unordered list item',
-        ),
+        text: AttributedText('This is an unordered list item'),
+      ),
+      ListItemNode.unordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('This is another list item'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is another list item',
-        ),
-      ),
-      ListItemNode.unordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-            text: 'This is a 3rd list item, with a link',
-            spans: AttributedSpans(
+            'This is a 3rd list item, with a link',
+            AttributedSpans(
               attributions: [
                 SpanMarker(
                     attribution: LinkAttribution(url: Uri.https('example.org', '')),
@@ -153,39 +146,31 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'First thing to do',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
         ),
       ),
       ListItemNode.ordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Second thing to do',
-        ),
+        text: AttributedText('First thing to do'),
       ),
       ListItemNode.ordered(
         id: Editor.createNodeId(),
+        text: AttributedText('Second thing to do'),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('Third thing to do'),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'Third thing to do',
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/demo_paragraphs.dart
+++ b/super_editor/example/lib/demos/demo_paragraphs.dart
@@ -44,33 +44,25 @@ MutableDocument _createInitialDocument() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Various paragraph formations',
-        ),
+        text: AttributedText('Various paragraph formations'),
         metadata: {
           'blockType': header1Attribution,
         },
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is left aligned',
-        ),
+        text: AttributedText('This is a short\nparagraph of text\nthat is left aligned'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is center aligned',
-        ),
+        text: AttributedText('This is a short\nparagraph of text\nthat is center aligned'),
         metadata: {
           'textAlign': 'center',
         },
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is right aligned',
-        ),
+        text: AttributedText('This is a short\nparagraph of text\nthat is right aligned'),
         metadata: {
           'textAlign': 'right',
         },
@@ -78,8 +70,7 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/demo_rtl.dart
+++ b/super_editor/example/lib/demos/demo_rtl.dart
@@ -47,9 +47,7 @@ MutableDocument _createInitialDocument() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -57,15 +55,12 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'مثال',
-        ),
+        text: AttributedText('مثال'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -74,26 +69,20 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.'),
-      ),
-      ListItemNode.unordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'فقرة رقم ١ في القائمة.',
+          'لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.',
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'فقرة رقم ٢ في القائمة.',
-        ),
+        text: AttributedText('فقرة رقم ١ في القائمة.'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'فقرة رقم ٣ في القائمة.',
-        ),
+        text: AttributedText('فقرة رقم ٢ في القائمة.'),
+      ),
+      ListItemNode.unordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('فقرة رقم ٣ في القائمة.'),
       ),
     ],
   );

--- a/super_editor/example/lib/demos/demo_switch_document_content.dart
+++ b/super_editor/example/lib/demos/demo_switch_document_content.dart
@@ -96,9 +96,7 @@ MutableDocument _createDocument1() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Document #1',
-        ),
+        text: AttributedText('Document #1'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -106,8 +104,7 @@ MutableDocument _createDocument1() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
     ],
@@ -119,9 +116,7 @@ MutableDocument _createDocument2() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Document #2',
-        ),
+        text: AttributedText('Document #2'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -129,8 +124,8 @@ MutableDocument _createDocument2() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+        ),
       ),
     ],
   );

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
@@ -218,9 +218,7 @@ MutableDocument _createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -229,73 +227,56 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is a blockquote!',
-        ),
+        text: AttributedText('This is a blockquote!'),
         metadata: {
           'blockType': blockquoteAttribution,
         },
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is an unordered list item',
-        ),
+        text: AttributedText('This is an unordered list item'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is another list item',
-        ),
+        text: AttributedText('This is another list item'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
+        text: AttributedText('This is a 3rd list item'),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is a 3rd list item',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+        ),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('First thing to do'),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('Second thing to do'),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('Third thing to do'),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'First thing to do',
-        ),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Second thing to do',
-        ),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Third thing to do',
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -183,9 +183,7 @@ MutableDocument _createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -194,73 +192,56 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is a blockquote!',
-        ),
+        text: AttributedText('This is a blockquote!'),
         metadata: {
           'blockType': blockquoteAttribution,
         },
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is an unordered list item',
-        ),
+        text: AttributedText('This is an unordered list item'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'This is another list item',
-        ),
+        text: AttributedText('This is another list item'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
+        text: AttributedText('This is a 3rd list item'),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is a 3rd list item',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+        ),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('First thing to do'),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('Second thing to do'),
+      ),
+      ListItemNode.ordered(
+        id: Editor.createNodeId(),
+        text: AttributedText('Third thing to do'),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'First thing to do',
-        ),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Second thing to do',
-        ),
-      ),
-      ListItemNode.ordered(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Third thing to do',
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -14,9 +14,7 @@ MutableDocument createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Welcome to Super Editor 💙 🚀',
-        ),
+        text: AttributedText('Welcome to Super Editor 💙 🚀'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -24,15 +22,12 @@ MutableDocument createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
+          "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Ready-made solutions 📦',
-        ),
+        text: AttributedText('Ready-made solutions 📦'),
         metadata: {
           'blockType': header2Attribution,
         },
@@ -40,62 +35,56 @@ MutableDocument createInitialDocument() {
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'SuperEditor is a ready-made, configurable document editing experience.',
+          'SuperEditor is a ready-made, configurable document editing experience.',
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'SuperTextField is a ready-made, configurable text field.',
+          'SuperTextField is a ready-made, configurable text field.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Quickstart 🚀',
-        ),
+        text: AttributedText('Quickstart 🚀'),
         metadata: {
           'blockType': header2Attribution,
         },
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'To get started with your own editing experience, take the following steps:'),
+        text: AttributedText('To get started with your own editing experience, take the following steps:'),
       ),
       TaskNode(
         id: Editor.createNodeId(),
         isComplete: false,
         text: AttributedText(
-          text: 'Create and configure your document, for example, by creating a new MutableDocument.',
+          'Create and configure your document, for example, by creating a new MutableDocument.',
         ),
       ),
       TaskNode(
         id: Editor.createNodeId(),
         isComplete: false,
         text: AttributedText(
-          text: "If you want programmatic control over the user's selection and styles, create a DocumentComposer.",
+          "If you want programmatic control over the user's selection and styles, create a DocumentComposer.",
         ),
       ),
       TaskNode(
         id: Editor.createNodeId(),
         isComplete: false,
         text: AttributedText(
-          text:
-              "Build a SuperEditor widget in your widget tree, configured with your Document and (optionally) your DocumentComposer.",
+          "Build a SuperEditor widget in your widget tree, configured with your Document and (optionally) your DocumentComposer.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "Now, you're off to the races! SuperEditor renders your document, and lets you select, insert, and delete content.",
+          "Now, you're off to the races! SuperEditor renders your document, and lets you select, insert, and delete content.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Explore the toolkit 🔎',
-        ),
+        text: AttributedText('Explore the toolkit 🔎'),
         metadata: {
           'blockType': header2Attribution,
         },
@@ -103,38 +92,37 @@ MutableDocument createInitialDocument() {
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "Use MutableDocument as an in-memory representation of a document.",
+          "Use MutableDocument as an in-memory representation of a document.",
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "Implement your own document data store by implementing the Document api.",
+          "Implement your own document data store by implementing the Document api.",
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "Implement your down DocumentLayout to position and size document components however you'd like.",
+          "Implement your down DocumentLayout to position and size document components however you'd like.",
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "Use SuperSelectableText to paint text with selection boxes and a caret.",
+          "Use SuperSelectableText to paint text with selection boxes and a caret.",
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'Use AttributedText to quickly and easily apply metadata spans to a string.',
+          'Use AttributedText to quickly and easily apply metadata spans to a string.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "We hope you enjoy using Super Editor. Let us know what you're building, and please file issues for any bugs that you find.",
+          "We hope you enjoy using Super Editor. Let us know what you're building, and please file issues for any bugs that you find.",
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -77,7 +77,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
 
     _urlFocusNode = FocusNode();
     _urlController = SingleLineAttributedTextEditingController(_applyLink) //
-      ..text = AttributedText(text: "https://");
+      ..text = AttributedText("https://");
   }
 
   @override

--- a/super_editor/example/lib/demos/experiments/demo_panel_behind_keyboard.dart
+++ b/super_editor/example/lib/demos/experiments/demo_panel_behind_keyboard.dart
@@ -56,67 +56,67 @@ class _PanelBehindKeyboardDemoState extends State<PanelBehindKeyboardDemo> {
     return MutableDocument(nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: "Example Doc"),
+        text: AttributedText("Example Doc"),
         metadata: {"blockType": header1Attribution},
       ),
       HorizontalRuleNode(id: Editor.createNodeId()),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: "Unordered list:"),
+        text: AttributedText("Unordered list:"),
       ),
       ListItemNode(
         id: Editor.createNodeId(),
         itemType: ListItemType.unordered,
-        text: AttributedText(text: "Unordered 1"),
+        text: AttributedText("Unordered 1"),
       ),
       ListItemNode(
         id: Editor.createNodeId(),
         itemType: ListItemType.unordered,
-        text: AttributedText(text: "Unordered 2"),
+        text: AttributedText("Unordered 2"),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: "Ordered list:"),
+        text: AttributedText("Ordered list:"),
       ),
       ListItemNode(
         id: Editor.createNodeId(),
         itemType: ListItemType.unordered,
-        text: AttributedText(text: "Ordered 1"),
+        text: AttributedText("Ordered 1"),
       ),
       ListItemNode(
         id: Editor.createNodeId(),
         itemType: ListItemType.unordered,
-        text: AttributedText(text: "Ordered 2"),
+        text: AttributedText("Ordered 2"),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'A blockquote:'),
+        text: AttributedText('A blockquote:'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'This is a blockquote.'),
+        text: AttributedText('This is a blockquote.'),
         metadata: {"blockType": blockquoteAttribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Some code:'),
+        text: AttributedText('Some code:'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: '{\n  // This is come code.\n}'),
+        text: AttributedText('{\n  // This is come code.\n}'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: "Header"),
+        text: AttributedText("Header"),
         metadata: {"blockType": header2Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'More stuff 1'),
+        text: AttributedText('More stuff 1'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'More stuff 2'),
+        text: AttributedText('More stuff 2'),
       ),
     ]);
   }

--- a/super_editor/example/lib/demos/features/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/features/feature_action_tags.dart
@@ -25,7 +25,12 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: ""))]);
+    _document = MutableDocument(nodes: [
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(""),
+      ),
+    ]);
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/demos/features/feature_pattern_tags.dart
+++ b/super_editor/example/lib/demos/features/feature_pattern_tags.dart
@@ -22,7 +22,12 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: ""))]);
+    _document = MutableDocument(nodes: [
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(""),
+      ),
+    ]);
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/demos/features/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/features/feature_stable_tags.dart
@@ -25,7 +25,12 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: ""))]);
+    _document = MutableDocument(nodes: [
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(""),
+      ),
+    ]);
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
+++ b/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
@@ -41,8 +41,8 @@ class _TaskAndChatWithCustomScrollViewDemoState extends State<TaskAndChatWithCus
         ParagraphNode(
           id: '1234',
           text: AttributedText(
-              text:
-                  'Notice that when this document is short enough, the messages are pushed to the bottom of the viewport.\n\nTry adding more content to see things scroll.'),
+            'Notice that when this document is short enough, the messages are pushed to the bottom of the viewport.\n\nTry adding more content to see things scroll.',
+          ),
         )
       ],
     );

--- a/super_editor/example/lib/demos/sliver_example_editor.dart
+++ b/super_editor/example/lib/demos/sliver_example_editor.dart
@@ -148,9 +148,7 @@ MutableDocument _createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -159,28 +157,25 @@ MutableDocument _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/styles/demo_doc_styles.dart
+++ b/super_editor/example/lib/demos/styles/demo_doc_styles.dart
@@ -149,41 +149,41 @@ MutableDocument _createSampleDocument() {
     nodes: [
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 1'),
+        text: AttributedText('Header 1'),
         metadata: {'blockType': header1Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 2'),
+        text: AttributedText('Header 2'),
         metadata: {'blockType': header2Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 3'),
+        text: AttributedText('Header 3'),
         metadata: {'blockType': header3Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 4'),
+        text: AttributedText('Header 4'),
         metadata: {'blockType': header4Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 5'),
+        text: AttributedText('Header 5'),
         metadata: {'blockType': header5Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'Header 6'),
+        text: AttributedText('Header 6'),
         metadata: {'blockType': header6Attribution},
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'This is a paragraph of regular text'),
+        text: AttributedText('This is a paragraph of regular text'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'This is a blockquote'),
+        text: AttributedText('This is a blockquote'),
         metadata: {'blockType': blockquoteAttribution},
       ),
     ],

--- a/super_editor/example/lib/demos/super_document/demo_read_only_scrolling_document.dart
+++ b/super_editor/example/lib/demos/super_document/demo_read_only_scrolling_document.dart
@@ -104,9 +104,7 @@ Document _createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Example Document',
-        ),
+        text: AttributedText('Example Document'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -115,28 +113,25 @@ Document _createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/super_document/example_document.dart
+++ b/super_editor/example/lib/demos/super_document/example_document.dart
@@ -14,9 +14,7 @@ Document createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Welcome to Super Editor 💙 🚀',
-        ),
+        text: AttributedText('Welcome to Super Editor 💙 🚀'),
         metadata: {
           'blockType': header1Attribution,
         },
@@ -24,102 +22,81 @@ Document createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
+          "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Ready-made solutions 📦',
-        ),
+        text: AttributedText('Ready-made solutions 📦'),
         metadata: {
           'blockType': header2Attribution,
         },
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'SuperEditor is a ready-made, configurable document editing experience.',
-        ),
+        text: AttributedText('SuperEditor is a ready-made, configurable document editing experience.'),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'SuperTextField is a ready-made, configurable text field.',
-        ),
+        text: AttributedText('SuperTextField is a ready-made, configurable text field.'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Quickstart 🚀',
-        ),
+        text: AttributedText('Quickstart 🚀'),
         metadata: {
           'blockType': header2Attribution,
         },
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(text: 'To get started with your own editing experience, take the following steps:'),
+        text: AttributedText('To get started with your own editing experience, take the following steps:'),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "Now, you're off to the races! SuperEditor renders your document, and lets you select, insert, and delete content.",
+          "Now, you're off to the races! SuperEditor renders your document, and lets you select, insert, and delete content.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: 'Explore the toolkit 🔎',
-        ),
+        text: AttributedText('Explore the toolkit 🔎'),
         metadata: {
           'blockType': header2Attribution,
         },
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: "Use MutableDocument as an in-memory representation of a document.",
-        ),
+        text: AttributedText("Use MutableDocument as an in-memory representation of a document."),
+      ),
+      ListItemNode.unordered(
+        id: Editor.createNodeId(),
+        text: AttributedText("Implement your own document data store by implementing the Document api."),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "Implement your own document data store by implementing the Document api.",
+          "Implement your down DocumentLayout to position and size document components however you'd like.",
         ),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: "Implement your down DocumentLayout to position and size document components however you'd like.",
-        ),
+        text: AttributedText("Use SuperSelectableText to paint text with selection boxes and a caret."),
       ),
       ListItemNode.unordered(
         id: Editor.createNodeId(),
-        text: AttributedText(
-          text: "Use SuperSelectableText to paint text with selection boxes and a caret.",
-        ),
+        text: AttributedText('Use AttributedText to quickly and easily apply metadata spans to a string.'),
       ),
-      ListItemNode.unordered(
+      ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'Use AttributedText to quickly and easily apply metadata spans to a string.',
+          "We hope you enjoy using Super Editor. Let us know what you're building, and please file issues for any bugs that you find.",
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              "We hope you enjoy using Super Editor. Let us know what you're building, and please file issues for any bugs that you find.",
-        ),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text: "Built by the Flutter Bounty Hunters",
-          spans: AttributedSpans(attributions: [
+          "Built by the Flutter Bounty Hunters",
+          AttributedSpans(attributions: [
             SpanMarker(
                 attribution: LinkAttribution(url: Uri.parse("https://flutterbountyhunters.com")),
                 offset: 13,
@@ -134,7 +111,7 @@ Document createInitialDocument() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: "",
+          "",
         ),
       ),
     ],

--- a/super_editor/example/lib/demos/supertextfield/_emojis_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_emojis_demo.dart
@@ -50,9 +50,7 @@ class _EmojisTextFieldDemoState extends State<EmojisTextFieldDemo> with TickerPr
   void _startDemo() {
     _textFieldController
       ..selection = const TextSelection.collapsed(offset: 0)
-      ..text = AttributedText(
-        text: 'turtle 🐢 bomb 💣 skull ☠',
-      );
+      ..text = AttributedText('turtle 🐢 bomb 💣 skull ☠');
 
     if (widget.direction == TextAffinity.upstream) {
       // simulate pressing backspace

--- a/super_editor/example/lib/demos/supertextfield/_expanding_multi_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_expanding_multi_line_demo.dart
@@ -12,16 +12,7 @@ class ExpandingMultiLineTextFieldDemo extends StatefulWidget {
 class _ExpandingMultiLineTextFieldDemoState extends State<ExpandingMultiLineTextFieldDemo>
     with TickerProviderStateMixin {
   final _textFieldController = AttributedTextEditingController(
-    text: AttributedText(
-        // text:
-        //     'Super Editor is an open source text editor for Flutter projects.\n\nThis is paragraph 2\n\nThis is paragraph 3',
-        // spans: AttributedSpans(
-        //   attributions: [
-        //     SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-        //     SpanMarker(attribution: 'bold', offset: 11, markerType: SpanMarkerType.end),
-        //   ],
-        // ),
-        ),
+    text: AttributedText(),
   );
 
   GlobalKey<SuperDesktopTextFieldState>? _textKey;
@@ -57,11 +48,11 @@ class _ExpandingMultiLineTextFieldDemoState extends State<ExpandingMultiLineText
       ..selection = const TextSelection.collapsed(offset: 0)
       ..text = AttributedText();
     _demoRobot
-      ..typeText(AttributedText(text: 'Hello World!'))
+      ..typeText(AttributedText('Hello World!'))
       ..pause(const Duration(milliseconds: 500))
-      ..typeText(AttributedText(text: '\n\nThis is a robot typing'))
+      ..typeText(AttributedText('\n\nThis is a robot typing'))
       ..pause(const Duration(milliseconds: 500))
-      ..typeText(AttributedText(text: '\nsome text into a SuperTextField.'))
+      ..typeText(AttributedText('\nsome text into a SuperTextField.'))
       ..start();
   }
 

--- a/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
@@ -14,13 +14,16 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
 
   final _textFieldController = AttributedTextEditingController(
     text: AttributedText(
-        text: 'Super Editor is an open source text editor for Flutter projects.',
-        spans: AttributedSpans(attributions: [
+      'Super Editor is an open source text editor for Flutter projects.',
+      AttributedSpans(
+        attributions: [
           const SpanMarker(attribution: brandAttribution, offset: 0, markerType: SpanMarkerType.start),
           const SpanMarker(attribution: brandAttribution, offset: 11, markerType: SpanMarkerType.end),
           const SpanMarker(attribution: flutterAttribution, offset: 47, markerType: SpanMarkerType.start),
           const SpanMarker(attribution: flutterAttribution, offset: 53, markerType: SpanMarkerType.end),
-        ])),
+        ],
+      ),
+    ),
   );
 
   OverlayEntry? _popupEntry;

--- a/super_editor/example/lib/demos/supertextfield/_single_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_single_line_demo.dart
@@ -11,16 +11,7 @@ class SingleLineTextFieldDemo extends StatefulWidget {
 
 class _SingleLineTextFieldDemoState extends State<SingleLineTextFieldDemo> with TickerProviderStateMixin {
   final _textFieldController = AttributedTextEditingController(
-    text: AttributedText(
-        // text:
-        //     'Super Editor is an open source text editor for Flutter projects.\n\nThis is paragraph 2\n\nThis is paragraph 3',
-        // spans: AttributedSpans(
-        //   attributions: [
-        //     SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-        //     SpanMarker(attribution: 'bold', offset: 11, markerType: SpanMarkerType.end),
-        //   ],
-        // ),
-        ),
+    text: AttributedText(),
   );
 
   GlobalKey<SuperDesktopTextFieldState>? _textKey;
@@ -56,7 +47,7 @@ class _SingleLineTextFieldDemoState extends State<SingleLineTextFieldDemo> with 
       ..selection = const TextSelection.collapsed(offset: 0)
       ..text = AttributedText();
     _demoRobot
-      ..typeText(AttributedText(text: 'Hello World! This is a robot typing some text into a SuperTextField.'))
+      ..typeText(AttributedText('Hello World! This is a robot typing some text into a SuperTextField.'))
       ..start();
   }
 

--- a/super_editor/example/lib/demos/supertextfield/_static_multi_line_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_static_multi_line_demo.dart
@@ -11,16 +11,7 @@ class StaticMultiLineTextFieldDemo extends StatefulWidget {
 
 class _StaticMultiLineTextFieldDemoState extends State<StaticMultiLineTextFieldDemo> with TickerProviderStateMixin {
   final _textFieldController = AttributedTextEditingController(
-    text: AttributedText(
-        // text:
-        //     'Super Editor is an open source text editor for Flutter projects.\n\nThis is paragraph 2\n\nThis is paragraph 3',
-        // spans: AttributedSpans(
-        //   attributions: [
-        //     SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-        //     SpanMarker(attribution: 'bold', offset: 11, markerType: SpanMarkerType.end),
-        //   ],
-        // ),
-        ),
+    text: AttributedText(),
   );
 
   GlobalKey<SuperDesktopTextFieldState>? _textKey;
@@ -56,11 +47,11 @@ class _StaticMultiLineTextFieldDemoState extends State<StaticMultiLineTextFieldD
       ..selection = const TextSelection.collapsed(offset: 0)
       ..text = AttributedText();
     _demoRobot
-      ..typeText(AttributedText(text: 'Hello World!'))
+      ..typeText(AttributedText('Hello World!'))
       ..pause(const Duration(milliseconds: 500))
-      ..typeText(AttributedText(text: '\n\nThis is a robot typing'))
+      ..typeText(AttributedText('\n\nThis is a robot typing'))
       ..pause(const Duration(milliseconds: 500))
-      ..typeText(AttributedText(text: '\nsome text into a SuperTextField.'))
+      ..typeText(AttributedText('\nsome text into a SuperTextField.'))
       ..start();
   }
 

--- a/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
@@ -35,8 +35,8 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
   Widget build(BuildContext context) {
     return MobileSuperTextFieldDemo(
       initialText: AttributedText(
-          text:
-              'This is a custom textfield implementation called SuperAndroidTextField. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.'),
+        'This is a custom textfield implementation called SuperAndroidTextField. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.',
+      ),
       textFieldFocusNode: _focusNode,
       textFieldTapRegionGroupId: _tapRegionGroupId,
       createTextField: _buildTextField,
@@ -54,7 +54,7 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
       textStyleBuilder: config.styleBuilder,
       hintBehavior: HintBehavior.displayHintUntilTextEntered,
       hintBuilder: StyledHintBuilder(
-          hintText: AttributedText(text: "Enter text"),
+          hintText: AttributedText("Enter text"),
           hintTextStyleBuilder: (attributions) {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           }).build,

--- a/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
@@ -36,8 +36,8 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
   Widget build(BuildContext context) {
     return MobileSuperTextFieldDemo(
       initialText: AttributedText(
-          text:
-              'This is a custom textfield implementation called SuperIOSTextfield. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.'),
+        'This is a custom textfield implementation called SuperIOSTextfield. It is super long so that we can mess with scrolling. This drags it out even further so that we can get multiline scrolling, too. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin tempor sapien est, in eleifend purus rhoncus fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla varius libero lorem, eget tincidunt ante porta accumsan. Morbi quis ante at nunc molestie ullamcorper.',
+      ),
       textFieldFocusNode: _focusNode,
       textFieldTapRegionGroupId: _tapRegionGroupId,
       createTextField: _buildTextField,
@@ -55,7 +55,7 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
       textStyleBuilder: config.styleBuilder,
       hintBehavior: HintBehavior.displayHintUntilTextEntered,
       hintBuilder: StyledHintBuilder(
-          hintText: AttributedText(text: "Enter text"),
+          hintText: AttributedText("Enter text"),
           hintTextStyleBuilder: (attributions) {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           }).build,

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -31,7 +31,7 @@ class _MarketingVideoState extends State<MarketingVideo> {
       nodes: [
         ParagraphNode(
           id: Editor.createNodeId(),
-          text: AttributedText(text: ''),
+          text: AttributedText(),
         ),
       ],
     );

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -321,7 +321,8 @@ class SplitBlockquoteCommand implements EditCommand {
     final blockquote = node as ParagraphNode;
     final text = blockquote.text;
     final startText = text.copyText(0, splitPosition.offset);
-    final endText = splitPosition.offset < text.text.length ? text.copyText(splitPosition.offset) : AttributedText();
+    final endText =
+        splitPosition.offset < text.text.length ? text.copyText(splitPosition.offset) : AttributedText();
 
     // Change the current node's content to just the text before the caret.
     // TODO: figure out how node changes should work in terms of

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1629,7 +1629,7 @@ class CommonEditorOperations {
             existingNodeId: extentNode.id,
             newNode: ParagraphNode(
               id: newNodeId,
-              text: AttributedText(text: ''),
+              text: AttributedText(),
             ),
           ),
           // Place the caret at the beginning of the new node.
@@ -1653,7 +1653,7 @@ class CommonEditorOperations {
             existingNodeId: extentNode.id,
             newNode: ParagraphNode(
               id: newNodeId,
-              text: AttributedText(text: ''),
+              text: AttributedText(),
             ),
           ),
           // Place the caret at the beginning of the new node.
@@ -2237,8 +2237,8 @@ class PasteEditorCommand implements EditCommand {
     for (final line in lines) {
       attributedLines.add(
         AttributedText(
-          text: line,
-          spans: _findUrlSpansInText(pastedText: lines.first),
+          line,
+          _findUrlSpansInText(pastedText: lines.first),
         ),
       );
     }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -138,7 +138,7 @@ class UnorderedListItemConversionReaction extends ParagraphPrefixConversionReact
         existingNodeId: paragraph.id,
         newNode: ListItemNode.unordered(
           id: paragraph.id,
-          text: AttributedText(text: ""),
+          text: AttributedText(),
         ),
       ),
       ChangeSelectionRequest(
@@ -180,7 +180,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
         existingNodeId: paragraph.id,
         newNode: ListItemNode.ordered(
           id: paragraph.id,
-          text: AttributedText(text: ""),
+          text: AttributedText(),
         ),
       ),
       ChangeSelectionRequest(
@@ -222,7 +222,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
         existingNodeId: paragraph.id,
         newNode: ParagraphNode(
           id: paragraph.id,
-          text: AttributedText(text: ""),
+          text: AttributedText(),
           metadata: {
             "blockType": blockquoteAttribution,
           },
@@ -274,7 +274,7 @@ class HorizontalRuleConversionReaction extends ParagraphPrefixConversionReaction
         existingNodeId: paragraph.id,
         newNode: ParagraphNode(
           id: paragraph.id,
-          text: AttributedText(text: ""),
+          text: AttributedText(),
         ),
       ),
       ChangeSelectionRequest(

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -479,7 +479,7 @@ class TextDeltasDocumentEditor {
             existingNodeId: extentNode.id,
             newNode: ParagraphNode(
               id: newNodeId,
-              text: AttributedText(text: ''),
+              text: AttributedText(),
             ),
           ),
           ChangeSelectionRequest(
@@ -502,7 +502,7 @@ class TextDeltasDocumentEditor {
             existingNodeId: extentNode.id,
             newNode: ParagraphNode(
               id: newNodeId,
-              text: AttributedText(text: ''),
+              text: AttributedText(),
             ),
           ),
         ]);

--- a/super_editor/lib/src/default_editor/document_ime/mobile_toolbar.dart
+++ b/super_editor/lib/src/default_editor/document_ime/mobile_toolbar.dart
@@ -310,7 +310,7 @@ class KeyboardEditingToolbarOperations {
         existingNodeId: selectedNode.id,
         newNode: ParagraphNode(
           id: selectedNode.id,
-          text: AttributedText(text: '---'),
+          text: AttributedText('---'),
         ),
       ),
       ChangeSelectionRequest(

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -665,7 +665,8 @@ class SplitListItemCommand implements EditCommand {
     final listItemNode = node as ListItemNode;
     final text = listItemNode.text;
     final startText = text.copyText(0, splitPosition.offset);
-    final endText = splitPosition.offset < text.text.length ? text.copyText(splitPosition.offset) : AttributedText();
+    final endText =
+        splitPosition.offset < text.text.length ? text.copyText(splitPosition.offset) : AttributedText();
     _log.log('SplitListItemCommand', 'Splitting list item:');
     _log.log('SplitListItemCommand', ' - start text: "$startText"');
     _log.log('SplitListItemCommand', ' - end text: "$endText"');

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -920,8 +920,8 @@ class AddTextAttributionsCommand implements EditCommand {
         // Create a new AttributedText with updated attribution spans, so that the presentation system can
         // see that we made a change, and re-renders the text in the document.
         node.text = AttributedText(
-          text: node.text.text,
-          spans: node.text.spans.copy()
+          node.text.text,
+          node.text.spans.copy()
             ..addAttribution(
               newAttribution: attribution,
               start: range.start,
@@ -1033,8 +1033,8 @@ class RemoveTextAttributionsCommand implements EditCommand {
         // Create a new AttributedText with updated attribution spans, so that the presentation system can
         // see that we made a change, and re-renders the text in the document.
         node.text = AttributedText(
-          text: node.text.text,
-          spans: node.text.spans.copy()
+          node.text.text,
+          node.text.spans.copy()
             ..removeAttribution(
               attributionToRemove: attribution,
               start: range.start,
@@ -1160,8 +1160,8 @@ class ToggleTextAttributionsCommand implements EditCommand {
         // Create a new AttributedText with updated attribution spans, so that the presentation system can
         // see that we made a change, and re-renders the text in the document.
         node.text = AttributedText(
-          text: node.text.text,
-          spans: node.text.spans.copy()
+          node.text.text,
+          node.text.spans.copy()
             ..toggleAttribution(
               attribution: attribution,
               start: range.start,
@@ -1227,7 +1227,7 @@ class InsertTextCommand implements EditCommand {
         TextInsertionEvent(
           nodeId: textNode.id,
           offset: textOffset,
-          text: AttributedText(text: textToInsert),
+          text: AttributedText(textToInsert),
         ),
       ),
     ]);
@@ -1693,7 +1693,7 @@ void _insertBlockLevelNewline({
           existingNodeId: extentNode.id,
           newNode: ParagraphNode(
             id: newNodeId,
-            text: AttributedText(text: ''),
+            text: AttributedText(''),
           ),
         ),
       );
@@ -1705,7 +1705,7 @@ void _insertBlockLevelNewline({
           existingNodeId: extentNode.id,
           newNode: ParagraphNode(
             id: newNodeId,
-            text: AttributedText(text: ''),
+            text: AttributedText(''),
           ),
         ),
       );

--- a/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
@@ -242,8 +242,8 @@ class FillInComposingUserTagCommand implements EditCommand {
       InsertAttributedTextCommand(
         documentPosition: tagBasePosition,
         textToInsert: AttributedText(
-          text: "${_tagRule.trigger}$_tag ",
-          spans: AttributedSpans(
+          "${_tagRule.trigger}$_tag ",
+          AttributedSpans(
             attributions: [
               SpanMarker(attribution: stableTagAttribution, offset: 0, markerType: SpanMarkerType.start),
               SpanMarker(attribution: stableTagAttribution, offset: _tag.length, markerType: SpanMarkerType.end),

--- a/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -270,7 +270,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
     if (_latestTextEditingValueSentToPlatform != currentTextEditingValue) {
       _sendTextChangesToPlatform = false;
-      text = AttributedText(text: value.text);
+      text = AttributedText(value.text);
       selection = value.selection;
       composingRegion = value.composing;
       _sendTextChangesToPlatform = true;
@@ -309,7 +309,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
           // and then push/expand the current selection as needed around the new content.
           insert(
             newText: AttributedText(
-              text: delta.textInserted,
+              delta.textInserted,
             ),
             insertIndex: delta.insertionOffset,
             newSelection: delta.selection,
@@ -327,7 +327,7 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       } else if (delta is TextEditingDeltaReplacement) {
         _log.fine('Processing replacement: $delta');
         replace(
-          newText: AttributedText(text: delta.replacementText),
+          newText: AttributedText(delta.replacementText),
           from: delta.replacedRange.start,
           to: delta.replacedRange.end,
           newSelection: delta.selection,

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -542,7 +542,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   Widget _buildSelectableText() {
     final textSpan = _textEditingController.text.text.isNotEmpty
         ? _textEditingController.text.computeTextSpan(widget.textStyleBuilder)
-        : AttributedText(text: "").computeTextSpan(widget.textStyleBuilder);
+        : AttributedText().computeTextSpan(widget.textStyleBuilder);
 
     CaretStyle caretStyle = widget.caretStyle;
 

--- a/super_editor/test/super_editor/bug_fix_test.dart
+++ b/super_editor/test/super_editor/bug_fix_test.dart
@@ -10,7 +10,7 @@ void main() {
       testWidgets("bug repro", (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "")),
+            ParagraphNode(id: "1", text: AttributedText()),
           ],
         );
         final composer = MutableDocumentComposer(
@@ -86,7 +86,7 @@ void main() {
       testWidgets("related to bug", (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "")),
+            ParagraphNode(id: "1", text: AttributedText()),
           ],
         );
         final composer = MutableDocumentComposer(

--- a/super_editor/test/super_editor/components/block_node_test.dart
+++ b/super_editor/test/super_editor/components/block_node_test.dart
@@ -604,7 +604,7 @@ void main() {
       testWidgets("deletes empty paragraph in node above when backspace pressed from upstream edge", (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "")),
+            ParagraphNode(id: "1", text: AttributedText()),
             HorizontalRuleNode(id: "2"),
           ],
         );

--- a/super_editor/test/super_editor/components/blockquote_test.dart
+++ b/super_editor/test/super_editor/components/blockquote_test.dart
@@ -27,7 +27,7 @@ MutableDocument _singleBlockquoteDoc() => MutableDocument(
       nodes: [
         ParagraphNode(
           id: '1',
-          text: AttributedText(text: "This is a blockquote."),
+          text: AttributedText("This is a blockquote."),
           metadata: {'blockType': blockquoteAttribution},
         )
       ],

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -15,7 +15,7 @@ void main() {
     testWidgetsOnAllPlatforms("toggles on tap", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -59,7 +59,7 @@ void main() {
     testWidgetsOnAllPlatforms("can be created from empty paragraph", (tester) async {
       final document = MutableDocument(
         nodes: [
-          ParagraphNode(id: "1", text: AttributedText(text: "This will be a task")),
+          ParagraphNode(id: "1", text: AttributedText("This will be a task")),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -93,7 +93,7 @@ void main() {
     testWidgetsOnAllPlatforms("inserts new task on ENTER at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -141,7 +141,7 @@ void main() {
     testWidgetsOnAndroid("inserts new task upon new line insertion at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -189,7 +189,7 @@ void main() {
     testWidgetsOnMobile("inserts new task upon new line input action at end of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -237,7 +237,7 @@ void main() {
     testWidgetsOnAllPlatforms("splits task into two on ENTER in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -283,7 +283,7 @@ void main() {
     testWidgetsOnAndroid("splits task into two upon new line insertion in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -329,7 +329,7 @@ void main() {
     testWidgetsOnMobile("splits task into two upon new line input action in middle of existing task", (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
       final composer = MutableDocumentComposer();
@@ -376,7 +376,7 @@ void main() {
         (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
 
@@ -416,7 +416,7 @@ void main() {
         (tester) async {
       final document = MutableDocument(
         nodes: [
-          TaskNode(id: "1", text: AttributedText(text: "This is a task"), isComplete: false),
+          TaskNode(id: "1", text: AttributedText("This is a task"), isComplete: false),
         ],
       );
 

--- a/super_editor/test/super_editor/infrastructure/attributed_text_styles_test.dart
+++ b/super_editor/test/super_editor/infrastructure/attributed_text_styles_test.dart
@@ -2,13 +2,12 @@ import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
 
 void main() {
   group('Attributed Text', () {
     test('no styles', () {
-      final text = AttributedText(
-        text: 'abcdefghij',
-      );
+      final text = AttributedText('abcdefghij');
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, 'abcdefghij');
@@ -16,15 +15,7 @@ void main() {
     });
 
     test('full-span style', () {
-      final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
-          attributions: [
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-          ],
-        ),
-      );
+      final text = attributedTextFromMarkdown("**abcdefghij**");
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, 'abcdefghij');
@@ -33,15 +24,7 @@ void main() {
     });
 
     test('single character style', () {
-      final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
-          attributions: [
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 1, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 1, markerType: SpanMarkerType.end),
-          ],
-        ),
-      );
+      final text = attributedTextFromMarkdown("a**b**cdefghij");
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -55,8 +38,8 @@ void main() {
 
     test('single character style - reverse order', () {
       final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
+        'abcdefghij',
+        AttributedSpans(
           attributions: [
             // Notice that the markers are provided in reverse order:
             // end then start. Order shouldn't matter within a single
@@ -78,7 +61,7 @@ void main() {
     });
 
     test('add single character style', () {
-      final text = AttributedText(text: 'abcdefghij');
+      final text = AttributedText('abcdefghij');
       text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 1, end: 1));
       final textSpan = text.computeTextSpan(_styleBuilder);
 
@@ -92,15 +75,7 @@ void main() {
     });
 
     test('partial style', () {
-      final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
-          attributions: [
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 7, markerType: SpanMarkerType.end),
-          ],
-        ),
-      );
+      final text = attributedTextFromMarkdown("ab**cdefgh**ij");
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -112,19 +87,11 @@ void main() {
     });
 
     test('add styled character to existing styled text', () {
-      final initialText = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
-          attributions: [
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-          ],
-        ),
-      );
+      final initialText = attributedTextFromMarkdown("abcdefghi**j**");
 
       final newText = initialText.copyAndAppend(AttributedText(
-        text: 'k',
-        spans: AttributedSpans(
+        'k',
+        AttributedSpans(
           attributions: [
             const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.end),
@@ -147,17 +114,7 @@ void main() {
     });
 
     test('non-mingled varying styles', () {
-      final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
-          attributions: [
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.end),
-            const SpanMarker(attribution: ExpectedSpans.italics, offset: 5, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: ExpectedSpans.italics, offset: 9, markerType: SpanMarkerType.end),
-          ],
-        ),
-      );
+      final text = attributedTextFromMarkdown("**abcde***fghij*");
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -171,9 +128,11 @@ void main() {
     });
 
     test('intermingled varying styles', () {
+      // Note: we configure attributed text directly because Markdown doesn't know
+      // how to parse overlapping bold and italics like we have in this test.
       final text = AttributedText(
-        text: 'abcdefghij',
-        spans: AttributedSpans(
+        'abcdefghij',
+        AttributedSpans(
           attributions: [
             const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),

--- a/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
+++ b/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
@@ -14,15 +14,13 @@ void main() {
         final document = MutableDocument(nodes: [
           ParagraphNode(
             id: "1",
-            text: AttributedText(
-              text: 'This is a blockquote!',
-            ),
+            text: AttributedText('This is a blockquote!'),
           ),
           ParagraphNode(
             id: "2",
             text: AttributedText(
-                text:
-                    'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+              'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+            ),
           ),
         ]);
         final composer = MutableDocumentComposer(
@@ -59,8 +57,8 @@ void main() {
           ParagraphNode(
             id: "2",
             text: AttributedText(
-                text:
-                    'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+              'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+            ),
           ),
         ]);
         final composer = MutableDocumentComposer(
@@ -96,8 +94,8 @@ void main() {
           ParagraphNode(
             id: "1",
             text: AttributedText(
-                text:
-                    'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+              'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+            ),
           ),
           HorizontalRuleNode(id: "2"),
         ]);
@@ -197,8 +195,8 @@ MutableDocument _singleParagraphWithLinkDoc() {
       ParagraphNode(
         id: "1",
         text: AttributedText(
-          text: "https://google.com",
-          spans: AttributedSpans(
+          "https://google.com",
+          AttributedSpans(
             attributions: [
               SpanMarker(
                 attribution: LinkAttribution(url: Uri.parse('https://google.com')),

--- a/super_editor/test/super_editor/infrastructure/document_editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/document_editor_test.dart
@@ -60,7 +60,8 @@ void main() {
         );
       });
 
-      test('when the node exists in the document, and the targetIndex is valid, moves it to the given target index', () {
+      test('when the node exists in the document, and the targetIndex is valid, moves it to the given target index',
+          () {
         final node = ParagraphNode(id: 'move-me', text: AttributedText());
         final document = MutableDocument(
           nodes: [
@@ -135,8 +136,8 @@ void main() {
         TextNode(
           id: '1',
           text: AttributedText(
-            text: 'a',
-            spans: AttributedSpans(),
+            'a',
+            AttributedSpans(),
           ),
         ),
       ]);
@@ -144,8 +145,8 @@ void main() {
         TextNode(
           id: '1',
           text: AttributedText(
-            text: 'a',
-            spans: AttributedSpans(),
+            'a',
+            AttributedSpans(),
           ),
         ),
       ]);

--- a/super_editor/test/super_editor/infrastructure/document_selection_test.dart
+++ b/super_editor/test/super_editor/infrastructure/document_selection_test.dart
@@ -193,8 +193,8 @@ void main() {
 
 final _testDoc = MutableDocument(
   nodes: [
-    ParagraphNode(id: "1", text: AttributedText(text: "Paragraph 1")),
-    ParagraphNode(id: "2", text: AttributedText(text: "Paragraph 2")),
-    ParagraphNode(id: "3", text: AttributedText(text: "Paragraph 3")),
+    ParagraphNode(id: "1", text: AttributedText("Paragraph 1")),
+    ParagraphNode(id: "2", text: AttributedText("Paragraph 2")),
+    ParagraphNode(id: "3", text: AttributedText("Paragraph 3")),
   ],
 );

--- a/super_editor/test/super_editor/infrastructure/document_test.dart
+++ b/super_editor/test/super_editor/infrastructure/document_test.dart
@@ -10,16 +10,16 @@ void main() {
             TextNode(
               id: '1',
               text: AttributedText(
-                text: 'a',
-                spans: AttributedSpans(),
+                'a',
+                AttributedSpans(),
               ),
             ),
             equals(
               TextNode(
                 id: '1',
                 text: AttributedText(
-                  text: 'a',
-                  spans: AttributedSpans(),
+                  'a',
+                  AttributedSpans(),
                 ),
               ),
             ),
@@ -31,15 +31,15 @@ void main() {
             TextNode(
                   id: '1',
                   text: AttributedText(
-                    text: 'a',
-                    spans: AttributedSpans(),
+                    'a',
+                    AttributedSpans(),
                   ),
                 ) ==
                 TextNode(
                   id: '1',
                   text: AttributedText(
-                    text: 'b',
-                    spans: AttributedSpans(),
+                    'b',
+                    AttributedSpans(),
                   ),
                 ),
             isFalse,
@@ -51,16 +51,16 @@ void main() {
             ParagraphNode(
               id: '1',
               text: AttributedText(
-                text: 'a',
-                spans: AttributedSpans(),
+                'a',
+                AttributedSpans(),
               ),
             ),
             equals(
               ParagraphNode(
                 id: '1',
                 text: AttributedText(
-                  text: 'a',
-                  spans: AttributedSpans(),
+                  'a',
+                  AttributedSpans(),
                 ),
               ),
             ),
@@ -72,15 +72,15 @@ void main() {
             ParagraphNode(
                   id: '1',
                   text: AttributedText(
-                    text: 'a',
-                    spans: AttributedSpans(),
+                    'a',
+                    AttributedSpans(),
                   ),
                 ) ==
                 ParagraphNode(
                   id: '1',
                   text: AttributedText(
-                    text: 'b',
-                    spans: AttributedSpans(),
+                    'b',
+                    AttributedSpans(),
                   ),
                 ),
             isFalse,
@@ -89,30 +89,30 @@ void main() {
 
         test("equivalent ListItemNodes are equal", () {
           expect(
-            ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText(text: 'abcdefghij')),
+            ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText('abcdefghij')),
             equals(
-              ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText(text: 'abcdefghij')),
+              ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText('abcdefghij')),
             ),
           );
 
           expect(
-            ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText(text: 'abcdefghij')),
+            ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText('abcdefghij')),
             equals(
-              ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText(text: 'abcdefghij')),
+              ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText('abcdefghij')),
             ),
           );
         });
 
         test("different ListItemNodes are not equal", () {
           expect(
-            ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText(text: 'abcdefghij')) ==
-                ListItemNode(id: '2', itemType: ListItemType.unordered, text: AttributedText(text: 'abcdefghij')),
+            ListItemNode(id: '1', itemType: ListItemType.ordered, text: AttributedText('abcdefghij')) ==
+                ListItemNode(id: '2', itemType: ListItemType.unordered, text: AttributedText('abcdefghij')),
             isFalse,
           );
 
           expect(
-            ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText(text: 'abcdefghij')) ==
-                ListItemNode(id: '2', itemType: ListItemType.ordered, text: AttributedText(text: 'abcdefghij')),
+            ListItemNode(id: '1', itemType: ListItemType.unordered, text: AttributedText('abcdefghij')) ==
+                ListItemNode(id: '2', itemType: ListItemType.ordered, text: AttributedText('abcdefghij')),
             isFalse,
           );
         });

--- a/super_editor/test/super_editor/infrastructure/editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/editor_test.dart
@@ -14,7 +14,7 @@ void main() {
         final editor = Editor(
           editables: {
             Editor.documentKey: MutableDocument(
-              nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: ""))],
+              nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText())],
             ),
           },
           requestHandlers: [],
@@ -82,7 +82,7 @@ void main() {
         // order is what we expect.
         List<EditEvent>? changeList;
         final document = MutableDocument(
-          nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: ""))],
+          nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText())],
         );
 
         final composer = MutableDocumentComposer(
@@ -152,7 +152,7 @@ void main() {
           nodes: [
             ParagraphNode(
               id: "1",
-              text: AttributedText(text: ""),
+              text: AttributedText(),
             )
           ],
         );
@@ -195,7 +195,7 @@ void main() {
 
       test('interrupts back-to-back commands to run a reaction', () {
         final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText(text: ""))],
+          nodes: [ParagraphNode(id: "1", text: AttributedText())],
         );
 
         final composer = MutableDocumentComposer(
@@ -285,7 +285,7 @@ void main() {
 
       test('reactions receive a change list with events from earlier reactions', () {
         final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText(text: ""))],
+          nodes: [ParagraphNode(id: "1", text: AttributedText())],
         );
 
         final composer = MutableDocumentComposer(
@@ -371,7 +371,7 @@ void main() {
 
       test('reactions do not run in response to reactions', () {
         final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText(text: ""))],
+          nodes: [ParagraphNode(id: "1", text: AttributedText())],
         );
 
         final composer = MutableDocumentComposer(

--- a/super_editor/test/super_editor/infrastructure/mutable_document_test.dart
+++ b/super_editor/test/super_editor/infrastructure/mutable_document_test.dart
@@ -8,7 +8,7 @@ void main() {
         nodes: [
           ParagraphNode(
             id: "1",
-            text: AttributedText(text: "This is a paragraph of text."),
+            text: AttributedText("This is a paragraph of text."),
           ),
         ],
       );
@@ -41,7 +41,7 @@ void main() {
         nodes: [
           ParagraphNode(
             id: "1",
-            text: AttributedText(text: "This is a paragraph of text."),
+            text: AttributedText("This is a paragraph of text."),
           ),
         ],
       );
@@ -90,7 +90,7 @@ void main() {
         // Insert a new node at the beginning.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeAt(0, thirdNode);
 
@@ -108,7 +108,7 @@ void main() {
         // Insert a new node between firstNode and secondNode.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeAt(1, thirdNode);
 
@@ -126,7 +126,7 @@ void main() {
         // Insert a new node at the end.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeAt(2, thirdNode);
 
@@ -144,7 +144,7 @@ void main() {
         // Insert a new node at the beginning.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeBefore(
           existingNode: firstNode,
@@ -165,7 +165,7 @@ void main() {
         // Insert a new node between the two nodes.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeBefore(
           existingNode: secondNode,
@@ -186,7 +186,7 @@ void main() {
         // Insert a new node between the two nodes.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeAfter(
           existingNode: firstNode,
@@ -207,7 +207,7 @@ void main() {
         // Insert a new node at the end.
         final thirdNode = ParagraphNode(
           id: "3",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
         document.insertNodeAfter(
           existingNode: secondNode,
@@ -338,7 +338,7 @@ void main() {
 
         final fourthNode = ParagraphNode(
           id: "4",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
 
         document.replaceNode(
@@ -361,7 +361,7 @@ void main() {
 
         final fourthNode = ParagraphNode(
           id: "4",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
 
         document.replaceNode(
@@ -384,7 +384,7 @@ void main() {
 
         final fourthNode = ParagraphNode(
           id: "4",
-          text: AttributedText(text: "This is the third paragraph."),
+          text: AttributedText("This is the third paragraph."),
         );
 
         document.replaceNode(
@@ -407,11 +407,11 @@ MutableDocument _createTwoParagraphDoc() {
     nodes: [
       ParagraphNode(
         id: "1",
-        text: AttributedText(text: "This is the first paragraph."),
+        text: AttributedText("This is the first paragraph."),
       ),
       ParagraphNode(
         id: "2",
-        text: AttributedText(text: "This is the second paragraph."),
+        text: AttributedText("This is the second paragraph."),
       ),
     ],
   );
@@ -422,15 +422,15 @@ MutableDocument _createThreeParagraphDoc() {
     nodes: [
       ParagraphNode(
         id: "1",
-        text: AttributedText(text: "This is the first paragraph."),
+        text: AttributedText("This is the first paragraph."),
       ),
       ParagraphNode(
         id: "2",
-        text: AttributedText(text: "This is the second paragraph."),
+        text: AttributedText("This is the second paragraph."),
       ),
       ParagraphNode(
         id: "3",
-        text: AttributedText(text: "This is the third paragraph."),
+        text: AttributedText("This is the third paragraph."),
       ),
     ],
   );

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -397,8 +397,7 @@ MutableDocument _createTestDocument() {
       ParagraphNode(
         id: '1',
         text: AttributedText(
-          text:
-              "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
+          "Super Editor is a toolkit to help you build document editors, document layouts, text fields, and more.",
         ),
       )
     ],

--- a/super_editor/test/super_editor/supereditor_components_test.dart
+++ b/super_editor/test/super_editor/supereditor_components_test.dart
@@ -111,8 +111,8 @@ class HintTextComponentBuilder implements ComponentBuilder {
           : {},
       // This is the text displayed as a hint.
       hintText: AttributedText(
-        text: 'this is hint text...',
-        spans: AttributedSpans(
+        'this is hint text...',
+        AttributedSpans(
           attributions: [
             const SpanMarker(attribution: italicsAttribution, offset: 12, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: italicsAttribution, offset: 15, markerType: SpanMarkerType.end),

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -449,7 +449,7 @@ Second paragraph"""). //
                   ),
                   ParagraphNode(
                     id: 'text-node',
-                    text: AttributedText(text: 'Paragraph'),
+                    text: AttributedText('Paragraph'),
                   ),
                 ],
               ),
@@ -509,7 +509,7 @@ Second paragraph"""). //
                   ),
                   ParagraphNode(
                     id: 'text-node',
-                    text: AttributedText(text: 'Paragraph'),
+                    text: AttributedText('Paragraph'),
                   ),
                 ],
               ),
@@ -568,7 +568,7 @@ Second paragraph"""). //
                   ),
                   ParagraphNode(
                     id: 'text-node',
-                    text: AttributedText(text: 'Paragraph'),
+                    text: AttributedText('Paragraph'),
                   ),
                 ],
               ),

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -15,7 +15,7 @@ void main() {
       testWidgetsOnAllPlatforms('at the beginning of existing text', (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "<- text here")),
+            ParagraphNode(id: "1", text: AttributedText("<- text here")),
           ],
         );
 
@@ -38,7 +38,7 @@ void main() {
       testWidgetsOnAllPlatforms('in the middle of existing text', (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "text here -><---")),
+            ParagraphNode(id: "1", text: AttributedText("text here -><---")),
           ],
         );
 
@@ -61,7 +61,7 @@ void main() {
       testWidgetsOnAllPlatforms('at the end of existing text', (tester) async {
         final document = MutableDocument(
           nodes: [
-            ParagraphNode(id: "1", text: AttributedText(text: "text here ->")),
+            ParagraphNode(id: "1", text: AttributedText("text here ->")),
           ],
         );
 
@@ -255,7 +255,7 @@ void main() {
         final document = MutableDocument(nodes: [
           ParagraphNode(
             id: "1",
-            text: AttributedText(text: "This is a sentence"),
+            text: AttributedText("This is a sentence"),
           ),
         ]);
         final composer = MutableDocumentComposer(
@@ -752,7 +752,7 @@ Paragraph two
         _expectTextEditingValue(
           actualTextEditingValue: DocumentImeSerializer(
             MutableDocument(nodes: [
-              ParagraphNode(id: "1", text: AttributedText(text: text)),
+              ParagraphNode(id: "1", text: AttributedText(text)),
             ]),
             const DocumentSelection(
               base: DocumentPosition(
@@ -777,8 +777,8 @@ Paragraph two
         _expectTextEditingValue(
           actualTextEditingValue: DocumentImeSerializer(
             MutableDocument(nodes: [
-              ParagraphNode(id: "1", text: AttributedText(text: text1)),
-              ParagraphNode(id: "2", text: AttributedText(text: text2)),
+              ParagraphNode(id: "1", text: AttributedText(text1)),
+              ParagraphNode(id: "2", text: AttributedText(text2)),
             ]),
             const DocumentSelection(
               base: DocumentPosition(
@@ -802,9 +802,9 @@ Paragraph two
         _expectTextEditingValue(
           actualTextEditingValue: DocumentImeSerializer(
             MutableDocument(nodes: [
-              ParagraphNode(id: "1", text: AttributedText(text: text)),
+              ParagraphNode(id: "1", text: AttributedText(text)),
               HorizontalRuleNode(id: "2"),
-              ParagraphNode(id: "3", text: AttributedText(text: text)),
+              ParagraphNode(id: "3", text: AttributedText(text)),
             ]),
             const DocumentSelection(
               base: DocumentPosition(
@@ -829,7 +829,7 @@ Paragraph two
           actualTextEditingValue: DocumentImeSerializer(
             MutableDocument(nodes: [
               HorizontalRuleNode(id: "1"),
-              ParagraphNode(id: "2", text: AttributedText(text: text)),
+              ParagraphNode(id: "2", text: AttributedText(text)),
               HorizontalRuleNode(id: "3"),
             ]),
             const DocumentSelection(
@@ -972,8 +972,8 @@ MutableDocument _singleParagraphWithLinkDoc() {
       ParagraphNode(
         id: "1",
         text: AttributedText(
-          text: "https://google.com",
-          spans: AttributedSpans(
+          "https://google.com",
+          AttributedSpans(
             attributions: [
               SpanMarker(
                 attribution: LinkAttribution(url: Uri.parse('https://google.com')),

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -927,7 +927,7 @@ void main() {
               nodes: [
                 ParagraphNode(
                   id: '1',
-                  text: AttributedText(text: 'This is some text'),
+                  text: AttributedText('This is some text'),
                 ),
               ],
             ))
@@ -961,11 +961,11 @@ void main() {
                 nodes: [
                   ParagraphNode(
                     id: '1',
-                    text: AttributedText(text: 'This is some text'),
+                    text: AttributedText('This is some text'),
                   ),
                   ParagraphNode(
                     id: '2',
-                    text: AttributedText(text: 'This is some text'),
+                    text: AttributedText('This is some text'),
                   ),
                 ],
               ),
@@ -1004,7 +1004,7 @@ void main() {
                   ),
                   ParagraphNode(
                     id: '2',
-                    text: AttributedText(text: 'This is some text'),
+                    text: AttributedText('This is some text'),
                   ),
                   ImageNode(
                     id: '3',
@@ -1046,7 +1046,7 @@ void main() {
                 nodes: [
                   ParagraphNode(
                     id: '1',
-                    text: AttributedText(text: 'Text with [DELETEME] selection'),
+                    text: AttributedText('Text with [DELETEME] selection'),
                   ),
                 ],
               ),
@@ -1094,7 +1094,7 @@ void main() {
                 nodes: [
                   ParagraphNode(
                     id: '1',
-                    text: AttributedText(text: 'Text with [DELETEME] selection'),
+                    text: AttributedText('Text with [DELETEME] selection'),
                   ),
                 ],
               ),
@@ -1142,7 +1142,7 @@ void main() {
                 nodes: [
                   ParagraphNode(
                     id: '1',
-                    text: AttributedText(text: 'Text with [DELETEME] selection'),
+                    text: AttributedText('Text with [DELETEME] selection'),
                   ),
                 ],
               ),
@@ -1191,7 +1191,7 @@ void main() {
                 nodes: [
                   ParagraphNode(
                     id: '1',
-                    text: AttributedText(text: 'Text with [SELECTME] selection'),
+                    text: AttributedText('Text with [SELECTME] selection'),
                   ),
                 ],
               ),
@@ -1240,7 +1240,7 @@ void main() {
               nodes: [
                 ParagraphNode(
                   id: '1',
-                  text: AttributedText(text: 'This is some text'),
+                  text: AttributedText('This is some text'),
                 ),
               ],
             ),
@@ -1308,7 +1308,7 @@ Future<TestDocumentContext> _pumpExplicitLineBreakTestSetup(
           ParagraphNode(
             id: '1',
             text: AttributedText(
-              text: 'Lorem ipsum dolor sit amet\nconsectetur adipiscing elit',
+              'Lorem ipsum dolor sit amet\nconsectetur adipiscing elit',
             ),
           ),
         ],

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -423,11 +423,11 @@ void main() {
               nodes: [
                 ParagraphNode(
                   id: "1",
-                  text: AttributedText(text: "First Paragraph"),
+                  text: AttributedText("First Paragraph"),
                 ),
                 ParagraphNode(
                   id: "2",
-                  text: AttributedText(text: "Second Paragraph"),
+                  text: AttributedText("Second Paragraph"),
                 ),
                 ImageNode(
                   id: "img-node",
@@ -816,7 +816,7 @@ MutableDocument _createExampleDocumentForScrolling() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'Example Document',
+          'Example Document',
         ),
         metadata: {
           'blockType': header1Attribution,
@@ -826,28 +826,25 @@ MutableDocument _createExampleDocumentForScrolling() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-            text:
-                'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
-      ),
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(
-          text:
-              'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+          'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+          'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+        ),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText(
+          'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
         ),
       ),
     ],

--- a/super_editor/test/super_editor/supereditor_shortcuts_test.dart
+++ b/super_editor/test/super_editor/supereditor_shortcuts_test.dart
@@ -66,7 +66,7 @@ Future<void> _pumpShortcutsAndSuperEditor(
 ) async {
   final document = MutableDocument(
     nodes: [
-      ParagraphNode(id: "1", text: AttributedText(text: "")),
+      ParagraphNode(id: "1", text: AttributedText()),
     ],
   );
   final composer = MutableDocumentComposer();

--- a/super_editor/test/super_editor/supereditor_smoke_test.dart
+++ b/super_editor/test/super_editor/supereditor_smoke_test.dart
@@ -67,18 +67,18 @@ void main() {
 
 final _expectedDocument = MutableDocument(
   nodes: [
-    ParagraphNode(id: "1", text: AttributedText(text: "This is the first paragraph of the document.")),
+    ParagraphNode(id: "1", text: AttributedText("This is the first paragraph of the document.")),
     ParagraphNode(
-        id: "2", text: AttributedText(text: "This is a blockquote."), metadata: {'blockType': blockquoteAttribution}),
-    ParagraphNode(id: "3", text: AttributedText(text: "This is an ordered list.")),
-    ListItemNode.ordered(id: "4", text: AttributedText(text: "item 1")),
-    ListItemNode.ordered(id: "5", text: AttributedText(text: "item 2")),
-    ListItemNode.ordered(id: "6", text: AttributedText(text: "item 3")),
-    ParagraphNode(id: "7", text: AttributedText(text: "This is an unordered list.")),
-    ListItemNode.unordered(id: "8", text: AttributedText(text: "item 1")),
-    ListItemNode.unordered(id: "9", text: AttributedText(text: "item 2")),
-    ListItemNode.unordered(id: "10", text: AttributedText(text: "item 3")),
+        id: "2", text: AttributedText("This is a blockquote."), metadata: {'blockType': blockquoteAttribution}),
+    ParagraphNode(id: "3", text: AttributedText("This is an ordered list.")),
+    ListItemNode.ordered(id: "4", text: AttributedText("item 1")),
+    ListItemNode.ordered(id: "5", text: AttributedText("item 2")),
+    ListItemNode.ordered(id: "6", text: AttributedText("item 3")),
+    ParagraphNode(id: "7", text: AttributedText("This is an unordered list.")),
+    ListItemNode.unordered(id: "8", text: AttributedText("item 1")),
+    ListItemNode.unordered(id: "9", text: AttributedText("item 2")),
+    ListItemNode.unordered(id: "10", text: AttributedText("item 3")),
     HorizontalRuleNode(id: "11"),
-    ParagraphNode(id: "12", text: AttributedText(text: "")),
+    ParagraphNode(id: "12", text: AttributedText("")),
   ],
 );

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -2,15 +2,15 @@ import 'package:super_editor/super_editor.dart';
 
 MutableDocument paragraphThenHrThenParagraphDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "This is the first node in a document.")),
+        ParagraphNode(id: "1", text: AttributedText("This is the first node in a document.")),
         HorizontalRuleNode(id: "2"),
-        ParagraphNode(id: "3", text: AttributedText(text: "This is the third node in a document.")),
+        ParagraphNode(id: "3", text: AttributedText("This is the third node in a document.")),
       ],
     );
 
 MutableDocument paragraphThenHrDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "Paragraph 1")),
+        ParagraphNode(id: "1", text: AttributedText("Paragraph 1")),
         HorizontalRuleNode(id: "2"),
       ],
     );
@@ -18,20 +18,20 @@ MutableDocument paragraphThenHrDoc() => MutableDocument(
 MutableDocument hrThenParagraphDoc() => MutableDocument(
       nodes: [
         HorizontalRuleNode(id: "1"),
-        ParagraphNode(id: "2", text: AttributedText(text: "Paragraph 1")),
+        ParagraphNode(id: "2", text: AttributedText("Paragraph 1")),
       ],
     );
 
 MutableDocument singleParagraphEmptyDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "")),
+        ParagraphNode(id: "1", text: AttributedText()),
       ],
     );
 
 MutableDocument twoParagraphEmptyDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "")),
-        ParagraphNode(id: "2", text: AttributedText(text: "")),
+        ParagraphNode(id: "1", text: AttributedText()),
+        ParagraphNode(id: "2", text: AttributedText()),
       ],
     );
 
@@ -41,8 +41,7 @@ MutableDocument singleParagraphDoc() => MutableDocument(
           id: "1",
           text: AttributedText(
             // String length is 445
-            text:
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
           ),
         ),
       ],
@@ -54,8 +53,8 @@ MutableDocument singleParagraphWithLinkDoc() => MutableDocument(
           id: "1",
           text: AttributedText(
             // "link" is 26->30
-            text: "This paragraph includes a link that the user can tap",
-            spans: AttributedSpans(
+            "This paragraph includes a link that the user can tap",
+            AttributedSpans(
               attributions: [
                 SpanMarker(
                     attribution: LinkAttribution(url: Uri.parse("https://fake.url")),
@@ -83,28 +82,25 @@ MutableDocument longTextDoc() => MutableDocument(
         ParagraphNode(
           id: "1",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "2",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "3",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "4",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
       ],
@@ -115,136 +111,121 @@ MutableDocument longDoc() => MutableDocument(
         ParagraphNode(
           id: "1",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "2",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "3",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "4",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
         ParagraphNode(
           id: "5",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "6",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "7",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "8",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
         ParagraphNode(
           id: "9",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "10",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "11",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "12",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
         ParagraphNode(
           id: "13",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "14",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "15",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "16",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
         ParagraphNode(
           id: "17",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "18",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "19",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "20",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
       ],

--- a/super_editor/test/super_editor/text_entry/attributions_test.dart
+++ b/super_editor/test/super_editor/text_entry/attributions_test.dart
@@ -6,9 +6,7 @@ void main() {
   group('Default editor attributions', () {
     group('links', () {
       test('different link attributions cannot overlap', () {
-        final text = AttributedText(
-          text: 'one two three',
-        );
+        final text = AttributedText('one two three');
 
         // Add link across "one two"
         text.addAttribution(
@@ -27,9 +25,7 @@ void main() {
       });
 
       test('identical link attributions can overlap', () {
-        final text = AttributedText(
-          text: 'one two three',
-        );
+        final text = AttributedText('one two three');
 
         final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
 

--- a/super_editor/test/super_editor/text_entry/super_editor_content_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/super_editor_content_conversion_test.dart
@@ -50,7 +50,7 @@ void main() {
               .createDocument()
               .withCustomContent(MutableDocument(
                 nodes: [
-                  ParagraphNode(id: "1", text: AttributedText(text: "Some text")),
+                  ParagraphNode(id: "1", text: AttributedText("Some text")),
                 ],
               ))
               .forDesktop()
@@ -80,7 +80,7 @@ void main() {
               .createDocument()
               .withCustomContent(MutableDocument(
                 nodes: [
-                  ParagraphNode(id: "1", text: AttributedText(text: "Some text")),
+                  ParagraphNode(id: "1", text: AttributedText("Some text")),
                 ],
               ))
               .forDesktop()
@@ -110,7 +110,7 @@ void main() {
               .createDocument()
               .withCustomContent(MutableDocument(
                 nodes: [
-                  ParagraphNode(id: "1", text: AttributedText(text: "Some text")),
+                  ParagraphNode(id: "1", text: AttributedText("Some text")),
                 ],
               ))
               .forDesktop()
@@ -215,8 +215,8 @@ MutableDocument _singleParagraphWithLinkDoc() {
       ParagraphNode(
         id: "1",
         text: AttributedText(
-          text: "https://google.com",
-          spans: AttributedSpans(
+          "https://google.com",
+          AttributedSpans(
             attributions: [
               SpanMarker(
                 attribution: LinkAttribution(url: Uri.parse('https://google.com')),

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -37,7 +37,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
             ],
           ),
@@ -65,7 +65,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -101,7 +101,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -140,7 +140,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -169,11 +169,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(""),
               ),
             ],
           ),
@@ -242,11 +242,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -304,11 +304,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -346,11 +346,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -392,11 +392,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -445,7 +445,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -547,7 +547,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -581,7 +581,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
             ],
           ),

--- a/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
@@ -55,7 +55,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
             ],
           ),
@@ -111,7 +111,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -149,7 +149,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -186,7 +186,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -289,7 +289,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -337,7 +337,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -380,7 +380,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),

--- a/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
@@ -36,7 +36,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
             ],
           ),
@@ -64,7 +64,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -96,7 +96,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -135,11 +135,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -206,11 +206,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -264,7 +264,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -374,7 +374,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -402,11 +402,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -444,11 +444,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -488,11 +488,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before  after"),
+                text: AttributedText("before  after"),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -539,7 +539,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -587,7 +587,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -625,7 +625,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -664,7 +664,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -703,7 +703,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -746,7 +746,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -789,7 +789,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -827,7 +827,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "before "),
+                text: AttributedText("before "),
               ),
             ],
           ),
@@ -865,7 +865,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),
@@ -902,7 +902,7 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: "one "),
+                text: AttributedText("one "),
               ),
             ],
           ),
@@ -952,11 +952,11 @@ void main() {
             nodes: [
               ParagraphNode(
                 id: "1",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
               ParagraphNode(
                 id: "2",
-                text: AttributedText(text: ""),
+                text: AttributedText(),
               ),
             ],
           ),

--- a/super_editor/test/super_editor/text_entry/text_test.dart
+++ b/super_editor/test/super_editor/text_entry/text_test.dart
@@ -13,7 +13,7 @@ void main() {
           nodes: [
             ParagraphNode(
               id: 'paragraph',
-              text: AttributedText(text: ' make me bold '),
+              text: AttributedText(' make me bold '),
             )
           ],
         );
@@ -111,7 +111,7 @@ void main() {
         (editContext.document as MutableDocument).add(
           ParagraphNode(
             id: 'paragraph',
-            text: AttributedText(text: 'This is some text'),
+            text: AttributedText('This is some text'),
           ),
         );
 
@@ -192,7 +192,7 @@ void main() {
         (editContext.document as MutableDocument).add(
           ParagraphNode(
             id: 'paragraph',
-            text: AttributedText(text: 'This is some text'),
+            text: AttributedText('This is some text'),
           ),
         );
 
@@ -249,7 +249,7 @@ void main() {
         (editContext.document as MutableDocument).add(
           ParagraphNode(
             id: 'paragraph',
-            text: AttributedText(text: 'This is some text'),
+            text: AttributedText('This is some text'),
           ),
         );
 
@@ -294,7 +294,7 @@ void main() {
         (editContext.document as MutableDocument).add(
           ParagraphNode(
             id: 'paragraph',
-            text: AttributedText(text: 'This is some text'),
+            text: AttributedText('This is some text'),
           ),
         );
 
@@ -338,7 +338,7 @@ void main() {
         test('throws if passed other types of NodePosition', () {
           final node = TextNode(
             id: 'text node',
-            text: AttributedText(text: 'text'),
+            text: AttributedText('text'),
           );
           expect(
             () => node.computeSelection(
@@ -352,7 +352,7 @@ void main() {
         test('preserves the affinity of extent', () {
           final node = TextNode(
             id: 'text node',
-            text: AttributedText(text: 'text'),
+            text: AttributedText('text'),
           );
 
           final selectionWithUpstream = node.computeSelection(

--- a/super_editor/test/super_reader/test_documents.dart
+++ b/super_editor/test/super_reader/test_documents.dart
@@ -2,15 +2,15 @@ import 'package:super_editor/super_editor.dart';
 
 MutableDocument paragraphThenHrThenParagraphDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "This is the first node in a document.")),
+        ParagraphNode(id: "1", text: AttributedText("This is the first node in a document.")),
         HorizontalRuleNode(id: "2"),
-        ParagraphNode(id: "3", text: AttributedText(text: "This is the third node in a document.")),
+        ParagraphNode(id: "3", text: AttributedText("This is the third node in a document.")),
       ],
     );
 
 MutableDocument paragraphThenHrDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "Paragraph 1")),
+        ParagraphNode(id: "1", text: AttributedText("Paragraph 1")),
         HorizontalRuleNode(id: "2"),
       ],
     );
@@ -18,20 +18,20 @@ MutableDocument paragraphThenHrDoc() => MutableDocument(
 MutableDocument hrThenParagraphDoc() => MutableDocument(
       nodes: [
         HorizontalRuleNode(id: "1"),
-        ParagraphNode(id: "2", text: AttributedText(text: "Paragraph 1")),
+        ParagraphNode(id: "2", text: AttributedText("Paragraph 1")),
       ],
     );
 
 MutableDocument singleParagraphEmptyDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "")),
+        ParagraphNode(id: "1", text: AttributedText()),
       ],
     );
 
 MutableDocument twoParagraphEmptyDoc() => MutableDocument(
       nodes: [
-        ParagraphNode(id: "1", text: AttributedText(text: "")),
-        ParagraphNode(id: "2", text: AttributedText(text: "")),
+        ParagraphNode(id: "1", text: AttributedText()),
+        ParagraphNode(id: "2", text: AttributedText()),
       ],
     );
 
@@ -41,8 +41,7 @@ MutableDocument singleParagraphDoc() => MutableDocument(
           id: "1",
           text: AttributedText(
             // String length is 445
-            text:
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
           ),
         ),
       ],
@@ -59,28 +58,25 @@ MutableDocument longTextDoc() => MutableDocument(
         ParagraphNode(
           id: "1",
           text: AttributedText(
-            text:
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
           ),
         ),
         ParagraphNode(
           id: "2",
           text: AttributedText(
-              text:
-                  'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.'),
+            'Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.',
+          ),
         ),
         ParagraphNode(
           id: "3",
           text: AttributedText(
-            text:
-                'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
+            'Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.',
           ),
         ),
         ParagraphNode(
           id: "4",
           text: AttributedText(
-            text:
-                'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+            'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
       ],

--- a/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
@@ -14,7 +14,7 @@ void main() {
       test("does nothing at beginning of text when collapsed", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection.collapsed(offset: 0);
 
@@ -33,7 +33,7 @@ void main() {
       test("does nothing at beginning of text when expanded", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection(extentOffset: 0, baseOffset: 3);
 
@@ -52,7 +52,7 @@ void main() {
       test("does nothing at end of text when collapsed", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection.collapsed(offset: 13); // at the end of the text.
 
@@ -71,7 +71,7 @@ void main() {
       test("does nothing at end of text when expanded", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection(extentOffset: 13, baseOffset: 8);
 
@@ -90,7 +90,7 @@ void main() {
       test("jumps word upstream", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection.collapsed(offset: 7);
 
@@ -109,7 +109,7 @@ void main() {
       test("jumps word downstream", () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'one two three',
+            'one two three',
           ),
         )..selection = const TextSelection.collapsed(offset: 4);
 
@@ -153,8 +153,8 @@ void main() {
       test('types new text in the middle of styled text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -175,8 +175,8 @@ void main() {
       test('types batch of new text in the middle of styled text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -197,8 +197,8 @@ void main() {
       test('types unstyled text in the middle of styled text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -219,8 +219,8 @@ void main() {
       test('clears composing attributions by deleting all styled text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -240,7 +240,7 @@ void main() {
       test('tries to delete previous character at beginning of text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         )
           ..selection = const TextSelection.collapsed(offset: 0)
@@ -252,7 +252,7 @@ void main() {
       test('deletes first character in text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         )
           ..selection = const TextSelection.collapsed(offset: 1)
@@ -265,7 +265,7 @@ void main() {
       test('tries to delete next character at end of text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         )
           ..selection = const TextSelection.collapsed(offset: 9)
@@ -277,7 +277,7 @@ void main() {
       test('deletes last character in text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         )
           ..selection = const TextSelection.collapsed(offset: 8)
@@ -309,7 +309,7 @@ void main() {
 
       test('into start of existing text', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection.collapsed(offset: 0),
         );
         controller.insertAtCaret(text: 'newtext');
@@ -319,7 +319,7 @@ void main() {
 
       test('into start of existing text and pushes caret back', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection.collapsed(offset: 0),
         );
         controller.insertAtCaret(text: 'newtext');
@@ -330,13 +330,13 @@ void main() {
 
       test('into start of existing text and pushes selection back', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection(
             baseOffset: 1,
             extentOffset: 9,
           ),
         );
-        controller.insert(newText: AttributedText(text: 'newtext'), insertIndex: 0);
+        controller.insert(newText: AttributedText('newtext'), insertIndex: 0);
 
         expect(controller.text.text, equals('newtext:existing text'));
         expect(
@@ -352,13 +352,13 @@ void main() {
 
       test('into start of existing text and expands existing selection', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection(
             baseOffset: 0,
             extentOffset: 9,
           ),
         );
-        controller.insert(newText: AttributedText(text: 'newtext'), insertIndex: 0);
+        controller.insert(newText: AttributedText('newtext'), insertIndex: 0);
 
         expect(controller.text.text, equals('newtext:existing text'));
         expect(
@@ -374,7 +374,7 @@ void main() {
 
       test('into end of existing text', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:'),
+          text: AttributedText('existing text:'),
           selection: const TextSelection.collapsed(offset: 14),
         );
         controller.insertAtCaret(text: 'newtext');
@@ -384,7 +384,7 @@ void main() {
 
       test('into end of existing text with caret before inserted text', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:'),
+          text: AttributedText('existing text:'),
           selection: const TextSelection.collapsed(offset: 14),
         );
         controller.insertAtCaret(text: 'newtext');
@@ -395,10 +395,10 @@ void main() {
 
       test('into end of existing text with selection before inserted text', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:'),
+          text: AttributedText('existing text:'),
           selection: const TextSelection(baseOffset: 0, extentOffset: 8),
         );
-        controller.insert(newText: AttributedText(text: 'newtext'), insertIndex: 14);
+        controller.insert(newText: AttributedText('newtext'), insertIndex: 14);
 
         expect(controller.text.text, equals('existing text:newtext'));
         expect(
@@ -415,7 +415,7 @@ void main() {
       test('into middle of text with caret at insertion', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:existing text',
+            '[]:existing text',
           ),
           selection: const TextSelection.collapsed(offset: 1),
         );
@@ -428,14 +428,14 @@ void main() {
       test('into middle of text with selection around insertion', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:existing text',
+            '[]:existing text',
           ),
           selection: const TextSelection(
             baseOffset: 0,
             extentOffset: 2,
           ),
         );
-        controller.insert(newText: AttributedText(text: 'newtext'), insertIndex: 1);
+        controller.insert(newText: AttributedText('newtext'), insertIndex: 1);
 
         expect(controller.text.text, equals('[newtext]:existing text'));
         expect(
@@ -452,14 +452,14 @@ void main() {
       test('into middle of text with selection after insertion', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:existing text',
+            '[]:existing text',
           ),
           selection: const TextSelection(
             baseOffset: 3,
             extentOffset: 11,
           ),
         );
-        controller.insert(newText: AttributedText(text: 'newtext'), insertIndex: 1);
+        controller.insert(newText: AttributedText('newtext'), insertIndex: 1);
 
         expect(controller.text.text, equals('[newtext]:existing text'));
         expect(
@@ -476,8 +476,8 @@ void main() {
       test('before styled text - the style is not extended', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:unstyled text',
-            spans: AttributedSpans(
+            '[]:unstyled text',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 2, markerType: SpanMarkerType.end),
@@ -497,8 +497,8 @@ void main() {
       test('into middle of styled text - the style is extended', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:unstyled text',
-            spans: AttributedSpans(
+            '[]:unstyled text',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 2, markerType: SpanMarkerType.end),
@@ -518,8 +518,8 @@ void main() {
       test('after styled text - the style is extended', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[]:unstyled text',
-            spans: AttributedSpans(
+            '[]:unstyled text',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.end),
@@ -540,23 +540,23 @@ void main() {
     group('replace', () {
       test('empty text with new text at beginning', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection.collapsed(offset: 0),
         );
-        controller.replace(newText: AttributedText(text: 'newtext'), from: 0, to: 0);
+        controller.replace(newText: AttributedText('newtext'), from: 0, to: 0);
 
         expect(controller.text.text, equals('newtext:existing text'));
       });
 
       test('empty text with new text at beginning with selection', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: ':existing text'),
+          text: AttributedText(':existing text'),
           selection: const TextSelection(
             baseOffset: 0,
             extentOffset: 1,
           ),
         );
-        controller.replace(newText: AttributedText(text: 'newtext'), from: 0, to: 0);
+        controller.replace(newText: AttributedText('newtext'), from: 0, to: 0);
 
         expect(controller.text.text, equals('newtext:existing text'));
         expect(
@@ -570,10 +570,10 @@ void main() {
 
       test('text with empty text at beginning', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'deleteme:existing text'),
+          text: AttributedText('deleteme:existing text'),
           selection: const TextSelection.collapsed(offset: 0),
         );
-        controller.replace(newText: AttributedText(text: ''), from: 0, to: 8);
+        controller.replace(newText: AttributedText(''), from: 0, to: 8);
 
         expect(controller.text.text, equals(':existing text'));
         expect(controller.selection, equals(const TextSelection.collapsed(offset: 0)));
@@ -581,10 +581,10 @@ void main() {
 
       test('text at beginning', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'replaceme:existing text'),
+          text: AttributedText('replaceme:existing text'),
           selection: const TextSelection(baseOffset: 0, extentOffset: 9),
         );
-        controller.replace(newText: AttributedText(text: 'newtext'), from: 0, to: 9);
+        controller.replace(newText: AttributedText('newtext'), from: 0, to: 9);
 
         expect(controller.text.text, equals('newtext:existing text'));
         expect(controller.selection, equals(const TextSelection.collapsed(offset: 7)));
@@ -592,10 +592,10 @@ void main() {
 
       test('text at end', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:replaceme'),
+          text: AttributedText('existing text:replaceme'),
           selection: const TextSelection(baseOffset: 14, extentOffset: 23),
         );
-        controller.replace(newText: AttributedText(text: 'newtext'), from: 14, to: 23);
+        controller.replace(newText: AttributedText('newtext'), from: 14, to: 23);
 
         expect(controller.text.text, equals('existing text:newtext'));
         expect(controller.selection, equals(const TextSelection.collapsed(offset: 21)));
@@ -603,10 +603,10 @@ void main() {
 
       test('text in the middle', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: '[replaceme]'),
+          text: AttributedText('[replaceme]'),
           selection: const TextSelection(baseOffset: 1, extentOffset: 10),
         );
-        controller.replace(newText: AttributedText(text: 'newtext'), from: 1, to: 10);
+        controller.replace(newText: AttributedText('newtext'), from: 1, to: 10);
 
         expect(controller.text.text, equals('[newtext]'));
       });
@@ -614,8 +614,8 @@ void main() {
       test('in middle of styled text with new styled text', () {
         final controller = AttributedTextEditingController(
           text: AttributedText(
-            text: '[replaceme]',
-            spans: AttributedSpans(
+            '[replaceme]',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.end),
@@ -624,8 +624,8 @@ void main() {
           ),
         );
         final newText = AttributedText(
-          text: 'newtext',
-          spans: AttributedSpans(
+          'newtext',
+          AttributedSpans(
             attributions: [
               const SpanMarker(attribution: italicsAttribution, offset: 0, markerType: SpanMarkerType.start),
               const SpanMarker(attribution: italicsAttribution, offset: 6, markerType: SpanMarkerType.end),
@@ -645,7 +645,7 @@ void main() {
     group('delete', () {
       test('from beginning', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'deleteme:existing text'),
+          text: AttributedText('deleteme:existing text'),
         );
         controller.delete(from: 0, to: 8);
 
@@ -654,7 +654,7 @@ void main() {
 
       test('from beginning with caret', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'deleteme:existing text'),
+          text: AttributedText('deleteme:existing text'),
           selection: const TextSelection.collapsed(offset: 8),
         );
         controller.delete(from: 0, to: 8);
@@ -665,7 +665,7 @@ void main() {
 
       test('from beginning with selection', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'deleteme:existing text'),
+          text: AttributedText('deleteme:existing text'),
           selection: const TextSelection(
             baseOffset: 4,
             extentOffset: 17,
@@ -687,7 +687,7 @@ void main() {
 
       test('from end', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:deleteme'),
+          text: AttributedText('existing text:deleteme'),
         );
         controller.delete(from: 14, to: 22);
 
@@ -696,7 +696,7 @@ void main() {
 
       test('from end with caret', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:deleteme'),
+          text: AttributedText('existing text:deleteme'),
           // Caret part of the way into the text that will be deleted.
           selection: const TextSelection.collapsed(offset: 18),
         );
@@ -713,7 +713,7 @@ void main() {
 
       test('from end with selection', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'existing text:deleteme'),
+          text: AttributedText('existing text:deleteme'),
           // Selection that starts near the end of remaining text and
           // extends part way into text that's deleted.
           selection: const TextSelection(baseOffset: 11, extentOffset: 18),
@@ -734,7 +734,7 @@ void main() {
 
       test('from middle', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: '[deleteme]'),
+          text: AttributedText('[deleteme]'),
         );
         controller.delete(from: 1, to: 9);
 
@@ -743,7 +743,7 @@ void main() {
 
       test('from middle with crosscutting selection at beginning', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: '[deleteme]'),
+          text: AttributedText('[deleteme]'),
           selection: const TextSelection(
             baseOffset: 0,
             extentOffset: 5,
@@ -765,7 +765,7 @@ void main() {
 
       test('from middle with partial selection in middle', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: '[deleteme]'),
+          text: AttributedText('[deleteme]'),
           selection: const TextSelection(
             baseOffset: 3,
             extentOffset: 6,
@@ -782,7 +782,7 @@ void main() {
 
       test('from middle with crosscutting selection at end', () {
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: '[deleteme]'),
+          text: AttributedText('[deleteme]'),
           selection: const TextSelection(
             baseOffset: 5,
             extentOffset: 10,
@@ -808,7 +808,7 @@ void main() {
         int listenerNotifyCount = 0;
 
         final controller = AttributedTextEditingController(
-          text: AttributedText(text: 'my text'),
+          text: AttributedText('my text'),
         )..addListener(() {
             listenerNotifyCount += 1;
           });
@@ -820,8 +820,8 @@ void main() {
     });
 
     test('set text', () {
-      final text1 = AttributedText(text: 'text1');
-      final text2 = AttributedText(text: 'text2');
+      final text1 = AttributedText('text1');
+      final text2 = AttributedText('text2');
 
       final controller = AttributedTextEditingController(text: text1);
       expect(controller.text, equals(text1));
@@ -838,7 +838,7 @@ void main() {
       group('removal', () {
         test('should remove the given attributions', () {
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: 'my text'),
+            text: AttributedText('my text'),
           );
           controller.addComposingAttributions(
             {boldAttribution, italicsAttribution, underlineAttribution},
@@ -853,7 +853,7 @@ void main() {
 
         test("does nothing when it doesn't have the given composing attributions", () {
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: 'my text'),
+            text: AttributedText('my text'),
           );
           controller.addComposingAttributions(
             {boldAttribution, italicsAttribution},

--- a/super_editor/test/super_textfield/ime_attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/ime_attributed_text_editing_controller_test.dart
@@ -133,7 +133,7 @@ void main() {
       final controller = ImeAttributedTextEditingController(
           controller: AttributedTextEditingController(
             text: AttributedText(
-              text: 'Some text',
+              'Some text',
             ),
           ),
           // Decorate the TextInputConnection to track the number of IME updates.
@@ -183,8 +183,8 @@ void main() {
       final controller = ImeAttributedTextEditingController(
           controller: AttributedTextEditingController(
         text: AttributedText(
-          text: 'before [] after',
-          spans: AttributedSpans(
+          'before [] after',
+          AttributedSpans(
             attributions: [
               const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
               const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -214,8 +214,8 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -246,8 +246,8 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -278,8 +278,8 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: 'before [] after',
-            spans: AttributedSpans(
+            'before [] after',
+            AttributedSpans(
               attributions: [
                 const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
                 const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -315,7 +315,7 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: '[replaceme]',
+            '[replaceme]',
           ),
         ),
       )
@@ -338,7 +338,7 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: '[replaceme]',
+            '[replaceme]',
           ),
         ),
       )
@@ -361,7 +361,7 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         ),
       )
@@ -383,7 +383,7 @@ void main() {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText(
-            text: 'some text',
+            'some text',
           ),
         ),
       )
@@ -405,7 +405,7 @@ void main() {
   testWidgets('isn\'t notified by inner controller after disposal', (tester) async {
     final innerController = AttributedTextEditingController(
       text: AttributedText(
-        text: 'some text',
+        'some text',
       ),
     );
 
@@ -429,7 +429,7 @@ void main() {
     );
 
     // Change the text of the inner controller to notify the listeners.
-    innerController.text = AttributedText(text: 'Another text');
+    innerController.text = AttributedText('Another text');
 
     // Reaching this point means that disposing the old controller didn't cause a crash.
   });

--- a/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_texfield_mouse_interaction_test.dart
@@ -15,12 +15,12 @@ void main() {
       // Start a gesture outside SuperDesktopTextField bounds
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);      
+      addTearDown(gesture.removePointer);
       await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
-      
+
       // Hover over the text inside SuperDesktopTextField
       // TODO: add the ability to SuperTextFieldInspector to lookup an offset for a content position
       await gesture.moveTo(tester.getTopLeft(find.byType(SuperText)));
@@ -42,14 +42,14 @@ void main() {
       // Start a gesture outside SuperDesktopTextField bounds
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);      
+      addTearDown(gesture.removePointer);
       await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
-      
-      // Hover over the empty space within SuperDesktopTextField      
-      await gesture.moveTo(tester.getBottomRight(find.byType(SuperDesktopTextField)) - const Offset(10, 10));      
+
+      // Hover over the empty space within SuperDesktopTextField
+      await gesture.moveTo(tester.getBottomRight(find.byType(SuperDesktopTextField)) - const Offset(10, 10));
       await tester.pump();
 
       // Ensure the cursor type is 'text' when hovering the empty space
@@ -68,12 +68,12 @@ void main() {
       // Start a gesture outside SuperDesktopTextField bounds
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer(location: Offset.zero);
-      addTearDown(gesture.removePointer);      
+      addTearDown(gesture.removePointer);
       await tester.pump();
 
       // Ensure the cursor type is 'basic' when not hovering SuperDesktopTextField
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
-      
+
       // Hover over the padding within SuperDesktopTextField
       await gesture.moveTo(tester.getTopLeft(find.byType(SuperDesktopTextField)) + const Offset(10, 10));
       await tester.pump();
@@ -87,29 +87,26 @@ void main() {
       // Ensure the cursor type is 'basic' again
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
     });
-  });  
+  });
 }
 
 /// Creates a test app with the given [padding] applied to [SuperDesktopTextField]
-Future<void> _pumpGestureTestApp(WidgetTester tester, {
-  double padding = 0.0
-}) async {
+Future<void> _pumpGestureTestApp(WidgetTester tester, {double padding = 0.0}) async {
   await tester.pumpWidget(
-    MaterialApp(          
+    MaterialApp(
       home: Scaffold(
         body: Container(
           width: 300,
           padding: const EdgeInsets.all(20.0),
-          child: SuperDesktopTextField(              
+          child: SuperDesktopTextField(
             padding: EdgeInsets.all(padding),
             textController: AttributedTextEditingController(
-              text: AttributedText(text: "abc"),
+              text: AttributedText("abc"),
             ),
             textStyleBuilder: (_) => const TextStyle(fontSize: 16),
-          ),        
-        ), 
+          ),
+        ),
       ),
     ),
   );
 }
-

--- a/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
+++ b/super_editor/test/super_textfield/super_desktop_textfield_keyboard_test.dart
@@ -26,7 +26,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: '--><--'),
+              text: AttributedText('--><--'),
             ),
           );
           await tester.placeCaretInSuperTextField(3);
@@ -41,7 +41,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: '-->'),
+              text: AttributedText('-->'),
             ),
           );
           await tester.placeCaretInSuperTextField(3);
@@ -56,7 +56,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: '-->REPLACE<--'),
+              text: AttributedText('-->REPLACE<--'),
             ),
           );
           await tester.selectSuperTextFieldText(2, 10);
@@ -73,7 +73,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(8);
@@ -88,7 +88,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -103,7 +103,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(17);
@@ -120,7 +120,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -151,7 +151,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -171,7 +171,7 @@ void main() {
           await _pumpSuperTextField(
               tester,
               AttributedTextEditingController(
-                text: AttributedText(text: _multilineLayoutText),
+                text: AttributedText(_multilineLayoutText),
               ));
           await tester.placeCaretInSuperTextField(18);
 
@@ -225,7 +225,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -244,7 +244,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           // TODO: we begin 1 character ahead of where we should because
@@ -260,7 +260,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           // TODO: we begin 1 character behind where we should because
@@ -278,7 +278,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(16);
@@ -292,7 +292,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -310,7 +310,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(18, null, TextAffinity.upstream);
@@ -331,7 +331,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -345,7 +345,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           // TODO: we begin 1 character ahead of where we should because
@@ -361,7 +361,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           // TODO: we begin 1 character after of where we should because
@@ -379,7 +379,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -393,7 +393,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(18);
@@ -407,7 +407,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(18);
@@ -421,7 +421,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(23);
@@ -437,7 +437,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(50);
@@ -452,7 +452,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -466,7 +466,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -480,7 +480,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -496,7 +496,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: ""),
+              text: AttributedText(),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -511,7 +511,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -526,7 +526,7 @@ void main() {
           // TODO: We create the controller outside the pump so that we can
           // explicitly set its selection because of bug #549.
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: _multilineLayoutText),
+            text: AttributedText(_multilineLayoutText),
           );
           await _pumpSuperTextField(
             tester,
@@ -547,7 +547,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: ""),
+              text: AttributedText(),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -562,7 +562,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(17);
@@ -577,7 +577,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -592,7 +592,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           // TODO: the starting offset is one index to the left because
@@ -614,7 +614,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -633,7 +633,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -652,7 +652,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -671,7 +671,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -692,7 +692,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -708,7 +708,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -724,7 +724,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -740,7 +740,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -757,7 +757,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -778,7 +778,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -796,7 +796,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -814,7 +814,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -834,7 +834,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -850,7 +850,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -866,7 +866,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -882,7 +882,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -901,7 +901,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -915,7 +915,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -931,7 +931,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -945,7 +945,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(16);
@@ -961,7 +961,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -975,7 +975,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -989,7 +989,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'super text field'),
+              text: AttributedText('super text field'),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -1003,7 +1003,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1017,7 +1017,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(17);
@@ -1033,7 +1033,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(4);
@@ -1048,7 +1048,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -1063,7 +1063,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(8);
@@ -1078,7 +1078,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.selectSuperTextFieldText(0, 10);
@@ -1095,7 +1095,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(28);
@@ -1113,7 +1113,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(31, null, TextAffinity.upstream);
@@ -1128,7 +1128,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "This is line 1\nThis is line 2\nThis is line 3"),
+              text: AttributedText("This is line 1\nThis is line 2\nThis is line 3"),
             ),
           );
           await tester.placeCaretInSuperTextField(23);
@@ -1143,7 +1143,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "This is line 1\nThis is line 2\nThis is line 3"),
+              text: AttributedText("This is line 1\nThis is line 2\nThis is line 3"),
             ),
           );
           await tester.placeCaretInSuperTextField(29, null, TextAffinity.upstream);
@@ -1158,7 +1158,7 @@ void main() {
           // TODO: We create the controller outside the pump so that we can
           // explicitly set its selection because of bug #549.
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: _multilineLayoutText),
+            text: AttributedText(_multilineLayoutText),
           );
           await _pumpSuperTextField(
             tester,
@@ -1179,7 +1179,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.placeCaretInSuperTextField(18);
@@ -1196,7 +1196,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1210,7 +1210,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1224,7 +1224,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1238,7 +1238,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1256,7 +1256,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(10);
@@ -1272,7 +1272,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(10);
@@ -1290,7 +1290,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -1308,7 +1308,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(12);
@@ -1329,7 +1329,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -1348,7 +1348,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -1367,7 +1367,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -1386,7 +1386,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
 
@@ -1407,7 +1407,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -1423,7 +1423,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -1439,7 +1439,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -1455,7 +1455,7 @@ void main() {
 
           await _pumpSuperTextField(
             tester,
-            AttributedTextEditingController(text: AttributedText(text: "Pasted content: ")),
+            AttributedTextEditingController(text: AttributedText("Pasted content: ")),
           );
           await tester.placeCaretInSuperTextField(16);
 
@@ -1472,7 +1472,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -1493,7 +1493,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -1511,7 +1511,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -1529,7 +1529,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'This is some text'),
+              text: AttributedText('This is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -1549,7 +1549,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(10);
@@ -1563,7 +1563,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(10);
@@ -1577,7 +1577,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is a text big enough that will cause auto line wrapping"),
+              text: AttributedText("this is a text big enough that will cause auto line wrapping"),
             ),
           );
 
@@ -1595,7 +1595,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field\nthis is second line"),
+              text: AttributedText("super text field\nthis is second line"),
             ),
           );
 
@@ -1615,7 +1615,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -1629,7 +1629,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field"),
+              text: AttributedText("super text field"),
             ),
           );
           await tester.placeCaretInSuperTextField(6);
@@ -1643,7 +1643,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is a text big enough that will cause auto line wrapping"),
+              text: AttributedText("this is a text big enough that will cause auto line wrapping"),
             ),
           );
 
@@ -1661,7 +1661,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "super text field\nthis is second line"),
+              text: AttributedText("super text field\nthis is second line"),
             ),
           );
 
@@ -1681,7 +1681,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(4);
@@ -1696,7 +1696,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -1712,7 +1712,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(8);
@@ -1727,7 +1727,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: _multilineLayoutText),
+              text: AttributedText(_multilineLayoutText),
             ),
           );
           await tester.selectSuperTextFieldText(0, 10);
@@ -1746,7 +1746,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1760,7 +1760,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1774,7 +1774,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(5);
@@ -1799,7 +1799,7 @@ const _multilineLayoutText = 'this text is long enough to be multiline in the av
 Future<void> _pumpEmptySuperTextField(WidgetTester tester) async {
   await _pumpSuperTextField(
     tester,
-    AttributedTextEditingController(text: AttributedText(text: '')),
+    AttributedTextEditingController(text: AttributedText('')),
   );
 }
 

--- a/super_editor/test/super_textfield/super_textfield_ancestor_shortcuts_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ancestor_shortcuts_test.dart
@@ -82,7 +82,7 @@ Future<void> _pumpShortcutsAndSuperTextField(
               width: 300,
               child: SuperTextField(
                 textController: AttributedTextEditingController(
-                  text: AttributedText(text: ""),
+                  text: AttributedText(),
                 ),
                 keyboardHandlers: keyboardActions,
               ),

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -120,7 +120,7 @@ void main() {
 
     testWidgetsOnAllPlatforms('auto scroll doesn\'t crash when text is empty', (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: 'Text before'),
+        text: AttributedText('Text before'),
       );
 
       await _pumpScaffold(
@@ -167,7 +167,7 @@ Future<void> _pumpTestApp(
               maxLines: lineCount,
               lineHeight: 24,
               textController: AttributedTextEditingController(
-                text: AttributedText(text: text),
+                text: AttributedText(text),
               ),
             ),
           ],

--- a/super_editor/test/super_textfield/super_textfield_emoji_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_emoji_test.dart
@@ -471,7 +471,7 @@ Future<void> _pumpSuperTextFieldEmojiTest(
   SuperTextFieldPlatformConfiguration configuration = SuperTextFieldPlatformConfiguration.desktop,
 }) async {
   final controller = AttributedTextEditingController(
-    text: AttributedText(text: text),
+    text: AttributedText(text),
   );
   await tester.pumpWidget(
     MaterialApp(

--- a/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_estimated_line_height_test.dart
@@ -21,7 +21,7 @@ void main() {
       final heightWithHintText = tester.getSize(find.byType(SuperTextField)).height;
 
       // Change the text, this should recompute viewport height.
-      controller.text = AttributedText(text: 'Leave a message');
+      controller.text = AttributedText('Leave a message');
       await tester.pumpAndSettle();
 
       // When the text field has content the line height should be the true line height.

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -265,7 +264,7 @@ void main() {
                     data: data,
                     child: SuperTextField(
                       textController: AttributedTextEditingController(
-                        text: AttributedText(text: 'a b c'),
+                        text: AttributedText('a b c'),
                       ),
                     ),
                   );
@@ -318,7 +317,7 @@ void main() {
                     data: data,
                     child: SuperTextField(
                       textController: AttributedTextEditingController(
-                        text: AttributedText(text: 'a b c'),
+                        text: AttributedText('a b c'),
                       ),
                     ),
                   );
@@ -471,7 +470,7 @@ Future<void> _pumpTestApp(
                     textAlign: textAlign ?? TextAlign.left,
                     textController: controller ??
                         AttributedTextEditingController(
-                          text: AttributedText(text: 'abc'),
+                          text: AttributedText('abc'),
                         ),
                   ),
                 ),

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -27,7 +27,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: '--><--'),
+              text: AttributedText('--><--'),
             ),
           );
           await tester.placeCaretInSuperTextField(3);
@@ -42,7 +42,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: '-->'),
+              text: AttributedText('-->'),
             ),
           );
           await tester.placeCaretInSuperTextField(3);
@@ -57,7 +57,7 @@ void main() {
           // TODO: We create the controller outside the pump so that we can explicitly set its selection
           //  because we don't support gesture selection on mobile, yet.
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: '-->REPLACE<--'),
+            text: AttributedText('-->REPLACE<--'),
           );
           await _pumpSuperTextField(
             tester,
@@ -102,7 +102,7 @@ void main() {
           await tester.ime.typeText('a', getter: imeClientGetter);
 
           // Manually set the value to "b" to send the value to the IME.
-          controller.text = AttributedText(text: 'b');
+          controller.text = AttributedText('b');
 
           // Ensure we send the value back to the IME.
           expect(sentToPlatform, true);
@@ -187,7 +187,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(8);
@@ -202,7 +202,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -217,7 +217,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(17);
@@ -232,7 +232,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(8);
@@ -247,7 +247,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -262,7 +262,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: 'this is some text'),
+              text: AttributedText('this is some text'),
             ),
           );
           await tester.placeCaretInSuperTextField(17);
@@ -279,7 +279,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: ""),
+              text: AttributedText(""),
             ),
           );
           await tester.placeCaretInSuperTextField(0);
@@ -294,7 +294,7 @@ void main() {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
-              text: AttributedText(text: "this is some text"),
+              text: AttributedText("this is some text"),
             ),
           );
           await tester.placeCaretInSuperTextField(2);
@@ -309,7 +309,7 @@ void main() {
           // TODO: We create the controller outside the pump so that we can explicitly set its selection
           //  because we don't support gesture selection on mobile, yet.
           final controller = AttributedTextEditingController(
-            text: AttributedText(text: _multilineLayoutText),
+            text: AttributedText(_multilineLayoutText),
           );
           await _pumpSuperTextField(
             tester,
@@ -378,7 +378,7 @@ void main() {
     testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a collapsed selection (on Android)',
         (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: 'This is a text'),
+        text: AttributedText('This is a text'),
       );
       await _pumpScaffoldForBuggyKeyboards(tester, controller: controller);
 
@@ -401,7 +401,7 @@ void main() {
     testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a expanded selection (on Android)',
         (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: 'This is a text'),
+        text: AttributedText('This is a text'),
       );
       await _pumpScaffoldForBuggyKeyboards(tester, controller: controller);
 
@@ -436,7 +436,7 @@ const _multilineLayoutText = 'this text is long enough to be multiline in the av
 Future<void> _pumpEmptySuperTextField(WidgetTester tester) async {
   await _pumpSuperTextField(
     tester,
-    AttributedTextEditingController(text: AttributedText(text: '')),
+    AttributedTextEditingController(text: AttributedText('')),
   );
 }
 
@@ -550,8 +550,8 @@ class _ObscuringTextController extends AttributedTextEditingController {
 
     update(
       text: AttributedText(
-        text: updatedText,
-        spans: textAfterInsertion.spans,
+        updatedText,
+        textAfterInsertion.spans,
       ),
       selection: updatedSelection,
       composingRegion: newComposingRegion,

--- a/super_editor/test/super_textfield/super_textfield_rendering_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_rendering_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('SuperTextField', () {
     testWidgetsOnAllPlatforms('renders text on the first frame when given a line height', (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: 'Editing text'),
+        text: AttributedText('Editing text'),
       );
 
       // Indicates whether we should display the Text or the SuperTextField.

--- a/super_editor/test/super_textfield/super_textfield_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_scroll_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('SuperTextField', () {
     testWidgetsOnAllPlatforms('single-line jumps scroll position horizontally as the user types', (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "ABCDEFG"),
+        text: AttributedText("ABCDEFG"),
       );
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
@@ -41,7 +41,7 @@ void main() {
 
     testWidgetsOnAllPlatforms('multi-line jumps scroll position vertically as the user types', (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "A\nB\nC\nD"),
+        text: AttributedText("A\nB\nC\nD"),
       );
 
       // Pump the widget tree with a SuperTextField with a maxHeight smaller
@@ -73,7 +73,7 @@ void main() {
         "multi-line jumps scroll position vertically when selection extent moves above or below the visible viewport area",
         (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "First line\nSecond Line\nThird Line\nFourth Line"),
+        text: AttributedText("First line\nSecond Line\nThird Line\nFourth Line"),
       );
 
       // Pump the widget tree with a SuperTextField which is two lines tall.
@@ -110,7 +110,7 @@ void main() {
     testWidgetsOnAllPlatforms("multi-line doesn't jump scroll position vertically when selection extent is visible",
         (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "First line\nSecond Line\nThird Line\nFourth Line"),
+        text: AttributedText("First line\nSecond Line\nThird Line\nFourth Line"),
       );
 
       // Pump the widget tree with a SuperTextField which is two lines tall.
@@ -160,7 +160,7 @@ void main() {
                 minLines: 1,
                 maxLines: null,
                 textController: AttributedTextEditingController(
-                  text: AttributedText(text: "SuperTextField"),
+                  text: AttributedText("SuperTextField"),
                 ),
                 textStyleBuilder: (_) => const TextStyle(
                   fontSize: 14,

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -392,7 +392,7 @@ void main() {
       // Change the text so the content height is greater
       // than the initial content height.
       controller.text = AttributedText(
-        text: """
+        """
 This is
 a
 multi-line
@@ -428,7 +428,7 @@ SuperTextField
       // Change the text, so the content height is greater
       // than the initial content height.
       controller.text = AttributedText(
-        text: """
+        """
 This is
 a
 multi-line

--- a/super_editor/test/super_textfield/super_textfield_text_alignment_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_text_alignment_test.dart
@@ -40,7 +40,7 @@ Widget _buildSuperTextField({
   int? maxLines,
 }) {
   final controller = AttributedTextEditingController(
-    text: AttributedText(text: text),
+    text: AttributedText(text),
   );
 
   return SizedBox(

--- a/super_editor/test/super_textfield/type_into_super_textfield_test.dart
+++ b/super_editor/test/super_textfield/type_into_super_textfield_test.dart
@@ -36,7 +36,7 @@ void main() {
         await _pumpDesktopScaffold(
           tester,
           AttributedTextEditingController(
-            text: AttributedText(text: "hello world"),
+            text: AttributedText("hello world"),
           ),
         );
         await tester.placeCaretInSuperTextField(6);

--- a/super_editor/test_goldens/editor/components/paragraph_test.dart
+++ b/super_editor/test_goldens/editor/components/paragraph_test.dart
@@ -21,7 +21,7 @@ MutableDocument _createParagraphTestDoc() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'Various paragraph formations',
+          'Various paragraph formations',
         ),
         metadata: {
           'blockType': header1Attribution,
@@ -30,13 +30,13 @@ MutableDocument _createParagraphTestDoc() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is left aligned',
+          'This is a short\nparagraph of text\nthat is left aligned',
         ),
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is center aligned',
+          'This is a short\nparagraph of text\nthat is center aligned',
         ),
         metadata: {
           'textAlign': 'center',
@@ -45,7 +45,7 @@ MutableDocument _createParagraphTestDoc() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: 'This is a short\nparagraph of text\nthat is right aligned',
+          'This is a short\nparagraph of text\nthat is right aligned',
         ),
         metadata: {
           'textAlign': 'right',
@@ -54,8 +54,7 @@ MutableDocument _createParagraphTestDoc() {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text:
-              'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
+          'orem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.',
         ),
       ),
     ],

--- a/super_editor/test_goldens/editor/components/text_with_hint_test.dart
+++ b/super_editor/test_goldens/editor/components/text_with_hint_test.dart
@@ -13,16 +13,16 @@ void main() {
           mainAxisSize: MainAxisSize.min,
           children: [
             TextWithHintComponent(
-              text: AttributedText(text: ''),
+              text: AttributedText(),
               textStyleBuilder: _textStyleBuilder,
-              hintText: AttributedText(text: "this is a hint..."),
+              hintText: AttributedText("this is a hint..."),
               hintStyleBuilder: (_) => _hintStyle,
             ),
             const SizedBox(height: 24),
             TextWithHintComponent(
-              text: AttributedText(text: 'This is content text.'),
+              text: AttributedText('This is content text.'),
               textStyleBuilder: _textStyleBuilder,
-              hintText: AttributedText(text: "this is a hint..."),
+              hintText: AttributedText("this is a hint..."),
               hintStyleBuilder: (_) => _hintStyle,
             ),
           ],

--- a/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
+++ b/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
@@ -871,8 +871,7 @@ MutableDocument _createSingleParagraphDoc() {
       ParagraphNode(
         id: "1",
         text: AttributedText(
-          text:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         ),
       ),
     ],

--- a/super_editor/test_goldens/super_textfield/super_textfield_scroll_test.dart
+++ b/super_editor/test_goldens/super_textfield/super_textfield_scroll_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('SuperTextField', () {
     testGoldensOnAndroid("multi-line accounts for padding when jumping scroll position down", (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "First line\nSecond Line\nThird Line\nFourth Line"),
+        text: AttributedText("First line\nSecond Line\nThird Line\nFourth Line"),
       );
 
       const description =
@@ -69,7 +69,7 @@ void main() {
 
     testGoldensOnAndroid("multi-line accounts for padding when jumping scroll position up", (tester) async {
       final controller = AttributedTextEditingController(
-        text: AttributedText(text: "First line\nSecond Line\nThird Line\nFourth Line"),
+        text: AttributedText("First line\nSecond Line\nThird Line\nFourth Line"),
       );
 
       const description =

--- a/super_editor/test_goldens/super_textfield/super_textfield_text_alignment_test.dart
+++ b/super_editor/test_goldens/super_textfield/super_textfield_text_alignment_test.dart
@@ -218,7 +218,7 @@ Widget _buildSuperTextField({
   int? maxLines,
 }) {
   final controller = AttributedTextEditingController(
-    text: AttributedText(text: text),
+    text: AttributedText(text),
   );
 
   return SizedBox(

--- a/super_editor/test_goldens/super_textfield/super_textfield_toolbar_test.dart
+++ b/super_editor/test_goldens/super_textfield/super_textfield_toolbar_test.dart
@@ -72,7 +72,7 @@ Widget _buildSuperTextField({
   SuperTextFieldPlatformConfiguration? configuration,
 }) {
   final controller = AttributedTextEditingController(
-    text: AttributedText(text: text),
+    text: AttributedText(text),
   );
 
   return SizedBox(

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -192,6 +192,8 @@ String? _convertAlignmentToMarkdown(String alignment) {
       return ':---:';
     case 'right':
       return '---:';
+    case 'justify':
+      return '-::-';
     default:
       return null;
   }

--- a/super_editor_markdown/lib/src/markdown_to_attributed_text_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_attributed_text_parsing.dart
@@ -1,0 +1,20 @@
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/src/markdown_to_document_parsing.dart';
+
+/// Parses [markdown] and returns it as [AttributedText].
+///
+/// The [markdown] is expected to represent a single paragraph of content. If
+/// the [markdown] isn't text-based (e.g., an image), or if the [markdown] includes
+/// more than one paragraph of content, an exception is thrown.
+AttributedText attributedTextFromMarkdown(String markdown) {
+  if (markdown.isEmpty) {
+    return AttributedText();
+  }
+
+  final document = deserializeMarkdownToDocument(markdown);
+  assert(document.nodes.length == 1,
+      "Tried to parse Markdown to AttributedText. Expected one paragraph node but ended up with ${document.nodes.length} parsed nodes.");
+  assert(document.nodes.first is ParagraphNode,
+      "Tried to parse Markdown to AttributedText. Expected text but found content type: ${document.nodes.first.runtimeType}");
+  return (document.nodes.first as ParagraphNode).text;
+}

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -48,7 +48,7 @@ MutableDocument deserializeMarkdownToDocument(
     // For the user to be able to interact with the editor, at least one
     // node is required, so we add an empty paragraph.
     documentNodes.add(
-      ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: '')),
+      ParagraphNode(id: Editor.createNodeId(), text: AttributedText()),
     );
   }
 
@@ -243,7 +243,7 @@ class _MarkdownToDocument implements md.NodeVisitor {
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText(
-          text: element.textContent,
+          element.textContent,
         ),
         metadata: {
           'blockType': codeAttribution,
@@ -358,7 +358,7 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
   @override
   void visitText(md.Text text) {
     final attributedText = _textStack.removeLast();
-    _textStack.add(attributedText.copyAndAppend(AttributedText(text: text.text)));
+    _textStack.add(attributedText.copyAndAppend(AttributedText(text.text)));
   }
 
   @override
@@ -446,8 +446,8 @@ class UnderlineSyntax extends md.TagSyntax {
 class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax {
   /// This pattern matches the text aligment notation.
   ///
-  /// Possible values are `:---`, `:---:` and `---:`
-  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:$');
+  /// Possible values are `:---`, `:---:`, `---:` and `-::-`.
+  static final _alignmentNotationPattern = RegExp(r'^:-{3}|:-{3}:|-{3}:|-::-$');
 
   const _ParagraphWithAlignmentSyntax();
 
@@ -506,6 +506,8 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
         return 'center';
       case '---:':
         return 'right';
+      case '-::-':
+        return 'justify';
       // As we already check that the input matches the notation,
       // we shouldn't reach this point.
       default:

--- a/super_editor_markdown/lib/src/super_editor_syntax.dart
+++ b/super_editor_markdown/lib/src/super_editor_syntax.dart
@@ -14,5 +14,7 @@ enum MarkdownSyntax {
   /// `:---:` represents center alignment.
   ///
   /// `---:` represents right alignment.
+  ///
+  /// `-::-` represents justify alignment.
   superEditor,
 }

--- a/super_editor_markdown/lib/super_editor_markdown.dart
+++ b/super_editor_markdown/lib/super_editor_markdown.dart
@@ -1,3 +1,4 @@
 export 'src/document_to_markdown_serializer.dart';
+export 'src/markdown_to_attributed_text_parsing.dart';
 export 'src/markdown_to_document_parsing.dart';
 export 'src/super_editor_syntax.dart';

--- a/super_editor_markdown/test/attributed_text_markdown_test.dart
+++ b/super_editor_markdown/test/attributed_text_markdown_test.dart
@@ -1,28 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor_markdown/src/document_to_markdown_serializer.dart';
+import 'package:super_editor_markdown/src/markdown_to_attributed_text_parsing.dart';
 
 void main() {
   group("AttributedText markdown serializes", () {
     test("un-styled text", () {
       expect(
-        AttributedText(text: "This is unstyled text.").toMarkdown(),
+        AttributedText("This is unstyled text.").toMarkdown(),
         "This is unstyled text.",
       );
     });
 
     test("single character styles", () {
       expect(
-        AttributedText(
-          text: "This is single character styles.",
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: italicsAttribution, offset: 23, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: italicsAttribution, offset: 23, markerType: SpanMarkerType.end),
-            ],
-          ),
+        attributedTextFromMarkdown(
+          "This is **s**ingle characte*r* styles.",
         ).toMarkdown(),
         "This is **s**ingle characte*r* styles.",
       );
@@ -30,14 +23,8 @@ void main() {
 
     test("bold text", () {
       expect(
-        AttributedText(
-          text: "This is bold text.",
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.end),
-            ],
-          ),
+        attributedTextFromMarkdown(
+          "This is **bold** text.",
         ).toMarkdown(),
         "This is **bold** text.",
       );
@@ -45,14 +32,8 @@ void main() {
 
     test("italics text", () {
       expect(
-        AttributedText(
-          text: "This is italics text.",
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: italicsAttribution, offset: 14, markerType: SpanMarkerType.end),
-            ],
-          ),
+        attributedTextFromMarkdown(
+          "This is *italics* text.",
         ).toMarkdown(),
         "This is *italics* text.",
       );
@@ -60,26 +41,22 @@ void main() {
 
     test("multiple styles across the same span", () {
       expect(
-        AttributedText(
-          text: "This is multiple styled text.",
-          spans: AttributedSpans(
-            attributions: [
-              SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: boldAttribution, offset: 22, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: italicsAttribution, offset: 22, markerType: SpanMarkerType.end),
-            ],
-          ),
+        attributedTextFromMarkdown(
+          "This is ***multiple styled*** text.",
         ).toMarkdown(),
         "This is ***multiple styled*** text.",
       );
     });
 
     test("partially overlapping styles", () {
+      // This test needs to manually configure attributed spans because it
+      // turns out that Markdown doesn't know how to parse overlapping styles,
+      // so we can't parse this text from Markdown, but we can still test our
+      // ability to serialize overlapping styles.
       expect(
         AttributedText(
-          text: "This is overlapping styles.",
-          spans: AttributedSpans(
+          "This is overlapping styles.",
+          AttributedSpans(
             attributions: [
               SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
               SpanMarker(attribution: boldAttribution, offset: 13, markerType: SpanMarkerType.end),

--- a/super_editor_markdown/test/custom_block_serializer_test.dart
+++ b/super_editor_markdown/test/custom_block_serializer_test.dart
@@ -11,9 +11,9 @@ void main() {
       final markdown = serializeDocumentToMarkdown(
         MutableDocument(
           nodes: [
-            ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: "Paragraph 1")),
+            ParagraphNode(id: Editor.createNodeId(), text: AttributedText("Paragraph 1")),
             UpsellNode(Editor.createNodeId()),
-            ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: "Paragraph 2")),
+            ParagraphNode(id: Editor.createNodeId(), text: AttributedText("Paragraph 2")),
           ],
         ),
         customNodeSerializers: [UpsellSerializer()],
@@ -33,21 +33,16 @@ Paragraph 2''',
       final markdown = serializeDocumentToMarkdown(
         MutableDocument(
           nodes: [
-            ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: "Paragraph 1")),
             ParagraphNode(
               id: Editor.createNodeId(),
-              text: AttributedText(
-                text: "This is a callout!",
-                spans: AttributedSpans(
-                  attributions: [
-                    SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
-                    SpanMarker(attribution: boldAttribution, offset: 17, markerType: SpanMarkerType.end),
-                  ],
-                ),
-              ),
+              text: AttributedText("Paragraph 1"),
+            ),
+            ParagraphNode(
+              id: Editor.createNodeId(),
+              text: attributedTextFromMarkdown("This is a **callout!**"),
               metadata: {"blockType": const NamedAttribution("callout")},
             ),
-            ParagraphNode(id: Editor.createNodeId(), text: AttributedText(text: "Paragraph 2")),
+            ParagraphNode(id: Editor.createNodeId(), text: AttributedText("Paragraph 2")),
           ],
         ),
         customNodeSerializers: [CalloutSerializer()],

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -144,7 +144,7 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
   @override
   void visitText(md.Text text) {
     final attributedText = _textStack.removeLast();
-    _textStack.add(attributedText.copyAndAppend(AttributedText(text: text.text)));
+    _textStack.add(attributedText.copyAndAppend(AttributedText(text.text)));
   }
 
   @override

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -9,7 +9,7 @@ void main() {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'My Header'),
+            text: AttributedText('My Header'),
           ),
         ]);
 
@@ -36,15 +36,7 @@ void main() {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'My Header',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 3, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown("My **Header**"),
             metadata: {'blockType': header1Attribution},
           ),
         ]);
@@ -56,7 +48,7 @@ void main() {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'This is a blockquote'),
+            text: AttributedText('This is a blockquote'),
             metadata: {'blockType': blockquoteAttribution},
           ),
         ]);
@@ -68,15 +60,7 @@ void main() {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a blockquote',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 19, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This is a **blockquote**'),
             metadata: {'blockType': blockquoteAttribution},
           ),
         ]);
@@ -88,7 +72,7 @@ void main() {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'This is some code'),
+            text: AttributedText('This is some code'),
             metadata: {'blockType': codeAttribution},
           ),
         ]);
@@ -106,7 +90,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'This is a paragraph.'),
+            text: AttributedText('This is a paragraph.'),
           ),
         ]);
 
@@ -117,15 +101,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This **is a** paragraph.'),
           ),
         ]);
 
@@ -136,17 +112,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: italicsAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This ***is a*** paragraph.'),
           ),
         ]);
 
@@ -157,17 +123,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: italicsAttribution, offset: 8, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: italicsAttribution, offset: 19, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('**This is** *a paragraph.*'),
           ),
         ]);
 
@@ -178,17 +134,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: italicsAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This ***is a** paragraph*.'),
           ),
         ]);
 
@@ -199,9 +145,11 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
+            // TODO: get code syntax to work
+            // text: attributedTextFromMarkdown('This `**is a**` paragraph.'),
             text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
+              'This is a paragraph.',
+              AttributedSpans(
                 attributions: [
                   const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
                   const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
@@ -220,21 +168,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 10,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 18,
-                      markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This is a [paragraph](https://example.org).'),
           ),
         ]);
 
@@ -245,23 +179,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 10,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 18,
-                      markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: boldAttribution, offset: 10, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 18, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This is a [**paragraph**](https://example.org).'),
           ),
         ]);
 
@@ -272,23 +190,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 0,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 18,
-                      markerType: SpanMarkerType.end),
-                  const SpanMarker(attribution: boldAttribution, offset: 5, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('[This **is a** paragraph](https://example.org).'),
           ),
         ]);
 
@@ -299,15 +201,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(attribution: underlineAttribution, offset: 10, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: underlineAttribution, offset: 18, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This is a ¬paragraph¬.'),
           ),
         ]);
 
@@ -318,15 +212,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'This is a paragraph.',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(attribution: strikethroughAttribution, offset: 10, markerType: SpanMarkerType.start),
-                  SpanMarker(attribution: strikethroughAttribution, offset: 18, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('This is a ~paragraph~.'),
           ),
         ]);
 
@@ -337,29 +223,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(
-              text: 'First LinkSecond Link',
-              spans: AttributedSpans(
-                attributions: [
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 0,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('example.org', '')),
-                      offset: 9,
-                      markerType: SpanMarkerType.end),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
-                      offset: 10,
-                      markerType: SpanMarkerType.start),
-                  SpanMarker(
-                      attribution: LinkAttribution(url: Uri.https('github.com', '')),
-                      offset: 20,
-                      markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('[First Link](https://example.org)[Second Link](https://github.com)'),
           ),
         ]);
 
@@ -370,7 +234,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'Paragraph1'),
+            text: AttributedText('Paragraph1'),
             metadata: {
               'textAlign': 'left',
             },
@@ -389,7 +253,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'Paragraph1'),
+            text: AttributedText('Paragraph1'),
             metadata: {
               'textAlign': 'center',
             },
@@ -403,7 +267,7 @@ This is some code
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'Paragraph1'),
+            text: AttributedText('Paragraph1'),
             metadata: {
               'textAlign': 'right',
             },
@@ -413,11 +277,25 @@ This is some code
         expect(serializeDocumentToMarkdown(doc), '---:\nParagraph1');
       });
 
+      test('paragraph with justify alignment', () {
+        final doc = MutableDocument(nodes: [
+          ParagraphNode(
+            id: '1',
+            text: AttributedText('Paragraph1'),
+            metadata: {
+              'textAlign': 'justify',
+            },
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '-::-\nParagraph1');
+      });
+
       test("doesn't serialize text alignment when not using supereditor syntax", () {
         final doc = MutableDocument(nodes: [
           ParagraphNode(
             id: '1',
-            text: AttributedText(text: 'Paragraph1'),
+            text: AttributedText('Paragraph1'),
             metadata: {
               'textAlign': 'center',
             },
@@ -430,9 +308,9 @@ This is some code
       test('empty paragraph', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
-            ParagraphNode(id: '2', text: AttributedText(text: '')),
-            ParagraphNode(id: '3', text: AttributedText(text: 'Paragraph3')),
+            ParagraphNode(id: '1', text: AttributedText('Paragraph1')),
+            ParagraphNode(id: '2', text: AttributedText('')),
+            ParagraphNode(id: '3', text: AttributedText('Paragraph3')),
           ]),
         );
 
@@ -446,9 +324,9 @@ Paragraph3""");
       test('separates multiple paragraphs with blank lines', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
-            ParagraphNode(id: '2', text: AttributedText(text: 'Paragraph2')),
-            ParagraphNode(id: '3', text: AttributedText(text: 'Paragraph3')),
+            ParagraphNode(id: '1', text: AttributedText('Paragraph1')),
+            ParagraphNode(id: '2', text: AttributedText('Paragraph2')),
+            ParagraphNode(id: '3', text: AttributedText('Paragraph3')),
           ]),
         );
 
@@ -462,7 +340,7 @@ Paragraph3""");
       test('separates paragraph from other blocks with blank lines', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'First Paragraph')),
+            ParagraphNode(id: '1', text: AttributedText('First Paragraph')),
             HorizontalRuleNode(id: '2'),
           ]),
         );
@@ -473,8 +351,8 @@ Paragraph3""");
       test('preserves linebreaks at the end of a paragraph', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1\n\n')),
-            ParagraphNode(id: '2', text: AttributedText(text: 'Paragraph2')),
+            ParagraphNode(id: '1', text: AttributedText('Paragraph1\n\n')),
+            ParagraphNode(id: '2', text: AttributedText('Paragraph2')),
           ]),
         );
 
@@ -484,7 +362,7 @@ Paragraph3""");
       test('preserves linebreaks within a paragraph', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'Line1\n\nLine2')),
+            ParagraphNode(id: '1', text: AttributedText('Line1\n\nLine2')),
           ]),
         );
 
@@ -494,8 +372,8 @@ Paragraph3""");
       test('preserves linebreaks at the beginning of a paragraph', () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: '\n\nParagraph1')),
-            ParagraphNode(id: '2', text: AttributedText(text: 'Paragraph2')),
+            ParagraphNode(id: '1', text: AttributedText('\n\nParagraph1')),
+            ParagraphNode(id: '2', text: AttributedText('Paragraph2')),
           ]),
         );
 
@@ -529,29 +407,29 @@ Paragraph3""");
           ListItemNode(
             id: '1',
             itemType: ListItemType.unordered,
-            text: AttributedText(text: 'Unordered 1'),
+            text: AttributedText('Unordered 1'),
           ),
           ListItemNode(
             id: '2',
             itemType: ListItemType.unordered,
-            text: AttributedText(text: 'Unordered 2'),
+            text: AttributedText('Unordered 2'),
           ),
           ListItemNode(
             id: '3',
             itemType: ListItemType.unordered,
             indent: 1,
-            text: AttributedText(text: 'Unordered 2.1'),
+            text: AttributedText('Unordered 2.1'),
           ),
           ListItemNode(
             id: '4',
             itemType: ListItemType.unordered,
             indent: 1,
-            text: AttributedText(text: 'Unordered 2.2'),
+            text: AttributedText('Unordered 2.2'),
           ),
           ListItemNode(
             id: '5',
             itemType: ListItemType.unordered,
-            text: AttributedText(text: 'Unordered 3'),
+            text: AttributedText('Unordered 3'),
           ),
         ]);
 
@@ -571,15 +449,7 @@ Paragraph3""");
           ListItemNode(
             id: '1',
             itemType: ListItemType.unordered,
-            text: AttributedText(
-              text: 'Unordered 1',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('**Unordered** 1'),
           ),
         ]);
 
@@ -591,29 +461,29 @@ Paragraph3""");
           ListItemNode(
             id: '1',
             itemType: ListItemType.ordered,
-            text: AttributedText(text: 'Ordered 1'),
+            text: AttributedText('Ordered 1'),
           ),
           ListItemNode(
             id: '2',
             itemType: ListItemType.ordered,
-            text: AttributedText(text: 'Ordered 2'),
+            text: AttributedText('Ordered 2'),
           ),
           ListItemNode(
             id: '3',
             itemType: ListItemType.ordered,
             indent: 1,
-            text: AttributedText(text: 'Ordered 2.1'),
+            text: AttributedText('Ordered 2.1'),
           ),
           ListItemNode(
             id: '4',
             itemType: ListItemType.ordered,
             indent: 1,
-            text: AttributedText(text: 'Ordered 2.2'),
+            text: AttributedText('Ordered 2.2'),
           ),
           ListItemNode(
             id: '5',
             itemType: ListItemType.ordered,
-            text: AttributedText(text: 'Ordered 3'),
+            text: AttributedText('Ordered 3'),
           ),
         ]);
 
@@ -633,15 +503,7 @@ Paragraph3""");
           ListItemNode(
             id: '1',
             itemType: ListItemType.ordered,
-            text: AttributedText(
-              text: 'Ordered 1',
-              spans: AttributedSpans(
-                attributions: [
-                  const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
-                  const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
-                ],
-              ),
-            ),
+            text: attributedTextFromMarkdown('**Ordered** 1'),
           ),
         ]);
 
@@ -656,54 +518,54 @@ Paragraph3""");
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'Example Doc'),
+            text: AttributedText('Example Doc'),
             metadata: {'blockType': header1Attribution},
           ),
           HorizontalRuleNode(id: Editor.createNodeId()),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'Unordered list:'),
+            text: AttributedText('Unordered list:'),
           ),
           ListItemNode(
             id: Editor.createNodeId(),
             itemType: ListItemType.unordered,
-            text: AttributedText(text: 'Unordered 1'),
+            text: AttributedText('Unordered 1'),
           ),
           ListItemNode(
             id: Editor.createNodeId(),
             itemType: ListItemType.unordered,
-            text: AttributedText(text: 'Unordered 2'),
+            text: AttributedText('Unordered 2'),
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'Ordered list:'),
+            text: AttributedText('Ordered list:'),
           ),
           ListItemNode(
             id: Editor.createNodeId(),
             itemType: ListItemType.ordered,
-            text: AttributedText(text: 'Ordered 1'),
+            text: AttributedText('Ordered 1'),
           ),
           ListItemNode(
             id: Editor.createNodeId(),
             itemType: ListItemType.ordered,
-            text: AttributedText(text: 'Ordered 2'),
+            text: AttributedText('Ordered 2'),
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'A blockquote:'),
+            text: AttributedText('A blockquote:'),
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'This is a blockquote.'),
+            text: AttributedText('This is a blockquote.'),
             metadata: {'blockType': blockquoteAttribution},
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: 'Some code:'),
+            text: AttributedText('Some code:'),
           ),
           ParagraphNode(
             id: Editor.createNodeId(),
-            text: AttributedText(text: '{\n  // This is some code.\n}'),
+            text: AttributedText('{\n  // This is some code.\n}'),
             metadata: {'blockType': codeAttribution},
           ),
         ]);
@@ -719,7 +581,7 @@ Paragraph3""");
       test("doesn't add empty lines at the end of the document", () {
         final serialized = serializeDocumentToMarkdown(
           MutableDocument(nodes: [
-            ParagraphNode(id: '1', text: AttributedText(text: 'Paragraph1')),
+            ParagraphNode(id: '1', text: AttributedText('Paragraph1')),
           ]),
         );
 
@@ -1008,6 +870,14 @@ This is some code
         expect(paragraph.text.text, 'Paragraph1');
       });
 
+      test('paragraph with justify alignment', () {
+        final doc = deserializeMarkdownToDocument('-::-\nParagraph1');
+
+        final paragraph = doc.nodes.first as ParagraphNode;
+        expect(paragraph.getMetadataValue('textAlign'), 'justify');
+        expect(paragraph.text.text, 'Paragraph1');
+      });
+
       test('treats alignment token as text at the end of the document', () {
         final doc = deserializeMarkdownToDocument('---:');
 
@@ -1124,7 +994,7 @@ Paragraph4""";
         expect(doc.nodes.last, isA<ParagraphNode>());
         expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
       });
-    
+
       test('document ending with an empty paragraph', () {
         final doc = deserializeMarkdownToDocument("""
 First Paragraph.


### PR DESCRIPTION
Adjusted cherry pick (main hash - 3ca24ada5f6e12e911f1770c25dbcc2cf371772e): Converted AttributedText to use optional position constructor parameters instead of named parameters, for brevity, and also added ability to create an AttributedText directly from a Markdown string (Resolves #488) (#1325)

Also for stable: added Markdown justification alignment which we apparently never cherry picked