### PR TITLE
Adjusted tag indices to only notify listeners when tags actually change (Resolves #1355)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -127,7 +127,6 @@ class _ExampleEditorState extends State<ExampleEditor> {
     }
 
     if (selectedNode is TextNode) {
-      appLog.fine("Showing text format toolbar");
       // Show the editor's toolbar for text styling.
       _showEditorToolbar();
       _hideImageToolbar();

--- a/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
@@ -1,4 +1,5 @@
 import 'package:attributed_text/attributed_text.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -129,12 +130,20 @@ class PatternTagIndex with ChangeNotifier implements Editable {
   }
 
   void _setTagsInNode(String nodeId, Set<IndexedTag> tags) {
+    if (const DeepCollectionEquality().equals(_tags[nodeId], tags)) {
+      return;
+    }
+
     _tags[nodeId] ??= <IndexedTag>{};
     _tags[nodeId]!.addAll(tags);
     _onChange();
   }
 
   void _clearNode(String nodeId) {
+    if (_tags[nodeId] == null || _tags[nodeId]!.isEmpty) {
+      return;
+    }
+
     _tags[nodeId]?.clear();
     _onChange();
   }

--- a/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
@@ -1022,7 +1022,6 @@ class TagUserReaction implements EditReaction {
           _findAllTagsInNode(document, change.nodeId, (attribution) => attribution == stableTagCancelledAttribution),
         );
       } else if (change is NodeChangeEvent) {
-        index._clearCommittedTagsInNode(change.nodeId);
         index._setCommittedTagsInNode(
           change.nodeId,
           _findAllTagsInNode(document, change.nodeId, (attribution) => attribution is CommittedStableTagAttribution),
@@ -1084,11 +1083,22 @@ class StableTagIndex with ChangeNotifier implements Editable {
 
   void _setCommittedTagsInNode(String nodeId, Set<IndexedTag> tags) {
     _committedTags[nodeId] ??= <IndexedTag>{};
-    _committedTags[nodeId]!.addAll(tags);
+
+    if (const DeepCollectionEquality().equals(_committedTags[nodeId], tags)) {
+      return;
+    }
+
+    _committedTags[nodeId]!
+      ..clear()
+      ..addAll(tags);
     _onChange();
   }
 
   void _clearCommittedTagsInNode(String nodeId) {
+    if (_committedTags[nodeId] == null || _committedTags[nodeId]!.isEmpty) {
+      return;
+    }
+
     _committedTags[nodeId]?.clear();
     _onChange();
   }
@@ -1107,11 +1117,22 @@ class StableTagIndex with ChangeNotifier implements Editable {
 
   void _setCancelledTagsInNode(String nodeId, Set<IndexedTag> tags) {
     _cancelledTags[nodeId] ??= <IndexedTag>{};
-    _cancelledTags[nodeId]!.addAll(tags);
+
+    if (const DeepCollectionEquality().equals(_cancelledTags[nodeId], tags)) {
+      return;
+    }
+
+    _cancelledTags[nodeId]!
+      ..clear()
+      ..addAll(tags);
     _onChange();
   }
 
   void _clearCancelledTagsInNode(String nodeId) {
+    if (_cancelledTags[nodeId] == null || _cancelledTags[nodeId]!.isEmpty) {
+      return;
+    }
+
     _cancelledTags[nodeId]?.clear();
     _onChange();
   }

--- a/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
@@ -279,6 +279,40 @@ void main() {
           const SpanRange(start: 15, end: 19),
         );
       });
+
+      testWidgetsOnAllPlatforms("only notifies tag index listeners when tags change", (tester) async {
+        final testContext = await _pumpTestEditor(
+          tester,
+          singleParagraphEmptyDoc(),
+        );
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Listen for tag notifications.
+        int tagNotificationCount = 0;
+        testContext.editor.context.patternTagIndex.addListener(() {
+          tagNotificationCount += 1;
+        });
+
+        // Type some non pattern text.
+        await tester.typeImeText("hello ");
+
+        // Ensure that no tag notifications were sent, because the typed text
+        // has no tag artifacts.
+        expect(tagNotificationCount, 0);
+
+        // Start a tag.
+        await tester.typeImeText("#");
+
+        // Ensure that no tag notifications were sent, because we haven't completed
+        // a tag.
+        expect(tagNotificationCount, 0);
+
+        // Create and update a tag.
+        await tester.typeImeText("world");
+
+        // Ensure that we received a notification for every letter in the tag.
+        expect(tagNotificationCount, 5);
+      });
     });
 
     group("caret placement >", () {


### PR DESCRIPTION
Adjusted tag indices to only notify listeners when tags actually change (Resolves #1355)

Previously the pattern tag and stable tag indices were sending notifications during every reaction. Now they only send notifications when a tag is added, removed, or changed.