### PR TITLE
[SuperTextField] Expose IME configuration (Resolves #1109) 

### DIFF
--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -131,7 +131,7 @@ class SuperAndroidTextField extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperTextFieldImeConfiguration? imeConfiguration;
+  final TextInputConfiguration? imeConfiguration;
 
   /// Whether to paint debug guides.
   final bool showDebugPaint;
@@ -222,11 +222,11 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
         widget.imeConfiguration != null &&
         _textEditingController.isAttachedToIme) {
       _textEditingController.updateTextInputConfiguration(
-        textInputAction: widget.imeConfiguration!.keyboardActionButton,
-        textInputType: widget.imeConfiguration!.keyboardInputType,
-        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        textInputAction: widget.imeConfiguration!.inputAction,
+        textInputType: widget.imeConfiguration!.inputType,
+        autocorrect: widget.imeConfiguration!.autocorrect,
         enableSuggestions: widget.imeConfiguration!.enableSuggestions,
-        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
+        keyboardAppearance: widget.imeConfiguration!.keyboardAppearance,
       );
     }
 

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -39,7 +39,7 @@ class SuperAndroidTextField extends StatefulWidget {
     this.blinkTimingMode = BlinkTimingMode.ticker,
     required this.selectionColor,
     required this.handlesColor,
-    this.textInputAction = TextInputAction.done,
+    this.textInputAction,
     this.imeConfiguration,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
@@ -128,7 +128,7 @@ class SuperAndroidTextField extends StatefulWidget {
   ///
   /// This property is ignored when an [imeConfiguration] is provided.
   @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
-  final TextInputAction textInputAction;
+  final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
   final SuperTextFieldImeConfiguration? imeConfiguration;
@@ -209,9 +209,11 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
     }
 
-    if (widget.textInputAction != oldWidget.textInputAction && _textEditingController.isAttachedToIme) {
+    if (widget.textInputAction != oldWidget.textInputAction &&
+        widget.textInputAction != null &&
+        _textEditingController.isAttachedToIme) {
       _textEditingController.updateTextInputConfiguration(
-        textInputAction: widget.textInputAction,
+        textInputAction: widget.textInputAction!,
         textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
       );
     }
@@ -330,7 +332,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             _textEditingController.attachToImeWithConfig(widget.imeConfiguration!);
           } else {
             _textEditingController.attachToIme(
-              textInputAction: widget.textInputAction,
+              textInputAction: widget.textInputAction ?? TextInputAction.done,
               textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
             );
           }

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -40,6 +40,7 @@ class SuperAndroidTextField extends StatefulWidget {
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
+    this.imeConfiguration,
     this.popoverToolbarBuilder = _defaultAndroidToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
@@ -124,7 +125,13 @@ class SuperAndroidTextField extends StatefulWidget {
 
   /// The type of action associated with the action button on the mobile
   /// keyboard.
+  ///
+  /// This property is ignored when an [imeConfiguration] is provided.
+  @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
   final TextInputAction textInputAction;
+
+  /// Preferences for how the platform IME should look and behave during editing.
+  final SuperTextFieldImeConfiguration? imeConfiguration;
 
   /// Whether to paint debug guides.
   final bool showDebugPaint;
@@ -206,6 +213,18 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       _textEditingController.updateTextInputConfiguration(
         textInputAction: widget.textInputAction,
         textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
+      );
+    }
+
+    if (widget.imeConfiguration != oldWidget.imeConfiguration &&
+        widget.imeConfiguration != null &&
+        _textEditingController.isAttachedToIme) {
+      _textEditingController.updateTextInputConfiguration(
+        textInputAction: widget.imeConfiguration!.keyboardActionButton,
+        textInputType: widget.imeConfiguration!.keyboardInputType,
+        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        enableSuggestions: widget.imeConfiguration!.enableSuggestions,
+        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
       );
     }
 
@@ -307,10 +326,14 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             _textEditingController.selection = TextSelection.collapsed(offset: _textEditingController.text.text.length);
           }
 
-          _textEditingController.attachToIme(
-            textInputAction: widget.textInputAction,
-            textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
-          );
+          if (widget.imeConfiguration != null) {
+            _textEditingController.attachToImeWithConfig(widget.imeConfiguration!);
+          } else {
+            _textEditingController.attachToIme(
+              textInputAction: widget.textInputAction,
+              textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
+            );
+          }
 
           _autoScrollToKeepTextFieldVisible();
           _showEditingControlsOverlay();

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -131,7 +131,7 @@ class SuperDesktopTextField extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperTextFieldImeConfiguration? imeConfiguration;
+  final TextInputConfiguration? imeConfiguration;
 
   @override
   SuperDesktopTextFieldState createState() => SuperDesktopTextFieldState();
@@ -1026,7 +1026,7 @@ class SuperTextFieldImeInteractor extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperTextFieldImeConfiguration? imeConfiguration;
+  final TextInputConfiguration? imeConfiguration;
 
   /// The rest of the subtree for this text field.
   final Widget child;
@@ -1080,11 +1080,11 @@ class _SuperTextFieldImeInteractorState extends State<SuperTextFieldImeInteracto
         widget.imeConfiguration != null &&
         widget.textController.isAttachedToIme) {
       widget.textController.updateTextInputConfiguration(
-        textInputAction: widget.imeConfiguration!.keyboardActionButton,
-        textInputType: widget.imeConfiguration!.keyboardInputType,
-        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        textInputAction: widget.imeConfiguration!.inputAction,
+        textInputType: widget.imeConfiguration!.inputType,
+        autocorrect: widget.imeConfiguration!.autocorrect,
         enableSuggestions: widget.imeConfiguration!.enableSuggestions,
-        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
+        keyboardAppearance: widget.imeConfiguration!.keyboardAppearance,
       );
     }
   }

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -63,6 +63,7 @@ class SuperDesktopTextField extends StatefulWidget {
     this.onRightClick,
     this.inputSource = TextInputSource.keyboard,
     this.textInputAction,
+    this.imeConfiguration,
     List<TextFieldKeyboardHandler>? keyboardHandlers,
   })  : keyboardHandlers = keyboardHandlers ??
             (inputSource == TextInputSource.keyboard
@@ -124,7 +125,13 @@ class SuperDesktopTextField extends StatefulWidget {
   final List<TextFieldKeyboardHandler> keyboardHandlers;
 
   /// The type of action associated with ENTER key.
+  ///
+  /// This property is ignored when an [imeConfiguration] is provided.
+  @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
   final TextInputAction? textInputAction;
+
+  /// Preferences for how the platform IME should look and behave during editing.
+  final SuperTextFieldImeConfiguration? imeConfiguration;
 
   @override
   SuperDesktopTextFieldState createState() => SuperDesktopTextFieldState();
@@ -405,6 +412,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
                 isMultiline: isMultiline,
                 selectorHandlers: defaultTextFieldSelectorHandlers,
                 textInputAction: widget.textInputAction,
+                imeConfiguration: widget.imeConfiguration,
                 child: child,
               )
             : child,
@@ -991,6 +999,7 @@ class SuperTextFieldImeInteractor extends StatefulWidget {
     required this.isMultiline,
     required this.selectorHandlers,
     this.textInputAction,
+    this.imeConfiguration,
     required this.child,
   }) : super(key: key);
 
