### PR TITLE
[SuperEditor][iOS] Fix floating cursor crash with expanded selections (Resolves #1174)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -217,6 +217,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
         SelectionReason.userInteraction,
       );
       onNextFrame((_) => _onFloatingCursorChange());
+      return;
     }
 
     if (_floatingCursorOffset.value == null) {


### PR DESCRIPTION
[SuperEditor][iOS] Fix floating cursor crash with expanded selections. Resolves #1174

#### Steps to reproduce

1. Double tap to select a word
2. Press and hold the spacebar

The editor shows the floating cursor and an exception is displayed in the console.

```console
════════ Exception caught by foundation library ════════════════════════════════
The following _TypeError was thrown while dispatching notifications for FloatingCursorController:
Null check operator used on a null value

When the exception was thrown, this was the stack:
#0      _IosDocumentTouchEditingControlsState._onFloatingCursorChange (package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart:233:42)
#1      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:433:24)
#2      FloatingCursorController.offset= (package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart:662:5)
#3      DocumentImeInputClient.updateFloatingCursor (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:280:36)
#4      DeltaTextInputClientDecorator.updateFloatingCursor (package:super_editor/src/default_editor/document_ime/ime_decoration.dart:134:14)
#5      TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1893:37)
#6      TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1762:20)
#7      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:552:55)
#8      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:545:34)
#9      _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:567:35)
#10     _invoke2 (dart:ui/hooks.dart:345:13)
#11     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
#12     _Channel.push (dart:ui/channel_buffers.dart:135:31)
#13     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
#14     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:689:22)
#15     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)

The FloatingCursorController sending notification was: Instance of 'FloatingCursorController'
════════════════════════════════════════════════════════════════════════════════

```

The root cause is that we are missing an early return `_onFloatingCursorChange` when the selection is expanded.

This PR adds the missing `return` statement.

When testing this issue I noticed another issue with the floating cursor and filed https://github.com/superlistapp/super_editor/issues/1449
