### PR TITLE
Cherry pick "[SuperEditor] Fix composer preferences after text replacement (Resolves #1167) (#1351)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1421,7 +1421,19 @@ class CommonEditorOperations {
       // The selection is expanded. Delete the selected content
       // and then insert the new text.
       editorOpsLog.fine("The selection is expanded. Deleting the selection before inserting text.");
+
+      // As we are replacing text by deleting the selection and then inserting the new text,
+      // we need to store the current attributions.
+      // This is required as deleting text can clear the composer current attributions.
+      // Without this, the new text doesn't preserve the attributions of the replaced text.
+      final composerAttributions = {...composer.preferences.currentAttributions};
+
       _deleteExpandedSelection();
+
+      // Restore the previous attributions.
+      composer.preferences
+        ..clearStyles()
+        ..addStyles(composerAttributions);
     }
 
     final extentNodePosition = composer.selection!.extent.nodePosition;

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -744,6 +744,45 @@ Paragraph two
         // Ensure we cleared the composing region on the IME so the previous entered text is preserved.
         expect(composingRegion, TextRange.empty);
       });
+
+      testWidgetsOnIos('applies keyboard suggestions and keeps styles', (tester) async {
+        // Pump an editor with a bold text.
+        final testContext = await tester //
+            .createDocument()
+            .fromMarkdown('**Fix**')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the end of the paragraph.
+        await tester.placeCaretInParagraph(testContext.document.nodes.first.id, 3);
+
+        // Type a letter simulating a typo. The current text results in "Fixs".
+        await tester.typeImeText('s');
+
+        // Simulate the user accepting a suggestion.
+        // The IME replaces the word and inserts a space after it.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaReplacement(
+            oldText: 'Fixs',
+            replacementText: 'Fixed',
+            replacedRange: TextRange(start: 0, end: 4),
+            selection: TextSelection.collapsed(offset: 5),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaInsertion(
+            oldText: 'Fixed',
+            textInserted: ' ',
+            insertionOffset: 5,
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          )
+        ], getter: imeClientGetter);
+
+        // Ensure the text was replaced and the style was preserved.
+        expect(testContext.document, equalsMarkdown('**Fixed **'));
+      });
     });
 
     group('moves caret', () {


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix composer preferences after text replacement (Resolves #1167) (#1351)" to stable.