@@ -1015,6 +1024,9 @@ class SuperTextFieldImeInteractor extends StatefulWidget {
 
   /// The type of action associated with ENTER key.
   final TextInputAction? textInputAction;
+
+  /// Preferences for how the platform IME should look and behave during editing.
+  final SuperTextFieldImeConfiguration? imeConfiguration;
 
   /// The rest of the subtree for this text field.
   final Widget child;
@@ -1063,6 +1075,18 @@ class _SuperTextFieldImeInteractorState extends State<SuperTextFieldImeInteracto
       }
       widget.textController.onPerformSelector ??= _onPerformSelector;
     }
+
+    if (widget.imeConfiguration != oldWidget.imeConfiguration &&
+        widget.imeConfiguration != null &&
+        widget.textController.isAttachedToIme) {
+      widget.textController.updateTextInputConfiguration(
+        textInputAction: widget.imeConfiguration!.keyboardActionButton,
+        textInputType: widget.imeConfiguration!.keyboardInputType,
+        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        enableSuggestions: widget.imeConfiguration!.enableSuggestions,
+        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
+      );
+    }
   }
 
   @override
@@ -1084,11 +1108,15 @@ class _SuperTextFieldImeInteractorState extends State<SuperTextFieldImeInteracto
             widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.text.length);
           }
 
