### PR TITLE
Cherry-pick "[attributed_text] Fix exception in hasAttributionsWithin (Resolves #1201) (#1401)" to stable

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -65,14 +65,20 @@ class AttributedSpans {
   }) {
     final attributionsToFind = Set.from(attributions);
     for (int i = start; i <= end; ++i) {
+      final foundAttributions = <Attribution>{};
       for (final attribution in attributionsToFind) {
         if (hasAttributionAt(i, attribution: attribution)) {
-          attributionsToFind.remove(attribution);
+          // Store the attributions we found so far to remove them
+          // from attributionsToFind after the loop.
+          //
+          // Removing from the set while iterating throws an exception.
+          foundAttributions.add(attribution);
         }
-
-        if (attributionsToFind.isEmpty) {
-          return true;
-        }
+      }
+      attributionsToFind.removeAll(foundAttributions);
+      if (attributionsToFind.isEmpty) {
+        // We found all attributions.
+        return true;
       }
     }
     return false;

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -157,6 +157,53 @@ void main() {
         );
       });
 
+      test('hasAttributionsWithin can look for multiple attributions at the same time', () {
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: ExpectedSpans.bold, start: 0, end: 8)
+          ..addAttribution(newAttribution: ExpectedSpans.italics, start: 1, end: 5)
+          ..addAttribution(newAttribution: ExpectedSpans.strikethrough, start: 5, end: 9);
+
+        ExpectedSpans(
+          [
+            'bbbbbbbbb_',
+            '_iiiii____',
+            '_____sssss',
+          ],
+        ).expectSpans(spans);
+
+        expect(
+          spans.hasAttributionsWithin(attributions: {
+            ExpectedSpans.bold,
+            ExpectedSpans.italics,
+            ExpectedSpans.strikethrough,
+          }, start: 0, end: 9),
+          true,
+        );
+
+        expect(
+          spans.hasAttributionsWithin(attributions: {
+            ExpectedSpans.bold,
+            ExpectedSpans.italics,
+          }, start: 0, end: 9),
+          true,
+        );
+
+        expect(
+            spans.hasAttributionsWithin(attributions: {
+              ExpectedSpans.bold,
+              ExpectedSpans.italics,
+            }, start: 0, end: 4),
+            true);
+
+        expect(
+          spans.hasAttributionsWithin(attributions: {
+            ExpectedSpans.bold,
+            ExpectedSpans.strikethrough,
+          }, start: 0, end: 4),
+          false,
+        );
+      });
+
       group('getAttributedRange', () {
         test('returns the range of a single attribution for an offset in the middle of a span', () {
           final spans = AttributedSpans(


### PR DESCRIPTION
This PR cherry-picks "[attributed_text] Fix exception in hasAttributionsWithin (Resolves #1201) (#1401)" to stable.