### PR TITLE
Fixed tagging NPEs - includes new ContentLayers layer widgets, IME focus policy adjustment (Resolves #1397)

### DIFF
--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -143,11 +143,7 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
             builder: (BuildContext context, Attribution attribution) {
               return Leader(
                 link: _composingLink,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.blue),
-                  ),
-                ),
+                child: const SizedBox(),
               );
             },
           ),

--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -44,12 +44,9 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
             : null,
         ...defaultRequestHandlers,
       ],
-      listeners: [
-        FunctionalEditListener(_onEdit),
-      ],
     );
 
-    _actionTagPlugin = ActionTagsPlugin();
+    _actionTagPlugin = ActionTagsPlugin()..composingActionTag.addListener(_updateActionTagList);
 
     _editorFocusNode = FocusNode();
   }
@@ -58,6 +55,8 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
   void dispose() {
     _editorFocusNode.dispose();
 
+    _actionTagPlugin.composingActionTag.removeListener(_updateActionTagList);
+
     _composer.dispose();
     _editor.dispose();
     _document.dispose();
@@ -65,16 +64,7 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
     super.dispose();
   }
 
-  void _onEdit(List<EditEvent> changeList) {
-    if (changeList.whereType<DocumentEdit>().isEmpty) {
-      return;
-    }
-
-    _updateActionTagList();
-  }
-
   void _updateActionTagList() {
-    print("_updateActionTagList()");
     setState(() {
       _actions.clear();
 

--- a/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
@@ -60,8 +60,6 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
 
   @override
   Widget build(BuildContext context) {
-    print("Building pattern tag demo");
-
     return InTheLabScaffold(
       content: _buildEditor(),
       supplemental: _buildTagList(),
@@ -93,7 +91,6 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
         documentOverlayBuilders: [
           DefaultCaretOverlayBuilder(
             caretStyle: CaretStyle().copyWith(color: Colors.redAccent),
-            blinkTimingMode: BlinkTimingMode.ticker,
           ),
         ],
         plugins: {

--- a/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
@@ -1,6 +1,7 @@
 import 'package:example/demos/in_the_lab/in_the_lab_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 class HashTagsFeatureDemo extends StatefulWidget {
   const HashTagsFeatureDemo({super.key});
@@ -59,6 +60,8 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
 
   @override
   Widget build(BuildContext context) {
+    print("Building pattern tag demo");
+
     return InTheLabScaffold(
       content: _buildEditor(),
       supplemental: _buildTagList(),
@@ -90,6 +93,7 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
         documentOverlayBuilders: [
           DefaultCaretOverlayBuilder(
             caretStyle: CaretStyle().copyWith(color: Colors.redAccent),
+            blinkTimingMode: BlinkTimingMode.ticker,
           ),
         ],
         plugins: {
@@ -115,37 +119,5 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
         ],
       ),
     );
-
-    // return Container(
-    //   width: 300,
-    //   decoration: BoxDecoration(
-    //     border: Border(
-    //       left: BorderSide(width: 1, color: Colors.white.withOpacity(0.1)),
-    //     ),
-    //   ),
-    //   padding: const EdgeInsets.all(24),
-    //   child: Center(
-    //     child: _tags.isNotEmpty
-    //         ? SingleChildScrollView(
-    //             child: Wrap(
-    //               spacing: 12,
-    //               runSpacing: 12,
-    //               alignment: WrapAlignment.center,
-    //               children: [
-    //                 for (final tag in _tags) //
-    //                   Chip(label: Text(tag.tag.raw)),
-    //               ],
-    //             ),
-    //           )
-    //         : Text(
-    //             "NO TAGS",
-    //             style: TextStyle(
-    //               color: Colors.white.withOpacity(0.1),
-    //               fontSize: 32,
-    //               fontWeight: FontWeight.bold,
-    //             ),
-    //           ),
-    //   ),
-    // );
   }
 }

--- a/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
@@ -146,11 +146,7 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
             builder: (context, attribution) {
               return Leader(
                 link: _composingLink,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.blue),
-                  ),
-                ),
+                child: const SizedBox(),
               );
             },
           ),

--- a/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
@@ -41,12 +41,11 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
       requestHandlers: [
         ...defaultRequestHandlers,
       ],
-      listeners: [
-        FunctionalEditListener(_onEdit),
-      ],
     );
 
-    _userTagPlugin = StableTagPlugin();
+    _userTagPlugin = StableTagPlugin()
+      ..tagIndex.composingStableTag.addListener(_updateUserTagList)
+      ..tagIndex.addListener(_updateUserTagList);
 
     _editorFocusNode = FocusNode();
   }
@@ -55,19 +54,15 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
   void dispose() {
     _editorFocusNode.dispose();
 
+    _userTagPlugin.tagIndex
+      ..composingStableTag.removeListener(_updateUserTagList)
+      ..removeListener(_updateUserTagList);
+
     _composer.dispose();
     _editor.dispose();
     _document.dispose();
 
     super.dispose();
-  }
-
-  void _onEdit(List<EditEvent> changeList) {
-    if (changeList.whereType<DocumentEdit>().isEmpty) {
-      return;
-    }
-
-    _updateUserTagList();
   }
 
   void _updateUserTagList() {
@@ -99,17 +94,6 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
           content: _buildEditor(),
           supplemental: _buildTagList(),
         ),
