### PR TITLE
[SuperTextField][mobile] Avoid calling `getMinIntrinsicHeight` in `TextScrollview` (Resolves #939)

### DIFF
--- a/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
@@ -1039,7 +1039,13 @@ class _RenderTextViewport extends RenderProxyBox {
     // The height we need to enforce if the child doesn't already respects the line restrictions.
     double? adjustedChildHeight;
 
-    final childIntrinsicHeight = child!.getMinIntrinsicHeight(constraints.maxWidth);
+    // Compute the height the child wants to be.
+    //
+    // We layout instead of computing the child's intrinsic height, because RenderFlex doesn't
+    // support calling getMinIntrinsicHeight if it has baseline cross-axis alignment.
+    child!.layout(constraints.copyWith(maxHeight: double.infinity), parentUsesSize: true);
+    final childIntrinsicHeight = child!.size.height;
+
     if (childIntrinsicHeight < minHeight) {
       adjustedChildHeight = minHeight;
     } else if (maxHeight != null && childIntrinsicHeight > maxHeight) {

--- a/super_editor/test/super_textfield/super_textfield_rendering_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_rendering_test.dart
@@ -88,6 +88,30 @@ void main() {
       final maxLinesHeight = textHeight / 2;
       expect(textFieldHeight, moreOrLessEquals(maxLinesHeight));
     });
+
+    testWidgetsOnAllPlatforms('renders a hint with baseline cross-axis alignment', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperTextField(
+              textController: AttributedTextEditingController(),
+              minLines: 1,
+              maxLines: 3,
+              hintBuilder: (context) => const Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text('Hint one'),
+                  Text('Hint two'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Reaching this point means that SuperTextField was able to render without errors.
+    });
   });
 }
 


### PR DESCRIPTION
[SuperTextField][mobile] Avoid calling `getMinIntrinsicHeight` in `TextScrollview. Resolves #939.

This PR fixes an issue pointed out by @knopp, where calling `getMinIntrinsicHeight` causes an exception in `RenderFlex` if it has a baseline `crossAxisAlignment`.

I was able to write a failing test with the previous implementation.

This PR removes the `getMinIntrinsicHeight` and instead, lays out the child with infinity height constraints. 