### PR TITLE
[SuperEditor] Bumped http lower bound to v1.0.0 (Resolves #1464)

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -35,8 +35,8 @@ dependencies:
 
   charcode: ^1.1.3
   flutter_keyboard_visibility: ^5.0.3
-  google_fonts: ^2.0.0
-  http: ^0.13.1
+  google_fonts: ^6.0.0
+  http: ^1.0.0
   linkify: ^5.0.0
   logging: ^1.0.1
   uuid: ^3.0.3

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   characters: ^1.2.0
   collection: ^1.15.0
   follow_the_leader: ^0.0.4+3
-  http: ">=0.13.1 <2.0.0"
+  http: ">=1.0.0 <2.0.0"
   linkify: ^5.0.0
   logging: ^1.0.1
   super_text_layout: ^0.1.7


### PR DESCRIPTION
[SuperEditor] Bumped http lower bound to v1.0.0, example deps updated (Resolves #1464)

This PR updates the lower bound of http version from 0.13.1 to 1.0.0

Also, updated super editor example deps that got affected due to this update.