### PR TITLE
Fixes `flutter_test` `TestWindow` deprecations

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -52,7 +52,7 @@ dependency_overrides:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
   mockito: ^5.0.4
   super_editor_markdown:
     path: ../super_editor_markdown

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
 
 flutter:
 # no Flutter configuration

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -26,7 +26,7 @@ dependency_overrides:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
   args: ^2.3.1
   meta: ^1.8.0
   golden_runner:


### PR DESCRIPTION
Needed for: https://github.com/flutter/flutter/pull/133176 and https://github.com/flutter/flutter/pull/133178

The deprecation period for the following `TestWindow` members has elapsed:
* `textScaleFactorTestValue`
* `clearTextScaleFactorTestValue`
* `platformBrightnessTestValue`
* `clearPlatformBrightnessTestValue`

Links to crashing tests: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing/61658/overview and https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing/61656/overview

These members are being removed from the framework so this PR helps update some dependencies that were using the deprecated members.

I have confirmed that customer tests now pass locally as the `golden_toolkit v 0.15.0` has updated their implementations to use non-deprecated `TestWindow` members. The commit that they were updated in was https://github.com/eBay/flutter_glove_box/commit/788c4e1a996cacdec9699d9294a99dd56d34b7ba as part of `v0.14.0`.

`v0.15.0` also includes a fix for properly taking into consideration `devicePixelRatio` https://github.com/eBay/flutter_glove_box/commit/2660a187405351c2a8560d4ea2443691a03c7acf