### PR TITLE
[SuperEditor] Fix pasting multiple lines (Resolves #871)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2366,7 +2366,7 @@ class PasteEditorCommand implements EditCommand {
   List<AttributedText> _inferAttributionsForLinesOfPastedText(String content) {
     // Split the pasted content by newlines, because each new line of content
     // needs to placed in its own ParagraphNode.
-    final lines = content.split('\n\n');
+    final lines = content.split('\n');
     editorOpsLog.fine("Breaking pasted content into lines and adding attributions:");
     editorOpsLog.fine("Lines of content:");
     for (final line in lines) {

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
@@ -58,7 +59,7 @@ void main() {
       expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
     });
 
-    testAllInputsOnMac('pastes multiple paragraphs', (
+    testAllInputsOnDesktop('pastes multiple paragraphs', (
       tester, {
       required TextInputSource inputSource,
     }) async {
@@ -77,36 +78,11 @@ void main() {
         ..setSimulatedClipboardContent('''This is a paragraph
 This is a second paragraph
 This is the third paragraph''');
-      await tester.pressCmdV();
-
-      // Ensure three paragraphs were created.
-      final doc = testContext.document;
-      expect(doc.nodes.length, 3);
-      expect((doc.nodes[0] as ParagraphNode).text.text, 'This is a paragraph');
-      expect((doc.nodes[1] as ParagraphNode).text.text, 'This is a second paragraph');
-      expect((doc.nodes[2] as ParagraphNode).text.text, 'This is the third paragraph');
-    });
-
-    testAllInputsOnWindowsAndLinux('pastes multiple paragraphs', (
-      tester, {
-      required TextInputSource inputSource,
-    }) async {
-      final testContext = await tester //
-          .createDocument()
-          .withSingleEmptyParagraph()
-          .withInputSource(inputSource)
-          .pump();
-
-      // Place the caret at the empty paragraph.
-      await tester.placeCaretInParagraph('1', 0);
-
-      // Simulate pasting multiple lines.
-      tester
-        ..simulateClipboard()
-        ..setSimulatedClipboardContent('''This is a paragraph
-This is a second paragraph
-This is the third paragraph''');
-      await tester.pressCtlV();
+      if (defaultTargetPlatform == TargetPlatform.macOS) {
+        await tester.pressCmdV();
+      } else {
+        await tester.pressCtlV();
+      }
 
       // Ensure three paragraphs were created.
       final doc = testContext.document;

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
+import '../test_runners.dart';
 import 'supereditor_test_tools.dart';
 
 void main() {
@@ -55,6 +56,35 @@ void main() {
       // Ensure that the text was pasted into the paragraph.
       final nodeId = doc.nodes.first.id;
       expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
+    });
+
+    testAllInputsOnMac('pastes multiple paragraphs', (
+      tester, {
+      required TextInputSource inputSource,
+    }) async {
+      final testContext = await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(inputSource)
+          .pump();
+
+      // Place the caret at the empty paragraph.
+      await tester.placeCaretInParagraph('1', 0);
+
+      // Simulate pasting multiple lines.
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent('''This is a paragraph
+This is a second paragraph
+This is the third paragraph''');
+      await tester.pressCmdV();
+
+      // Ensure three paragraphs were created.
+      final doc = testContext.document;
+      expect(doc.nodes.length, 3);
+      expect((doc.nodes[0] as ParagraphNode).text.text, 'This is a paragraph');
+      expect((doc.nodes[1] as ParagraphNode).text.text, 'This is a second paragraph');
+      expect((doc.nodes[2] as ParagraphNode).text.text, 'This is the third paragraph');
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -86,5 +86,34 @@ This is the third paragraph''');
       expect((doc.nodes[1] as ParagraphNode).text.text, 'This is a second paragraph');
       expect((doc.nodes[2] as ParagraphNode).text.text, 'This is the third paragraph');
     });
+
+    testAllInputsOnWindowsAndLinux('pastes multiple paragraphs', (
+      tester, {
+      required TextInputSource inputSource,
+    }) async {
+      final testContext = await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(inputSource)
+          .pump();
+
+      // Place the caret at the empty paragraph.
+      await tester.placeCaretInParagraph('1', 0);
+
+      // Simulate pasting multiple lines.
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent('''This is a paragraph
+This is a second paragraph
+This is the third paragraph''');
+      await tester.pressCtlV();
+
+      // Ensure three paragraphs were created.
+      final doc = testContext.document;
+      expect(doc.nodes.length, 3);
+      expect((doc.nodes[0] as ParagraphNode).text.text, 'This is a paragraph');
+      expect((doc.nodes[1] as ParagraphNode).text.text, 'This is a second paragraph');
+      expect((doc.nodes[2] as ParagraphNode).text.text, 'This is the third paragraph');
+    });
   });
 }


### PR DESCRIPTION
[SuperEditor] Fix pasting multiple lines. Resolves #871.

When pasting multiple lines, the editor is creating a single paragraph containing all the lines. We are requiring two line breaks to create a new paragraph.

This PR changes the paste behavior to split the paragraphs by a single line break.

This test is running on mac only because we use the mac shortcut to paste: `await tester.pressCmdV()`. We could also add methods in the robot to simulate common shortcuts depending on the platform. For example: `await tester.pressPasteCombo()`.

