### PR TITLE
Upgrade test robots package version and adjust for some Flutter bugs (Resolves #1344)

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # Dependencies for testing tools that we ship with super_editor
   flutter_test:
     sdk: flutter
-  flutter_test_robots: ^0.0.17
+  flutter_test_robots: 0.0.21
 
 dependency_overrides:
 #  # Override to local mono-repo path so devs can test this repo

--- a/super_editor/test/super_reader/super_reader_keyboard_test.dart
+++ b/super_editor/test/super_reader/super_reader_keyboard_test.dart
@@ -213,9 +213,9 @@ void main() {
       // Hold shift and move the caret to the beginning of the selected word, which
       // collapses the selection. Release the shift key pressed, which should check
       // the selection, see that it's collapsed, and then remove it.
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.pressKeyDown(LogicalKeyboardKey.shift);
       await tester.pressCtlLeftArrow();
-      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.releaseKeyUp(LogicalKeyboardKey.shift);
 
       // Ensure that the selection is gone.
       expect(

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -329,7 +329,8 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 18));
         });
 
-        testWidgetsOnWindowsAndLinux('when NUMPAD ENTER is pressed in middle of text', (tester) async {
+        // TODO: Make this a Windows + Linux test when Flutter supports numpad enter on windows
+        testWidgetsOnLinux('when NUMPAD ENTER is pressed in middle of text', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
@@ -362,7 +363,8 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 9));
         });
 
-        testWidgetsOnWindowsAndLinux('when NUMPAD ENTER is pressed at beginning of text', (tester) async {
+        // TODO: Make this a Windows + Linux test when Flutter supports numpad enter on windows
+        testWidgetsOnLinux('when NUMPAD ENTER is pressed at beginning of text', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
@@ -395,7 +397,8 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 1));
         });
 
-        testWidgetsOnWindowsAndLinux('when NUMPAD ENTER is pressed at end of text', (tester) async {
+        // TODO: Make this a Windows + Linux test when Flutter supports numpad enter on windows
+        testWidgetsOnLinux('when NUMPAD ENTER is pressed at end of text', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(


### PR DESCRIPTION
Upgrade test robots package version and adjust for some Flutter bugs (Resolves #1344)

In case this is needed for future reference: We had to release a few revisions of the robots package, and even alter some tests in `super_editor`, because a new robots feature uncovered a number of bugs related to how Flutter handles the simulated `platform` in key presses.