### PR TITLE
Cherry-pick "Flutter Team: Upgrades golden_toolkit for `flutter_test` `TestWindow` deprecations (#1343)" to stable

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -52,7 +52,7 @@ dependency_overrides:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
   mockito: ^5.0.4
   super_editor_markdown:
     path: ../super_editor_markdown

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
 
 flutter:
 # no Flutter configuration

--- a/super_text_layout/pubspec.yaml
+++ b/super_text_layout/pubspec.yaml
@@ -26,7 +26,7 @@ dependency_overrides:
 
 dev_dependencies:
   flutter_lints: ^2.0.1
-  golden_toolkit: ^0.13.0
+  golden_toolkit: ^0.15.0
   args: ^2.3.1
   meta: ^1.8.0
   golden_runner:


### PR DESCRIPTION
This PR cherry-picks "Flutter Team: Upgrades golden_toolkit for `flutter_test` `TestWindow` deprecations (#1343)" to stable.