### PR TITLE
[SuperEditor][iOS] Fix magnifier (Resolves #1329)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -55,7 +55,7 @@ Widget _circleMagnifierBuilder(BuildContext context, Offset offsetFromFocalPoint
     );
 
 class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
-  static const _magnification = 1.0;
+  static const _magnification = 1.5;
 
   const IOSRoundedRectangleMagnifyingGlass({
     this.offsetFromFocalPoint = Offset.zero,
@@ -67,14 +67,6 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        MagnifyingGlass(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(24)),
-          ),
-          size: const Size(72, 48),
-          offsetFromFocalPoint: offsetFromFocalPoint,
-          magnificationScale: _magnification,
-        ),
         Container(
           width: 72,
           height: 48,
@@ -89,6 +81,14 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
               ),
             ],
           ),
+        ),
+        MagnifyingGlass(
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(24)),
+          ),
+          size: const Size(72, 48),
+          offsetFromFocalPoint: offsetFromFocalPoint,
+          magnificationScale: _magnification,
         ),
       ],
     );


### PR DESCRIPTION
[SuperEditor][iOS] Fix magnifier. Resolves #1329.

On iOS, the magnifier is flickering when moving and it also doesn't magnify at all.

The reason is that we are applying a `1.0` magnification scale.

After adjusting the scale, the shadows are being displayed above the magnifier. This happens only on impeller. 

![image](https://github.com/superlistapp/super_editor/assets/7597082/e0d643c0-a043-4155-8b93-70b890cc1890)

I changed the order between the `Container` which displays the shadows and the magnifier and the issue stopped:


https://github.com/superlistapp/super_editor/assets/7597082/f8586099-15bb-4191-b94d-5dbf1a160752

