### PR TITLE
Cherry-pick "[SuperEditor][iOS] Fix floating cursor crash with expanded selections (Resolves #1174) (#1450)" to stable

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -217,6 +217,7 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
         SelectionReason.userInteraction,
       );
       onNextFrame((_) => _onFloatingCursorChange());
+      return;
     }
 
     if (_floatingCursorOffset.value == null) {


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor][iOS] Fix floating cursor crash with expanded selections (Resolves #1174) (#1450)" to stable