### PR TITLE
[super_editor_markdown] Add support for task syntax (Resolves #1294)

### DIFF
--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -68,6 +68,10 @@ class _MarkdownSerializationDemoState extends State<MarkdownSerializationDemo> {
               editor: _docEditor,
               document: _doc,
               composer: _composer,
+              componentBuilders: [
+                TaskComponentBuilder(_docEditor),
+                ...defaultComponentBuilders,
+              ],
               stylesheet: defaultStylesheet.copyWith(
                 documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
               ),
@@ -171,6 +175,20 @@ MutableDocument _createInitialDocument() {
         id: Editor.createNodeId(),
         text: AttributedText(
           'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: false,
+        text: AttributedText(
+          'This is an incomplete task',
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: true,
+        text: AttributedText(
+          'This is a completed task',
         ),
       ),
     ],

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -24,6 +24,7 @@ String serializeDocumentToMarkdown(
     const ImageNodeSerializer(),
     const HorizontalRuleNodeSerializer(),
     const ListItemNodeSerializer(),
+    const TaskNodeSerializer(),
     ParagraphNodeSerializer(syntax),
   ];
 
@@ -181,6 +182,19 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
     }
 
     return buffer.toString();
+  }
+}
+
+/// [DocumentNodeMarkdownSerializer] for serializing [TaskNode]s using Github's style syntax.
+///
+/// A completed task is serialized as `- [x] This is a completed task`
+/// An incomplete task is serialized as `- [ ] This is an incomplete task`
+class TaskNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<TaskNode> {
+  const TaskNodeSerializer();
+
+  @override
+  String doSerialization(Document document, TaskNode node) {
+    return '- [${node.isComplete ? 'x' : ' '}] ${node.text.text}';
   }
 }
 

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -28,6 +28,7 @@ MutableDocument deserializeMarkdownToDocument(
       if (syntax == MarkdownSyntax.superEditor) //
         _ParagraphWithAlignmentSyntax(),
       _EmptyLinePreservingParagraphSyntax(),
+      _TaskSyntax(),
     ],
   );
   final blockParser = md.BlockParser(markdownLines, markdownDoc);
@@ -148,6 +149,9 @@ class _MarkdownToDocument implements md.NodeVisitor {
         break;
       case 'hr':
         _addHorizontalRule();
+        break;
+      case 'task':
+        _addTask(element);
         break;
     }
 
@@ -282,6 +286,16 @@ class _MarkdownToDocument implements md.NodeVisitor {
         itemType: listItemType,
         indent: indent,
         text: _parseInlineText(element),
+      ),
+    );
+  }
+
+  void _addTask(md.Element element) {
+    _content.add(
+      TaskNode(
+        id: Editor.createNodeId(),
+        text: _parseInlineText(element),
+        isComplete: element.attributes['completed'] == 'x',
       ),
     );
   }
@@ -644,6 +658,57 @@ class _LineBreakSeparatedElement extends md.Element {
   }
 }
 
+/// A [md.BlockSyntax] that parses tasks.
+///
+/// A compled task starts with `- [x] ` followed by the task's content.
+///
+/// An incomplete task starts with `- [ ] ` followed by the task's content.
+///
+/// Tasks can have multiple lines of content.
+class _TaskSyntax extends md.BlockSyntax {
+  const _TaskSyntax();
+
+  /// Parses the first line of a task.
+  ///
+  /// `- [x] ` or `- [ ]` followed by any text.
+  @override
+  RegExp get pattern => RegExp(r'^- \[( |x)\] (.*)');
+
+  @override
+  md.Node? parse(md.BlockParser parser) {
+    final match = pattern.firstMatch(parser.current);
+    if (match == null) {
+      return null;
+    }
+
+    final completionToken = match.group(1)!;
+
+    // Add the first line of content to the buffer.
+    final buffer = StringBuffer(match.group(2)!);
+
+    // Consume the first line.
+    parser.advance();
+
+    // Consume the following lines until we:
+    // - reach the end of the input OR
+    // - find a blank line OR
+    // - find the start of another block element (including another task)
+    while (!parser.isDone &&
+        !_blankLinePattern.hasMatch(parser.current) &&
+        !_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(parser.current))) {
+      buffer.write('\n');
+      buffer.write(parser.current);
+
+      parser.advance();
+    }
+
+    return md.Element(
+      'task',
+      [md.Text(buffer.toString())],
+    )..attributes['completed'] = completionToken;
+  }
+}
+
 /// Matches empty lines or lines containing only whitespace.
 final _blankLinePattern = RegExp(r'^(?:[ \t]*)$');
 
@@ -653,6 +718,7 @@ const List<md.BlockSyntax> _standardNonParagraphBlockSyntaxes = [
   md.FencedCodeBlockSyntax(),
   md.BlockquoteSyntax(),
   md.HorizontalRuleSyntax(),
+  _TaskSyntax(),
   md.UnorderedListSyntax(),
   md.OrderedListSyntax(),
 ];

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -295,7 +295,7 @@ class _MarkdownToDocument implements md.NodeVisitor {
       TaskNode(
         id: Editor.createNodeId(),
         text: _parseInlineText(element),
-        isComplete: element.attributes['completed'] == 'x',
+        isComplete: element.attributes['completed'] == 'true',
       ),
     );
   }
@@ -682,11 +682,11 @@ class _TaskSyntax extends md.BlockSyntax {
     }
 
     final completionToken = match.group(1)!;