-          widget.textController.attachToIme(
-            textInputType: widget.isMultiline ? TextInputType.multiline : TextInputType.text,
-            textInputAction:
-                widget.textInputAction ?? (widget.isMultiline ? TextInputAction.newline : TextInputAction.done),
-          );
+          if (widget.imeConfiguration != null) {
+            widget.textController.attachToImeWithConfig(widget.imeConfiguration!);
+          } else {
+            widget.textController.attachToIme(
+              textInputType: widget.isMultiline ? TextInputType.multiline : TextInputType.text,
+              textInputAction:
+                  widget.textInputAction ?? (widget.isMultiline ? TextInputAction.newline : TextInputAction.done),
+            );
+          }
         });
       }
     } else {

--- a/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -123,24 +123,26 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
       return;
     }
 
-    final config = SuperTextFieldImeConfiguration(
-      enableAutocorrect: autocorrect,
+    final config = TextInputConfiguration(
+      enableDeltaModel: true,
+      autocorrect: autocorrect,
       enableSuggestions: enableSuggestions,
-      keyboardInputType: textInputType,
-      keyboardActionButton: textInputAction,
-      keyboardBrightness: _keyboardAppearance,
+      inputType: textInputType,
+      inputAction: textInputAction,
+      keyboardAppearance: _keyboardAppearance,
     );
 
     attachToImeWithConfig(config);
   }
 
