### PR TITLE
[SuperEditor][web] Fix new line duplication (Resolves #1219)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -106,7 +106,7 @@ class SuperEditor extends StatefulWidget {
     this.imePolicies = const SuperEditorImePolicies(),
     this.imeConfiguration = const SuperEditorImeConfiguration(),
     this.imeOverrides,
-    List<DocumentKeyboardAction>? keyboardActions,
+    this.keyboardActions,
     this.gestureMode,
     this.contentTapDelegateFactory = superEditorLaunchLinkTapHandlerFactory,
     this.androidHandleColor,
@@ -122,8 +122,6 @@ class SuperEditor extends StatefulWidget {
     this.debugPaint = const DebugPaintConfig(),
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
-        keyboardActions = keyboardActions ??
-            (inputSource == TextInputSource.keyboard ? defaultKeyboardActions : defaultImeKeyboardActions),
         componentBuilders = componentBuilders != null
             ? [...componentBuilders, const UnknownComponentBuilder()]
             : [...defaultComponentBuilders, const UnknownComponentBuilder()],
@@ -273,10 +271,7 @@ class SuperEditor extends StatefulWidget {
   /// All actions that this editor takes in response to key
   /// events, e.g., text entry, newlines, character deletion,
   /// copy, paste, etc.
-  ///
-  /// These actions are only used when in [TextInputSource.keyboard]
-  /// mode.
-  final List<DocumentKeyboardAction> keyboardActions;
+  final List<DocumentKeyboardAction>? keyboardActions;
 
   /// Plugins that add sets of behaviors to the editing experience.
   final Set<SuperEditorPlugin> plugins;
@@ -323,6 +318,11 @@ class SuperEditorState extends State<SuperEditor> {
 
   @visibleForTesting
   SingleColumnLayoutPresenter get presenter => _docLayoutPresenter!;
+
+  /// Returns the key handlers that respond to keyboard events within [SuperEditor].
+  List<DocumentKeyboardAction> get _keyboardActions =>
+      widget.keyboardActions ??
+      (inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions);
 
   @override
   void initState() {
@@ -555,7 +555,7 @@ class SuperEditorState extends State<SuperEditor> {
           keyboardActions: [
             for (final plugin in widget.plugins) //
               ...plugin.keyboardActions,
-            ...widget.keyboardActions,
+            ..._keyboardActions,
           ],
           child: child,
         );
@@ -573,7 +573,7 @@ class SuperEditorState extends State<SuperEditor> {
           hardwareKeyboardActions: [
             for (final plugin in widget.plugins) //
               ...plugin.keyboardActions,
-            ...widget.keyboardActions,
+            ..._keyboardActions,
           ],
           floatingCursorController: _floatingCursorController,
           child: child,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -123,7 +123,7 @@ class SuperEditor extends StatefulWidget {
   })  : stylesheet = stylesheet ?? defaultStylesheet,
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         keyboardActions = keyboardActions ??
-            (inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions),
+            (inputSource == TextInputSource.keyboard ? defaultKeyboardActions : defaultImeKeyboardActions),
         componentBuilders = componentBuilders != null
             ? [...componentBuilders, const UnknownComponentBuilder()]
             : [...defaultComponentBuilders, const UnknownComponentBuilder()],

--- a/super_editor/test/super_editor/components/block_node_test.dart
+++ b/super_editor/test/super_editor/components/block_node_test.dart
@@ -651,6 +651,7 @@ Widget _buildHardwareKeyboardEditor(MutableDocument document, MutableDocumentCom
           ],
         ),
         gestureMode: DocumentGestureMode.mouse,
+        inputSource: TextInputSource.keyboard,
         autofocus: true,
       ),
     ),


### PR DESCRIPTION
[SuperEditor][web] Fix new line duplication. Resolves #1219.

In the Sliver Editor Demo in the Demo App, pressing ENTER is still causing the editor to duplicate the new lines.

The cause is that, if the `inputSource` isn't passed in the constructor, the editor uses IME as the input source, but still uses the keyboard handlers for the desktop input source.

This PR inverts the condition, as a `null` `inputSource` in the constructor will default to IME.

We could also write it as the following: 

```dart
keyboardActions = keyboardActions ??
            (inputSource == null || inputSource == TextInputSource.ime
                ? defaultImeKeyboardActions
                : defaultKeyboardActions),
```

or also

```dart
((inputSource ?? TextInputSource.ime) == TextInputSource.ime
                ? defaultImeKeyboardActions
                : defaultKeyboardActions),
```

I'm happy with updating the PR to match the prefered style.