+    final taskDescriptionFirstLine = match.group(2)!;
 
-    // Add the first line of content to the buffer.
-    final buffer = StringBuffer(match.group(2)!);
+    final buffer = StringBuffer(taskDescriptionFirstLine);
 
-    // Consume the first line.
+    // Move to the second line.
     parser.advance();
 
     // Consume the following lines until we:
@@ -705,7 +705,7 @@ class _TaskSyntax extends md.BlockSyntax {
     return md.Element(
       'task',
       [md.Text(buffer.toString())],
-    )..attributes['completed'] = completionToken;
+    )..attributes['completed'] = (completionToken == 'x').toString();
   }
 }
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -510,6 +510,43 @@ Paragraph3""");
         expect(serializeDocumentToMarkdown(doc), '  1. **Ordered** 1');
       });
 
+      test('tasks', () {
+        final doc = MutableDocument(
+          nodes: [
+            TaskNode(
+              id: '1',
+              text: AttributedText('Task 1'),
+              isComplete: true,
+            ),
+            TaskNode(
+              id: '2',
+              text: AttributedText('Task 2\nwith multiple lines'),
+              isComplete: false,
+            ),
+            TaskNode(
+              id: '3',
+              text: AttributedText('Task 3'),
+              isComplete: false,
+            ),
+            TaskNode(
+              id: '4',
+              text: AttributedText('Task 4'),
+              isComplete: true,
+            ),
+          ],
+        );
+
+        expect(
+          serializeDocumentToMarkdown(doc),
+          '''
+- [x] Task 1
+- [ ] Task 2
+with multiple lines
+- [ ] Task 3
+- [x] Task 4''',
+        );
+      });
+
       test('example doc', () {
         final doc = MutableDocument(nodes: [
           ImageNode(
@@ -567,6 +604,16 @@ Paragraph3""");
             id: Editor.createNodeId(),
             text: AttributedText('{\n  // This is some code.\n}'),
             metadata: {'blockType': codeAttribution},
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 1'),
+            isComplete: true,
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 2'),
+            isComplete: false,
           ),
         ]);
 
@@ -791,10 +838,40 @@ This is some code
         expect((document.nodes[4] as ListItemNode).indent, 0);
       });
 
+      test('tasks', () {
+        const markdown = '''
+- [x] Task 1
+- [ ] Task 2
+- [ ] Task 3
+with multiple lines
+- [x] Task 4''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 4);
+
+        expect(document.nodes[0], isA<TaskNode>());
+        expect(document.nodes[1], isA<TaskNode>());
+        expect(document.nodes[2], isA<TaskNode>());
+        expect(document.nodes[3], isA<TaskNode>());
+
+        expect((document.nodes[0] as TaskNode).text.text, 'Task 1');
+        expect((document.nodes[0] as TaskNode).isComplete, isTrue);
+
+        expect((document.nodes[1] as TaskNode).text.text, 'Task 2');
+        expect((document.nodes[1] as TaskNode).isComplete, isFalse);
+
+        expect((document.nodes[2] as TaskNode).text.text, 'Task 3\nwith multiple lines');
+        expect((document.nodes[2] as TaskNode).isComplete, isFalse);
+
+        expect((document.nodes[3] as TaskNode).text.text, 'Task 4');
+        expect((document.nodes[3] as TaskNode).isComplete, isTrue);
+      });
+
       test('example doc 1', () {
         final document = deserializeMarkdownToDocument(exampleMarkdownDoc1);
 
-        expect(document.nodes.length, 18);
+        expect(document.nodes.length, 21);
 
         expect(document.nodes[0], isA<ParagraphNode>());
         expect((document.nodes[0] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
@@ -819,7 +896,13 @@ This is some code
 
         expect(document.nodes[16], isA<ImageNode>());
 
-        expect(document.nodes[17], isA<ParagraphNode>());
+        expect(document.nodes[17], isA<TaskNode>());
+
+        expect(document.nodes[18], isA<ParagraphNode>());
+
+        expect(document.nodes[19], isA<TaskNode>());
+
+        expect(document.nodes[20], isA<ParagraphNode>());
       });
 
       test('paragraph with strikethrough', () {
@@ -1047,6 +1130,13 @@ It includes multiple paragraphs, ordered list items, unordered list items, image
 ---
 
 ![Image alt text](https://images.com/some/image.png)
+
+- [ ] Pending task
+with multiple lines
+
+Another paragraph
+
+- [x] Completed task
 
 The end!
 ''';

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -612,8 +612,22 @@ with multiple lines
           ),
           TaskNode(
             id: Editor.createNodeId(),
-            text: AttributedText('Task 2'),
+            text: AttributedText('Task 2\nwith multiple lines'),
             isComplete: false,
+          ),
+          ParagraphNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('A paragraph between tasks'),
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 3'),
+            isComplete: false,
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 4\nwith multiple lines'),
+            isComplete: true,
           ),
         ]);
 


### PR DESCRIPTION
[super_editor_markdown] Add support for task syntax. Resolves #1294 

SuperEditor now includes support for tasks by default, but it doesn't support serializing/deserializing them.

This PR implements markdown serialization/deserialization for tasks using the github style syntax:

```
- [x] A completed task
- [ ] An incomplete task
```

Tasks can also be multiline, for example:

```
- [ ] A task
with multiple lines
- [ ] Another task
```
The previous input renders:

- [ ] A task
with multiple lines
- [ ] Another task
