### PR TITLE
[SuperEditor][SuperReader] Remove scroll listener when disposing (Resolves #1117)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -249,9 +249,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
 
-    // TODO: I commented this out because the scroll position is already
-    //       disposed by the time this runs and it causes an error.
-    // _activeScrollPosition?.removeListener(_onScrollChange);
+    _activeScrollPosition?.removeListener(_onScrollChange);
 
     // We dispose the EditingController on the next frame because
     // the ListenableBuilder that uses it throws an error if we

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -280,6 +280,7 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
     _removeEditingOverlayControls();
 
     _teardownScrollController();
+    _activeScrollPosition?.removeListener(_onScrollChange);
 
     _handleAutoScrolling.dispose();
 
@@ -895,9 +896,13 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
       if (scrollPosition is ScrollPositionWithSingleContext) {
         (scrollPosition as ScrollPositionWithSingleContext).goBallistic(-details.velocity.pixelsPerSecond.dy);
 
-        // We add the scroll change listener again, because going ballistic
-        // seems to switch out the scroll position.
-        scrollPosition.addListener(_onScrollChange);
+        if (_activeScrollPosition != scrollPosition) {
+          // We add the scroll change listener again, because going ballistic
+          // seems to switch out the scroll position.
+          _activeScrollPosition?.removeListener(_onScrollChange);
+          _activeScrollPosition = scrollPosition;
+          scrollPosition.addListener(_onScrollChange);
+        }
       }
     } else {
       // The user was dragging a handle. Stop any auto-scrolling that may have started.
@@ -1260,6 +1265,8 @@ class _IOSDocumentTouchInteractorState extends State<IOSDocumentTouchInteractor>
         scheduleBuildAfterBuild();
       } else {
         if (scrollPosition != _activeScrollPosition) {
+          _activeScrollPosition?.removeListener(_onScrollChange);
+
           _activeScrollPosition = scrollPosition;
           _activeScrollPosition?.addListener(_onScrollChange);
         }

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -230,9 +230,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
 
-    // TODO: I commented this out because the scroll position is already
-    //       disposed by the time this runs and it causes an error.
-    // _activeScrollPosition?.removeListener(_onScrollChange);
+    _activeScrollPosition?.removeListener(_onScrollChange);
 
     // We dispose the EditingController on the next frame because
     // the ListenableBuilder that uses it throws an error if we

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -272,6 +272,7 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
     _removeEditingOverlayControls();
 
     widget.scrollController.removeListener(_onScrollChange);
+    _activeScrollPosition?.removeListener(_onScrollChange);
 
     _handleAutoScrolling.dispose();
 
@@ -704,9 +705,13 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
       if (scrollPosition is ScrollPositionWithSingleContext) {
         (scrollPosition as ScrollPositionWithSingleContext).goBallistic(-details.velocity.pixelsPerSecond.dy);
 
-        // We add the scroll change listener again, because going ballistic
-        // seems to switch out the scroll position.
-        scrollPosition.addListener(_onScrollChange);
+        if (_activeScrollPosition != scrollPosition) {
+          // We add the scroll change listener again, because going ballistic
+          // seems to switch out the scroll position.
+          _activeScrollPosition?.removeListener(_onScrollChange);
+          _activeScrollPosition = scrollPosition;
+          scrollPosition.addListener(_onScrollChange);
+        }
       }
     } else {
       // The user was dragging a handle. Stop any auto-scrolling that may have started.
@@ -957,6 +962,8 @@ class _ReadOnlyIOSDocumentTouchInteractorState extends State<ReadOnlyIOSDocument
         scheduleBuildAfterBuild();
       } else {
         if (scrollPosition != _activeScrollPosition) {
+          _activeScrollPosition?.removeListener(_onScrollChange);
+
           _activeScrollPosition = scrollPosition;
           _activeScrollPosition?.addListener(_onScrollChange);
         }

--- a/super_editor/test/super_editor/supereditor_switching_test.dart
+++ b/super_editor/test/super_editor/supereditor_switching_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/default_document_editor.dart';
+import 'package:super_editor/src/default_editor/super_editor.dart';
+import 'package:super_editor/src/super_reader/super_reader.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+import 'package:super_editor/src/test/super_reader_test/super_reader_robot.dart';
+
+import 'test_documents.dart';
+
+void main() {
+  group('SuperEditor', () {
+    testWidgetsOnAllPlatforms('can be switched with a SuperReader', (tester) async {
+      final isEditable = ValueNotifier<bool>(true);
+      final document = longDoc();
+      final scrollController = ScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _EditorReaderSwitchDemo(
+            document: document,
+            isEditable: isEditable,
+            scrollController: scrollController,
+          ),
+        ),
+      );
+
+      // Select the first word and scroll the viewport an arbitrary amount of pixels.
+      await SuperEditorRobot(tester).doubleTapInParagraph('1', 0);
+      scrollController.jumpTo(100.0);
+      await tester.pump();
+
+      // Switch the SuperEditor with a SuperReader.
+      isEditable.value = false;
+      await tester.pump();
+
+      // Select the first word and scroll the viewport an arbitrary amount of pixels.
+      await SuperReaderRobot(tester).doubleTapInParagraph('1', 0);
+      scrollController.jumpTo(150.0);
+      await tester.pump();
+
+      // Switch back to the editor.
+      isEditable.value = true;
+      await tester.pump();
+
+      // Select the first word and scroll the viewport an arbitrary amount of pixels.
+      await SuperEditorRobot(tester).doubleTapInParagraph('1', 0);
+      scrollController.jumpTo(200.0);
+      await tester.pump();
+    });
+  });
+}
+
+/// A Scaffold which switches between a [SuperEditor] and a [SuperEditor] depending
+/// on the value of [isEditable].
+class _EditorReaderSwitchDemo extends StatefulWidget {
+  const _EditorReaderSwitchDemo({
+    Key? key,
+    required this.isEditable,
+    required this.document,
+    required this.scrollController,
+  }) : super(key: key);
+
+  final MutableDocument document;
+
+  /// When `true` a [SuperEditor] is displayed. Otherwise, display a [SuperReader].
+  final ValueListenable<bool> isEditable;
+
+  /// Scroll controller of the viewport.
+  final ScrollController scrollController;
+
+  @override
+  State<_EditorReaderSwitchDemo> createState() => _EditorReaderSwitchDemoState();
+}
+
+class _EditorReaderSwitchDemoState extends State<_EditorReaderSwitchDemo> {
+  late Editor _docEditor;
+  late MutableDocumentComposer _composer;
+
+  @override
+  void initState() {
+    _composer = MutableDocumentComposer();
+    _docEditor = createDefaultDocumentEditor(
+      document: widget.document,
+      composer: _composer,
+    );
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        controller: widget.scrollController,
+        slivers: [
+          const SliverAppBar(),
+          SliverToBoxAdapter(
+            child: ListenableBuilder(
+              listenable: widget.isEditable,
+              builder: (context, _) {
+                return _buildEditorOrReader();
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditorOrReader() {
+    if (widget.isEditable.value) {
+      return SuperEditor(
+        document: widget.document,
+        composer: _composer,
+        editor: _docEditor,
+      );
+    } else {
+      return SuperReader(
+        document: widget.document,
+      );
+    }
+  }
+}

--- a/super_editor/test/super_editor/supereditor_switching_test.dart
+++ b/super_editor/test/super_editor/supereditor_switching_test.dart
@@ -51,6 +51,8 @@ void main() {
       await SuperEditorRobot(tester).doubleTapInParagraph('1', 0);
       scrollController.jumpTo(200.0);
       await tester.pump();
+
+      // Reaching this point means we switched between SuperEditor and SuperReader without any crashes.
     });
   });
 }


### PR DESCRIPTION
[SuperEditor] Remove scroll listener when disposing. Resolves #1117

When switching a `SuperEditor` with a `SuperEditor` (or vice-versa), scrolling  causes the following exception to be displayed at the console: 

```console
════════ Exception caught by foundation library ════════════════════════════════
The following _TypeError was thrown while dispatching notifications for ScrollPositionWithSingleContext:
type 'Null' is not a subtype of type 'DocumentLayout' in type cast

When the exception was thrown, this was the stack:
#0      SuperReaderState._createReaderContext.<anonymous closure> (package:super_editor/src/super_reader/super_reader.dart:267:59)
#1      SuperReaderContext.documentLayout (package:super_editor/src/super_reader/reader_context.dart:30:58)
#2      SuperReaderState._buildIOSGestureSystem.<anonymous closure> (package:super_editor/src/super_reader/super_reader.dart:412:47)
#3      _ReadOnlyIOSDocumentTouchInteractorState._docLayout (package:super_editor/src/super_reader/read_only_document_ios_touch_interactor.dart:376:60)
#4      _ReadOnlyIOSDocumentTouchInteractorState._positionToolbar (package:super_editor/src/super_reader/read_only_document_ios_touch_interactor.dart:863:27)
#5      _ReadOnlyIOSDocumentTouchInteractorState._onScrollChange (package:super_editor/src/super_reader/read_only_document_ios_touch_interactor.dart:371:5)
#6      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:433:24)
#7      ScrollPosition.notifyListeners (package:flutter/src/widgets/scroll_position.dart:1070:11)
#8      ScrollPosition.forcePixels (package:flutter/src/widgets/scroll_position.dart:468:5)
#9      ScrollPositionWithSingleContext.jumpTo (package:flutter/src/widgets/scroll_position_with_single_context.dart:203:7)
#10     _IOSDocumentTouchInteractorState._onPanUpdate (package:super_editor/src/default_editor/document_gestures_touch_ios.dart:826:22)
#11     DragGestureRecognizer._checkUpdate.<anonymous closure> (package:flutter/src/gestures/monodrag.dart:550:55)
#12     GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:275:24)
#13     DragGestureRecognizer._checkUpdate (package:flutter/src/gestures/monodrag.dart:550:7)
#14     DragGestureRecognizer._checkDrag (package:flutter/src/gestures/monodrag.dart:509:7)
#15     DragGestureRecognizer.acceptGesture (package:flutter/src/gestures/monodrag.dart:431:7)
#16     GestureArenaManager._resolveInFavorOf (package:flutter/src/gestures/arena.dart:281:12)
#17     GestureArenaManager._resolve (package:flutter/src/gestures/arena.dart:239:9)
#18     GestureArenaEntry.resolve (package:flutter/src/gestures/arena.dart:53:12)
#19     OneSequenceGestureRecognizer.resolve (package:flutter/src/gestures/recognizer.dart:375:13)
#20     DragGestureRecognizer.handleEvent (package:flutter/src/gestures/monodrag.dart:414:13)
#21     PointerRouter._dispatch (package:flutter/src/gestures/pointer_router.dart:98:12)
#22     PointerRouter._dispatchEventToRoutes.<anonymous closure> (package:flutter/src/gestures/pointer_router.dart:143:9)
#23     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:633:13)
#24     PointerRouter._dispatchEventToRoutes (package:flutter/src/gestures/pointer_router.dart:141:18)
#25     PointerRouter.route (package:flutter/src/gestures/pointer_router.dart:127:7)
#26     GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:488:19)
#27     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:468:22)
#28     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:439:11)
#29     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:413:7)
#30     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:376:5)
#31     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:323:7)
#32     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:292:9)
#33     _invoke1 (dart:ui/hooks.dart:329:13)
#34     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:377:7)
#35     _dispatchPointerDataPacket (dart:ui/hooks.dart:262:31)

The ScrollPositionWithSingleContext sending notification was: ScrollPositionWithSingleContext#48400(offset: 28.0, range: 0.0..1309.6, viewport: 852.0, ScrollableState, BouncingScrollPhysics -> RangeMaintainingScrollPhysics, IdleScrollActivity#0a2c7, ScrollDirection.idle)
```

The issue is that the editor/reader isn't removing the scroll listener from the `ScrollPosition` when being disposed. Because of that, scrolling is causing the editor/reader to be notified, causing it to try to access the document layout, which is now `null`. 

Because of that we are also leaking memory, as the `ScrollPosition` is preventing the editor/reader from freed by the GC.

This PR changes both `SuperEditor` and `SuperReader` to remove the scroll listener when being disposed. 

There are some comments in the code mentioning that the `ScrollPosition` is already disposed by the time we are being disposed, but I couldn't reproduce this. If there is an example of when this might happen I can adjust the code.