-  void attachToImeWithConfig(SuperTextFieldImeConfiguration configuration) {
+  void attachToImeWithConfig(TextInputConfiguration configuration) {
     if (isAttachedToIme) {
       // We're already connected to the IME.
       return;
     }
 
-    final imeConfig = configuration.toTextInputConfiguration();
+    // Delta model is required for SuperTextField to work.
+    final imeConfig = configuration.copyWith(enableDeltaModel: true);
     final inputConnection = _inputConnectionFactory?.call(this, imeConfig) ?? TextInput.attach(this, imeConfig);
     inputConnection.show();
 
@@ -675,77 +677,3 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
 
 typedef TextInputConnectionFactory = TextInputConnection Function(
     TextInputClient client, TextInputConfiguration configuration);
-
-/// Input Method Engine (IME) configuration for text input.
-class SuperTextFieldImeConfiguration {
-  const SuperTextFieldImeConfiguration({
-    this.enableAutocorrect = true,
-    this.enableSuggestions = true,
-    this.keyboardInputType = TextInputType.text,
-    this.keyboardBrightness = Brightness.light,
-    this.keyboardActionButton = TextInputAction.newline,
-  });
-
-  /// Whether the OS should offer auto-correction options to the user.
-  final bool enableAutocorrect;
-
-  /// Whether the OS should offer text completion suggestions to the user.
-  final bool enableSuggestions;
-
-  /// The brightness of the software keyboard (only applies to platforms
-  /// with a software keyboard).
-  final Brightness keyboardBrightness;
-
-  /// The action button that's displayed on a software keyboard, e.g.,
-  /// new-line, done, go, etc.
-  final TextInputAction keyboardActionButton;
-
-  /// Configures the keyboard layout to a specific type of information.
-  final TextInputType keyboardInputType;
-
-  TextInputConfiguration toTextInputConfiguration() {
-    return TextInputConfiguration(
-      enableDeltaModel: true,
-      autocorrect: enableAutocorrect,
-      enableSuggestions: enableSuggestions,
-      inputAction: keyboardActionButton,
-      inputType: keyboardInputType,
-      keyboardAppearance: keyboardBrightness,
-    );
-  }
-
-  SuperTextFieldImeConfiguration copyWith({
-    bool? enableAutocorrect,
-    bool? enableSuggestions,
-    Brightness? keyboardBrightness,
-    TextInputType? keyboardInputType,
-    TextInputAction? keyboardActionButton,
-  }) {
-    return SuperTextFieldImeConfiguration(
-      enableAutocorrect: enableAutocorrect ?? this.enableAutocorrect,
-      enableSuggestions: enableSuggestions ?? this.enableSuggestions,
-      keyboardBrightness: keyboardBrightness ?? this.keyboardBrightness,
-      keyboardActionButton: keyboardActionButton ?? this.keyboardActionButton,
-      keyboardInputType: keyboardInputType ?? this.keyboardInputType,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is SuperTextFieldImeConfiguration &&
-          runtimeType == other.runtimeType &&
-          enableAutocorrect == other.enableAutocorrect &&
-          enableSuggestions == other.enableSuggestions &&
-          keyboardBrightness == other.keyboardBrightness &&
-          keyboardActionButton == other.keyboardActionButton &&
-          keyboardInputType == other.keyboardInputType;
-
-  @override
-  int get hashCode =>
-      enableAutocorrect.hashCode ^
-      enableSuggestions.hashCode ^
-      keyboardBrightness.hashCode ^
-      keyboardActionButton.hashCode ^
-      keyboardInputType.hashCode;
-}

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -135,7 +135,7 @@ class SuperIOSTextField extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperTextFieldImeConfiguration? imeConfiguration;
+  final TextInputConfiguration? imeConfiguration;
 
   /// Builder that creates the popover toolbar widget that appears when text is selected.
   final Widget Function(BuildContext, IOSEditingOverlayController) popoverToolbarBuilder;
@@ -253,11 +253,11 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         widget.imeConfiguration != null &&
         _textEditingController.isAttachedToIme) {
       _textEditingController.updateTextInputConfiguration(
-        textInputAction: widget.imeConfiguration!.keyboardActionButton,
-        textInputType: widget.imeConfiguration!.keyboardInputType,
-        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        textInputAction: widget.imeConfiguration!.inputAction,
+        textInputType: widget.imeConfiguration!.inputType,
+        autocorrect: widget.imeConfiguration!.autocorrect,
         enableSuggestions: widget.imeConfiguration!.enableSuggestions,
-        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
+        keyboardAppearance: widget.imeConfiguration!.keyboardAppearance,
       );
     }
 

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -44,6 +44,7 @@ class SuperIOSTextField extends StatefulWidget {
     required this.selectionColor,
     required this.handlesColor,
     this.textInputAction = TextInputAction.done,
+    this.imeConfiguration,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
     this.padding,
@@ -128,7 +129,13 @@ class SuperIOSTextField extends StatefulWidget {
 
   /// The type of action associated with the action button on the mobile
   /// keyboard.
+  ///
+  /// This property is ignored when an [imeConfiguration] is provided.
+  @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
   final TextInputAction textInputAction;
+
+  /// Preferences for how the platform IME should look and behave during editing.
+  final SuperTextFieldImeConfiguration? imeConfiguration;
 
   /// Builder that creates the popover toolbar widget that appears when text is selected.
   final Widget Function(BuildContext, IOSEditingOverlayController) popoverToolbarBuilder;
@@ -242,6 +249,18 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         ..onPerformActionPressed ??= _onPerformActionPressed;
     }
 
+    if (widget.imeConfiguration != oldWidget.imeConfiguration &&
+        widget.imeConfiguration != null &&
+        _textEditingController.isAttachedToIme) {
+      _textEditingController.updateTextInputConfiguration(
+        textInputAction: widget.imeConfiguration!.keyboardActionButton,
+        textInputType: widget.imeConfiguration!.keyboardInputType,
+        autocorrect: widget.imeConfiguration!.enableAutocorrect,
+        enableSuggestions: widget.imeConfiguration!.enableSuggestions,
+        keyboardAppearance: widget.imeConfiguration!.keyboardBrightness,
+      );
+    }
+
     if (widget.showDebugPaint != oldWidget.showDebugPaint) {
       onNextFrame((_) => _rebuildHandles());
     }
@@ -327,10 +346,14 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             _textEditingController.selection = TextSelection.collapsed(offset: _textEditingController.text.text.length);
           }
 
-          _textEditingController.attachToIme(
-            textInputAction: widget.textInputAction,
-            textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
-          );
+          if (widget.imeConfiguration != null) {
+            _textEditingController.attachToImeWithConfig(widget.imeConfiguration!);
+          } else {
+            _textEditingController.attachToIme(
+              textInputAction: widget.textInputAction,
+              textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
+            );
+          }
 
           _autoScrollToKeepTextFieldVisible();
           _showHandles();

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -43,7 +43,7 @@ class SuperIOSTextField extends StatefulWidget {
     this.blinkTimingMode = BlinkTimingMode.ticker,
     required this.selectionColor,
     required this.handlesColor,
-    this.textInputAction = TextInputAction.done,
+    this.textInputAction,
     this.imeConfiguration,
     this.popoverToolbarBuilder = _defaultPopoverToolbarBuilder,
     this.showDebugPaint = false,
@@ -132,7 +132,7 @@ class SuperIOSTextField extends StatefulWidget {
   ///
   /// This property is ignored when an [imeConfiguration] is provided.
   @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
-  final TextInputAction textInputAction;
+  final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
   final SuperTextFieldImeConfiguration? imeConfiguration;
@@ -350,7 +350,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             _textEditingController.attachToImeWithConfig(widget.imeConfiguration!);
           } else {
             _textEditingController.attachToIme(
-              textInputAction: widget.textInputAction,
+              textInputAction: widget.textInputAction ?? TextInputAction.done,
               textInputType: _isMultiline ? TextInputType.multiline : TextInputType.text,
             );
           }

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -189,7 +189,7 @@ class SuperTextField extends StatefulWidget {
   final TextInputAction? textInputAction;
 
   /// Preferences for how the platform IME should look and behave during editing.
-  final SuperTextFieldImeConfiguration? imeConfiguration;
+  final TextInputConfiguration? imeConfiguration;
 
   @override
   State<SuperTextField> createState() => SuperTextFieldState();

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -71,6 +71,7 @@ class SuperTextField extends StatefulWidget {
     this.keyboardHandlers,
     this.padding,
     this.textInputAction,
+    this.imeConfiguration,
   }) : super(key: key);
 
   final FocusNode? focusNode;
@@ -178,11 +179,17 @@ class SuperTextField extends StatefulWidget {
 
   /// The main action for the virtual keyboard, e.g. [TextInputAction.done].
   ///
+  /// This property is ignored when an [imeConfiguration] is provided.
+  ///
   /// When `null`, and in single-line mode, the action will be [TextInputAction.done],
   /// and when in multi-line mode, the action will be  [TextInputAction.newline].
   ///
   /// Only used on mobile.
+  @Deprecated('This will be removed in a future release. Use imeConfiguration instead')
   final TextInputAction? textInputAction;
+
+  /// Preferences for how the platform IME should look and behave during editing.
+  final SuperTextFieldImeConfiguration? imeConfiguration;
 
   @override
   State<SuperTextField> createState() => SuperTextFieldState();
@@ -323,6 +330,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           padding: widget.padding ?? EdgeInsets.zero,
           inputSource: _inputSource,
           textInputAction: _textInputAction,
+          imeConfiguration: widget.imeConfiguration,
         );
       case SuperTextFieldPlatformConfiguration.android:
         return Shortcuts(
@@ -346,6 +354,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
             textInputAction: _textInputAction,
+            imeConfiguration: widget.imeConfiguration,
             padding: widget.padding,
           ),
         );
@@ -371,6 +380,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
             maxLines: widget.maxLines,
             lineHeight: widget.lineHeight,
             textInputAction: _textInputAction,
+            imeConfiguration: widget.imeConfiguration,
             padding: widget.padding,
           ),
         );

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -530,6 +530,61 @@ void main() {
       // Ensure the IME connection is closed.
       expect(controller.isAttachedToIme, isFalse);
     });
