### PR TITLE
[SuperEditor] Bump linkify to v5.0.0 (Resolves #1383)

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   flutter_keyboard_visibility: ^5.0.3
   google_fonts: ^2.0.0
   http: ^0.13.1
-  linkify: ^4.0.0
+  linkify: ^5.0.0
   logging: ^1.0.1
   uuid: ^3.0.3
 

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   collection: ^1.15.0
   follow_the_leader: ^0.0.4+3
   http: ">=0.13.1 <2.0.0"
-  linkify: ^4.0.0
+  linkify: ^5.0.0
   logging: ^1.0.1
   super_text_layout: ^0.1.7
   url_launcher: ^6.1.9
@@ -39,10 +39,10 @@ dependencies:
   flutter_test_robots: 0.0.21
 
 dependency_overrides:
-#  # Override to local mono-repo path so devs can test this repo
-#  # against changes that they're making to other mono-repo packages
+  #  # Override to local mono-repo path so devs can test this repo
+  #  # against changes that they're making to other mono-repo packages
   attributed_text:
-   path: ../attributed_text
+    path: ../attributed_text
   super_text_layout:
     path: ../super_text_layout
 #


### PR DESCRIPTION
[SuperEditor] Bump linkify to v5.0.0. Resolves #1383

This PR bumps linkify dependency from 4.0.0 to 5.0.0

Although it is a major release there isn't any changes needed in our code.