### PR TITLE
[SuperEditor][SuperReader][Android] Fix scrolling with an ancestor Scrollable (Resolves #1535)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -497,6 +497,13 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
+    if (_isScrolling) {
+      // When the editor has an ancestor scrollable, dragging won't trigger a pan gesture
+      // is this widget. Because of that, the timer still fires after the timeout.
+      // Do nothing to let the user scroll.
+      return;
+    }
+
     _longPressStrategy = AndroidDocumentLongPressSelectionStrategy(
       document: widget.document,
       documentLayout: _docLayout,

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -480,6 +480,13 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
 
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
+    if (_isScrolling) {
+      // When the reader has an ancestor scrollable, dragging won't trigger a pan gesture
+      // is this widget. Because of that, the timer still fires after the timeout.
+      // Do nothing to let the user scroll.
+      return;
+    }
+
     _longPressStrategy = AndroidDocumentLongPressSelectionStrategy(
       document: widget.document,
       documentLayout: _docLayout,

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -581,6 +581,60 @@ void main() {
         expect(caretOffset.dy, greaterThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary));
       });
 
+      testWidgetsOnMobile('scrolls when dragging without attaching to IME', (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump an editor inside a CustomScrollView without enough room to display
+        // the whole content.
+        await tester
+            .createDocument() //
+            .withLongTextContent()
+            .withCustomWidgetTreeBuilder(
+              (superEditor) => MaterialApp(
+                home: Scaffold(
+                  body: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 200),
+                    child: CustomScrollView(
+                      controller: scrollController,
+                      slivers: [
+                        SliverToBoxAdapter(
+                          child: superEditor,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure the scrollview didn't start scrolled.
+        expect(scrollController.offset, 0);
+
+        final scrollableRect = tester.getRect(find.byType(CustomScrollView));
+
+        const dragFrameCount = 10;
+        final dragAmountPerFrame = scrollableRect.height / dragFrameCount;
+
+        // Drag from the bottom all the way up to the top of the scrollable.
+        final dragGesture = await tester.startGesture(scrollableRect.bottomCenter - const Offset(0, 1));
+        for (int i = 0; i < dragFrameCount; i += 1) {
+          await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
+          await tester.pump();
+        }
+
+        // The editor supports long press to select.
+        // Wait long enough to make sure  this gesture wasn't confused with a long press.
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+        await dragGesture.up();
+        await dragGesture.removePointer();
+
+        // Ensure we scrolled, didn't changed the selection and didn't attach to the IME.
+        expect(scrollController.offset, greaterThan(0));
+        expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        expect(tester.testTextInput.hasAnyClients, isFalse);
+      });
+
       group('respects horizontal scrolling', () {
         testWidgetsOnAllPlatforms('inside a TabBar', (tester) async {
           final tabController = TabController(length: 2, vsync: tester);

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -581,7 +581,7 @@ void main() {
         expect(caretOffset.dy, greaterThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary));
       });
 
-      testWidgetsOnMobile('scrolls when dragging without attaching to IME', (tester) async {
+      testWidgetsOnMobile('scrolling doesn\'t cause the keyboard to open', (tester) async {
         final scrollController = ScrollController();
 
         // Pump an editor inside a CustomScrollView without enough room to display

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -314,7 +314,7 @@ void main() {
     });
 
     group("with ancestor scrollable", () {
-      testWidgetsOnMobile('scrolls when dragging without selecting content', (tester) async {
+      testWidgetsOnMobile('scrolling doesn\'t change selection', (tester) async {
         final scrollController = ScrollController();
 
         // Pump a reader inside a CustomScrollView without enough room to display

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -312,6 +312,61 @@ void main() {
         variant: _scrollDirectionVariant,
       );
     });
+
+    group("with ancestor scrollable", () {
+      testWidgetsOnMobile('scrolls when dragging without selecting content', (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump a reader inside a CustomScrollView without enough room to display
+        // the whole content.
+        await tester
+            .createDocument() //
+            .withLongTextContent()
+            .withCustomWidgetTreeBuilder(
+              (superReader) => MaterialApp(
+                home: Scaffold(
+                  body: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 200),
+                    child: CustomScrollView(
+                      controller: scrollController,
+                      slivers: [
+                        SliverToBoxAdapter(
+                          child: superReader,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure the scrollview didn't start scrolled.
+        expect(scrollController.offset, 0);
+
+        final scrollableRect = tester.getRect(find.byType(CustomScrollView));
+
+        const dragFrameCount = 10;
+        final dragAmountPerFrame = scrollableRect.height / dragFrameCount;
+
+        // Drag from the bottom all the way up to the top of the scrollable.
+        final dragGesture = await tester.startGesture(scrollableRect.bottomCenter - const Offset(0, 1));
+        for (int i = 0; i < dragFrameCount; i += 1) {
+          await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
+          await tester.pump();
+        }
+
+        // The reader supports long press to select.
+        // Wait long enough to make sure  this gesture wasn't confused with a long press.
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+        await dragGesture.up();
+        await dragGesture.removePointer();
+
+        // Ensure we scrolled and didn't change the selection.
+        expect(scrollController.offset, greaterThan(0));
+        expect(SuperReaderInspector.findDocumentSelection(), isNull);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
[SuperEditor][SuperReader][Android] Fix scrolling with an ancestor Scrollable. Resolves #1535.

When the editor or reader is inside a `CustomScrollview`, trying to drag is opening the software keyboard and changing the selection.

The root cause is the long press to select handling. When the user taps down we start a timer to track a long press. Dragging after the tap down starts a pan gesture and we cancel the timer. However,  if we have an ancestor `Scrollable`, dragging starts a pan gesture on the `Scrollable`, not in the editor/reader. Because of that, the timer still fires after the timeout.

This PR adds a guard clause to avoid doing a long press if we are scrolling.