### PR TITLE
[SuperEditor] Fix crash in release mode (Resolves #1424)

### DIFF
--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -424,6 +424,17 @@ class RenderContentLayers extends RenderBox {
   RenderBox? _content;
   final _overlays = <RenderBox>[];
 
+  /// Whether this render object's layout information or its content
+  /// layout information is dirty.
+  ///
+  /// This is set to `true` when `markNeedsLayout` is called and it's
+  /// set to `false` after laying out the content.
+  bool get contentNeedsLayout => _contentNeedsLayout;
+  bool _contentNeedsLayout = true;
+
+  /// Whether we are at the middle of a [performLayout] call.
+  bool _runningLayout = false;
+
   @override
   void attach(PipelineOwner owner) {
     contentLayersLog.info("Attaching RenderContentLayers to owner: $owner");
@@ -445,6 +456,19 @@ class RenderContentLayers extends RenderBox {
     visitChildren((child) {
       child.detach();
     });
+  }
+
+  @override
+  void markNeedsLayout() {
+    super.markNeedsLayout();
+
+    if (_runningLayout) {
+      // We are already in a layout phase.
+      // When we call ContentLayerElement.buildLayers, markNeedsLayout is called again.
+      // We don't to mark the content as dirty, because otherwise the layers will never build.
+      return;
+    }
+    _contentNeedsLayout = true;
   }
 
   @override
@@ -573,8 +597,11 @@ class RenderContentLayers extends RenderBox {
     contentLayersLog.info("Laying out ContentLayers");
     if (_content == null) {
       size = Size.zero;
+      _contentNeedsLayout = false;
       return;
     }
+
+    _runningLayout = true;
 
     // Always layout the content first, so that layers can inspect the content layout.
     contentLayersLog.fine("Laying out content - $_content");
@@ -583,6 +610,8 @@ class RenderContentLayers extends RenderBox {
 
     // The size of the layers, and the our size, is exactly the same as the content.
     size = _content!.size;
+
+    _contentNeedsLayout = false;
 
     // Build the underlay and overlays during the layout phase so that they can inspect an
     // up-to-date content layout.
@@ -607,6 +636,8 @@ class RenderContentLayers extends RenderBox {
       contentLayersLog.fine("Laying out overlay: $overlay");
       overlay.layout(layerConstraints);
     }
+
+    _runningLayout = false;
     contentLayersLog.finer("Done laying out layers");
   }
 
@@ -842,7 +873,7 @@ abstract class ContentLayerState<WidgetType extends ContentLayerStatefulWidget, 
     final contentLayers = (context as Element).findAncestorContentLayers();
     final contentLayout = contentLayers?._content?.findRenderObject();
 
-    if (contentLayers != null && (!kDebugMode || !contentLayers.renderObject._content!.debugNeedsLayout)) {
+    if (contentLayers != null && !contentLayers.renderObject.contentNeedsLayout) {
       _layoutData = computeLayoutData(contentLayout);
     }
 

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
@@ -841,7 +842,7 @@ abstract class ContentLayerState<WidgetType extends ContentLayerStatefulWidget, 
     final contentLayers = (context as Element).findAncestorContentLayers();
     final contentLayout = contentLayers?._content?.findRenderObject();
 
-    if (contentLayers != null && !contentLayers.renderObject._content!.debugNeedsLayout) {
+    if (contentLayers != null && (!kDebugMode || !contentLayers.renderObject._content!.debugNeedsLayout)) {
       _layoutData = computeLayoutData(contentLayout);
     }
 


### PR DESCRIPTION
[SuperEditor] Fix crash in release mode. Resolves #1424.

Running on release mode causes the editor to display only a grey box:

<img width="501" alt="Screenshot 2023-09-10 at 1 49 51 PM" src="https://github.com/superlistapp/super_editor/assets/6467808/d71cfa79-bcdc-4425-8c64-1b2cd545c8f4">

The console shows the following exception:

```console
flutter: LateInitializationError: Local 'result' has not been initialized.
flutter: #0      LateError._throwLocalNotInitialized (dart:_internal-patch/internal_patch.dart:197)
flutter: #1      RenderObject.debugNeedsLayout (package:flutter/src/rendering/object.dart:2156)
flutter: #2      ContentLayerState.build (package:super_editor/src/infrastructure/content_layers.dart:845)
flutter: #3      StatefulElement.build (package:flutter/src/widgets/framework.dart:5572)
flutter: #4      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5460)
flutter: #5      StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:5623)
flutter: #6      Element.rebuild (package:flutter/src/widgets/framework.dart:5176)
flutter: #7      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:5442)
flutter: #8      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:5614)
flutter: #9      ComponentElement.mount (package:flutter/src/widgets/framework.dart:5436)
flutter: #10     Element.inflateWidget (package:flutter/src/widgets/framework.dart:4315)
flutter: #11     ContentLayersElement.inflateWidget (package:super_editor/src/infrastructure/content_layers.dart:280)
flutter: #12     ContentLayersElement.buildLayers.<anonymous closure> (package:super_editor/src/infrastructure/content_layers.dart:268)
flutter: #13     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2824)
flutter: #14     ContentLayersElement.buildLayers (package:super_editor/src/infrastructure/content_layers.dart:251)
flutter: #15     RenderContentLayers.performLayout.<anonymous closure> (package:super_editor/src/infrastructure/content_layers.dart:594)
flutter: #16     RenderObject.invokeLayoutCallback.<anonymous closure> (package:flutter/src/rendering/object.dart:2659)
flutter: #17     PipelineOwner._enableMutationsToDirtySubtrees (package:flutter/src/rendering/object.dart:1073)
flutter: #18     RenderObject.invokeLayoutCallback (package:flutter/src/rendering/object.dart:2659)
flutter: #19     RenderContentLayers.performLayout (package:super_editor/src/infrastructure/content_layers.dart:593)
flutter: #20     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #21     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #22     RenderPositionedBox.performLayout (package:flutter/src/rendering/shifted_box.dart:438)
flutter: #23     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #24     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #25     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:52)
flutter: #26     RenderStack._computeSize (package:flutter/src/rendering/stack.dart:589)
flutter: #27     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:616)
flutter: #28     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #29     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #30     RenderViewportBoundsReplicator.performLayout (package:super_editor/src/infrastructure/viewport_size_reporting.dart:197)
flutter: #31     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #32     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #33     _RenderSingleChildViewport.performLayout (package:flutter/src/widgets/single_child_scroll_view.dart:494)
flutter: #34     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #35     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #36     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #37     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #38     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #39     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #40     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #41     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #42     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #43     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #44     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #45     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #46     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #47     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #48     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #49     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #50     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #51     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #52     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #53     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #54     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #55     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #56     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #57     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #58     RenderCustomPaint.performLayout (package:flutter/src/rendering/custom_paint.dart:571)
flutter: #59     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #60     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #61     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #62     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #63     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #64     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #65     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #66     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #67     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #68     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #69     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #70     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #71     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #72     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #73     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #74     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #75     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #76     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:52)
flutter: #77     RenderStack._computeSize (package:flutter/src/rendering/stack.dart:589)
flutter: #78     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:616)
flutter: #79     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #80     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #81     RenderViewportBoundsReporter.performLayout (package:super_editor/src/infrastructure/viewport_size_reporting.dart:154)
flutter: #82     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #83     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #84     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #85     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #86     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #87     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:104)
flutter: #88     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #89     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #90     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:52)
flutter: #91     RenderFlex._computeSizes (package:flutter/src/rendering/flex.dart:868)
flutter: #92     RenderFlex.performLayout (package:flutter/src/rendering/flex.dart:903)
flutter: #93     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #94     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: #95     ChildLayoutHelper.layoutChild (package:flutter/src/rendering/layout_helper.dart:52)
flutter: #96     RenderStack._computeSize (package:flutter/src/rendering/stack.dart:589)
flutter: #97     RenderStack.performLayout (package:flutter/src/rendering/stack.dart:616)
flutter: #98     RenderObject.layout (package:flutter/src/rendering/object.dart:2548)
flutter: #99     RenderBox.layout (package:flutter/src/rendering/box.dart:2391)
flutter: Another exception was thrown: Instance of 'DiagnosticsProperty<void>'

```

The reason is that, in `ContentLayers` we are checking `debugNeedsLayout`. This getter isn't intended to be called in release mode. Doing so crashes because an uninitialized value:

```dart
/// Whether this render object's layout information is dirty.
  ///
  /// This is only set in debug mode. In general, render objects should not need
  /// to condition their runtime behavior on whether they are dirty or not,
  /// since they should only be marked dirty immediately prior to being laid
  /// out and painted. In release builds, this throws.
  ///
  /// It is intended to be used by tests and asserts.
  bool get debugNeedsLayout {
    late bool result;
    assert(() {
      result = _needsLayout;
      return true;
    }());
    return result; // Crashes here.
  }
```

If we do need to check if layout is needed we have to find another way, as it seems `_needsLayout` is not accessible in any other way.
