### PR TITLE
Fix null pointer exception in document overlays due to setState() timing (Resolves #1330)

### DIFF
--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -192,11 +192,6 @@ class ContentLayersElement extends RenderObjectElement {
       return true;
     }
 
-    // if (element.renderObject?.debugNeedsLayout == true) {
-    //   contentLayersLog.finest("Found a dirty render object: $element, ${element.renderObject}");
-    //   return true;
-    // }
-
     bool isDirty = false;
     element.visitChildren((childElement) {
       isDirty = isDirty || _isSubtreeDirty(childElement);


### PR DESCRIPTION
Fix null pointer exception in document overlays due to setState() timing (Resolves #1330)

This problem is a continuation of nuanced widget build ordering and timing within Flutter. This problem is described in an existing Flutter ticket: https://github.com/flutter/flutter/issues/123305

The problem in this ticket is that a number of editor interactions were generating null pointer exceptions when the selection leader overlay would lookup offsets and sizes in the document layout.

After a lot of digging, I was eventually able to write a test that recreated the exception. The situation that seemed to trigger this error is one in which an overlay calls `setState()` on itself, but also the `State` object that contains the whole `SuperEditor` also calls `setState()` in the same frame.

When I worked on getting this test to pass, I found that the specific situation at issue is one in which the content subtree marks itself as dirty in the same frame that at least one layer marks its subtree as dirty, too.

The crux of solving this issue is the same crux that we've been dealing with form day one of `ContentLayers`. Flutter exposes very little control over when rebuilds happen. There's no designated API to prevent a subtree from rebuilding, nor is there is a designated API to allow an ancestor to monitor descendent rebuilds.

**Here's the path I took to resolve this issue:**

First, though it's not intended to work this way, we hijack the `onBuildScheduled` callback within `BuildOwner`. I believe this callback is called every time that something calls `setState()` for the first time between frames, thus scheduling a new build frame. The reason we hijack this callback is because there's no other framework-level way to know that one of our descendants may have requested a rebuild. As a reminder, our `ContentLayers` `Element` needs to know when any of its child subtrees requests a rebuild.

Second, in `onBuildScheduled` we schedule a frame callback. The timing here is important. We need to run some code AFTER all the `Elements` have marked themselves dirty, but BEFORE Flutter actually rebuilds any `Element`s. Based on experimentation, the only callback that we can register, which is run at this desired time, is a `scheduleFrameCallback()` callback.

Third, within the `scheduleFrameCallback()`, we recursively inspect the `Element`s in our child subtrees. This is where we finally check if our content is dirty and if any layers are dirty. If both our content is dirty, and at least one layer is dirty, then this represents the situation that caused the null pointer exception. To prevent the NPE, we deactivate the layer `Element`s so that Flutter won't build them in the next build pass. Then, when Flutter runs the next layout pass, we reactivate and rebuild those layers.