### PR TITLE
[SuperEditor] Fix composer preferences after text replacement (Resolves #1167)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1417,8 +1417,6 @@ class CommonEditorOperations {
       return false;
     }
 
-    late Set<Attribution>? replacedTextAttributions;
-
     if (!composer.selection!.isCollapsed) {
       // The selection is expanded. Delete the selected content
       // and then insert the new text.
@@ -1428,8 +1426,14 @@ class CommonEditorOperations {
       // we need to store the current attributions.
       // This is required as deleting text can clear the composer current attributions.
       // Without this, the new text doesn't preserve the attributions of the replaced text.
-      replacedTextAttributions = {...composer.preferences.currentAttributions};
+      final composerAttributions = {...composer.preferences.currentAttributions};
+
       _deleteExpandedSelection();
+
+      // Restore the previous attributions.
+      composer.preferences
+        ..clearStyles()
+        ..addStyles(composerAttributions);
     }
 
     final extentNodePosition = composer.selection!.extent.nodePosition;
@@ -1450,18 +1454,9 @@ class CommonEditorOperations {
       InsertTextRequest(
         documentPosition: composer.selection!.extent,
         textToInsert: text,
-        attributions: replacedTextAttributions ?? composer.preferences.currentAttributions,
+        attributions: composer.preferences.currentAttributions,
       ),
     ]);
-
-    if (replacedTextAttributions != null) {
-      // As we are replacing text we restore the composer current attributions.
-      // This is needed to ensure that, after replacing the text, newly inserted characters
-      // will use the existing attributions.
-      composer.preferences
-        ..clearStyles()
-        ..addStyles(replacedTextAttributions);
-    }
 
     return true;
   }

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -744,6 +744,45 @@ Paragraph two
         // Ensure we cleared the composing region on the IME so the previous entered text is preserved.
         expect(composingRegion, TextRange.empty);
       });
+
+      testWidgetsOnIos('applies keyboard suggestions and keeps styles', (tester) async {
+        // Pump an editor with a bold text.
+        final testContext = await tester //
+            .createDocument()
+            .fromMarkdown('**Fix**')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(testContext.document.nodes.first.id, 3);
+
+        // Type a letter simulating a typo. The current text results in "Fixs".
+        await tester.typeImeText('s');
+
+        // Simulate the user accepting a suggestion.
+        // The IME replaces the word and inserts a space after it.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaReplacement(
+            oldText: 'Fixs',
+            replacementText: 'Fixed',
+            replacedRange: TextRange(start: 0, end: 4),
+            selection: TextSelection.collapsed(offset: 5),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaInsertion(
+            oldText: 'Fixed',
+            textInserted: ' ',
+            insertionOffset: 5,
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          )
+        ], getter: imeClientGetter);
+
+        // Ensure the text was replaced and the style was preserved.
+        expect(testContext.document, equalsMarkdown('**Fixed **'));
+      });
     });
 
     group('moves caret', () {


### PR DESCRIPTION
[SuperEditor] Fix composer preferences after text replacement. Resolves #1167 

Accepting keyboard suggestions can cause the text to lose the style, as can be seen in the following video:

https://github.com/superlistapp/super_editor/assets/37604230/ec610720-acb2-49e9-beae-c0f19b436934

When we receive the replacement delta generated by the IME, we first delete the old text and then insert the new one. Deleting the old text might clear the composer current attributions. This is what is causing the issue.

This PR changes `insertPlainText`, so when we are replacing text, we store the current attributions. After deleting the old text we insert the new one with the stored attributions.  