### PR TITLE
[SuperEditor][iOS] Fix exception when moving floating cursor between paragraphs (Resolves #1449)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -191,7 +191,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       return;
     }
 
-    if (_isFloatingCursorVisible) {
+    if (_isFloatingCursorVisible && textEditingDeltas.every((e) => e is TextEditingDeltaNonTextUpdate)) {
       // On iOS, dragging the floating cursor generates non-text deltas to update the selection.
       //
       // When dragging the floating cursor between paragraphs, we receive a non-text delta for the previously

--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -68,6 +68,11 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   /// For the list of selectors, see [MacOsSelectors].
   final void Function(String selectorName) onPerformSelector;
 
+  /// Whether the floating cursor is being displayed.
+  ///
+  /// This value is updated on [updateFloatingCursor].
+  bool _isFloatingCursorVisible = false;
+
   void _onContentChange() {
     if (!attached) {
       return;
@@ -186,6 +191,18 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       return;
     }
 
+    if (_isFloatingCursorVisible) {
+      // On iOS, dragging the floating cursor generates non-text deltas to update the selection.
+      //
+      // When dragging the floating cursor between paragraphs, we receive a non-text delta for the previously
+      // selected paragraph when our selection already changed to another paragraph. If the previously selected
+      // paragraph is bigger than the newly selected paragraph, a mapping error occurs, because we try
+      // to select an offset bigger than the paragraph's length.
+      //
+      // As we already change the selection when the floating cursor moves, we ignore these deltas.
+      return;
+    }
+
     editorImeLog.fine("Received edit deltas from platform: ${textEditingDeltas.length} deltas");
     for (final delta in textEditingDeltas) {
       editorImeLog.fine("$delta");
@@ -276,10 +293,14 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   void updateFloatingCursor(RawFloatingCursorPoint point) {
     switch (point.state) {
       case FloatingCursorDragState.Start:
+        _isFloatingCursorVisible = true;
+        _floatingCursorController?.offset = point.offset;
+        break;
       case FloatingCursorDragState.Update:
         _floatingCursorController?.offset = point.offset;
         break;
       case FloatingCursorDragState.End:
+        _isFloatingCursorVisible = false;
         _floatingCursorController?.offset = null;
         break;
     }


### PR DESCRIPTION
[SuperEditor][iOS] Fix exception when moving floating cursor between paragraphs. Resolves #1449

Moving the floating cursor between paragraphs causes an exception when the selection sits at an offset bigger than the newly selected paragraph length.

The cause is that the IME generates non-text deltas while the floating cursor is moving. After the selection already changed to the other paragraph, we receive a non-text delta for the previously selected paragraph. This causes an IME mapping error.

This PR changes `DocumentImeInputClient` to ignore deltas while the floating cursor is being displayed.

Related flutter ticket: https://github.com/flutter/flutter/issues/134989