### PR TITLE
Remove attribution merge check when finding markers (Resolves #561)

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -259,11 +259,8 @@ class AttributedSpans {
     return _markers //
         .reversed // search from the end so its the nearest start marker
         .where((marker) {
-      return attribution == null ||
-          (marker.attribution.id == attribution.id && marker.attribution.canMergeWith(attribution));
-    })
-        // .where((marker) => attribution == null || marker.attribution.id == attribution.id)
-        .firstWhereOrNull((marker) => marker.isStart && marker.offset <= offset);
+      return attribution == null || (marker.attribution.id == attribution.id);
+    }).firstWhereOrNull((marker) => marker.isStart && marker.offset <= offset);
   }
 
   /// Finds and returns the nearest [end] marker that appears at or after the
@@ -271,9 +268,7 @@ class AttributedSpans {
   /// the given [attribution].
   SpanMarker? _getEndingMarkerAtOrAfter(int offset, {Attribution? attribution}) {
     return _markers
-        .where((marker) =>
-            attribution == null ||
-            (marker.attribution.id == attribution.id && marker.attribution.canMergeWith(attribution)))
+        .where((marker) => attribution == null || (marker.attribution.id == attribution.id))
         .firstWhereOrNull((marker) => marker.isEnd && marker.offset >= offset);
   }
 


### PR DESCRIPTION
Remove attribution merge check when finding markers (Resolves #561)

Issue #561 mentioned that we're checking if an attribution is merge-able with a given attribution, when searching for the next or previous marker. It was unclear why this was needed, and it seems possible that this condition could cause unexpected results. I removed that condition and all tests still passed. So now I'm merging that removal.