### PR TITLE
[golden_runner] Await on addStream (Resolves #1479)

### DIFF
--- a/golden_runner/lib/src/commands.dart
+++ b/golden_runner/lib/src/commands.dart
@@ -318,8 +318,8 @@ Future<void> _runProcess({
     workingDirectory: workingDirectory,
   );
 
-  stdout.addStream(process.stdout);
-  stderr.addStream(process.stderr);
+  await stdout.addStream(process.stdout);
+  await stdout.addStream(process.stderr);
 
   final exitCode = await process.exitCode;
 

--- a/golden_runner/lib/src/commands.dart
+++ b/golden_runner/lib/src/commands.dart
@@ -319,7 +319,7 @@ Future<void> _runProcess({
   );
 
   await stdout.addStream(process.stdout);
-  await stdout.addStream(process.stderr);
+  await stderr.addStream(process.stderr);
 
   final exitCode = await process.exitCode;
 


### PR DESCRIPTION
[golden_runner] Await on addStream. Resolves #1479

Trying to use the golden_runner is throwing the following exception: 

```console
Unhandled exception:
Bad state: StreamSink is already bound to a stream
#0      _StreamSinkImpl.addStream (dart:io/io_sink.dart:166:7)
#1      _StdSink.addStream (dart:io/stdio.dart:361:55)
#2      _runProcess (package:golden_runner/src/commands.dart:322:10)
<asynchronous suspension>
#3      GoldenTestCommand.run (package:golden_runner/src/commands.dart:98:5)
<asynchronous suspension>
#4      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#5      main (file:///Users/rutviktak/flutter_projects/mc/super_editor/golden_runner/bin/goldens.dart:13:5)
<asynchronous suspension>
```

It seems that the example on the dart docs of `Process.start` are a bit incorrect:

```dart
 /// The following code uses `Process.start` to grep for `main` in the
 /// file `test.dart` on Linux.  
 var process = await Process.start('grep', ['-i', 'main', 'test.dart']);
 stdout.addStream(process.stdout);
 stderr.addStream(process.stderr);
```

`addStream` returns a `Future`, so we should `await` on that method.

This PR adds the missing `await`s.

I'm not sure why this issue didn't happen before...