### PR TITLE
Fix cherry_pick_to_stable.yaml workflow (Resolves #1513)

### DIFF
--- a/.github/workflows/cherry_pick_to_stable.yaml
+++ b/.github/workflows/cherry_pick_to_stable.yaml
@@ -17,23 +17,41 @@ jobs:
   cherry-pick-to-stable:
     runs-on: ubuntu-latest
     name: Cherry pick from main to stable
+
     # Only cherry pick merged PRs. Don't merge PRs marked with "no-cherry-pick" label.
     if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-cherry-pick') }}
+
+    # These ENV variables can be accessed directly when they're used in shell commands, e.g.:
+    #
+    #     echo "My name is $NAME"
+    # 
+    # When referencing ENV variables in declarative YAML, they must be accessed via "env.", e.g.:
+    #
+    #     someProperty: "My name is ${{ env.NAME }}"
+    #
+    # GitHub pull request data: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
+    env:
+      CHERRY_PICK_BRANCH_NAME: "cherry-pick_${{ github.event.pull_request.head.ref }}_${{ github.event.pull_request.merge_commit_sha }}"
+      CHERRY_PICK_PR_TITLE: "Cherry Pick: ${{ github.event.pull_request.title }}"
+      CHERRY_PICK_PR_BODY: "Cherry Pick: Original PR - #${{ github.event.pull_request.number }}"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0    
+
       - name: Cherry pick into stable
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
           branch: stable
-          cherry-pick-branch: cherry-pick_${{ inputs.branch }}_${{ commitSha }}
-          title: 'Cherry Pick: ${{ old_title }}'
-          body: 'Cherry Pick: Original PR - #${{ old_pull_request_id }}'
+          cherry-pick-branch: "${{ env.CHERRY_PICK_BRANCH_NAME }}"
+          title: "${{ env.CHERRY_PICK_PR_TITLE }}"
+          body: "${{ env.CHERRY_PICK_PR_BODY }}"
           labels: |
             cherry-pick
           reviewers: |
             matthew-carroll
+            "${{ gitHub.event.pull_request.user.login }}"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The cherry pick GitHub Action wasn't working as intended. I couldn't seem to get the cherry pick action's variables to interpolate.

I ran about a million different attempts over at https://github.com/matthew-carroll/experiment_ci_cherry_pick_pr

Eventually I decided the only way to interpolate the names we want for things like the branch, title, body, etc, was to define our own environment variables, where we pull the desired information out of the GitHub payload. That's what this PR does.