-        // FeatureDemoScaffold(
-        //   child: Row(
-        //     crossAxisAlignment: CrossAxisAlignment.stretch,
-        //     children: [
-        //       Expanded(
-        //         child: _buildEditor(),
-        //       ),
-        //       _buildTagList(),
-        //     ],
-        //   ),
-        // ),
         if (_userTagPlugin.tagIndex.composingStableTag.value != null)
           Follower.withOffset(
             link: _composingLink,

--- a/super_editor/example/lib/demos/in_the_lab/popover_list.dart
+++ b/super_editor/example/lib/demos/in_the_lab/popover_list.dart
@@ -89,6 +89,7 @@ class _PopoverListState extends State<PopoverList> {
   }
 
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    print("_onKeyEvent() - $event");
     final reservedKeys = {
       LogicalKeyboardKey.arrowUp,
       LogicalKeyboardKey.arrowDown,
@@ -99,6 +100,7 @@ class _PopoverListState extends State<PopoverList> {
 
     final key = event.logicalKey;
     if (!reservedKeys.contains(key)) {
+      print("Ignoring this key. Letting ancestors handle it.");
       return KeyEventResult.ignored;
     }
 
@@ -130,32 +132,39 @@ class _PopoverListState extends State<PopoverList> {
         widget.onCancelRequested();
     }
 
+    print("We handled this key");
     return KeyEventResult.handled;
   }
 
   @override
   Widget build(BuildContext context) {
-    return Focus(
-      focusNode: _focusNode,
-      parentNode: widget.editorFocusNode,
-      onKeyEvent: _onKeyEvent,
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) {
-          return DecoratedBox(
-            decoration: BoxDecoration(
-              border: Border.all(color: _focusNode.hasFocus ? Colors.blue : Colors.transparent),
-            ),
-            child: CupertinoPopoverMenu(
-              focalPoint: LeaderMenuFocalPoint(link: widget.leaderLink),
-              child: SizedBox(
-                width: 200,
-                height: 125,
-                child: _buildContent(),
-              ),
-            ),
-          );
-        },
+    return Shortcuts(
+      shortcuts: {},
+      child: Actions(
+        actions: {},
+        child: Focus(
+          focusNode: _focusNode,
+          parentNode: widget.editorFocusNode,
+          onKeyEvent: _onKeyEvent,
+          child: ListenableBuilder(
+            listenable: _focusNode,
+            builder: (context, child) {
+              return DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: _focusNode.hasFocus ? Colors.blue : Colors.transparent),
+                ),
+                child: CupertinoPopoverMenu(
+                  focalPoint: LeaderMenuFocalPoint(link: widget.leaderLink),
+                  child: SizedBox(
+                    width: 200,
+                    height: 125,
+                    child: _buildContent(),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
       ),
     );
   }

--- a/super_editor/example/lib/demos/in_the_lab/popover_list.dart
+++ b/super_editor/example/lib/demos/in_the_lab/popover_list.dart
@@ -89,7 +89,6 @@ class _PopoverListState extends State<PopoverList> {
   }
 
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
-    print("_onKeyEvent() - $event");
     final reservedKeys = {
       LogicalKeyboardKey.arrowUp,
       LogicalKeyboardKey.arrowDown,
@@ -100,7 +99,6 @@ class _PopoverListState extends State<PopoverList> {
 
     final key = event.logicalKey;
     if (!reservedKeys.contains(key)) {
-      print("Ignoring this key. Letting ancestors handle it.");
       return KeyEventResult.ignored;
     }
 
@@ -132,39 +130,32 @@ class _PopoverListState extends State<PopoverList> {
         widget.onCancelRequested();
     }
 
-    print("We handled this key");
     return KeyEventResult.handled;
   }
 
   @override
   Widget build(BuildContext context) {
-    return Shortcuts(
-      shortcuts: {},
-      child: Actions(
-        actions: {},
-        child: Focus(
-          focusNode: _focusNode,
-          parentNode: widget.editorFocusNode,
-          onKeyEvent: _onKeyEvent,
-          child: ListenableBuilder(
-            listenable: _focusNode,
-            builder: (context, child) {
-              return DecoratedBox(
-                decoration: BoxDecoration(
-                  border: Border.all(color: _focusNode.hasFocus ? Colors.blue : Colors.transparent),
-                ),
-                child: CupertinoPopoverMenu(
-                  focalPoint: LeaderMenuFocalPoint(link: widget.leaderLink),
-                  child: SizedBox(
-                    width: 200,
-                    height: 125,
-                    child: _buildContent(),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
+    return Focus(
+      focusNode: _focusNode,
+      parentNode: widget.editorFocusNode,
+      onKeyEvent: _onKeyEvent,
+      child: ListenableBuilder(
+        listenable: _focusNode,
+        builder: (context, child) {
+          return DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(color: _focusNode.hasFocus ? Colors.blue : Colors.transparent),
+            ),
+            child: CupertinoPopoverMenu(
+              focalPoint: LeaderMenuFocalPoint(link: widget.leaderLink),
+              child: SizedBox(
+                width: 200,
+                height: 125,
+                child: _buildContent(),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/super_editor/example/lib/demos/in_the_lab/popover_list.dart
+++ b/super_editor/example/lib/demos/in_the_lab/popover_list.dart
@@ -135,27 +135,25 @@ class _PopoverListState extends State<PopoverList> {
 
   @override
   Widget build(BuildContext context) {
-    return Focus(
-      focusNode: _focusNode,
-      parentNode: widget.editorFocusNode,
-      onKeyEvent: _onKeyEvent,
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) {
-          return DecoratedBox(
-            decoration: BoxDecoration(
-              border: Border.all(color: _focusNode.hasFocus ? Colors.blue : Colors.transparent),
-            ),
-            child: CupertinoPopoverMenu(
+    return GestureDetector(
+      onTap: () => !_focusNode.hasPrimaryFocus ? _focusNode.requestFocus() : null,
+      child: Focus(
+        focusNode: _focusNode,
+        parentNode: widget.editorFocusNode,
+        onKeyEvent: _onKeyEvent,
+        child: ListenableBuilder(
+          listenable: _focusNode,
+          builder: (context, child) {
+            return CupertinoPopoverMenu(
               focalPoint: LeaderMenuFocalPoint(link: widget.leaderLink),
               child: SizedBox(
                 width: 200,
                 height: 125,
                 child: _buildContent(),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }
@@ -183,7 +181,9 @@ class _PopoverListState extends State<PopoverList> {
           const SizedBox(height: 8),
           for (int i = 0; i < widget.listItems.length; i += 1) ...[
             ColoredBox(
-              color: i == _selectedValueIndex ? Colors.white.withOpacity(0.05) : Colors.transparent,
+              color: i == _selectedValueIndex && _focusNode.hasPrimaryFocus
+                  ? Colors.white.withOpacity(0.05)
+                  : Colors.transparent,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                 child: Row(

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -40,7 +40,7 @@ import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
 Future<void> main() async {
-  initLoggers(Level.FINE, {
+  initLoggers(Level.FINEST, {
     // editorScrollingLog,
     // editorGesturesLog,
     // editorImeLog,
@@ -52,7 +52,7 @@ Future<void> main() async {
     // editorStyleLog,
     // textFieldLog,
     // editorUserTagsLog,
-    // contentLayersLog,
+    contentLayersLog,
     appLog,
   });
 

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -40,7 +40,7 @@ import 'demos/supertextfield/android/demo_superandroidtextfield.dart';
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
 Future<void> main() async {
-  initLoggers(Level.FINEST, {
+  initLoggers(Level.FINE, {
     // editorScrollingLog,
     // editorGesturesLog,
     // editorImeLog,
@@ -52,7 +52,7 @@ Future<void> main() async {
     // editorStyleLog,
     // textFieldLog,
     // editorUserTagsLog,
-    contentLayersLog,
+    // contentLayersLog,
     appLog,
   });
 

--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:super_editor/src/default_editor/common_editor_operations.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 
@@ -24,6 +25,7 @@ class SuperEditorContext {
     required DocumentLayout Function() getDocumentLayout,
     required this.composer,
     required this.scroller,
+    required this.hasPrimaryFocus,
     required this.commonOps,
   }) : _getDocumentLayout = getDocumentLayout;
 
@@ -46,6 +48,8 @@ class SuperEditorContext {
   /// The [DocumentScroller] that provides status and control over [SuperEditor]
   /// scrolling.
   final DocumentScroller scroller;
+
+  final ValueListenable<bool> hasPrimaryFocus;
 
   /// Common operations that can be executed to apply common, complex changes to
   /// the document.

--- a/super_editor/lib/src/core/edit_context.dart
+++ b/super_editor/lib/src/core/edit_context.dart
@@ -49,6 +49,7 @@ class SuperEditorContext {
   /// scrolling.
   final DocumentScroller scroller;
 
+  /// Whether `SuperEditor` currently has primary focus.
   final ValueListenable<bool> hasPrimaryFocus;
 
   /// Common operations that can be executed to apply common, complex changes to

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -211,7 +211,8 @@ ExecutionInstruction sendKeyEventToMacOs({
     // For the full list of selectors handled by SuperEditor, see the MacOsSelectors class.
     //
     // This is needed for the interaction with the accent panel to work.
-    return ExecutionInstruction.blocked;
+    // return ExecutionInstruction.blocked;
+    return editContext.hasPrimaryFocus.value ? ExecutionInstruction.blocked : ExecutionInstruction.continueExecution;
   }
 
   return ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -211,8 +211,18 @@ ExecutionInstruction sendKeyEventToMacOs({
     // For the full list of selectors handled by SuperEditor, see the MacOsSelectors class.
     //
     // This is needed for the interaction with the accent panel to work.
-    // return ExecutionInstruction.blocked;
-    return editContext.hasPrimaryFocus.value ? ExecutionInstruction.blocked : ExecutionInstruction.continueExecution;
+
+    if (!editContext.hasPrimaryFocus.value) {
+      // SuperEditor has focus, but not primary focus. This can happen, for example,
+      // when an app displays a popover that takes primary focus. In this case, because
+      // SuperEditor no longer has primary focus, Flutter might intercept keys and do
+      // things we don't want, like move focus around when the user presses arrow keys.
+      // To prevent Flutter from doing things we don't want, in this case we run the
+      // standard key handlers instead of sending the signal to the OS.
+      return ExecutionInstruction.continueExecution;
+    }
+
+    return ExecutionInstruction.blocked;
   }
 
   return ExecutionInstruction.continueExecution;

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/debug_visualization.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/flutter/flutter_pipeline.dart';
 import 'package:super_editor/src/infrastructure/ime_input_owner.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
@@ -269,7 +270,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
     // For example, the editor might be resized or moved around the screen.
     // Because of this, we update our size, transform and caret rect at every frame.
     // FIXME: This call seems to be scheduling frames. When the caret is in Timer mode, we see this method running continuously even though the only change should be the caret blinking every half a second
-    // onNextFrame((_) => _reportVisualInformationToIme());
+    onNextFrame((_) => _reportVisualInformationToIme());
   }
 
   /// Compute the caret rect in the editor's content space.

--- a/super_editor/lib/src/default_editor/document_layers/attributed_text_bounds_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_layers/attributed_text_bounds_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/infrastructure/attribution_layout_bounds.dart';
+import 'package:super_editor/src/infrastructure/content_layers.dart';
 
 class AttributedTextBoundsOverlay implements SuperEditorLayerBuilder {
   const AttributedTextBoundsOverlay({
@@ -13,7 +14,7 @@ class AttributedTextBoundsOverlay implements SuperEditorLayerBuilder {
   final AttributionBoundsBuilder builder;
 
   @override
-  Widget build(BuildContext context, SuperEditorContext editContext) {
+  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) {
     return AttributionBounds(
       document: editContext.document,
       layout: editContext.documentLayout,

--- a/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
@@ -231,6 +231,7 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
       editorLayoutLog.info('Could not find any component for node position: $position');
       return null;
     }
+
     final componentRect = component.getRectForPosition(position.nodePosition);
 
     final componentBox = component.context.findRenderObject() as RenderBox;

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -18,6 +18,7 @@ import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
@@ -308,9 +309,10 @@ class SuperEditorState extends State<SuperEditor> {
   late SingleColumnLayoutCustomComponentStyler _docLayoutPerComponentBlockStyler;
   late SingleColumnLayoutSelectionStyler _docLayoutSelectionStyler;
 
-  late FocusNode _focusNode;
   @visibleForTesting
   FocusNode get focusNode => _focusNode;
+  late FocusNode _focusNode;
+  final _primaryFocusListener = ValueNotifier(false);
 
   late DocumentComposer _composer;
 
@@ -425,6 +427,7 @@ class SuperEditorState extends State<SuperEditor> {
       composer: _composer,
       getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
       scroller: _scroller,
+      hasPrimaryFocus: _primaryFocusListener,
       commonOps: CommonEditorOperations(
         editor: widget.editor,
         document: widget.document,
@@ -479,6 +482,7 @@ class SuperEditorState extends State<SuperEditor> {
 
   void _onFocusChange() {
     _recomputeIfLayoutShouldShowCaret();
+    _primaryFocusListener.value = _focusNode.hasPrimaryFocus;
   }
 
   void _recomputeIfLayoutShouldShowCaret() {
@@ -685,7 +689,7 @@ class _SelectionLeadersDocumentLayerBuilder implements SuperEditorLayerBuilder {
   final bool showDebugLeaderBounds;
 
   @override
-  Widget build(BuildContext context, SuperEditorContext editContext) {
+  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) {
     return SelectionLeadersDocumentLayer(
       document: editContext.document,
       selection: editContext.composer.selectionNotifier,
@@ -797,7 +801,7 @@ class SuperEditorSelectionPolicies {
 /// Builds widgets that are displayed at the same position and size as
 /// the document layout within a [SuperEditor].
 abstract class SuperEditorLayerBuilder {
-  Widget build(BuildContext context, SuperEditorContext editContext);
+  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext);
 }
 
 /// A [SuperEditorLayerBuilder] that's implemented with a given function, so
@@ -805,10 +809,11 @@ abstract class SuperEditorLayerBuilder {
 class FunctionalSuperEditorLayerBuilder implements SuperEditorLayerBuilder {
   const FunctionalSuperEditorLayerBuilder(this._delegate);
 
-  final Widget Function(BuildContext context, SuperEditorContext editContext) _delegate;
+  final ContentLayerStatefulWidget Function(BuildContext context, SuperEditorContext editContext) _delegate;
 
   @override
-  Widget build(BuildContext context, SuperEditorContext editContext) => _delegate(context, editContext);
+  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) =>
+      _delegate(context, editContext);
 }
 
 /// A [SuperEditorLayerBuilder] that paints a caret at the primary selection extent
@@ -841,24 +846,14 @@ class DefaultCaretOverlayBuilder implements SuperEditorLayerBuilder {
   final BlinkTimingMode blinkTimingMode;
 
   @override
-  Widget build(BuildContext context, SuperEditorContext editContext) {
-    // By default, don't show a caret on mobile because SuperEditor displays
-    // mobile carets and handles elsewhere. This can be overridden by settings
-    // `displayOnAllPlatforms` to true.
-    final platform = platformOverride ?? defaultTargetPlatform;
-    if (!displayOnAllPlatforms && (platform == TargetPlatform.android || platform == TargetPlatform.iOS)) {
-      return const SizedBox();
-    }
-
-    return IgnorePointer(
-      // ^ ignore pointer so that user gestures fall through to the document gesture
-      //   system, which sits beneath the document.
-      child: CaretDocumentOverlay(
-        composer: editContext.composer,
-        documentLayoutResolver: () => editContext.documentLayout,
-        caretStyle: caretStyle,
-        blinkTimingMode: blinkTimingMode,
-      ),
+  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) {
+    return CaretDocumentOverlay(
+      composer: editContext.composer,
+      documentLayoutResolver: () => editContext.documentLayout,
+      caretStyle: caretStyle,
+      platformOverride: platformOverride,
+      displayOnAllPlatforms: displayOnAllPlatforms,
+      blinkTimingMode: blinkTimingMode,
     );
   }
 }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -689,7 +689,7 @@ class _SelectionLeadersDocumentLayerBuilder implements SuperEditorLayerBuilder {
   final bool showDebugLeaderBounds;
 
   @override
-  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) {
+  ContentLayerWidget build(BuildContext context, SuperEditorContext editContext) {
     return SelectionLeadersDocumentLayer(
       document: editContext.document,
       selection: editContext.composer.selectionNotifier,
@@ -801,7 +801,7 @@ class SuperEditorSelectionPolicies {
 /// Builds widgets that are displayed at the same position and size as
 /// the document layout within a [SuperEditor].
 abstract class SuperEditorLayerBuilder {
-  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext);
+  ContentLayerWidget build(BuildContext context, SuperEditorContext editContext);
 }
 
 /// A [SuperEditorLayerBuilder] that's implemented with a given function, so
@@ -809,11 +809,10 @@ abstract class SuperEditorLayerBuilder {
 class FunctionalSuperEditorLayerBuilder implements SuperEditorLayerBuilder {
   const FunctionalSuperEditorLayerBuilder(this._delegate);
 
-  final ContentLayerStatefulWidget Function(BuildContext context, SuperEditorContext editContext) _delegate;
+  final ContentLayerWidget Function(BuildContext context, SuperEditorContext editContext) _delegate;
 
   @override
-  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) =>
-      _delegate(context, editContext);
+  ContentLayerWidget build(BuildContext context, SuperEditorContext editContext) => _delegate(context, editContext);
 }
 
 /// A [SuperEditorLayerBuilder] that paints a caret at the primary selection extent
@@ -846,7 +845,7 @@ class DefaultCaretOverlayBuilder implements SuperEditorLayerBuilder {
   final BlinkTimingMode blinkTimingMode;
 
   @override
-  ContentLayerStatefulWidget build(BuildContext context, SuperEditorContext editContext) {
+  ContentLayerWidget build(BuildContext context, SuperEditorContext editContext) {
     return CaretDocumentOverlay(
       composer: editContext.composer,
       documentLayoutResolver: () => editContext.documentLayout,

--- a/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
+++ b/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
@@ -26,10 +26,11 @@ class AttributionBounds extends ContentLayerStatefulWidget {
   final AttributionBoundsBuilder builder;
 
   @override
-  ContentLayerState<ContentLayerStatefulWidget, List<_AttributionBounds>> createState() => _AttributionBoundsState();
+  ContentLayerState<ContentLayerStatefulWidget, List<AttributionBoundsLayout>> createState() =>
+      _AttributionBoundsState();
 }
 
-class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<_AttributionBounds>> {
+class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<AttributionBoundsLayout>> {
   @override
   void initState() {
     super.initState();
@@ -53,8 +54,8 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
   }
 
   @override
-  List<_AttributionBounds>? computeLayoutData(RenderObject? contentLayout) {
-    final bounds = <_AttributionBounds>[];
+  List<AttributionBoundsLayout>? computeLayoutData(RenderObject? contentLayout) {
+    final bounds = <AttributionBoundsLayout>[];
 
     for (final node in widget.document.nodes) {
       if (node is! TextNode) {
@@ -73,7 +74,7 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
         );
 
         bounds.add(
-          _AttributionBounds(
+          AttributionBoundsLayout(
             span.attribution,
             widget.layout.getRectForSelection(range.start, range.end) ?? Rect.zero,
           ),
@@ -85,7 +86,7 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
   }
 
   @override
-  Widget doBuild(BuildContext context, List<_AttributionBounds>? layoutData) {
+  Widget doBuild(BuildContext context, List<AttributionBoundsLayout>? layoutData) {
     if (layoutData == null) {
       return const SizedBox();
     }
@@ -97,7 +98,7 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
     );
   }
 
-  List<Widget> _buildBounds(List<_AttributionBounds> bounds) {
+  List<Widget> _buildBounds(List<AttributionBoundsLayout> bounds) {
     final boundWidgets = <Widget>[];
     for (final bound in bounds) {
       final boundWidget = widget.builder(context, bound.attribution);
@@ -115,8 +116,8 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
   }
 }
 
-class _AttributionBounds {
-  const _AttributionBounds(this.attribution, this.rect);
+class AttributionBoundsLayout {
+  const AttributionBoundsLayout(this.attribution, this.rect);
 
   final Attribution attribution;
   final Rect rect;

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -70,9 +70,28 @@ class ContentLayers extends RenderObjectWidget {
 ///
 /// Must have a [renderObject] of type [RenderContentLayers].
 class ContentLayersElement extends RenderObjectElement {
+  /// The real Flutter framework `onBuildScheduled` callback.
+  ///
+  /// This property is non-null when one or more [ContentLayersElement]s are in the
+  /// tree, and `null` otherwise.
+  ///
+  /// This callback is held statically, rather than per-instance, because Flutter
+  /// might activate a new [ContentLayersElement] before deactivating an old
+  /// [ContentLayersElement], or there might be multiple [ContentLayersElement]s
+  /// in the tree. In these cases, we can't consistently replace Flutter's
+  /// `onBuildScheduled` callback without losing the original callback.
   static VoidCallback? _realOnBuildScheduled;
+
+  /// Listeners that are registered by [ContentLayersElement]s to find out when
+  /// the Flutter framework schedules builds, so that [ContentLayerElement]s can
+  /// manage their layers to avoid invalid build timing.
   static final _onBuildListeners = <VoidCallback>{};
 
+  /// The Flutter framework has scheduled a build by calling `onBuildScheduled`
+  /// on a [BuildOwner].
+  ///
+  /// This global static method calls build schedule listeners on all instances
+  /// of [ContentLayersElement], which registered a listener with [_onBuildListeners].
   static void _globalOnBuildScheduled() {
     // Call the real Flutter onBuildScheduled callback so Flutter works as expected.
     _realOnBuildScheduled!();

--- a/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
@@ -62,11 +62,11 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
 
   /// Layers that are displayed below the document layout, aligned
   /// with the location and size of the document layout.
-  final List<WidgetBuilder> underlays;
+  final List<ContentLayerWidgetBuilder> underlays;
 
   /// Layers that are displayed on top of the document layout, aligned
   /// with the location and size of the document layout.
-  final List<WidgetBuilder> overlays;
+  final List<ContentLayerWidgetBuilder> overlays;
 
   /// Paints some extra visual ornamentation to help with debugging.
   final DebugPaintConfig debugPaint;

--- a/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
@@ -5,6 +5,7 @@ import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/infrastructure/content_layers.dart';
 
 /// A document layer that positions leader widgets at the user's selection bounds.
 ///
@@ -14,7 +15,7 @@ import 'package:super_editor/src/core/document_selection.dart';
 /// on the document's self-reported caret height for the given document position.
 ///
 /// When no selection exists, no leaders are built in the layer's widget tree.
-class SelectionLeadersDocumentLayer extends StatefulWidget {
+class SelectionLeadersDocumentLayer extends ContentLayerStatefulWidget {
   const SelectionLeadersDocumentLayer({
     Key? key,
     required this.document,
@@ -43,17 +44,13 @@ class SelectionLeadersDocumentLayer extends StatefulWidget {
   final bool showDebugLeaderBounds;
 
   @override
-  State<SelectionLeadersDocumentLayer> createState() => _SelectionLeadersDocumentLayerState();
+  ContentLayerState<ContentLayerStatefulWidget, SelectionLeaderLayoutData> createState() =>
+      _SelectionLeadersDocumentLayerState();
 }
 
-class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocumentLayer>
+class _SelectionLeadersDocumentLayerState
+    extends ContentLayerState<SelectionLeadersDocumentLayer, SelectionLeaderLayoutData>
     with SingleTickerProviderStateMixin {
-  Rect? _caret;
-
-  Rect? _upstream;
-  Rect? _downstream;
-  Rect? _expandedSelectionBounds;
-
   @override
   void initState() {
     super.initState();
@@ -79,7 +76,7 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
   }
 
   void _onSelectionChange() {
-    if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
+    if (mounted && SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
       // The Flutter pipeline isn't running. Schedule a re-build and re-position the caret.
       setState(() {
         // The leaders are positioned in the build() call.
@@ -88,15 +85,11 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
   }
 
   /// Updates the caret rect, immediately, without scheduling a rebuild.
-  void _positionCaret() {
-    _caret = null;
-    _upstream = null;
-    _downstream = null;
-    _expandedSelectionBounds = null;
-
+  @override
+  SelectionLeaderLayoutData? computeLayoutData(RenderObject? contentLayout) {
     final documentSelection = widget.selection.value;
     if (documentSelection == null) {
-      return;
+      return null;
     }
 
     final documentLayout = widget.documentLayoutResolver();
@@ -105,38 +98,44 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
       // Assume that we're in a momentary transitive state where the document layout
       // just gained or lost a component. We expect this method ot run again in a moment
       // to correct for this.
-      return;
+      return null;
     }
 
     if (documentSelection.isCollapsed) {
-      _caret = documentLayout.getRectForPosition(documentSelection.extent)!;
+      return SelectionLeaderLayoutData(
+        caret: documentLayout.getRectForPosition(documentSelection.extent)!,
+      );
     } else {
-      _upstream = documentLayout.getRectForPosition(
-        widget.document.selectUpstreamPosition(documentSelection.base, documentSelection.extent),
-      )!;
-      _downstream = documentLayout.getRectForPosition(
-        widget.document.selectDownstreamPosition(documentSelection.base, documentSelection.extent),
-      )!;
-      _expandedSelectionBounds = documentLayout.getRectForSelection(
-        documentSelection.base,
-        documentSelection.extent,
+      return SelectionLeaderLayoutData(
+        upstream: documentLayout.getRectForPosition(
+          widget.document.selectUpstreamPosition(documentSelection.base, documentSelection.extent),
+        )!,
+        downstream: documentLayout.getRectForPosition(
+          widget.document.selectDownstreamPosition(documentSelection.base, documentSelection.extent),
+        )!,
+        expandedSelectionBounds: documentLayout.getRectForSelection(
+          documentSelection.base,
+          documentSelection.extent,
+        ),
       );
     }
   }
 
   @override
-  Widget build(BuildContext context) {
-    _positionCaret();
+  Widget doBuild(BuildContext context, SelectionLeaderLayoutData? selectionLayout) {
+    if (selectionLayout == null) {
+      return const SizedBox();
+    }
 
     return IgnorePointer(
       child: Stack(
         children: [
-          if (_caret != null)
+          if (selectionLayout.caret != null)
             Positioned(
-              top: _caret!.top,
-              left: _caret!.left,
+              top: selectionLayout.caret!.top,
+              left: selectionLayout.caret!.left,
               width: 1,
-              height: _caret!.height,
+              height: selectionLayout.caret!.height,
               child: Leader(
                 link: widget.links.caretLink,
                 child: widget.showDebugLeaderBounds
@@ -146,12 +145,12 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_upstream != null)
+          if (selectionLayout.upstream != null)
             Positioned(
-              top: _upstream!.top,
-              left: _upstream!.left,
+              top: selectionLayout.upstream!.top,
+              left: selectionLayout.upstream!.left,
               width: 1,
-              height: _upstream!.height,
+              height: selectionLayout.upstream!.height,
               child: Leader(
                 link: widget.links.upstreamLink,
                 child: widget.showDebugLeaderBounds
@@ -161,12 +160,12 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_downstream != null)
+          if (selectionLayout.downstream != null)
             Positioned(
-              top: _downstream!.top,
-              left: _downstream!.left,
+              top: selectionLayout.downstream!.top,
+              left: selectionLayout.downstream!.left,
               width: 1,
-              height: _downstream!.height,
+              height: selectionLayout.downstream!.height,
               child: Leader(
                 link: widget.links.downstreamLink,
                 child: widget.showDebugLeaderBounds
@@ -176,9 +175,9 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
                     : null,
               ),
             ),
-          if (_expandedSelectionBounds != null)
+          if (selectionLayout.expandedSelectionBounds != null)
             Positioned.fromRect(
-              rect: _expandedSelectionBounds!,
+              rect: selectionLayout.expandedSelectionBounds!,
               child: Leader(
                 link: widget.links.expandedSelectionBoundsLink,
                 child: widget.showDebugLeaderBounds
@@ -192,6 +191,20 @@ class _SelectionLeadersDocumentLayerState extends State<SelectionLeadersDocument
       ),
     );
   }
+}
+
+class SelectionLeaderLayoutData {
+  SelectionLeaderLayoutData({
+    this.caret,
+    this.upstream,
+    this.downstream,
+    this.expandedSelectionBounds,
+  });
+
+  final Rect? caret;
+  final Rect? upstream;
+  final Rect? downstream;
+  final Rect? expandedSelectionBounds;
 }
 
 /// A collection of [LayerLink]s that should be positioned near important

--- a/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
@@ -44,12 +44,12 @@ class SelectionLeadersDocumentLayer extends ContentLayerStatefulWidget {
   final bool showDebugLeaderBounds;
 
   @override
-  ContentLayerState<ContentLayerStatefulWidget, SelectionLeaderLayout> createState() =>
+  ContentLayerState<ContentLayerStatefulWidget, DocumentSelectionLayout> createState() =>
       _SelectionLeadersDocumentLayerState();
 }
 
 class _SelectionLeadersDocumentLayerState
-    extends ContentLayerState<SelectionLeadersDocumentLayer, SelectionLeaderLayout>
+    extends ContentLayerState<SelectionLeadersDocumentLayer, DocumentSelectionLayout>
     with SingleTickerProviderStateMixin {
   @override
   void initState() {
@@ -86,7 +86,7 @@ class _SelectionLeadersDocumentLayerState
 
   /// Updates the caret rect, immediately, without scheduling a rebuild.
   @override
-  SelectionLeaderLayout? computeLayoutData(RenderObject? contentLayout) {
+  DocumentSelectionLayout? computeLayoutData(RenderObject? contentLayout) {
     final documentSelection = widget.selection.value;
     if (documentSelection == null) {
       return null;
@@ -102,11 +102,11 @@ class _SelectionLeadersDocumentLayerState
     }
 
     if (documentSelection.isCollapsed) {
-      return SelectionLeaderLayout(
+      return DocumentSelectionLayout(
         caret: documentLayout.getRectForPosition(documentSelection.extent)!,
       );
     } else {
-      return SelectionLeaderLayout(
+      return DocumentSelectionLayout(
         upstream: documentLayout.getRectForPosition(
           widget.document.selectUpstreamPosition(documentSelection.base, documentSelection.extent),
         )!,
@@ -122,7 +122,7 @@ class _SelectionLeadersDocumentLayerState
   }
 
   @override
-  Widget doBuild(BuildContext context, SelectionLeaderLayout? selectionLayout) {
+  Widget doBuild(BuildContext context, DocumentSelectionLayout? selectionLayout) {
     if (selectionLayout == null) {
       return const SizedBox();
     }
@@ -193,8 +193,10 @@ class _SelectionLeadersDocumentLayerState
   }
 }
 
-class SelectionLeaderLayout {
-  SelectionLeaderLayout({
+/// Visual layout bounds related to a user selection in a document, such as the
+/// caret rect, a bounding box around all selected content, etc.
+class DocumentSelectionLayout {
+  DocumentSelectionLayout({
     this.caret,
     this.upstream,
     this.downstream,

--- a/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/selection_leader_document_layer.dart
@@ -44,12 +44,12 @@ class SelectionLeadersDocumentLayer extends ContentLayerStatefulWidget {
   final bool showDebugLeaderBounds;
 
   @override
-  ContentLayerState<ContentLayerStatefulWidget, SelectionLeaderLayoutData> createState() =>
+  ContentLayerState<ContentLayerStatefulWidget, SelectionLeaderLayout> createState() =>
       _SelectionLeadersDocumentLayerState();
 }
 
 class _SelectionLeadersDocumentLayerState
-    extends ContentLayerState<SelectionLeadersDocumentLayer, SelectionLeaderLayoutData>
+    extends ContentLayerState<SelectionLeadersDocumentLayer, SelectionLeaderLayout>
     with SingleTickerProviderStateMixin {
   @override
   void initState() {
@@ -86,7 +86,7 @@ class _SelectionLeadersDocumentLayerState
 
   /// Updates the caret rect, immediately, without scheduling a rebuild.
   @override
-  SelectionLeaderLayoutData? computeLayoutData(RenderObject? contentLayout) {
+  SelectionLeaderLayout? computeLayoutData(RenderObject? contentLayout) {
     final documentSelection = widget.selection.value;
     if (documentSelection == null) {
       return null;
@@ -102,11 +102,11 @@ class _SelectionLeadersDocumentLayerState
     }
 
     if (documentSelection.isCollapsed) {
-      return SelectionLeaderLayoutData(
+      return SelectionLeaderLayout(
         caret: documentLayout.getRectForPosition(documentSelection.extent)!,
       );
     } else {
-      return SelectionLeaderLayoutData(
+      return SelectionLeaderLayout(
         upstream: documentLayout.getRectForPosition(
           widget.document.selectUpstreamPosition(documentSelection.base, documentSelection.extent),
         )!,
@@ -122,7 +122,7 @@ class _SelectionLeadersDocumentLayerState
   }
 
   @override
-  Widget doBuild(BuildContext context, SelectionLeaderLayoutData? selectionLayout) {
+  Widget doBuild(BuildContext context, SelectionLeaderLayout? selectionLayout) {
     if (selectionLayout == null) {
       return const SizedBox();
     }
@@ -193,8 +193,8 @@ class _SelectionLeadersDocumentLayerState
   }
 }
 
-class SelectionLeaderLayoutData {
-  SelectionLeaderLayoutData({
+class SelectionLeaderLayout {
+  SelectionLeaderLayout({
     this.caret,
     this.upstream,
     this.downstream,

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -21,6 +21,7 @@ import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/default_editor/unknown_component.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/document_gestures_interaction_overrides.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
@@ -442,7 +443,7 @@ class _SelectionLeadersDocumentLayerBuilder implements ReadOnlyDocumentLayerBuil
   final bool showDebugLeaderBounds;
 
   @override
-  Widget build(BuildContext context, SuperReaderContext readerContext) {
+  ContentLayerStatefulWidget build(BuildContext context, SuperReaderContext readerContext) {
     return SelectionLeadersDocumentLayer(
       document: readerContext.document,
       selection: readerContext.selection,
@@ -456,7 +457,7 @@ class _SelectionLeadersDocumentLayerBuilder implements ReadOnlyDocumentLayerBuil
 /// Builds widgets that are displayed at the same position and size as
 /// the document layout within a [SuperReader].
 abstract class ReadOnlyDocumentLayerBuilder {
-  Widget build(BuildContext context, SuperReaderContext documentContext);
+  ContentLayerStatefulWidget build(BuildContext context, SuperReaderContext documentContext);
 }
 
 typedef SuperReaderContentTapDelegateFactory = ContentTapDelegate Function(SuperReaderContext editContext);

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -443,7 +443,7 @@ class _SelectionLeadersDocumentLayerBuilder implements ReadOnlyDocumentLayerBuil
   final bool showDebugLeaderBounds;
 
   @override
-  ContentLayerStatefulWidget build(BuildContext context, SuperReaderContext readerContext) {
+  ContentLayerWidget build(BuildContext context, SuperReaderContext readerContext) {
     return SelectionLeadersDocumentLayer(
       document: readerContext.document,
       selection: readerContext.selection,
@@ -457,7 +457,7 @@ class _SelectionLeadersDocumentLayerBuilder implements ReadOnlyDocumentLayerBuil
 /// Builds widgets that are displayed at the same position and size as
 /// the document layout within a [SuperReader].
 abstract class ReadOnlyDocumentLayerBuilder {
-  ContentLayerStatefulWidget build(BuildContext context, SuperReaderContext documentContext);
+  ContentLayerWidget build(BuildContext context, SuperReaderContext documentContext);
 }
 
 typedef SuperReaderContentTapDelegateFactory = ContentTapDelegate Function(SuperReaderContext editContext);

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -19,6 +19,7 @@ export 'src/default_editor/attributions.dart';
 export 'src/default_editor/blockquote.dart';
 export 'src/default_editor/box_component.dart';
 export 'src/default_editor/common_editor_operations.dart';
+export 'src/default_editor/composer/composer_reactions.dart';
 export 'src/default_editor/debug_visualization.dart';
 export 'src/default_editor/default_document_editor.dart';
 export 'src/default_editor/default_document_editor_reactions.dart';

--- a/super_editor/test/super_editor/text_entry/text_test.dart
+++ b/super_editor/test/super_editor/text_entry/text_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
@@ -417,6 +418,7 @@ SuperEditorContext _createEditContext() {
     getDocumentLayout: () => fakeLayout,
     composer: composer,
     scroller: FakeSuperEditorScroller(),
+    hasPrimaryFocus: ValueNotifier(false),
     commonOps: CommonEditorOperations(
       editor: documentEditor,
       document: document,


### PR DESCRIPTION
Fixed tagging NPEs - includes new ContentLayers layer widgets, IME focus policy adjustment (Resolves #1397)

The tangible goal of this PR is to fix issues found with the tagging system in the Example app. Before this PR, the tagging examples were producing NPEs on every character the user entered.

To fix the tagging experience, a few changes were made:

## Content Layers
Despite my best attempts to hack the Flutter build order, every time the user inserted a new character into a tag, it would trigger a build timing problem where the caret overlay would try to inspect the document layout before the document layout was run.

I was unable to further hack the Flutter build order to resolve this. At this point, I had to bring some level of new responsibility to the widgets that are displayed as layers.

As of this PR, any widget that's provided as a layer in `ContentLayers` must be a subclass of `ContentLayerWidget`. I've created a few options to facilitate different use-cases:

- `ContentLayerProxyWidget` - Let's users display regular widgets that don't care about the content layout. This is essentially an escape hatch for when you don't care about any of the rest of this.
- `ContentLayerStatelessWidget` - A stateless widget that wants to base its widget tree on the content layout render object.
- `ContentLayerStatefulWidget` - A stateful widget that wants to base its widget tree on the content layout render object. 

## IME and Focus
User tag and action tag demos display a popover, where the user can press up/down to select a tag. As a result, the popover needs to hold primary focus, meaning `SuperEditor` has non-primary focus. Previously, we were automatically closing the IME when `SuperEditor` loses primary focus. This focus policy breaks expected behavior because the user can't type anything once the popover appears. Therefore, this PR changes the default focus policy so that `SuperEditor` keeps the IME open as long as it has focus, even if it's not primary focus.

Also related to focus is Mac OS selectors. When `SuperEditor` moves to non-primary focus, and some other part of the UI takes primary focus, like a popover, Flutter jumps in and responds to certain keys, like arrow keys. For example, Flutter tries to move focus to other widgets when the user presses arrow keys. We don't want this. We want arrow keys to either move selection in the popover, or move the caret in `SuperEditor`. To prevent Flutter from taking over, when `SuperEditor` has non-primary focus, we no longer ignore the key press on Mac. Instead, we respond to all key presses on Mac when `SuperEditor` has non-primary focus so that we can block Flutter from doing things we don't want.