### PR TITLE
[SuperReader] Migrate to DocumentScroller API (Resolves #1306)

### DIFF
--- a/super_editor/lib/src/infrastructure/documents/document_scroller.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scroller.dart
@@ -29,6 +29,11 @@ class DocumentScroller {
     _scrollPosition!.jumpTo(newScrollOffset);
   }
 
+  /// Immediately moves the [scrollOffset] by [delta] pixels.
+  void jumpBy(double delta) {
+    _scrollPosition!.jumpTo(_scrollPosition!.pixels + delta);
+  }
+
   /// Animates [scrollOffset] from its current offset to [to], over the given [duration]
   /// of time, following the given animation [curve].
   void animateTo(

--- a/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
@@ -158,7 +158,7 @@ final scrollUpWithArrowKey = createShortcut(
     required SuperReaderContext documentContext,
     required RawKeyEvent keyEvent,
   }) {
-    documentContext.scrollController.jumpBy(-20);
+    documentContext.scroller.jumpBy(-20);
     return ExecutionInstruction.haltExecution;
   },
   keyPressedOrReleased: LogicalKeyboardKey.arrowUp,
@@ -170,7 +170,7 @@ final scrollDownWithArrowKey = createShortcut(
     required SuperReaderContext documentContext,
     required RawKeyEvent keyEvent,
   }) {
-    documentContext.scrollController.jumpBy(20);
+    documentContext.scroller.jumpBy(20);
     return ExecutionInstruction.haltExecution;
   },
   keyPressedOrReleased: LogicalKeyboardKey.arrowDown,

--- a/super_editor/lib/src/super_reader/reader_context.dart
+++ b/super_editor/lib/src/super_reader/reader_context.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
-import 'package:super_editor/src/default_editor/document_scrollable.dart';
+import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 
 /// Collection of core artifacts used to display a read-only document.
 ///
@@ -18,7 +18,7 @@ class SuperReaderContext {
     required this.document,
     required DocumentLayout Function() getDocumentLayout,
     required this.selection,
-    required this.scrollController,
+    required this.scroller,
   }) : _getDocumentLayout = getDocumentLayout;
 
   /// The [Document] that's currently being displayed.
@@ -33,7 +33,7 @@ class SuperReaderContext {
   /// The current selection within the displayed document.
   final ValueNotifier<DocumentSelection?> selection;
 
-  /// The [AutoScrollController] that scrolls a document up/down within the
-  /// document's viewport.
-  final AutoScrollController scrollController;
+  /// The [DocumentScroller] that provides status and control over [SuperReader]
+  /// scrolling.
+  final DocumentScroller scroller;
 }

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -266,7 +266,7 @@ class SuperReaderState extends State<SuperReader> {
       document: widget.document,
       getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
       selection: _selection,
-      scrollController: _autoScrollController,
+      scroller: _scroller,
     );
 
     _contentTapDelegate?.dispose();
@@ -345,7 +345,6 @@ class SuperReaderState extends State<SuperReader> {
         gestureBuilder: _buildGestureInteractor,
         scrollController: _scrollController,
         autoScrollController: _autoScrollController,
-        // TODO: Finish integrating the DocumentScroller in SuperReader (https://github.com/superlistapp/super_editor/issues/1306)
         scroller: _scroller,
         presenter: _docLayoutPresenter!,
         componentBuilders: widget.componentBuilders,

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -727,6 +727,9 @@ class FakeSuperEditorScroller implements DocumentScroller {
   void jumpTo(double newScrollOffset) => throw UnimplementedError();
 
   @override
+  void jumpBy(double delta) => throw UnimplementedError();
+
+  @override
   void animateTo(double to, {required Duration duration, Curve curve = Curves.easeInOut}) => throw UnimplementedError();
 
   @override

--- a/super_editor/test/super_reader/reader_test_tools.dart
+++ b/super_editor/test/super_reader/reader_test_tools.dart
@@ -4,7 +4,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/test/super_reader_test/super_reader_inspector.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor_markdown/super_editor_markdown.dart';
@@ -212,7 +211,7 @@ class TestDocumentConfigurator {
       document: _document!,
       getDocumentLayout: () => layoutKey.currentState as DocumentLayout,
       selection: ValueNotifier<DocumentSelection?>(_selection),
-      scrollController: AutoScrollController(),
+      scroller: DocumentScroller(),
     );
     final testContext = TestDocumentContext._(
       focusNode: _focusNode ?? FocusNode(),


### PR DESCRIPTION
[SuperReader] Migrate to DocumentScroller API. Resolves #1306

https://github.com/superlistapp/super_editor/issues/1288 introduced the `DocumentScroller` API, but it wasn't fully migrated within `SuperReader`.

`SuperReader` already uses a `DocumentScaffold`, which uses `DocumentScrollable` to attach/detach from the scroller.

The only things I found still left to do is to migrate `SuperReaderContext` to take a `DocumentScroller` instead of an `AutoScrollController` and adjust key up/down handlers.
