### PR TITLE
Cherry-pick "[SuperTextField][Mac] Allow selector handlers configuration (Resolves #1439) (#1444)" to stable

### DIFF
--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -64,6 +64,7 @@ class SuperDesktopTextField extends StatefulWidget {
     this.inputSource = TextInputSource.keyboard,
     this.textInputAction,
     this.imeConfiguration,
+    this.selectorHandlers,
     List<TextFieldKeyboardHandler>? keyboardHandlers,
   })  : keyboardHandlers = keyboardHandlers ??
             (inputSource == TextInputSource.keyboard
@@ -123,6 +124,12 @@ class SuperDesktopTextField extends StatefulWidget {
   /// using [TextEditingDelta]s, so this list shouldn't include handlers
   /// that input text based on individual character key presses.
   final List<TextFieldKeyboardHandler> keyboardHandlers;
+
+  /// Handlers for all Mac OS "selectors" reported by the IME.
+  ///
+  /// The IME reports selectors as unique `String`s, therefore selector handlers are
+  /// defined as a mapping from selector names to handler functions.
+  final Map<String, SuperTextFieldSelectorHandler>? selectorHandlers;
 
   /// The type of action associated with ENTER key.
   ///
@@ -405,7 +412,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
                 focusNode: _focusNode,
                 textController: _controller,
                 isMultiline: isMultiline,
-                selectorHandlers: defaultTextFieldSelectorHandlers,
+                selectorHandlers: widget.selectorHandlers ?? defaultTextFieldSelectorHandlers,
                 textInputAction: widget.textInputAction,
                 imeConfiguration: widget.imeConfiguration,
                 child: child,

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -69,6 +69,7 @@ class SuperTextField extends StatefulWidget {
     this.lineHeight,
     this.inputSource,
     this.keyboardHandlers,
+    this.selectorHandlers,
     this.padding,
     this.textInputAction,
     this.imeConfiguration,
@@ -172,6 +173,12 @@ class SuperTextField extends StatefulWidget {
   ///
   /// Only used on desktop.
   final List<TextFieldKeyboardHandler>? keyboardHandlers;
+
+  /// Handlers for all Mac OS "selectors" reported by the IME.
+  ///
+  /// The IME reports selectors as unique `String`s, therefore selector handlers are
+  /// defined as a mapping from selector names to handler functions.
+  final Map<String, SuperTextFieldSelectorHandler>? selectorHandlers;
 
   /// Padding placed around the text content of this text field, but within the
   /// scrollable viewport.
@@ -327,6 +334,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           minLines: widget.minLines,
           maxLines: widget.maxLines,
           keyboardHandlers: widget.keyboardHandlers,
+          selectorHandlers: widget.selectorHandlers,
           padding: widget.padding ?? EdgeInsets.zero,
           inputSource: _inputSource,
           textInputAction: _textInputAction,

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -588,6 +589,46 @@ void main() {
       expect(enableSuggestions, false);
       expect(enableDeltaModel, true);
       expect(keyboardAppearance, 'Brightness.dark');
+    });
+
+    testWidgetsOnMac('allows apps to handle selectors in their own way', (tester) async {
+      bool customHandlerCalled = false;
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText('Selectors test'),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+            inputSource: TextInputSource.ime,
+            selectorHandlers: {
+              MacOsSelectors.moveRight: ({
+                required AttributedTextEditingController controller,
+                required textLayout,
+              }) {
+                customHandlerCalled = true;
+              }
+            },
+          ),
+        ),
+      );
+
+      // Place the caret at the beginning of the text field.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Press right arrow key to trigger the MacOsSelectors.moveRight selector.
+      await tester.pressRightArrow();
+
+      // Ensure the custom handler was called.
+      expect(customHandlerCalled, isTrue);
+
+      // Ensure that the textfield didn't execute the default handler for the MacOsSelectors.moveRight selector.
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 0),
+      );
     });
   });
 


### PR DESCRIPTION
This PR cherry-picks "[SuperTextField][Mac] Allow selector handlers configuration (Resolves #1439) (#1444)" to stable