### PR TITLE
Removed named parameters from SpanRange constructor for less verbosity (Resolves #1191)

### DIFF
--- a/attributed_text/analysis_options.yaml
+++ b/attributed_text/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+    exclude: [build/**]
+
+linter:
+    rules:
+        omit_local_variable_types: false
+        avoid_renaming_method_parameters: false

--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -247,8 +247,8 @@ class AttributedSpans {
     // Note: maxStartMarkerOffset and minEndMarkerOffset are non-null because we verified
     // that all desired attributions are present at the given offset.
     return SpanRange(
-      start: maxStartMarkerOffset!,
-      end: minEndMarkerOffset!,
+      maxStartMarkerOffset!,
+      minEndMarkerOffset!,
     );
   }
 
@@ -1090,7 +1090,7 @@ class AttributionSpan {
   final int end;
 
   /// Returns a [SpanRange] from [start] to [end].
-  SpanRange get range => SpanRange(start: start, end: end);
+  SpanRange get range => SpanRange(start, end);
 
   /// Create a returns a copy of this [AttributionSpan], which is constrained
   /// by the given [start] and [end], i.e., the returned value's `start` is
@@ -1171,7 +1171,7 @@ class MultiAttributionSpan {
           runtimeType == other.runtimeType &&
           start == other.start &&
           end == other.end &&
-          DeepCollectionEquality().equals(attributions, other.attributions);
+          const DeepCollectionEquality().equals(attributions, other.attributions);
 
   @override
   int get hashCode => attributions.hashCode ^ start.hashCode ^ end.hashCode;

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -126,14 +126,14 @@ class AttributedText {
   /// Returns all spans in this [AttributedText] for the given [attributions].
   Set<AttributionSpan> getAttributionSpans(Set<Attribution> attributions) => getAttributionSpansInRange(
         attributionFilter: (a) => attributions.contains(a),
-        range: SpanRange(start: 0, end: text.length),
+        range: SpanRange(0, text.length),
       );
 
   /// Returns all spans in this [AttributedText], for attributions that are
   /// selected by the given [filter].
   Set<AttributionSpan> getAttributionSpansByFilter(AttributionFilter filter) => getAttributionSpansInRange(
         attributionFilter: filter,
-        range: SpanRange(start: 0, end: text.length),
+        range: SpanRange(0, text.length),
       );
 
   /// Returns spans for each attribution that (at least partially) appear
@@ -314,7 +314,7 @@ class AttributedText {
 
     _log.fine('creating new attributed text for insertion');
     final insertedText = AttributedText(textToInsert);
-    final insertTextRange = SpanRange(start: 0, end: textToInsert.length - 1);
+    final insertTextRange = SpanRange(0, textToInsert.length - 1);
     for (dynamic attribution in applyAttributions) {
       insertedText.addAttribution(attribution, insertTextRange);
     }
@@ -372,8 +372,8 @@ class AttributedText {
   /// is notified about italics beginning at `6`, visitor is NOT notified that bold applies
   /// at that same index.
   void visitAttributions(AttributionVisitor visitor) {
-    final startingAttributions = Set<Attribution>();
-    final endingAttributions = Set<Attribution>();
+    final startingAttributions = <Attribution>{};
+    final endingAttributions = <Attribution>{};
     int currentIndex = -1;
 
     visitor.onVisitBegin();
@@ -462,7 +462,7 @@ class AttributedText {
 
   @override
   String toString() {
-    return '[AttributedText] - "$text"\n' + spans.toString();
+    return '[AttributedText] - "$text"\n$spans';
   }
 }
 

--- a/attributed_text/lib/src/logging.dart
+++ b/attributed_text/lib/src/logging.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:logging/logging.dart' as logging;
 
 class LogNames {
@@ -16,7 +18,7 @@ void initLoggers(logging.Level level, Set<logging.Logger> loggers) {
   if (level == logging.Level.OFF) {
     return;
   }
-  
+
   logging.hierarchicalLoggingEnabled = true;
 
   for (final logger in loggers) {

--- a/attributed_text/lib/src/span_range.dart
+++ b/attributed_text/lib/src/span_range.dart
@@ -3,7 +3,7 @@
 /// This was copied from Flutter so that attributed_text could be distributed
 /// as a Dart package, instead of a Flutter package.
 class SpanRange {
-  /// Creates a text range.
+  /// Creates a span range.
   ///
   /// The [start] and [end] arguments must not be null. Both the [start] and
   /// [end] must either be greater than or equal to zero or both exactly -1.
@@ -11,15 +11,15 @@ class SpanRange {
   /// The text included in the range includes the character at [start], but not
   /// the one at [end].
   ///
-  /// Instead of creating an empty text range, consider using the [empty]
+  /// Instead of creating an empty span range, consider using the [empty]
   /// constant.
-  const SpanRange({
-    required this.start,
-    required this.end,
-  })  : assert(start >= -1),
+  const SpanRange(
+    this.start,
+    this.end,
+  )   : assert(start >= -1),
         assert(end >= -1);
 
-  /// A text range that starts and ends at offset.
+  /// A span range that starts and ends at offset.
   ///
   /// The [offset] argument must be non-null and greater than or equal to -1.
   const SpanRange.collapsed(int offset)
@@ -27,8 +27,8 @@ class SpanRange {
         start = offset,
         end = offset;
 
-  /// A text range that contains nothing and is not in the text.
-  static const SpanRange empty = SpanRange(start: -1, end: -1);
+  /// A span range that contains nothing and is not in the text.
+  static const SpanRange empty = SpanRange(-1, -1);
 
   /// The index of the first character in the range.
   ///
@@ -77,5 +77,5 @@ class SpanRange {
   int get hashCode => start.hashCode ^ end.hashCode;
 
   @override
-  String toString() => 'TextRange(start: $start, end: $end)';
+  String toString() => 'SpanRange(start: $start, end: $end)';
 }

--- a/attributed_text/lib/src/test_tools.dart
+++ b/attributed_text/lib/src/test_tools.dart
@@ -61,6 +61,7 @@ class ExpectedSpans {
         }
 
         if (!spans.hasAttributionAt(characterIndex, attribution: namedAttribution)) {
+          // ignore: avoid_print
           print("SPAN MISMATCH: missing $namedAttribution at $characterIndex");
         }
         expect(spans.hasAttributionAt(characterIndex, attribution: namedAttribution), true);

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -161,91 +161,91 @@ void main() {
         test('returns the range of a single attribution for an offset in the middle of a span', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold}, 5);
-          expect(range, SpanRange(start: 4, end: 9));
+          expect(range, const SpanRange(4, 9));
         });
 
         test('returns the range of a single attribution for an offset at the beginning of a span', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold}, 4);
-          expect(range, SpanRange(start: 4, end: 9));
+          expect(range, const SpanRange(4, 9));
         });
 
         test('returns the range of a single attribution for an offset at the end of a span', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold}, 9);
-          expect(range, SpanRange(start: 4, end: 9));
+          expect(range, const SpanRange(4, 9));
         });
 
         test('returns the range for multiple attributions for an offset in the middle of the overlapping range', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 5);
-          expect(range, SpanRange(start: 4, end: 7));
+          expect(range, const SpanRange(4, 7));
         });
 
         test('returns the range for multiple attributions for an offset at the beginning of the overlapping range', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 4);
-          expect(range, SpanRange(start: 4, end: 7));
+          expect(range, const SpanRange(4, 7));
         });
 
         test('returns the range for multiple attributions for an offset at the end of the overlapping range', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
           final range = spans.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 7);
-          expect(range, SpanRange(start: 4, end: 7));
+          expect(range, const SpanRange(4, 7));
         });
 
         test('throws when given an empty attribution set', () {
@@ -257,8 +257,8 @@ void main() {
         test('throws when any attribution is not present at the given offset', () {
           final spans = AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
             ],
           );
 
@@ -760,7 +760,8 @@ class _LinkAttribution implements Attribution {
   }
 
   @override
-  bool operator ==(Object other) => identical(this, other) || other is _LinkAttribution && runtimeType == other.runtimeType && url == other.url;
+  bool operator ==(Object other) =>
+      identical(this, other) || other is _LinkAttribution && runtimeType == other.runtimeType && url == other.url;
 
   @override
   int get hashCode => url.hashCode;

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -23,7 +23,7 @@ void main() {
 
       expect(newText.text, 'aabcdefghij');
       expect(
-        newText.hasAttributionsWithin(attributions: {ExpectedSpans.bold}, range: const SpanRange(start: 0, end: 10)),
+        newText.hasAttributionsWithin(attributions: {ExpectedSpans.bold}, range: const SpanRange(0, 10)),
         true,
       );
     });
@@ -34,19 +34,19 @@ void main() {
           "this that other",
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
-        final slice = text.copyTextInRange(SpanRange(start: 5, end: 9));
+        final slice = text.copyTextInRange(const SpanRange(5, 9));
         expect(slice.text, "that");
         expect(slice.length, 4);
-        expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), SpanRange(start: 0, end: 1));
-        expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), SpanRange(start: 2, end: 3));
+        expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), const SpanRange(0, 1));
+        expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), const SpanRange(2, 3));
       });
 
       test('can be copied as attributed text with start and end bounds', () {
@@ -54,10 +54,10 @@ void main() {
           "this that other",
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -65,8 +65,8 @@ void main() {
         final slice = text.copyText(5, 9);
         expect(slice.text, "that");
         expect(slice.length, 4);
-        expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), SpanRange(start: 0, end: 1));
-        expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), SpanRange(start: 2, end: 3));
+        expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), const SpanRange(0, 1));
+        expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), const SpanRange(2, 3));
       });
 
       test('can be copied as plain text with a SpanRange', () {
@@ -74,15 +74,15 @@ void main() {
           "this that other",
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
-        final substring = text.substringInRange(SpanRange(start: 5, end: 9));
+        final substring = text.substringInRange(const SpanRange(5, 9));
         expect(substring, "that");
       });
 
@@ -91,10 +91,10 @@ void main() {
           "this that other",
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 14, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -108,59 +108,59 @@ void main() {
       test('combines overlapping spans when adding from left to right', () {
         // Note: span overlaps at the boundary had a bug that was filed in #582.
         final text = AttributedText('01234567');
-        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
-        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(0, 4));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(4, 8));
 
         // Ensure that the spans were merged into a single span.
         expect(text.spans.markers.length, 2);
         expect(
           text.spans.markers.first,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
         );
         expect(
           text.spans.markers.last,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
         );
       });
 
       test('combines overlapping spans when adding from left to right', () {
         final text = AttributedText('01234567');
-        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 4, end: 8));
-        text.addAttribution(ExpectedSpans.bold, SpanRange(start: 0, end: 4));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(4, 8));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(0, 4));
 
         // Ensure that the spans were merged into a single span.
         expect(text.spans.markers.length, 2);
         expect(
           text.spans.markers.first,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
         );
         expect(
           text.spans.markers.last,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
         );
       });
 
       test('automatically combines back-to-back spans after addition', () {
         final text = AttributedText('ABCD');
-        text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 0, end: 1));
-        text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 2, end: 3));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(0, 1));
+        text.addAttribution(ExpectedSpans.bold, const SpanRange(2, 3));
 
         // Ensure that we only have a single span
         expect(text.spans.markers.length, 2);
         expect(
           text.spans.markers.first,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
         );
         expect(
           text.spans.markers.last,
-          SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
+          const SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
         );
       });
 
       test('keeps back-to-back spans separate when requested', () {
         final text = AttributedText('#john#sally');
-        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 0, end: 4));
-        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 5, end: 10), autoMerge: false);
+        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(0, 4));
+        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(5, 10), autoMerge: false);
 
         // Ensure that the hash tag spans were kept separate
         expect(text.spans.markers.length, 2 * 2);
@@ -170,30 +170,30 @@ void main() {
         // #john
         expect(
           markers[0],
-          SpanMarker(attribution: ExpectedSpans.hashTag, offset: 0, markerType: SpanMarkerType.start),
+          const SpanMarker(attribution: ExpectedSpans.hashTag, offset: 0, markerType: SpanMarkerType.start),
         );
         expect(
           markers[1],
-          SpanMarker(attribution: ExpectedSpans.hashTag, offset: 4, markerType: SpanMarkerType.end),
+          const SpanMarker(attribution: ExpectedSpans.hashTag, offset: 4, markerType: SpanMarkerType.end),
         );
 
         // #sally
         expect(
           markers[2],
-          SpanMarker(attribution: ExpectedSpans.hashTag, offset: 5, markerType: SpanMarkerType.start),
+          const SpanMarker(attribution: ExpectedSpans.hashTag, offset: 5, markerType: SpanMarkerType.start),
         );
         expect(
           markers[3],
-          SpanMarker(attribution: ExpectedSpans.hashTag, offset: 10, markerType: SpanMarkerType.end),
+          const SpanMarker(attribution: ExpectedSpans.hashTag, offset: 10, markerType: SpanMarkerType.end),
         );
       });
 
       test('throws exception when compatible attributions overlap but auto-merge is false', () {
         final text = AttributedText('#john#sally');
-        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 0, end: 4));
+        text.addAttribution(ExpectedSpans.hashTag, const SpanRange(0, 4));
 
         expect(
-          () => text.addAttribution(ExpectedSpans.hashTag, const SpanRange(start: 0, end: 10), autoMerge: false),
+          () => text.addAttribution(ExpectedSpans.hashTag, const SpanRange(0, 10), autoMerge: false),
           throwsA(isA<IncompatibleOverlappingAttributionsException>()),
         );
       });
@@ -207,7 +207,7 @@ void main() {
         listenerCalled = true;
       });
 
-      text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 1, end: 1));
+      text.addAttribution(ExpectedSpans.bold, const SpanRange(1, 1));
 
       expect(listenerCalled, isTrue);
     });
@@ -303,12 +303,12 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -319,9 +319,9 @@ void main() {
         expect(
           ranges,
           [
-            AttributionSpan(attribution: ExpectedSpans.bold, start: 2, end: 3),
-            AttributionSpan(attribution: ExpectedSpans.bold, start: 6, end: 7),
-            AttributionSpan(attribution: ExpectedSpans.bold, start: 9, end: 10),
+            const AttributionSpan(attribution: ExpectedSpans.bold, start: 2, end: 3),
+            const AttributionSpan(attribution: ExpectedSpans.bold, start: 6, end: 7),
+            const AttributionSpan(attribution: ExpectedSpans.bold, start: 9, end: 10),
           ],
         );
       });
@@ -331,14 +331,14 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 5, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 9, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 5, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 9, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -349,10 +349,10 @@ void main() {
         expect(
           ranges,
           [
-            AttributionSpan(attribution: ExpectedSpans.bold, start: 2, end: 3),
-            AttributionSpan(attribution: ExpectedSpans.italics, start: 5, end: 7),
-            AttributionSpan(attribution: ExpectedSpans.bold, start: 6, end: 7),
-            AttributionSpan(attribution: ExpectedSpans.italics, start: 9, end: 10),
+            const AttributionSpan(attribution: ExpectedSpans.bold, start: 2, end: 3),
+            const AttributionSpan(attribution: ExpectedSpans.italics, start: 5, end: 7),
+            const AttributionSpan(attribution: ExpectedSpans.bold, start: 6, end: 7),
+            const AttributionSpan(attribution: ExpectedSpans.italics, start: 9, end: 10),
           ],
         );
       });
@@ -362,8 +362,8 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 3, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -378,14 +378,14 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
         final range = attributedText.getAttributedRange({ExpectedSpans.bold}, 5);
-        expect(range, SpanRange(start: 4, end: 9));
+        expect(range, const SpanRange(4, 9));
       });
 
       test('finds all bold and italics text around a character', () {
@@ -393,18 +393,18 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 9, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 7, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
         final range = attributedText.getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics}, 5);
-        expect(range, SpanRange(start: 4, end: 7));
+        expect(range, const SpanRange(4, 7));
       });
 
       test(
@@ -414,19 +414,19 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 1, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 3, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 4, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 1, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 3, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
         final range = attributedText
             .getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics, ExpectedSpans.strikethrough}, 2);
-        expect(range, SpanRange(start: 1, end: 3));
+        expect(range, const SpanRange(1, 3));
       });
     });
 
@@ -436,8 +436,8 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -467,8 +467,8 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -498,10 +498,10 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -533,10 +533,10 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 8, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -568,8 +568,8 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -591,16 +591,16 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
         final expectedVisits = [
-          MultiAttributionSpan(attributions: {}, start: 0, end: 1),
+          const MultiAttributionSpan(attributions: {}, start: 0, end: 1),
           MultiAttributionSpan(attributions: {ExpectedSpans.bold}, start: 2, end: 8),
-          MultiAttributionSpan(attributions: {}, start: 9, end: 10),
+          const MultiAttributionSpan(attributions: {}, start: 9, end: 10),
         ];
 
         attributedText.visitAttributionSpans(
@@ -616,10 +616,10 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 6, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 4, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 10, markerType: SpanMarkerType.end),
             ],
           ),
         );
@@ -643,18 +643,18 @@ void main() {
           'Hello world',
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 2, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: ExpectedSpans.italics, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.bold, offset: 8, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 2, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: ExpectedSpans.italics, offset: 8, markerType: SpanMarkerType.end),
             ],
           ),
         );
 
         final expectedVisits = [
-          MultiAttributionSpan(attributions: {}, start: 0, end: 1),
+          const MultiAttributionSpan(attributions: {}, start: 0, end: 1),
           MultiAttributionSpan(attributions: {ExpectedSpans.bold, ExpectedSpans.italics}, start: 2, end: 8),
-          MultiAttributionSpan(attributions: {}, start: 9, end: 10),
+          const MultiAttributionSpan(attributions: {}, start: 9, end: 10),
         ];
 
         attributedText.visitAttributionSpans(
@@ -689,8 +689,8 @@ class _AttributionVisit {
       other is _AttributionVisit &&
           runtimeType == other.runtimeType &&
           index == other.index &&
-          DeepCollectionEquality().equals(startingAttributions, other.startingAttributions) &&
-          DeepCollectionEquality().equals(endingAttributions, other.endingAttributions);
+          const DeepCollectionEquality().equals(startingAttributions, other.startingAttributions) &&
+          const DeepCollectionEquality().equals(endingAttributions, other.endingAttributions);
 
   @override
   int get hashCode => index.hashCode ^ startingAttributions.hashCode ^ endingAttributions.hashCode;

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -239,12 +239,12 @@ class _TextRangeSelectorState extends State<TextRangeSelector> {
           rangeStart = i;
         }
       } else if (rangeStart >= 0) {
-        ranges.add(SpanRange(start: rangeStart, end: i - 1));
+        ranges.add(SpanRange(rangeStart, i - 1));
         rangeStart = -1;
       }
     }
     if (rangeStart >= 0) {
-      ranges.add(SpanRange(start: rangeStart, end: widget.cellCount - 1));
+      ranges.add(SpanRange(rangeStart, widget.cellCount - 1));
     }
 
     widget.onRangesChange!(ranges);

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -295,7 +295,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
     final extentOffset = (selection.extent.nodePosition as TextPosition).offset;
     final selectionStart = min(baseOffset, extentOffset);
     final selectionEnd = max(baseOffset, extentOffset);
-    final selectionRange = SpanRange(start: selectionStart, end: selectionEnd - 1);
+    final selectionRange = SpanRange(selectionStart, selectionEnd - 1);
 
     final textNode = widget.document.getNodeById(selection.extent.nodeId) as TextNode;
     final text = textNode.text;
@@ -316,7 +316,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
     final extentOffset = (selection.extent.nodePosition as TextPosition).offset;
     final selectionStart = min(baseOffset, extentOffset);
     final selectionEnd = max(baseOffset, extentOffset);
-    final selectionRange = SpanRange(start: selectionStart, end: selectionEnd - 1);
+    final selectionRange = SpanRange(selectionStart, selectionEnd - 1);
 
     final textNode = widget.document.getNodeById(selection.extent.nodeId) as TextNode;
     final text = textNode.text;
@@ -347,7 +347,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
         // the entire link attribution.
         text.removeAttribution(
           overlappingLinkSpan.attribution,
-          SpanRange(start: overlappingLinkSpan.start, end: overlappingLinkSpan.end),
+          SpanRange(overlappingLinkSpan.start, overlappingLinkSpan.end),
         );
       }
     } else {
@@ -405,7 +405,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
       endOffset -= 1;
     }
 
-    return SpanRange(start: startOffset, end: endOffset);
+    return SpanRange(startOffset, endOffset);
   }
 
   /// Changes the alignment of the current selected text node

--- a/super_editor/example/lib/demos/features/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/features/feature_action_tags.dart
@@ -84,7 +84,7 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
 
         final actionSpans = node.text.getAttributionSpansInRange(
           attributionFilter: (a) => a == actionTagComposingAttribution,
-          range: SpanRange(start: 0, end: node.text.text.length - 1),
+          range: SpanRange(0, node.text.text.length - 1),
         );
 
         for (final actionSpan in actionSpans) {

--- a/super_editor/example/lib/demos/features/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/features/feature_stable_tags.dart
@@ -80,7 +80,7 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
 
         final userSpans = node.text.getAttributionSpansInRange(
           attributionFilter: (a) => a is CommittedStableTagAttribution,
-          range: SpanRange(start: 0, end: node.text.text.length - 1),
+          range: SpanRange(0, node.text.text.length - 1),
         );
 
         for (final userSpan in userSpans) {

--- a/super_editor/example/lib/demos/supertextfield/_mobile_style_bar.dart
+++ b/super_editor/example/lib/demos/supertextfield/_mobile_style_bar.dart
@@ -16,7 +16,7 @@ class MobileStyleBar extends StatelessWidget {
       final selection = textController.selection;
       return textController.text.hasAttributionsThroughout(
         attributions: {attribution},
-        range: SpanRange(start: selection.start, end: selection.end - 1),
+        range: SpanRange(selection.start, selection.end - 1),
       );
     }
   }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -537,7 +537,7 @@ class LinkifyReaction implements EditReaction {
         if (textNode.text
             .getAttributionSpansInRange(
               attributionFilter: (attribution) => attribution is LinkAttribution,
-              range: SpanRange(start: wordStartOffset, end: linkifyCandidate.offset),
+              range: SpanRange(wordStartOffset, linkifyCandidate.offset),
             )
             .isNotEmpty) {
           // There are link attributions in the preceding word. We don't want to mess with them.
@@ -560,7 +560,7 @@ class LinkifyReaction implements EditReaction {
 
           textNode.text.addAttribution(
             LinkAttribution(url: uri),
-            SpanRange(start: wordStartOffset, end: linkifyCandidate.offset - 1),
+            SpanRange(wordStartOffset, linkifyCandidate.offset - 1),
           );
         }
       }

--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -144,7 +144,7 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
                         originalTextColor: componentTextColor,
                         selectionHighlightColor: _selectionStyles.selectionColor,
                       )),
-                      SpanRange(start: textSelection.start, end: textSelection.end - 1)))
+                      SpanRange(textSelection.start, textSelection.end - 1)))
                 : viewModel.text;
 
         viewModel

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -393,7 +393,7 @@ class SplitParagraphCommand implements EditCommand {
       // of one paragraph, to the beginning of a new paragraph.
       final newParagraphAttributions = endText.getAttributionSpansInRange(
         attributionFilter: (a) => true,
-        range: const SpanRange(start: 0, end: 0),
+        range: const SpanRange(0, 0),
       );
       for (final attributionRange in newParagraphAttributions) {
         if (attributionsToExtendToNewParagraph(attributionRange.attribution)) {
@@ -405,7 +405,7 @@ class SplitParagraphCommand implements EditCommand {
         // This attribution shouldn't extend from one paragraph to another. Remove it.
         endText.removeAttribution(
           attributionRange.attribution,
-          SpanRange(start: attributionRange.start, end: attributionRange.end),
+          SpanRange(attributionRange.start, attributionRange.end),
         );
       }
     }

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -181,7 +181,7 @@ extension DocumentSelectionWithText on Document {
         endOffset = max(textNode.text.text.length - 1, 0);
       }
 
-      final selectionRange = SpanRange(start: startOffset, end: endOffset);
+      final selectionRange = SpanRange(startOffset, endOffset);
 
       if (textNode.text.hasAttributionsWithin(
         attributions: attributions,
@@ -1143,7 +1143,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
         endOffset = max(textNode.text.text.length - 1, 0);
       }
 
-      final selectionRange = SpanRange(start: startOffset, end: endOffset);
+      final selectionRange = SpanRange(startOffset, endOffset);
 
       alreadyHasAttributions = alreadyHasAttributions ||
           textNode.text.hasAttributionsWithin(

--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -372,7 +372,7 @@ class ActionTagComposingReaction implements EditReaction {
   List<EditRequest> _healCancelledTagsInTextNode(RequestDispatcher requestDispatcher, TextNode node) {
     final cancelledTagRanges = node.text.getAttributionSpansInRange(
       attributionFilter: (a) => a == actionTagCancelledAttribution,
-      range: SpanRange(start: 0, end: node.text.text.length - 1),
+      range: SpanRange(0, node.text.text.length - 1),
     );
 
     final changeRequests = <EditRequest>[];

--- a/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
@@ -78,7 +78,7 @@ class PatternTagPlugin extends SuperEditorPlugin {
 
       final tagSpans = node.text.getAttributionSpansInRange(
         attributionFilter: (a) => a is PatternTagAttribution,
-        range: SpanRange(start: 0, end: node.text.text.length - 1),
+        range: SpanRange(0, node.text.text.length - 1),
       );
 
       final tags = <IndexedTag>{};
@@ -246,7 +246,7 @@ class PatternTagReaction implements EditReaction {
       return;
     }
 
-    final tagRange = SpanRange(start: tag.indexedTag.startOffset, end: tag.indexedTag.endOffset);
+    final tagRange = SpanRange(tag.indexedTag.startOffset, tag.indexedTag.endOffset);
     final hasTagAttributionThroughout =
         tag.indexedTag.computeLeadingSpanForAttribution(document, const PatternTagAttribution()) == tagRange;
     if (hasTagAttributionThroughout) {
@@ -427,7 +427,7 @@ class PatternTagReaction implements EditReaction {
   void _splitBackToBackTagsInTextNode(RequestDispatcher requestDispatcher, TextNode node) {
     final patternTags = node.text.getAttributionSpansInRange(
       attributionFilter: (attribution) => attribution is PatternTagAttribution,
-      range: SpanRange(start: 0, end: node.text.text.length),
+      range: SpanRange(0, node.text.text.length),
     );
     if (patternTags.isEmpty) {
       return;
@@ -453,7 +453,7 @@ class PatternTagReaction implements EditReaction {
       editorPatternTagsLog.finer("There are multiple triggers in this tag. Splitting.");
 
       // Remove the existing attribution, which covers multiple pattern tags.
-      spanRemovals.add(SpanRange(start: patternTag.start, end: patternTag.end));
+      spanRemovals.add(SpanRange(patternTag.start, patternTag.end));
       editorPatternTagsLog.finer(
           "Removing multi-tag span: ${patternTag.start} -> ${patternTag.end}, '${node.text.text.substring(patternTag.start, patternTag.end + 1)}'");
 
@@ -469,8 +469,8 @@ class PatternTagReaction implements EditReaction {
           editorPatternTagsLog.finer(
               "Adding a split tag span: ${patternTag.start + triggerSymbolIndex} -> ${patternTag.start + tagEnd}, '${node.text.text.substring(patternTag.start + triggerSymbolIndex, patternTag.start + tagEnd + 1)}'");
           spanCreations.add(SpanRange(
-            start: patternTag.start + triggerSymbolIndex,
-            end: patternTag.start + tagEnd,
+            patternTag.start + triggerSymbolIndex,
+            patternTag.start + tagEnd,
           ));
         }
 
@@ -537,7 +537,7 @@ class PatternTagReaction implements EditReaction {
       // We only care about deleted text when the deleted text contains at least one tag.
       final tagsInDeletedText = change.deletedText.getAttributionSpansInRange(
         attributionFilter: (attribution) => attribution is PatternTagAttribution,
-        range: SpanRange(start: 0, end: change.deletedText.text.length),
+        range: SpanRange(0, change.deletedText.text.length),
       );
       if (tagsInDeletedText.isEmpty) {
         continue;
@@ -555,7 +555,7 @@ class PatternTagReaction implements EditReaction {
       final textNode = document.getNodeById(nodeId) as TextNode;
       final allTags = textNode.text.getAttributionSpansInRange(
         attributionFilter: (attribution) => attribution is PatternTagAttribution,
-        range: SpanRange(start: 0, end: textNode.text.text.length - 1),
+        range: SpanRange(0, textNode.text.text.length - 1),
       );
 
       for (final tag in allTags) {
@@ -625,7 +625,7 @@ class PatternTagReaction implements EditReaction {
     final allTags = textNode.text
         .getAttributionSpansInRange(
           attributionFilter: (attribution) => attribution is PatternTagAttribution,
-          range: SpanRange(start: 0, end: textNode.text.text.length - 1),
+          range: SpanRange(0, textNode.text.text.length - 1),
         )
         .map(
           (span) => IndexedTag(

--- a/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
@@ -454,7 +454,7 @@ class TagUserReaction implements EditReaction {
   List<EditRequest> _healCancelledTagsInTextNode(RequestDispatcher requestDispatcher, TextNode node) {
     final cancelledTagRanges = node.text.getAttributionSpansInRange(
       attributionFilter: (a) => a == stableTagCancelledAttribution,
-      range: SpanRange(start: 0, end: node.text.text.length - 1),
+      range: SpanRange(0, node.text.text.length - 1),
     );
 
     final changeRequests = <EditRequest>[];
@@ -513,8 +513,7 @@ class TagUserReaction implements EditReaction {
 
     final composingToken = _findComposingTagAtCaret(editContext);
     if (composingToken != null) {
-      final tagRange =
-          SpanRange(start: composingToken.indexedTag.startOffset, end: composingToken.indexedTag.endOffset);
+      final tagRange = SpanRange(composingToken.indexedTag.startOffset, composingToken.indexedTag.endOffset);
       final hasComposingThroughout =
           composingToken.indexedTag.computeLeadingSpanForAttribution(document, stableTagComposingAttribution) ==
               tagRange;
@@ -570,7 +569,7 @@ class TagUserReaction implements EditReaction {
       final tagsInDeletedText = change.deletedText.getAttributionSpansInRange(
         attributionFilter: (attribution) =>
             attribution == stableTagComposingAttribution || attribution is CommittedStableTagAttribution,
-        range: SpanRange(start: 0, end: change.deletedText.text.length),
+        range: SpanRange(0, change.deletedText.text.length),
       );
       if (tagsInDeletedText.isEmpty) {
         continue;
@@ -589,7 +588,7 @@ class TagUserReaction implements EditReaction {
       // If a composing tag no longer contains a trigger ("@"), remove the attribution.
       final allComposingTags = textNode.text.getAttributionSpansInRange(
         attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
-        range: SpanRange(start: 0, end: textNode.text.text.length - 1),
+        range: SpanRange(0, textNode.text.text.length - 1),
       );
 
       for (final tag in allComposingTags) {
@@ -629,7 +628,7 @@ class TagUserReaction implements EditReaction {
       final allStableTags = textNode.text
           .getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution is CommittedStableTagAttribution,
-            range: SpanRange(start: 0, end: textNode.text.text.length - 1),
+            range: SpanRange(0, textNode.text.text.length - 1),
           )
           .sorted((tag1, tag2) => tag2.start - tag1.start);
 
@@ -1041,7 +1040,7 @@ class TagUserReaction implements EditReaction {
     final allTags = textNode.text
         .getAttributionSpansInRange(
           attributionFilter: attributionFilter,
-          range: SpanRange(start: 0, end: textNode.text.text.length - 1),
+          range: SpanRange(0, textNode.text.text.length - 1),
         )
         .map(
           (span) => IndexedTag(
@@ -1390,8 +1389,8 @@ class AdjustSelectionAroundTagReaction implements EditReaction {
 
     final tokenAttributions = paragraphText.getAllAttributionsThroughout(
       SpanRange(
-        start: tagAroundCaret.indexedTag.startOffset,
-        end: tagAroundCaret.indexedTag.endOffset - 1,
+        tagAroundCaret.indexedTag.startOffset,
+        tagAroundCaret.indexedTag.endOffset - 1,
       ),
     );
     if (tokenAttributions.any((attribution) => attribution is CommittedStableTagAttribution)) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
@@ -67,7 +67,7 @@ class TagFinder {
     // Make end off exclusive.
     tokenEndOffset += 1;
 
-    final tokenRange = SpanRange(start: tokenStartOffset, end: tokenEndOffset);
+    final tokenRange = SpanRange(tokenStartOffset, tokenEndOffset);
     if (tokenRange.end - tokenRange.start <= 0) {
       return null;
     }

--- a/super_editor/lib/src/infrastructure/attributed_text_styles.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text_styles.dart
@@ -9,7 +9,7 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 typedef AttributionStyleBuilder = TextStyle Function(Set<Attribution> attributions);
 
 extension ToSpanRange on TextRange {
-  SpanRange toSpanRange() => SpanRange(start: start, end: end);
+  SpanRange toSpanRange() => SpanRange(start, end);
 }
 
 extension ComputeTextSpan on AttributedText {

--- a/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
+++ b/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
@@ -65,7 +65,7 @@ class _AttributionBoundsState extends State<AttributionBounds> {
 
       final spans = node.text.getAttributionSpansInRange(
         attributionFilter: widget.selector,
-        range: SpanRange(start: 0, end: node.text.text.length - 1),
+        range: SpanRange(0, node.text.text.length - 1),
       );
 
       for (final span in spans) {

--- a/super_editor/lib/src/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -49,7 +49,7 @@ class AttributedTextEditingController with ChangeNotifier {
       _composingAttributions
         ..clear()
         ..addAll(text.getAllAttributionsThroughout(
-          SpanRange(start: selection.start, end: selection.end),
+          SpanRange(selection.start, selection.end),
         ));
     }
   }
@@ -119,7 +119,7 @@ class AttributedTextEditingController with ChangeNotifier {
     for (final attribution in attributions) {
       _text.toggleAttribution(
         attribution,
-        SpanRange(start: selection.start, end: selection.end - 1),
+        SpanRange(selection.start, selection.end - 1),
       );
     }
 
@@ -133,7 +133,7 @@ class AttributedTextEditingController with ChangeNotifier {
     }
 
     _text.clearAttributions(
-      SpanRange(start: selection.start, end: selection.end - 1),
+      SpanRange(selection.start, selection.end - 1),
     );
 
     notifyListeners();

--- a/super_editor/test/super_editor/infrastructure/attributed_text_styles_test.dart
+++ b/super_editor/test/super_editor/infrastructure/attributed_text_styles_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     test('add single character style', () {
       final text = AttributedText('abcdefghij');
-      text.addAttribution(ExpectedSpans.bold, const SpanRange(start: 1, end: 1));
+      text.addAttribution(ExpectedSpans.bold, const SpanRange(1, 1));
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);

--- a/super_editor/test/super_editor/text_entry/attributions_test.dart
+++ b/super_editor/test/super_editor/text_entry/attributions_test.dart
@@ -11,7 +11,7 @@ void main() {
         // Add link across "one two"
         text.addAttribution(
           LinkAttribution(url: Uri.parse('https://flutter.dev')),
-          const SpanRange(start: 0, end: 6),
+          const SpanRange(0, 6),
         );
 
         // Try to add a different link across "two three" and expect
@@ -19,7 +19,7 @@ void main() {
         expect(() {
           text.addAttribution(
             LinkAttribution(url: Uri.parse('https://pub.dev')),
-            const SpanRange(start: 4, end: 12),
+            const SpanRange(4, 12),
           );
         }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
       });
@@ -32,12 +32,12 @@ void main() {
         // Add link across "one two"
         text.addAttribution(
           linkAttribution,
-          const SpanRange(start: 0, end: 6),
+          const SpanRange(0, 6),
         );
 
         text.addAttribution(
           LinkAttribution(url: Uri.parse('https://flutter.dev')),
-          const SpanRange(start: 4, end: 12),
+          const SpanRange(4, 12),
         );
 
         expect(text.spans.hasAttributionsWithin(attributions: {linkAttribution}, start: 0, end: 12), true);

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(
         text.getAttributionSpansInRange(
           attributionFilter: (attribution) => true,
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isEmpty,
       );
@@ -48,7 +48,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("https://www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 2),
+          range: SpanRange(0, text.text.length - 2),
         ),
         isTrue,
       );
@@ -77,7 +77,7 @@ void main() {
       expect(
         text.getAttributionSpansInRange(
           attributionFilter: (attribution) => true,
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isEmpty,
       );
@@ -94,7 +94,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("https://google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 2),
+          range: SpanRange(0, text.text.length - 2),
         ),
         isTrue,
       );
@@ -129,7 +129,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("https://www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 2),
+          range: SpanRange(0, text.text.length - 2),
         ),
         isTrue,
       );
@@ -204,7 +204,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isTrue,
       );
@@ -238,7 +238,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isTrue,
       );
@@ -273,7 +273,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isTrue,
       );
@@ -307,7 +307,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: SpanRange(start: 0, end: text.text.length - 1),
+          range: SpanRange(0, text.text.length - 1),
         ),
         isTrue,
       );
@@ -341,7 +341,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: const SpanRange(start: 0, end: 12),
+          range: const SpanRange(0, 12),
         ),
         isTrue,
       );
@@ -350,7 +350,7 @@ void main() {
           attributions: {
             LinkAttribution(url: Uri.parse("www.google.com")),
           },
-          range: SpanRange(start: 13, end: text.text.length - 1),
+          range: SpanRange(13, text.text.length - 1),
         ),
         isFalse,
       );
@@ -388,7 +388,7 @@ void main() {
       expect(
         newParagraphText.getAttributionSpansInRange(
           attributionFilter: (a) => a is LinkAttribution,
-          range: SpanRange(start: 0, end: newParagraphText.text.length - 1),
+          range: SpanRange(0, newParagraphText.text.length - 1),
         ),
         isEmpty,
       );
@@ -430,7 +430,7 @@ void main() {
       expect(
         newListItemText.getAttributionSpansInRange(
           attributionFilter: (a) => a is LinkAttribution,
-          range: SpanRange(start: 0, end: newListItemText.text.length - 1),
+          range: SpanRange(0, newListItemText.text.length - 1),
         ),
         isEmpty,
       );

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -26,7 +26,7 @@ void main() {
         expect(text.text, "/header");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 0),
-          const SpanRange(start: 0, end: 6),
+          const SpanRange(0, 6),
         );
       });
 
@@ -54,7 +54,7 @@ void main() {
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
       });
 
@@ -84,13 +84,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 18),
+            range: const SpanRange(0, 18),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -119,7 +119,7 @@ void main() {
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
 
         await tester.typeImeText(" after");
@@ -129,7 +129,7 @@ void main() {
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 19),
+          const SpanRange(7, 19),
         );
       });
 
@@ -158,7 +158,7 @@ void main() {
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -205,7 +205,7 @@ void main() {
         AttributedText text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
 
         // Expand the selection to "before |/header|"
@@ -220,7 +220,7 @@ void main() {
         text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
 
         // Expand the selection to "befor|e /header|"
@@ -231,7 +231,7 @@ void main() {
         text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
       });
 
@@ -293,7 +293,7 @@ void main() {
         AttributedText text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 13),
+          const SpanRange(7, 13),
         );
       });
 
@@ -335,7 +335,7 @@ void main() {
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -381,7 +381,7 @@ void main() {
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -434,7 +434,7 @@ void main() {
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -461,7 +461,7 @@ void main() {
         var text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Cancel composing.
@@ -472,13 +472,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 7),
+            range: const SpanRange(0, 7),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Start typing again.
@@ -490,13 +490,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 8),
+            range: const SpanRange(0, 8),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Add a space, cause the tag to end.
@@ -508,13 +508,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 9),
+            range: const SpanRange(0, 9),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -610,7 +610,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 6),
+            range: const SpanRange(0, 6),
           ),
           isEmpty,
         );
@@ -644,7 +644,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 12),
+            range: const SpanRange(0, 12),
           ),
           isEmpty,
         );

--- a/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
@@ -44,7 +44,7 @@ void main() {
         expect(text.text, "#flutter");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 0),
-          const SpanRange(start: 0, end: 7),
+          const SpanRange(0, 7),
         );
       });
 
@@ -72,7 +72,7 @@ void main() {
         expect(text.text, "before #flutter after");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 7),
-          const SpanRange(start: 7, end: 14),
+          const SpanRange(7, 14),
         );
       });
 
@@ -130,7 +130,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution is PatternTagAttribution,
-            range: const SpanRange(start: 0, end: 18),
+            range: const SpanRange(0, 18),
           ),
           {
             const AttributionSpan(
@@ -167,7 +167,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution is PatternTagAttribution,
-            range: const SpanRange(start: 0, end: 19),
+            range: const SpanRange(0, 19),
           ),
           {
             const AttributionSpan(
@@ -208,7 +208,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution is PatternTagAttribution,
-            range: const SpanRange(start: 0, end: 19),
+            range: const SpanRange(0, 19),
           ),
           {
             const AttributionSpan(
@@ -234,11 +234,11 @@ void main() {
         expect(text.text, "hello #flutter#d");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
-          const SpanRange(start: 6, end: 13),
+          const SpanRange(6, 13),
         );
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 14),
-          const SpanRange(start: 14, end: 15),
+          const SpanRange(14, 15),
         );
 
         // Finish the second hash tag.
@@ -249,11 +249,11 @@ void main() {
         expect(text.text, "hello #flutter#dart");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
-          const SpanRange(start: 6, end: 13),
+          const SpanRange(6, 13),
         );
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 14),
-          const SpanRange(start: 14, end: 18),
+          const SpanRange(14, 18),
         );
       });
 
@@ -272,11 +272,11 @@ void main() {
         expect(text.text, "hello #flutter #dart");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
-          const SpanRange(start: 6, end: 13),
+          const SpanRange(6, 13),
         );
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 15),
-          const SpanRange(start: 15, end: 19),
+          const SpanRange(15, 19),
         );
       });
 
@@ -479,7 +479,7 @@ void main() {
         expect(text.text, "#bcdfghi ");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 0),
-          const SpanRange(start: 0, end: 7),
+          const SpanRange(0, 7),
         );
       });
     });

--- a/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
@@ -25,7 +25,7 @@ void main() {
         expect(text.text, "@john");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 0),
-          const SpanRange(start: 0, end: 4),
+          const SpanRange(0, 4),
         );
       });
 
@@ -53,7 +53,7 @@ void main() {
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -83,7 +83,7 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 18),
+            range: const SpanRange(0, 18),
           ),
           isEmpty,
         );
@@ -114,7 +114,7 @@ void main() {
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
 
         await tester.typeImeText(" after");
@@ -124,7 +124,7 @@ void main() {
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 17),
+          const SpanRange(7, 17),
         );
       });
 
@@ -171,7 +171,7 @@ void main() {
         AttributedText text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
 
         // Expand the selection to "before |@john|"
@@ -184,7 +184,7 @@ void main() {
         text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
 
         // Expand the selection to "befor|e @john|"
@@ -195,7 +195,7 @@ void main() {
         text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -253,7 +253,7 @@ void main() {
         AttributedText text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -280,7 +280,7 @@ void main() {
         var text = SuperEditorInspector.findTextInParagraph("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Cancel composing.
@@ -291,13 +291,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 7),
+            range: const SpanRange(0, 7),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({stableTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Start typing again.
@@ -309,13 +309,13 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 8),
+            range: const SpanRange(0, 8),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({stableTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
 
         // Add a space, cause the tag to end.
@@ -327,20 +327,20 @@ void main() {
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
-            range: const SpanRange(start: 0, end: 9),
+            range: const SpanRange(0, 9),
           ),
           isEmpty,
         );
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution is CommittedStableTagAttribution,
-            range: const SpanRange(start: 0, end: 9),
+            range: const SpanRange(0, 9),
           ),
           isEmpty,
         );
         expect(
           text.getAttributedRange({stableTagCancelledAttribution}, 7),
-          const SpanRange(start: 7, end: 7),
+          const SpanRange(7, 7),
         );
       });
 
@@ -411,7 +411,7 @@ void main() {
         expect(text.text, "@john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 0),
-          const SpanRange(start: 0, end: 4),
+          const SpanRange(0, 4),
         );
       });
 
@@ -439,7 +439,7 @@ void main() {
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -481,7 +481,7 @@ void main() {
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -525,7 +525,7 @@ void main() {
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
 
@@ -574,7 +574,7 @@ void main() {
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
-          const SpanRange(start: 7, end: 11),
+          const SpanRange(7, 11),
         );
       });
     });

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -384,42 +384,27 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
     if (element.tag == 'strong') {
       styledText.addAttribution(
         boldAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == 'em') {
       styledText.addAttribution(
         italicsAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == "del") {
       styledText.addAttribution(
         strikethroughAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == "u") {
       styledText.addAttribution(
         underlineAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == 'a') {
       styledText.addAttribution(
         LinkAttribution(url: Uri.parse(element.attributes['href']!)),
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     }
 

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -156,42 +156,27 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
     if (element.tag == 'strong') {
       styledText.addAttribution(
         boldAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == 'em') {
       styledText.addAttribution(
         italicsAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == "del") {
       styledText.addAttribution(
         strikethroughAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == "u") {
       styledText.addAttribution(
         underlineAttribution,
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     } else if (element.tag == 'a') {
       styledText.addAttribution(
         LinkAttribution(url: Uri.parse(element.attributes['href']!)),
-        SpanRange(
-          start: 0,
-          end: styledText.text.length - 1,
-        ),
+        SpanRange(0, styledText.text.length - 1),
       );
     }
 


### PR DESCRIPTION
Removed named parameters from SpanRange constructor for less verbosity (Resolves #1191)