+
+    testWidgetsOnAllPlatforms('applies custom IME configuration', (tester) async {
+      // Pump a SuperTextField with an IME configuration with values
+      // that differ from the defaults.
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: const SuperTextField(
+            inputSource: TextInputSource.ime,
+            imeConfiguration: SuperTextFieldImeConfiguration(
+              enableSuggestions: false,
+              enableAutocorrect: false,
+              keyboardActionButton: TextInputAction.search,
+              keyboardBrightness: Brightness.dark,
+              keyboardInputType: TextInputType.number,
+            ),
+          ),
+        ),
+      );
+
+      // Holds the IME configuration values passed to the platform.
+      String? inputAction;
+      String? inputType;
+      bool? autocorrect;
+      bool? enableSuggestions;
+      String? keyboardAppearance;
+
+      // Intercept the setClient message sent to the platform to check the configuration.
+      tester
+          .interceptChannel(SystemChannels.textInput.name) //
+          .interceptMethod(
+        'TextInput.setClient',
+        (methodCall) {
+          final params = methodCall.arguments[1] as Map;
+          inputAction = params['inputAction'];
+          autocorrect = params['autocorrect'];
+          enableSuggestions = params['enableSuggestions'];
+          keyboardAppearance = params['keyboardAppearance'];
+
+          final inputTypeConfig = params['inputType'] as Map;
+          inputType = inputTypeConfig['name'];
+
+          return null;
+        },
+      );
+
+      // Tap to focus the text field and attach to the IME.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Ensure we use the values from the configuration.
+      expect(inputAction, 'TextInputAction.search');
+      expect(inputType, 'TextInputType.number');
+      expect(autocorrect, false);
+      expect(enableSuggestions, false);
+      expect(keyboardAppearance, 'Brightness.dark');
+    });
   });
 
   group('SuperTextField on some bad Android software keyboards', () {

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -538,12 +538,13 @@ void main() {
         _buildScaffold(
           child: const SuperTextField(
             inputSource: TextInputSource.ime,
-            imeConfiguration: SuperTextFieldImeConfiguration(
+            imeConfiguration: TextInputConfiguration(
               enableSuggestions: false,
-              enableAutocorrect: false,
-              keyboardActionButton: TextInputAction.search,
-              keyboardBrightness: Brightness.dark,
-              keyboardInputType: TextInputType.number,
+              autocorrect: false,
+              inputAction: TextInputAction.search,
+              keyboardAppearance: Brightness.dark,
+              inputType: TextInputType.number,
+              enableDeltaModel: false,
             ),
           ),
         ),
@@ -555,6 +556,7 @@ void main() {
       bool? autocorrect;
       bool? enableSuggestions;
       String? keyboardAppearance;
+      bool? enableDeltaModel;
 
       // Intercept the setClient message sent to the platform to check the configuration.
       tester
@@ -567,6 +569,7 @@ void main() {
           autocorrect = params['autocorrect'];
           enableSuggestions = params['enableSuggestions'];
           keyboardAppearance = params['keyboardAppearance'];
+          enableDeltaModel = params['enableDeltaModel'];
 
           final inputTypeConfig = params['inputType'] as Map;
           inputType = inputTypeConfig['name'];
@@ -583,6 +586,7 @@ void main() {
       expect(inputType, 'TextInputType.number');
       expect(autocorrect, false);
       expect(enableSuggestions, false);
+      expect(enableDeltaModel, true);
       expect(keyboardAppearance, 'Brightness.dark');
     });
   });


### PR DESCRIPTION
[SuperTextField] Expose IME configuration. Resolves #1109 

Currently, we can configure the textfield's `textInputAction` but we can't configure other IME aspects, like keyboard type and autocorrection.

This PR  introduces a `SuperTextFieldImeConfiguration`, which users can use to configure the IME. As both `SuperTextFieldImeConfiguration` and `textInputAction` configures the input action, the `textInputAction` is being deprecated.

I added an `attachToImeWithConfig` method in `ImeAttributedTextEditingController` instead of changing the existing method to avoid a breaking change. If we should just change `attachToIme` then I can make this change.
