### PR TITLE
[SuperEditor] Add placeCaretInParagraph tests (Resolves #627)

### DIFF
--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -181,6 +181,29 @@ void main() {
       expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!");
     });
 
+    testWidgetsOnDesktop("enters text with hardware keyboard with multiple taps", (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(TextInputSource.keyboard)
+          .pump();
+
+      // Tap to place the caret in the first paragraph.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Type some text by simulating hardware keyboard key presses.
+      await tester.typeKeyboardText("Hello, world!");
+
+      // Place the caret at the end of the paragraph.
+      await tester.placeCaretInParagraph("1", 13);
+
+      // Type another text.
+      await tester.typeKeyboardText("ABC");
+
+      // Ensure that the text is inserted.
+      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
+    });
+
     testWidgetsOnDesktop("enters text with IME keyboard", (tester) async {
       // Configure and render a document.
       await tester //
@@ -199,6 +222,29 @@ void main() {
 
       // Verify that SuperEditor displays the text we typed.
       expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!");
+    });
+
+    testWidgetsOnDesktop("enters text with IME keyboard with multiple taps", (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      // Tap to place the caret in the first paragraph.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Type some text by simulating IME keyboard key presses.
+      await tester.typeImeText("Hello, world!");
+
+      // Place the caret at the end of the paragraph.
+      await tester.placeCaretInParagraph("1", 13);
+
+      // Type another text.
+      await tester.typeImeText("ABC");
+
+      // Ensure that the text is inserted.
+      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -246,5 +246,49 @@ void main() {
       // Ensure that the text is inserted.
       expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
     });
+
+    testWidgetsOnAllPlatforms("performs back to back taps with hardware keyboard", (tester) async {
+      final testContext = await tester //
+          .createDocument()
+          .fromMarkdown('Hello, world!')
+          .withInputSource(TextInputSource.keyboard)
+          .pump();
+
+      final nodeId = testContext.document.nodes.first.id;
+
+      // Tap to place the caret in the first paragraph.
+      await tester.placeCaretInParagraph(nodeId, 0);
+
+      // Place the caret at 'Hello, |world!'.
+      await tester.placeCaretInParagraph(nodeId, 7);
+
+      // Type another text.
+      await tester.typeKeyboardText("new ");
+
+      // Ensure that the text is inserted.
+      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Hello, new world!");
+    });
+
+    testWidgetsOnAllPlatforms("performs back to back taps with software keyboard", (tester) async {
+      final testContext = await tester //
+          .createDocument()
+          .fromMarkdown('Hello, world!')
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      final nodeId = testContext.document.nodes.first.id;
+
+      // Tap to place the caret in the first paragraph.
+      await tester.placeCaretInParagraph(nodeId, 0);
+
+      // Place the caret at 'Hello, |world!'.
+      await tester.placeCaretInParagraph(nodeId, 7);
+
+      // Type another text.
+      await tester.typeImeText("new ");
+
+      // Ensure that the text is inserted.
+      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Hello, new world!");
+    });
   });
 }


### PR DESCRIPTION
[SuperEditor] Add placeCaretInParagraph tests. Resolves #627

The tickets mentioned that calling `placeCaretInParagraph` was not working. A failing test was provided:

```dart
testWidgets("enters text with hardware keyboard", (tester) async {
    // Configure and render a document.
    await tester //
        .createDocument()
        .withSingleEmptyParagraph()
        .forDesktop()
        .autoFocus(true)
        .pump();

    // Tap to place the caret in the first paragraph.
    await tester.placeCaretInParagraph("1", 0);
    // await tester.placeCaretInParagraph("1", 0);

    // Type some text by simulating hardware keyboard key presses.
    await tester.typeKeyboardText("Hello, world!");

    await tester.placeCaretInParagraph("1", 13);

    await tester.typeKeyboardText("ABC");

    // Verify that SuperEditor displays the text we typed.
    expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
  });
```

I tested and it seems to be working now. 

This PR adds tests to ensure we can call `placeCaretInParagraph` a second time.