### PR TITLE
Cherry-pick "[SuperTextField][Mobile] Always compute the viewport height in the first frame (Resolves #939) (#1319)" to stable

### DIFF
--- a/super_editor/test/super_textfield/super_textfield_rendering_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_rendering_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../test_tools.dart';
 
@@ -31,6 +32,62 @@ void main() {
       // Ensure the SuperTextField rendered the text.
       expect(find.text('Editing text', findRichText: true), findsOneWidget);
     });
+
+    testWidgetsOnMobile('expands to respect minLines', (tester) async {
+      // Indicates whether we should display the Text or the SuperTextField.
+      final showTextField = ValueNotifier<bool>(false);
+
+      // Pump the widget tree showing the Text widget.
+      await _pumpSwitchableTestApp(
+        tester,
+        controller: AttributedTextEditingController(
+          text: AttributedText('1'),
+        ),
+        showTextField: showTextField,
+        minLines: 5,
+      );
+
+      // Switch to display the SuperTextField, so we can inspect it on its first frame.
+      showTextField.value = true;
+      await tester.pump();
+
+      // Ensure the text is rendered in the first frame.
+      expect(find.text('1', findRichText: true), findsOneWidget);
+
+      // Ensure the text field expanded to the height of minLines.
+      final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
+      final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
+      final minLinesHeight = textHeight * 5;
+      expect(textFieldHeight, moreOrLessEquals(minLinesHeight));
+    });
+
+    testWidgetsOnMobile('shrinks to fit maxLines', (tester) async {
+      // Indicates whether we should display the Text or the SuperTextField.
+      final showTextField = ValueNotifier<bool>(false);
+
+      // Pump the widget tree showing the Text widget.
+      await _pumpSwitchableTestApp(
+        tester,
+        controller: AttributedTextEditingController(
+          text: AttributedText('1\n2\n3\n4\n5\n6'),
+        ),
+        showTextField: showTextField,
+        maxLines: 3,
+      );
+
+      // Switch to display the SuperTextField, so we can inspect it on its first frame.
+      showTextField.value = true;
+      await tester.pump();
+
+      // Ensure the text is rendered in the first frame.
+      expect(find.text('1\n2\n3\n4\n5\n6', findRichText: true), findsOneWidget);
+
+      // Ensure the text field shrank to half of the text size.
+      final textHeight = tester.getSize(find.byType(SuperTextWithSelection)).height;
+      final textFieldHeight = tester.getSize(find.byType(SuperTextField)).height;
+      final maxLinesHeight = textHeight / 2;
+      expect(textFieldHeight, moreOrLessEquals(maxLinesHeight));
+    });
   });
 }
 
@@ -40,6 +97,8 @@ Future<void> _pumpSwitchableTestApp(
   required AttributedTextEditingController controller,
   required ValueNotifier<bool> showTextField,
   double? lineHeight,
+  int? minLines,
+  int? maxLines,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -51,6 +110,8 @@ Future<void> _pumpSwitchableTestApp(
                 ? SuperTextField(
                     textController: controller,
                     lineHeight: lineHeight,
+                    minLines: minLines,
+                    maxLines: maxLines,
                   )
                 : const Text('');
           },


### PR DESCRIPTION
This PR cherry-picks "[SuperTextField][Mobile] Always compute the viewport height in the first frame (Resolves #939) (#1319)" to stable.