### PR TITLE
[SuperEditor] Apply theme brightness to the software keyboard (Resolves #1003)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -106,7 +106,7 @@ class SuperEditor extends StatefulWidget {
     this.inputSource,
     this.softwareKeyboardController,
     this.imePolicies = const SuperEditorImePolicies(),
-    this.imeConfiguration = const SuperEditorImeConfiguration(),
+    this.imeConfiguration,
     this.imeOverrides,
     this.keyboardActions,
     this.selectorHandlers,
@@ -198,7 +198,7 @@ class SuperEditor extends StatefulWidget {
   final SuperEditorImePolicies imePolicies;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperEditorImeConfiguration imeConfiguration;
+  final SuperEditorImeConfiguration? imeConfiguration;
 
   /// Overrides for IME actions.
   ///
@@ -581,7 +581,10 @@ class SuperEditorState extends State<SuperEditor> {
           clearSelectionWhenImeConnectionCloses: widget.selectionPolicies.clearSelectionWhenImeConnectionCloses,
           softwareKeyboardController: widget.softwareKeyboardController,
           imePolicies: widget.imePolicies,
-          imeConfiguration: widget.imeConfiguration,
+          imeConfiguration: widget.imeConfiguration ??
+              SuperEditorImeConfiguration(
+                keyboardBrightness: Theme.of(context).brightness,
+              ),
           imeOverrides: widget.imeOverrides,
           hardwareKeyboardActions: [
             for (final plugin in widget.plugins) //

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1067,17 +1067,9 @@ Paragraph two
         // Holds the keyboard appearance sent to the platform.
         String? keyboardAppearance;
 
-        // Intercept the setClient message sent to the platform so we can check
-        // the keyboardAppearance that was sent.
-        tester
-            .interceptChannel(SystemChannels.textInput.name) //
-            .interceptMethod(
-          'TextInput.setClient',
-          (methodCall) {
-            final params = methodCall.arguments[1] as Map;
-            keyboardAppearance = params['keyboardAppearance'];
-            return null;
-          },
+        _interceptKeyboardAppearanceSentToPlatform(
+          tester,
+          (appearance) => keyboardAppearance = appearance,
         );
 
         // Place the caret at the empty paragraph to trigger the software keyboard.
@@ -1097,17 +1089,9 @@ Paragraph two
         // Holds the keyboard appearance sent to the platform.
         String? keyboardAppearance;
 
-        // Intercept the setClient message sent to the platform so we can check
-        // the keyboardAppearance that was sent.
-        tester
-            .interceptChannel(SystemChannels.textInput.name) //
-            .interceptMethod(
-          'TextInput.setClient',
-          (methodCall) {
-            final params = methodCall.arguments[1] as Map;
-            keyboardAppearance = params['keyboardAppearance'];
-            return null;
-          },
+        _interceptKeyboardAppearanceSentToPlatform(
+          tester,
+          (appearance) => keyboardAppearance = appearance,
         );
 
         // Place the caret at the empty paragraph to trigger the software keyboard.
@@ -1134,17 +1118,9 @@ Paragraph two
         // Holds the keyboard appearance sent to the platform.
         String? keyboardAppearance;
 
-        // Intercept the setClient message sent to the platform so we can check
-        // the keyboardAppearance that was sent.
-        tester
-            .interceptChannel(SystemChannels.textInput.name) //
-            .interceptMethod(
-          'TextInput.setClient',
-          (methodCall) {
-            final params = methodCall.arguments[1] as Map;
-            keyboardAppearance = params['keyboardAppearance'];
-            return null;
-          },
+        _interceptKeyboardAppearanceSentToPlatform(
+          tester,
+          (appearance) => keyboardAppearance = appearance,
         );
 
         // Place the caret at the empty paragraph to trigger the software keyboard.
@@ -1155,6 +1131,22 @@ Paragraph two
       });
     });
   });
+}
+
+/// Intercepts `TextInput.setClient` calls and invokes [onSetKeyboard]
+/// with the configured keyboard keyboardAppearance.
+void _interceptKeyboardAppearanceSentToPlatform(
+    WidgetTester tester, void Function(String keyboardAppearance) onSetKeyboard) {
+  tester
+      .interceptChannel(SystemChannels.textInput.name) //
+      .interceptMethod(
+    'TextInput.setClient',
+    (methodCall) {
+      final params = methodCall.arguments[1] as Map;
+      onSetKeyboard(params['keyboardAppearance']);
+      return null;
+    },
+  );
 }
 
 /// Expects that the given [expectedTextWithSelection] corresponds to a

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1055,6 +1055,105 @@ Paragraph two
         );
       });
     });
