### PR TITLE
[SuperEditor][SuperReader][Android] Fix long-press firing after scrolling and releasing the pointer (Resolves #1535)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -324,6 +324,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     if (isScrolling) {
       _isScrolling = true;
+
+      // The long-press timer is cancelled if a pan gesture is detected.
+      // However, if we have an ancestor scrollable, we won't receive a pan gesture in this widget.
+      // Cancel the timer as soon as the user started scrolling.
+      _tapDownLongPressTimer?.cancel();
+      _tapDownLongPressTimer = null;
     } else {
       onNextFrame((_) {
         // Set our scrolling flag to false on the next frame, so that our tap handlers
@@ -497,13 +503,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
-    if (_isScrolling) {
-      // When the editor has an ancestor scrollable, dragging won't trigger a pan gesture
-      // is this widget. Because of that, the timer still fires after the timeout.
-      // Do nothing to let the user scroll.
-      return;
-    }
-
     _longPressStrategy = AndroidDocumentLongPressSelectionStrategy(
       document: widget.document,
       documentLayout: _docLayout,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -325,9 +325,8 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     if (isScrolling) {
       _isScrolling = true;
 
-      // The long-press timer is cancelled if a pan gesture is detected.
-      // However, if we have an ancestor scrollable, we won't receive a pan gesture in this widget.
-      // Cancel the timer as soon as the user started scrolling.
+      // The user started to scroll.
+      // Cancel the timer to stop trying to detect a long press.
       _tapDownLongPressTimer?.cancel();
       _tapDownLongPressTimer = null;
     } else {

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -304,6 +304,12 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
 
     if (isScrolling) {
       _isScrolling = true;
+
+      // The long-press timer is cancelled if a pan gesture is detected.
+      // However, if we have an ancestor scrollable, we won't receive a pan gesture in this widget.
+      // Cancel the timer as soon as the user started scrolling.
+      _tapDownLongPressTimer?.cancel();
+      _tapDownLongPressTimer = null;
     } else {
       onNextFrame((_) {
         // Set our scrolling flag to false on the next frame, so that our tap handlers

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -581,7 +581,7 @@ void main() {
         expect(caretOffset.dy, greaterThanOrEqualTo(screenSizeWithKeyboard.height - trailingBoundary));
       });
 
-      testWidgetsOnMobile('scrolling doesn\'t cause the keyboard to open', (tester) async {
+      testWidgetsOnMobile('scrolling and holding the pointer doesn\'t cause the keyboard to open', (tester) async {
         final scrollController = ScrollController();
 
         // Pump an editor inside a CustomScrollView without enough room to display
@@ -626,8 +626,63 @@ void main() {
         // The editor supports long press to select.
         // Wait long enough to make sure  this gesture wasn't confused with a long press.
         await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+
+        // Ensure we scrolled, didn't changed the selection and didn't attach to the IME.
+        expect(scrollController.offset, greaterThan(0));
+        expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        expect(tester.testTextInput.hasAnyClients, isFalse);
+      });
+
+      testWidgetsOnMobile('scrolling and releasing the pointer doesn\'t cause the keyboard to open', (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump an editor inside a CustomScrollView without enough room to display
+        // the whole content.
+        await tester
+            .createDocument() //
+            .withLongTextContent()
+            .withCustomWidgetTreeBuilder(
+              (superEditor) => MaterialApp(
+                home: Scaffold(
+                  body: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 200),
+                    child: CustomScrollView(
+                      controller: scrollController,
+                      slivers: [
+                        SliverToBoxAdapter(
+                          child: superEditor,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure the scrollview didn't start scrolled.
+        expect(scrollController.offset, 0);
+
+        final scrollableRect = tester.getRect(find.byType(CustomScrollView));
+
+        const dragFrameCount = 10;
+        final dragAmountPerFrame = scrollableRect.height / dragFrameCount;
+
+        // Drag from the bottom all the way up to the top of the scrollable.
+        final dragGesture = await tester.startGesture(scrollableRect.bottomCenter - const Offset(0, 1));
+        for (int i = 0; i < dragFrameCount; i += 1) {
+          await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
+          await tester.pump();
+        }
+
+        // Stop the scrolling gesture.
         await dragGesture.up();
         await dragGesture.removePointer();
+        await tester.pump();
+
+        // The editor supports long press to select.
+        // Wait long enough to make sure  this gesture wasn't confused with a long press.
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
 
         // Ensure we scrolled, didn't changed the selection and didn't attach to the IME.
         expect(scrollController.offset, greaterThan(0));

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -631,6 +631,10 @@ void main() {
         expect(scrollController.offset, greaterThan(0));
         expect(SuperEditorInspector.findDocumentSelection(), isNull);
         expect(tester.testTextInput.hasAnyClients, isFalse);
+
+        // Release the pointer.
+        await dragGesture.up();
+        await dragGesture.removePointer();
       });
 
       testWidgetsOnMobile('scrolling and releasing the pointer doesn\'t cause the keyboard to open', (tester) async {


### PR DESCRIPTION
[SuperEditor][SuperReader][Android] Fix long-press firing after scrolling and releasing the pointer. Resolves #1535

When the editor or reader is inside a CustomScrollview, trying to drag is opening the software keyboard and changing the selection. This was partially solved in https://github.com/superlistapp/super_editor/pull/1536. However one issue remained:

Starting a scroll gestures and the releasing the pointer is still causing the issue. The cause is that, when the timer fires, we aren't scrolling anymore.

To fix that, this PR cancels the long-press timer as soon as the user starts the scrolling gesture.

I kept the existing test, which simulates the user dragging and holding down the pointer, and added another one simulating the user starting a drag gesture and then releasing the pointer.