### PR TITLE
[SuperEditor][web] Defer to browser toolbar and magnifier (Resolves #1390)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -20,6 +20,7 @@ import 'package:super_editor/src/infrastructure/platforms/android/magnifier.dart
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
 import 'package:super_editor/src/infrastructure/selection_leader_document_layer.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/src/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 import 'package:super_editor/src/super_textfield/metrics.dart';
@@ -1306,14 +1307,17 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
                   // Build the caret
                   _buildCaret(),
                   // Build the drag handles (if desired)
-                  ..._buildHandles(),
+                  if (!isWeb) //
+                    ..._buildHandles(),
                   // Build the focal point for the magnifier
                   if (_isDraggingHandle) _buildMagnifierFocalPoint(),
                   // Build the magnifier (this needs to be done before building
                   // the handles so that the magnifier doesn't show the handles
-                  if (widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
+                  if (!isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
                   // Build the editing toolbar
-                  if (widget.editingController.shouldDisplayToolbar && widget.editingController.isToolbarPositioned)
+                  if (!isWeb &&
+                      widget.editingController.shouldDisplayToolbar &&
+                      widget.editingController.isToolbarPositioned)
                     _buildToolbar(context),
                   // Build a UI that's useful for debugging, if desired.
                   if (widget.showDebugPaint)

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1306,15 +1306,18 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
                 children: [
                   // Build the caret
                   _buildCaret(),
-                  // Build the drag handles (if desired)
+                  // Build the drag handles (if desired).
+                  // We don't show handles on web because the browser already displays the native handles.
                   if (!isWeb) //
                     ..._buildHandles(),
                   // Build the focal point for the magnifier
                   if (_isDraggingHandle) _buildMagnifierFocalPoint(),
                   // Build the magnifier (this needs to be done before building
-                  // the handles so that the magnifier doesn't show the handles
+                  // the handles so that the magnifier doesn't show the handles.
+                  // We don't show magnifier on web because the browser already displays the native magnifier.
                   if (!isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
-                  // Build the editing toolbar
+                  // Build the editing toolbar.
+                  // We don't show toolbar on web because the browser already displays the native toolbar.
                   if (!isWeb &&
                       widget.editingController.shouldDisplayToolbar &&
                       widget.editingController.isToolbarPositioned)

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -275,14 +275,17 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
                     _buildHandles(),
                     // Build the floating cursor
                     _buildFloatingCursor(),
-                    // Build the editing toolbar
+                    // Build the editing toolbar.
+                    // We don't show toolbar on web because the browser already displays the native toolbar.
                     if (!isWeb &&
                         widget.editingController.shouldDisplayToolbar &&
                         widget.editingController.isToolbarPositioned)
                       _buildToolbar(),
-                    // Build the focal point for the magnifier
+                    // Build the focal point for the magnifier.
+                    // Don't build the focal point on web because, on web, we defer to the native magnifier.
                     if (!isWeb && widget.magnifierFocalPointOffset != null) _buildMagnifierFocalPoint(),
-                    // Build the magnifier
+                    // Build the magnifier.
+                    // We don't show magnifier on web because the browser already displays the native magnifier.
                     if (!isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
                     if (widget.showDebugPaint)
                       IgnorePointer(

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_pipeline.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/src/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 import 'package:super_text_layout/super_text_layout.dart';
@@ -275,12 +276,14 @@ class _IosDocumentTouchEditingControlsState extends State<IosDocumentTouchEditin
                     // Build the floating cursor
                     _buildFloatingCursor(),
                     // Build the editing toolbar
-                    if (widget.editingController.shouldDisplayToolbar && widget.editingController.isToolbarPositioned)
+                    if (!isWeb &&
+                        widget.editingController.shouldDisplayToolbar &&
+                        widget.editingController.isToolbarPositioned)
                       _buildToolbar(),
                     // Build the focal point for the magnifier
-                    if (widget.magnifierFocalPointOffset != null) _buildMagnifierFocalPoint(),
+                    if (!isWeb && widget.magnifierFocalPointOffset != null) _buildMagnifierFocalPoint(),
                     // Build the magnifier
-                    if (widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
+                    if (!isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
                     if (widget.showDebugPaint)
                       IgnorePointer(
                         child: Container(


### PR DESCRIPTION
[SuperEditor][web] Defer to browser toolbar and magnifier. Resolves #1390

On web, both our toolbar and the browser text selection toolbar are displayed.

This PR changes `SuperEditor` to avoid rendering the toolbar and drag handles on web on both Android and iOS:

https://github.com/superlistapp/super_editor/assets/7597082/b3c32b5e-7149-4979-a963-49b01652fdd8

However, the Android drag handles aren't positioned exactly at the correct position.

https://github.com/superlistapp/super_editor/assets/7597082/358422a4-1114-4293-a9c3-8a299f9d9915