+
+    group('applies keyboard appearance', () {
+      testWidgetsOnIos('dark from theme', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .useAppTheme(ThemeData.dark())
+            .pump();
+
+        // Holds the keyboard appearance sent to the platform.
+        String? keyboardAppearance;
+
+        // Intercept the setClient message sent to the platform so we can check
+        // the keyboardAppearance that was sent.
+        tester
+            .interceptChannel(SystemChannels.textInput.name) //
+            .interceptMethod(
+          'TextInput.setClient',
+          (methodCall) {
+            final params = methodCall.arguments[1] as Map;
+            keyboardAppearance = params['keyboardAppearance'];
+            return null;
+          },
+        );
+
+        // Place the caret at the empty paragraph to trigger the software keyboard.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Ensure the given keyboardAppearance was applied.
+        expect(keyboardAppearance, 'Brightness.dark');
+      });
+
+      testWidgetsOnIos('light from theme', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .useAppTheme(ThemeData.light())
+            .pump();
+
+        // Holds the keyboard appearance sent to the platform.
+        String? keyboardAppearance;
+
+        // Intercept the setClient message sent to the platform so we can check
+        // the keyboardAppearance that was sent.
+        tester
+            .interceptChannel(SystemChannels.textInput.name) //
+            .interceptMethod(
+          'TextInput.setClient',
+          (methodCall) {
+            final params = methodCall.arguments[1] as Map;
+            keyboardAppearance = params['keyboardAppearance'];
+            return null;
+          },
+        );
+
+        // Place the caret at the empty paragraph to trigger the software keyboard.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Ensure the given keyboardAppearance was applied.
+        expect(keyboardAppearance, 'Brightness.light');
+      });
+
+      testWidgetsOnIos('from the given configuration', (tester) async {
+        // Pump an editor with a light theme to ensure we are a configuration
+        // with different brightness.
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .useAppTheme(ThemeData.light())
+            .withImeConfiguration(
+              const SuperEditorImeConfiguration(
+                keyboardBrightness: Brightness.dark,
+              ),
+            )
+            .pump();
+
+        // Holds the keyboard appearance sent to the platform.
+        String? keyboardAppearance;
+
+        // Intercept the setClient message sent to the platform so we can check
+        // the keyboardAppearance that was sent.
+        tester
+            .interceptChannel(SystemChannels.textInput.name) //
+            .interceptMethod(
+          'TextInput.setClient',
+          (methodCall) {
+            final params = methodCall.arguments[1] as Map;
+            keyboardAppearance = params['keyboardAppearance'];
+            return null;
+          },
+        );
+
+        // Place the caret at the empty paragraph to trigger the software keyboard.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Ensure the given keyboardAppearance was applied.
+        expect(keyboardAppearance, 'Brightness.dark');
+      });
+    });
   });
 }
 

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -404,7 +404,7 @@ class TestSuperEditorConfigurator {
       selectionPolicies: _config.selectionPolicies ?? const SuperEditorSelectionPolicies(),
       softwareKeyboardController: _config.softwareKeyboardController,
       imePolicies: _config.imePolicies ?? const SuperEditorImePolicies(),
-      imeConfiguration: _config.imeConfiguration ?? const SuperEditorImeConfiguration(),
+      imeConfiguration: _config.imeConfiguration,
       imeOverrides: _config.imeOverrides,
       keyboardActions: [
         ..._config.prependedKeyboardActions,


### PR DESCRIPTION
[SuperEditor] Apply theme brightness to the software keyboard. Resolves #1003

Currently, SuperEditor doesn't look at the theme to determine the keyboard appearance. The ticket mentioned that the keyboard is always dark, but it seems to be the contrary. Even when the the brightness is `dark`, the keyboard stays in `light` mode.

It's already possible to customize the keyboard appearance by passing a `SuperEditorImeConfiguration` to the editor. When a configuration isn't given, the editor uses a default `SuperEditorImeConfiguration`, which always use light keyboard appearance.

This PR makes `imeConfiguration` optional, and resolves the default configuration during build.

 