### PR TITLE
Cherry-pick "[super_editor_markdown] Add support for task syntax (Resolves #1294) (#1360)" to stable

### DIFF
--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -68,6 +68,10 @@ class _MarkdownSerializationDemoState extends State<MarkdownSerializationDemo> {
               editor: _docEditor,
               document: _doc,
               composer: _composer,
+              componentBuilders: [
+                TaskComponentBuilder(_docEditor),
+                ...defaultComponentBuilders,
+              ],
               stylesheet: defaultStylesheet.copyWith(
                 documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
               ),
@@ -171,6 +175,20 @@ MutableDocument _createInitialDocument() {
         id: Editor.createNodeId(),
         text: AttributedText(
           'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: false,
+        text: AttributedText(
+          'This is an incomplete task',
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: true,
+        text: AttributedText(
+          'This is a completed task',
         ),
       ),
     ],

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -24,6 +24,7 @@ String serializeDocumentToMarkdown(
     const ImageNodeSerializer(),
     const HorizontalRuleNodeSerializer(),
     const ListItemNodeSerializer(),
+    const TaskNodeSerializer(),
     ParagraphNodeSerializer(syntax),
   ];
 
@@ -181,6 +182,19 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
     }
 
     return buffer.toString();
+  }
+}
+
+/// [DocumentNodeMarkdownSerializer] for serializing [TaskNode]s using Github's style syntax.
+///
+/// A completed task is serialized as `- [x] This is a completed task`
+/// An incomplete task is serialized as `- [ ] This is an incomplete task`
+class TaskNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<TaskNode> {
+  const TaskNodeSerializer();
+
+  @override
+  String doSerialization(Document document, TaskNode node) {
+    return '- [${node.isComplete ? 'x' : ' '}] ${node.text.text}';
   }
 }
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -510,6 +510,43 @@ Paragraph3""");
         expect(serializeDocumentToMarkdown(doc), '  1. **Ordered** 1');
       });
 
+      test('tasks', () {
+        final doc = MutableDocument(
+          nodes: [
+            TaskNode(
+              id: '1',
+              text: AttributedText('Task 1'),
+              isComplete: true,
+            ),
+            TaskNode(
+              id: '2',
+              text: AttributedText('Task 2\nwith multiple lines'),
+              isComplete: false,
+            ),
+            TaskNode(
+              id: '3',
+              text: AttributedText('Task 3'),
+              isComplete: false,
+            ),
+            TaskNode(
+              id: '4',
+              text: AttributedText('Task 4'),
+              isComplete: true,
+            ),
+          ],
+        );
+
+        expect(
+          serializeDocumentToMarkdown(doc),
+          '''
+- [x] Task 1
+- [ ] Task 2
+with multiple lines
+- [ ] Task 3
+- [x] Task 4''',
+        );
+      });
+
       test('example doc', () {
         final doc = MutableDocument(nodes: [
           ImageNode(
@@ -567,6 +604,30 @@ Paragraph3""");
             id: Editor.createNodeId(),
             text: AttributedText('{\n  // This is some code.\n}'),
             metadata: {'blockType': codeAttribution},
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 1'),
+            isComplete: true,
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 2\nwith multiple lines'),
+            isComplete: false,
+          ),
+          ParagraphNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('A paragraph between tasks'),
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 3'),
+            isComplete: false,
+          ),
+          TaskNode(
+            id: Editor.createNodeId(),
+            text: AttributedText('Task 4\nwith multiple lines'),
+            isComplete: true,
           ),
         ]);
 
@@ -791,10 +852,40 @@ This is some code
         expect((document.nodes[4] as ListItemNode).indent, 0);
       });
 
+      test('tasks', () {
+        const markdown = '''
+- [x] Task 1
+- [ ] Task 2
+- [ ] Task 3
+with multiple lines
+- [x] Task 4''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 4);
+
+        expect(document.nodes[0], isA<TaskNode>());
+        expect(document.nodes[1], isA<TaskNode>());
+        expect(document.nodes[2], isA<TaskNode>());
+        expect(document.nodes[3], isA<TaskNode>());
+
+        expect((document.nodes[0] as TaskNode).text.text, 'Task 1');
+        expect((document.nodes[0] as TaskNode).isComplete, isTrue);
+
+        expect((document.nodes[1] as TaskNode).text.text, 'Task 2');
+        expect((document.nodes[1] as TaskNode).isComplete, isFalse);
+
+        expect((document.nodes[2] as TaskNode).text.text, 'Task 3\nwith multiple lines');
+        expect((document.nodes[2] as TaskNode).isComplete, isFalse);
+
+        expect((document.nodes[3] as TaskNode).text.text, 'Task 4');
+        expect((document.nodes[3] as TaskNode).isComplete, isTrue);
+      });
+
       test('example doc 1', () {
         final document = deserializeMarkdownToDocument(exampleMarkdownDoc1);
 
-        expect(document.nodes.length, 18);
+        expect(document.nodes.length, 21);
 
         expect(document.nodes[0], isA<ParagraphNode>());
         expect((document.nodes[0] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
@@ -819,7 +910,13 @@ This is some code
 
         expect(document.nodes[16], isA<ImageNode>());
 
-        expect(document.nodes[17], isA<ParagraphNode>());
+        expect(document.nodes[17], isA<TaskNode>());
+
+        expect(document.nodes[18], isA<ParagraphNode>());
+
+        expect(document.nodes[19], isA<TaskNode>());
+
+        expect(document.nodes[20], isA<ParagraphNode>());
       });
 
       test('paragraph with strikethrough', () {
@@ -1047,6 +1144,13 @@ It includes multiple paragraphs, ordered list items, unordered list items, image
 ---
 
 ![Image alt text](https://images.com/some/image.png)
+
+- [ ] Pending task
+with multiple lines
+
+Another paragraph
+
+- [x] Completed task
 
 The end!
 ''';


### PR DESCRIPTION
This PR cherry-picks "[super_editor_markdown] Add support for task syntax (Resolves #1294) (#1360)" to stable.