### PR TITLE
Cherry-Pick: [SuperEditor][SuperReader] - Lock scrolling when content fits within available space (Resolves #1409) (#1421)

### DIFF
--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -373,6 +373,11 @@ class AutoScrollController with ChangeNotifier {
     }
 
     final scrollPosition = _getScrollPosition!();
+
+    if (scrollPosition.maxScrollExtent == 0) {
+      return;
+    }
+
     scrollPosition.jumpTo(
       (scrollPosition.pixels + delta).clamp(0.0, scrollPosition.maxScrollExtent),
     );
@@ -388,7 +393,9 @@ class AutoScrollController with ChangeNotifier {
     }
 
     if (pos is ScrollPositionWithSingleContext) {
-      pos.goBallistic(pixelsPerSecond);
+      if (pos.maxScrollExtent > 0) {
+        pos.goBallistic(pixelsPerSecond);
+      }
       pos.context.setIgnorePointer(false);
     }
   }


### PR DESCRIPTION
Lock scrolling when content fits within available space (Resolves #1409)