### PR TITLE
[SuperEditor][SuperReader][Android] Fix scroll physics (Resolves #1539)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -145,7 +145,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   final _longPressMagnifierGlobalOffset = ValueNotifier<Offset?>(null);
 
   /// Holds the drag gesture that scrolls the document.
-  Drag? _drag;
+  Drag? _dragToScroll;
 
   @override
   void initState() {
@@ -743,7 +743,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     if (!_isLongPressInProgress) {
       // We only care about starting a pan if we're long-press dragging.
-      _drag = scrollPosition.drag(details, () {
+      _dragToScroll = scrollPosition.drag(details, () {
         // Allows receiving touches while scrolling due to scroll momentum.
         // This is needed to allow the user to stop scrolling by tapping down.
         scrollPosition.context.setIgnorePointer(false);
@@ -792,9 +792,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_drag != null) {
+    if (_dragToScroll != null) {
       // The user is trying to scroll the document. Change the scroll offset.
-      _drag!.update(details);
+      _dragToScroll!.update(details);
     }
   }
 
@@ -826,14 +826,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_drag != null) {
-      _drag!.end(details);
-    }
-
-    final pos = scrollPosition;
-    if (pos is ScrollPositionWithSingleContext) {
-      pos.goBallistic(-details.velocity.pixelsPerSecond.dy);
-      pos.context.setIgnorePointer(false);
+    if (_dragToScroll != null) {
+      // The user was performing a drag gesture to scroll the document.
+      // End the drag gesture.
+      _dragToScroll!.end(details);
     }
   }
 
@@ -843,8 +839,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_drag != null) {
-      _drag!.cancel();
+    if (_dragToScroll != null) {
+      // The user was performing a drag gesture to scroll the document.
+      // End the drag gesture.
+      _dragToScroll!.cancel();
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -136,6 +136,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   double? _dragStartScrollOffset;
   Offset? _globalDragOffset;
   Offset? _dragEndInInteractor;
+
+  /// Holds the drag gesture that scrolls the document.
+  Drag? _scrollingDrag;
+
   SelectionHandleType? _selectionType;
 
   Timer? _tapDownLongPressTimer;
@@ -143,9 +147,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   bool get _isLongPressInProgress => _longPressStrategy != null;
   AndroidDocumentLongPressSelectionStrategy? _longPressStrategy;
   final _longPressMagnifierGlobalOffset = ValueNotifier<Offset?>(null);
-
-  /// Holds the drag gesture that scrolls the document.
-  Drag? _dragToScroll;
 
   @override
   void initState() {
@@ -743,7 +744,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     if (!_isLongPressInProgress) {
       // We only care about starting a pan if we're long-press dragging.
-      _dragToScroll = scrollPosition.drag(details, () {
+      _scrollingDrag = scrollPosition.drag(details, () {
         // Allows receiving touches while scrolling due to scroll momentum.
         // This is needed to allow the user to stop scrolling by tapping down.
         scrollPosition.context.setIgnorePointer(false);
@@ -792,9 +793,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user is trying to scroll the document. Change the scroll offset.
-      _dragToScroll!.update(details);
+      _scrollingDrag!.update(details);
     }
   }
 
@@ -826,10 +827,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user was performing a drag gesture to scroll the document.
-      // End the drag gesture.
-      _dragToScroll!.end(details);
+      // End the scroll activity and let the document scrolling with momentum.
+      _scrollingDrag!.end(details);
     }
   }
 
@@ -839,10 +840,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user was performing a drag gesture to scroll the document.
       // End the drag gesture.
-      _dragToScroll!.cancel();
+      _scrollingDrag!.cancel();
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -785,7 +785,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     }
 
     // The user is trying to scroll the document. Change the scroll offset.
-    scrollPosition.jumpTo(scrollPosition.pixels - details.delta.dy);
+    scrollPosition.pointerScroll(-details.delta.dy);
   }
 
   void _updateLongPressSelection(DocumentSelection newSelection) {

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -998,20 +998,25 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       ..hideMagnifier()
       ..blinkCaret();
 
-    if (_dragMode == DragMode.scroll) {
-      // The user was performing a drag gesture to scroll the document.
-      // End the scroll activity and let the document scrolling with momentum.
-      _scrollingDrag!.end(details);
-      _scrollingDrag = null;
-      _dragMode = null;
-
-      return;
-    }
-
-    if (_dragMode != null) {
-      // The user was dragging a selection change in some way, either with handles
-      // or with a long-press. Finish that interaction.
-      _onDragSelectionEnd();
+    switch (_dragMode) {
+      case DragMode.scroll:
+        // The user was performing a drag gesture to scroll the document.
+        // End the scroll activity and let the document scrolling with momentum.
+        _scrollingDrag!.end(details);
+        _scrollingDrag = null;
+        _dragMode = null;
+        break;
+      case DragMode.collapsed:
+      case DragMode.base:
+      case DragMode.extent:
+      case DragMode.longPress:
+        // The user was dragging a selection change in some way, either with handles
+        // or with a long-press. Finish that interaction.
+        _onDragSelectionEnd();
+        break;
+      case null:
+        // The user wasn't dragging over a selection. Do nothing.
+        break;
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -921,7 +921,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     // scroll the document. Scroll it, accordingly.
     if (_dragMode == null && _drag != null) {
       _drag!.update(details);
-      _positionToolbar();
       return;
     }
 

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -136,7 +136,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   final _longPressMagnifierGlobalOffset = ValueNotifier<Offset?>(null);
 
   /// Holds the drag gesture that scrolls the document.
-  Drag? _drag;
+  Drag? _dragToScroll;
 
   @override
   void initState() {
@@ -677,7 +677,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
 
     if (!_isLongPressInProgress) {
       // We only care about starting a pan if we're long-press dragging.
-      _drag = scrollPosition.drag(details, () {
+      _dragToScroll = scrollPosition.drag(details, () {
         // Allows receiving touches while scrolling due to scroll momentum.
         // This is needed to allow the user to stop scrolling by tapping down.
         scrollPosition.context.setIgnorePointer(false);
@@ -726,9 +726,9 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_drag != null) {
+    if (_dragToScroll != null) {
       // The user is trying to scroll the document. Change the scroll offset.
-      _drag!.update(details);
+      _dragToScroll!.update(details);
     }
   }
 
@@ -760,14 +760,10 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_drag != null) {
-      _drag!.end(details);
-    }
-
-    final pos = scrollPosition;
-    if (pos is ScrollPositionWithSingleContext) {
-      pos.goBallistic(-details.velocity.pixelsPerSecond.dy);
-      pos.context.setIgnorePointer(false);
+    if (_dragToScroll != null) {
+      // The user was performing a drag gesture to scroll the document.
+      // End the drag gesture.
+      _dragToScroll!.end(details);
     }
   }
 
@@ -777,8 +773,10 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_drag != null) {
-      _drag!.cancel();
+    if (_dragToScroll != null) {
+      // The user was performing a drag gesture to scroll the document.
+      // Cancel the drag gesture.
+      _dragToScroll!.cancel();
     }
   }
 

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -718,7 +718,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    scrollPosition.jumpTo(scrollPosition.pixels - details.delta.dy);
+    scrollPosition.pointerScroll(-details.delta.dy);
   }
 
   void _updateLongPressSelection(DocumentSelection newSelection) {

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -136,7 +136,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   final _longPressMagnifierGlobalOffset = ValueNotifier<Offset?>(null);
 
   /// Holds the drag gesture that scrolls the document.
-  Drag? _dragToScroll;
+  Drag? _scrollingDrag;
 
   @override
   void initState() {
@@ -677,7 +677,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
 
     if (!_isLongPressInProgress) {
       // We only care about starting a pan if we're long-press dragging.
-      _dragToScroll = scrollPosition.drag(details, () {
+      _scrollingDrag = scrollPosition.drag(details, () {
         // Allows receiving touches while scrolling due to scroll momentum.
         // This is needed to allow the user to stop scrolling by tapping down.
         scrollPosition.context.setIgnorePointer(false);
@@ -726,9 +726,9 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user is trying to scroll the document. Change the scroll offset.
-      _dragToScroll!.update(details);
+      _scrollingDrag!.update(details);
     }
   }
 
@@ -760,10 +760,10 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user was performing a drag gesture to scroll the document.
-      // End the drag gesture.
-      _dragToScroll!.end(details);
+      // End the scroll activity and let the document scrolling with momentum.
+      _scrollingDrag!.end(details);
     }
   }
 
@@ -773,10 +773,10 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
       return;
     }
 
-    if (_dragToScroll != null) {
+    if (_scrollingDrag != null) {
       // The user was performing a drag gesture to scroll the document.
       // Cancel the drag gesture.
-      _dragToScroll!.cancel();
+      _scrollingDrag!.cancel();
     }
   }
 

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -729,7 +729,6 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     // scroll the document. Scroll it, accordingly.
     if (_dragMode == null && _drag != null) {
       _drag!.update(details);
-      _positionToolbar();
       return;
     }
 

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -713,23 +713,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -769,23 +755,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -824,23 +796,8 @@ void main() {
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -865,26 +822,14 @@ void main() {
       testWidgetsOnAndroid("doesn't overscroll when dragging up", (tester) async {
         final scrollController = ScrollController();
 
+        // Pump an editor inside a CustomScrollView without enough room to display
+        // the whole content.
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.
@@ -917,23 +862,8 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -967,23 +897,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superEditor) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superEditor,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -525,7 +525,7 @@ void main() {
       // End the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
     });
 
@@ -554,7 +554,7 @@ void main() {
       // End the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
     });
 
@@ -583,7 +583,7 @@ void main() {
       // Release the pointer to end the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the top.
@@ -617,7 +617,7 @@ void main() {
       // Release the pointer to end the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the end.
@@ -858,7 +858,7 @@ void main() {
         // End the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
       });
 
@@ -905,7 +905,7 @@ void main() {
         // End the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
       });
 
@@ -952,7 +952,7 @@ void main() {
         // Release the pointer to end the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the top.
@@ -1003,7 +1003,7 @@ void main() {
         // Release the pointer to end the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the end.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -714,7 +714,8 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -755,7 +756,8 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -794,7 +796,8 @@ void main() {
         await tester
             .createDocument() //
             .withSingleParagraph()
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -825,7 +828,8 @@ void main() {
             .createDocument()
             .withSingleParagraph()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.
@@ -855,7 +859,8 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -890,7 +895,8 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView(scrollController)
+            .insideCustomScrollView()
+            .withScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -714,8 +714,7 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -756,8 +755,7 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -794,10 +792,9 @@ void main() {
         final scrollController = ScrollController();
 
         await tester
-            .createDocument()
+            .createDocument() //
             .withSingleParagraph()
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -828,8 +825,7 @@ void main() {
             .createDocument()
             .withSingleParagraph()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Jump to the bottom.
@@ -840,9 +836,6 @@ void main() {
           startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 10),
           totalDragOffset: const Offset(0, -400.0),
         );
-
-        // Ensure we don't scroll.
-        expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
         // Ensure we don't scroll.
         expect(scrollController.offset, scrollController.position.maxScrollExtent);
@@ -862,8 +855,7 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -898,8 +890,7 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
-            .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .insideCustomScrollView(scrollController)
             .pump();
 
         // Jump to the bottom.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -513,11 +513,10 @@ void main() {
       // Ensure the editor didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Drag an amount of pixels chosen experimentally from the top of the editor.
-      final dragGesture = await tester.dragInMultipleFrames(
-        startLocation: tester.getTopLeft(find.byType(SuperEditor)),
-        dragAmount: const Offset(0, 200.0),
-        frameCount: 10,
+      // Drag an arbitrary amount of pixels from the top of the editor with a small margin.
+      final dragGesture = await tester.dragByFrameCount(
+        startLocation: tester.getRect(find.byType(SuperEditor)).topCenter + const Offset(0, 5),
+        totalDragOffset: const Offset(0, 200.0),
       );
 
       // Ensure the drag gesture didn't scroll the editor.
@@ -542,12 +541,11 @@ void main() {
       // Jump to the bottom.
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-      // Drag an amount of pixels chosen experimentally from the bottom of the editor.
-      // The gesture starts with a small margin from the bottom, also chosen experimentally.
-      final dragGesture = await tester.dragInMultipleFrames(
-        startLocation: tester.getBottomLeft(find.byType(SuperEditor)) - const Offset(0, 10),
-        dragAmount: const Offset(0, -200.0),
-        frameCount: 10,
+      // Drag an arbitrary amount of pixels from the bottom of the editor.
+      // The gesture starts with an arbitrary small margin from the bottom.
+      final dragGesture = await tester.dragByFrameCount(
+        startLocation: tester.getRect(find.byType(SuperEditor)).bottomCenter - const Offset(0, 10),
+        totalDragOffset: const Offset(0, -200.0),
       );
 
       // Ensure we don't scroll.
@@ -572,11 +570,10 @@ void main() {
       // Ensure the scrollview didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Drag an amount of pixels chosen experimentally a few pixels below the top of the editor.
-      final dragGesture = await tester.dragInMultipleFrames(
+      // Drag an arbitrary amount of pixels a few pixels below the top of the editor.
+      final dragGesture = await tester.dragByFrameCount(
         startLocation: tester.getRect(find.byType(SuperEditor)).topCenter + const Offset(0, 5),
-        dragAmount: const Offset(0, 80.0),
-        frameCount: 10,
+        totalDragOffset: const Offset(0, 80.0),
       );
 
       // Ensure we are overscrolling while holding the pointer down.
@@ -606,12 +603,11 @@ void main() {
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
       await tester.pumpAndSettle();
 
-      // Drag an amount of pixels chosen experimentally from the bottom of the editor.
-      // The gesture starts with a small margin from the bottom, also chosen experimentally.
-      final dragGesture = await tester.dragInMultipleFrames(
+      // Drag an arbitrary amount of pixels from the bottom of the editor.
+      // The gesture starts with an arbitrary margin from the bottom.
+      final dragGesture = await tester.dragByFrameCount(
         startLocation: tester.getRect(find.byType(SuperEditor)).bottomCenter - const Offset(0, 5),
-        dragAmount: const Offset(0, -200.0),
-        frameCount: 10,
+        totalDragOffset: const Offset(0, -200.0),
       );
 
       // Ensure we are overscrolling while holding the pointer down.
@@ -850,11 +846,10 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        // Drag an amount of pixels chosen experimentally from the top of the editor.
-        final dragGesture = await tester.dragInMultipleFrames(
-          startLocation: tester.getTopLeft(find.byType(SuperEditor)),
-          dragAmount: const Offset(0, 400.0),
-          frameCount: 10,
+        // Drag an arbitrary amount of pixels from the top of the editor.
+        final dragGesture = await tester.dragByFrameCount(
+          startLocation: tester.getRect(find.byType(SuperEditor)).topCenter + const Offset(0, 5),
+          totalDragOffset: const Offset(0, 400.0),
         );
 
         // Ensure we don't scroll.
@@ -895,11 +890,10 @@ void main() {
         // Jump to the bottom.
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-        // Drag an amount of pixels chosen experimentally from the bottom of the editor.
-        final dragGesture = await tester.dragInMultipleFrames(
-          startLocation: tester.getBottomLeft(find.byType(CustomScrollView)) - const Offset(0, 10),
-          dragAmount: const Offset(0, -400.0),
-          frameCount: 10,
+        // Drag an arbitrary amount of pixels from the bottom of the editor.
+        final dragGesture = await tester.dragByFrameCount(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 10),
+          totalDragOffset: const Offset(0, -400.0),
         );
 
         // Ensure we don't scroll.
@@ -946,11 +940,9 @@ void main() {
         expect(scrollController.offset, 0);
 
         // Drag an arbitrary amount, smaller than the editor size.
-        // Drag an amount of pixels chosen experimentally from the top of the editor.
-        final dragGesture = await tester.dragInMultipleFrames(
+        final dragGesture = await tester.dragByFrameCount(
           startLocation: tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5),
-          dragAmount: const Offset(0, 80.0),
-          frameCount: 10,
+          totalDragOffset: const Offset(0, 80.0),
         );
 
         // Ensure we are overscrolling while holding the pointer down.
@@ -999,11 +991,9 @@ void main() {
         await tester.pumpAndSettle();
 
         // Drag up an arbitrary amount, smaller than the editor size.
-        // Drag an amount of pixels chosen experimentally from the bottom of the editor.
-        final dragGesture = await tester.dragInMultipleFrames(
+        final dragGesture = await tester.dragByFrameCount(
           startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5),
-          dragAmount: const Offset(0, -100.0),
-          frameCount: 10,
+          totalDragOffset: const Offset(0, -100.0),
         );
 
         // Ensure we are overscrolling while holding the pointer down.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -8,6 +8,7 @@ import 'package:super_editor/src/infrastructure/blinking_caret.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
+import '../test_tools.dart';
 import 'supereditor_test_tools.dart';
 import 'test_documents.dart';
 
@@ -503,98 +504,80 @@ void main() {
     testWidgetsOnAndroid("doesn't overscroll when dragging down", (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withInputSource(TextInputSource.ime)
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
-      // Ensure the scrollview didn't start scrolled.
+      // Ensure the editor didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      final editorRect = tester.getRect(find.byType(SuperEditor));
+      // Drag an amount of pixels chosen experimentally from the top of the editor.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getTopLeft(find.byType(SuperEditor)),
+        dragAmount: const Offset(0, 200.0),
+        frameCount: 10,
+      );
 
-      const dragFrameCount = 10;
-      final dragAmountPerFrame = editorRect.height / dragFrameCount;
-
-      // Drag from the top all the way up to the bottom of the editor.
-      final dragGesture = await tester.startGesture(editorRect.topCenter);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(Offset(0, dragAmountPerFrame));
-        await tester.pump();
-
-        // Ensure we don't scroll.
-        expect(scrollController.offset, 0);
-      }
+      // Ensure the drag gesture didn't scroll the editor.
+      expect(scrollController.offset, 0);
 
       // End the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
     });
 
     testWidgetsOnAndroid("doesn't overscroll when dragging up", (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withInputSource(TextInputSource.ime)
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
       // Jump to the bottom.
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-      final editorRect = tester.getRect(find.byType(SuperEditor));
+      // Drag an amount of pixels chosen experimentally from the bottom of the editor.
+      // The gesture starts with a small margin from the bottom, also chosen experimentally.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getBottomLeft(find.byType(SuperEditor)) - const Offset(0, 10),
+        dragAmount: const Offset(0, -200.0),
+        frameCount: 10,
+      );
 
-      const dragFrameCount = 10;
-      final dragAmountPerFrame = editorRect.height / dragFrameCount;
-
-      // Drag from the bottom all the way up to the top of the editor.
-      final dragGesture = await tester.startGesture(editorRect.topCenter);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
-        await tester.pump();
-
-        // Ensure we don't scroll.
-        expect(scrollController.offset, scrollController.position.maxScrollExtent);
-      }
+      // Ensure we don't scroll.
+      expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
       // End the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
     });
 
     testWidgetsOnIos('overscrolls when dragging down', (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withInputSource(TextInputSource.ime)
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
       // Ensure the scrollview didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Start a drag gesture a few pixels below the top of the editor.
-      final dragGesture =
-          await tester.startGesture(tester.getRect(find.byType(SuperEditor)).topCenter + const Offset(0, 5));
-
-      // Drag an arbitrary amount, smaller than the editor size.
-      const dragFrameCount = 10;
-      const dragAmountPerFrame = (80 / dragFrameCount);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(const Offset(0, dragAmountPerFrame));
-        await tester.pump();
-      }
+      // Drag an amount of pixels chosen experimentally a few pixels below the top of the editor.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getRect(find.byType(SuperEditor)).topCenter + const Offset(0, 5),
+        dragAmount: const Offset(0, 80.0),
+        frameCount: 10,
+      );
 
       // Ensure we are overscrolling while holding the pointer down.
       await tester.pumpAndSettle();
@@ -602,7 +585,8 @@ void main() {
 
       // Release the pointer to end the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the top.
@@ -612,11 +596,9 @@ void main() {
     testWidgetsOnIos('overscrolls when dragging up', (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withInputSource(TextInputSource.ime)
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
@@ -624,17 +606,13 @@ void main() {
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
       await tester.pumpAndSettle();
 
-      // Start a drag gesture a few pixels above the top of the editor.
-      final dragGesture =
-          await tester.startGesture(tester.getRect(find.byType(SuperEditor)).bottomCenter - const Offset(0, 5));
-
-      // Drag up an arbitrary amount, smaller than the editor size.
-      const dragFrameCount = 10;
-      const dragAmountPerFrame = (200 / dragFrameCount);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(const Offset(0, -dragAmountPerFrame));
-        await tester.pump();
-      }
+      // Drag an amount of pixels chosen experimentally from the bottom of the editor.
+      // The gesture starts with a small margin from the bottom, also chosen experimentally.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getRect(find.byType(SuperEditor)).bottomCenter - const Offset(0, 5),
+        dragAmount: const Offset(0, -200.0),
+        frameCount: 10,
+      );
 
       // Ensure we are overscrolling while holding the pointer down.
       await tester.pumpAndSettle();
@@ -642,7 +620,8 @@ void main() {
 
       // Release the pointer to end the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the end.
@@ -849,7 +828,6 @@ void main() {
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withInputSource(TextInputSource.ime)
             .withCustomWidgetTreeBuilder(
               (superEditor) => MaterialApp(
                 home: Scaffold(
@@ -872,24 +850,20 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        final editorRect = tester.getRect(find.byType(SuperEditor));
+        // Drag an amount of pixels chosen experimentally from the top of the editor.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getTopLeft(find.byType(SuperEditor)),
+          dragAmount: const Offset(0, 400.0),
+          frameCount: 10,
+        );
 
-        const dragFrameCount = 10;
-        final dragAmountPerFrame = editorRect.height / dragFrameCount;
-
-        // Drag from the top all the way up to the bottom of the editor.
-        final dragGesture = await tester.startGesture(editorRect.topCenter);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(Offset(0, dragAmountPerFrame));
-          await tester.pump();
-
-          // Ensure we don't scroll.
-          expect(scrollController.offset, 0);
-        }
+        // Ensure we don't scroll.
+        expect(scrollController.offset, 0);
 
         // End the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
       });
 
@@ -899,7 +873,6 @@ void main() {
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withInputSource(TextInputSource.ime)
             .withCustomWidgetTreeBuilder(
               (superEditor) => MaterialApp(
                 home: Scaffold(
@@ -922,25 +895,23 @@ void main() {
         // Jump to the bottom.
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-        final editorRect = tester.getRect(find.byType(SuperEditor));
+        // Drag an amount of pixels chosen experimentally from the bottom of the editor.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getBottomLeft(find.byType(CustomScrollView)) - const Offset(0, 10),
+          dragAmount: const Offset(0, -400.0),
+          frameCount: 10,
+        );
 
-        const dragFrameCount = 10;
-        final dragAmountPerFrame = editorRect.height / dragFrameCount;
+        // Ensure we don't scroll.
+        expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
-        // Drag from the bottom all the way up to the top of the editor.
-        final dragGesture = await tester.startGesture(editorRect.topCenter);
-        addTearDown(() => dragGesture.removePointer());
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
-          await tester.pump();
-
-          // Ensure we don't scroll.
-          expect(scrollController.offset, scrollController.position.maxScrollExtent);
-        }
+        // Ensure we don't scroll.
+        expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
         // End the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
       });
 
@@ -974,17 +945,13 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        // Start a drag gesture a few pixels below the top of the editor.
-        final dragGesture =
-            await tester.startGesture(tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5));
-
         // Drag an arbitrary amount, smaller than the editor size.
-        const dragFrameCount = 10;
-        const dragAmountPerFrame = (80 / dragFrameCount);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(const Offset(0, dragAmountPerFrame));
-          await tester.pump();
-        }
+        // Drag an amount of pixels chosen experimentally from the top of the editor.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5),
+          dragAmount: const Offset(0, 80.0),
+          frameCount: 10,
+        );
 
         // Ensure we are overscrolling while holding the pointer down.
         await tester.pumpAndSettle();
@@ -992,7 +959,8 @@ void main() {
 
         // Release the pointer to end the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the top.
@@ -1030,17 +998,13 @@ void main() {
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
         await tester.pumpAndSettle();
 
-        // Start a drag gesture a few pixels above the top of the editor.
-        final dragGesture =
-            await tester.startGesture(tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5));
-
         // Drag up an arbitrary amount, smaller than the editor size.
-        const dragFrameCount = 10;
-        const dragAmountPerFrame = (200 / dragFrameCount);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(const Offset(0, -dragAmountPerFrame));
-          await tester.pump();
-        }
+        // Drag an amount of pixels chosen experimentally from the bottom of the editor.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5),
+          dragAmount: const Offset(0, -100.0),
+          frameCount: 10,
+        );
 
         // Ensure we are overscrolling while holding the pointer down.
         await tester.pumpAndSettle();
@@ -1048,7 +1012,8 @@ void main() {
 
         // Release the pointer to end the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the end.

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -304,15 +304,8 @@ class TestSuperEditorConfigurator {
   /// Configures the [SuperEditor] to be displayed inside a [CustomScrollView].
   ///
   /// The [CustomScrollView] is constrained by the size provided in [withEditorSize].
-  TestSuperEditorConfigurator insideCustomScrollView() {
+  TestSuperEditorConfigurator insideCustomScrollView([ScrollController? scrollController]) {
     _config.insideCustomScrollView = true;
-    return this;
-  }
-
-  /// Configures the ancestor [CustomScrollView] to use the given [scrollController].
-  ///
-  /// The [CustomScrollView] must be added to the configuration by calling [insideCustomScrollView].
-  TestSuperEditorConfigurator withCustomScrollViewScrollController(ScrollController? scrollController) {
     _config.customScrollViewScrollController = scrollController;
     return this;
   }
@@ -417,17 +410,18 @@ class TestSuperEditorConfigurator {
 
   /// Places [child] inside a [CustomScrollView], based on configurations in this class.
   Widget _buildAncestorScrollable({required Widget child}) {
-    if (_config.insideCustomScrollView) {
-      return CustomScrollView(
-        controller: _config.customScrollViewScrollController,
-        slivers: [
-          SliverToBoxAdapter(
-            child: child,
-          ),
-        ],
-      );
+    if (!_config.insideCustomScrollView) {
+      return child;
     }
-    return child;
+
+    return CustomScrollView(
+      controller: _config.customScrollViewScrollController,
+      slivers: [
+        SliverToBoxAdapter(
+          child: child,
+        ),
+      ],
+    );
   }
 
   /// Builds a [SuperEditor] widget based on the configuration of the given
@@ -487,6 +481,8 @@ class SuperEditorTestConfiguration {
   List<ComponentBuilder>? componentBuilders;
   Stylesheet? stylesheet;
   ScrollController? scrollController;
+  bool insideCustomScrollView = false;
+  ScrollController? customScrollViewScrollController;
   DocumentGestureMode? gestureMode;
   TextInputSource? inputSource;
   SuperEditorSelectionPolicies? selectionPolicies;
@@ -507,9 +503,6 @@ class SuperEditorTestConfiguration {
   final plugins = <SuperEditorPlugin>{};
 
   WidgetTreeBuilder? widgetTreeBuilder;
-
-  bool insideCustomScrollView = false;
-  ScrollController? customScrollViewScrollController;
 }
 
 /// Must return a widget tree containing the given [superEditor]

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -302,6 +302,8 @@ class TestSuperEditorConfigurator {
   }
 
   /// Configures the [SuperEditor] to be displayed inside a [CustomScrollView].
+  ///
+  /// The [CustomScrollView] is constrained by the size provided in [withEditorSize].
   TestSuperEditorConfigurator insideCustomScrollView() {
     _config.insideCustomScrollView = true;
     return this;

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -301,6 +301,20 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  /// Configures the [SuperEditor] to be displayed inside a [CustomScrollView].
+  TestSuperEditorConfigurator insideCustomScrollView() {
+    _config.insideCustomScrollView = true;
+    return this;
+  }
+
+  /// Configures the ancestor [CustomScrollView] to use the given [scrollController].
+  ///
+  /// The [CustomScrollView] must be added to the configuration by calling [insideCustomScrollView].
+  TestSuperEditorConfigurator withCustomScrollViewScrollController(ScrollController? scrollController) {
+    _config.customScrollViewScrollController = scrollController;
+    return this;
+  }
+
   /// Pumps a [SuperEditor] widget tree with the desired configuration, and returns
   /// a [TestDocumentContext], which includes the artifacts connected to the widget
   /// tree, e.g., the [DocumentEditor], [DocumentComposer], etc.
@@ -333,7 +347,9 @@ class TestSuperEditorConfigurator {
   ConfiguredSuperEditorWidget _build([TestDocumentContext? testDocumentContext]) {
     final context = testDocumentContext ?? _createTestDocumentContext();
     final superEditor = _buildConstrainedContent(
-      _buildSuperEditor(context),
+      _buildAncestorScrollable(
+        child: _buildSuperEditor(context),
+      ),
     );
 
     return ConfiguredSuperEditorWidget(
@@ -395,6 +411,21 @@ class TestSuperEditorConfigurator {
       );
     }
     return superEditor;
+  }
+
+  /// Places [child] inside a [CustomScrollView], based on configurations in this class.
+  Widget _buildAncestorScrollable({required Widget child}) {
+    if (_config.insideCustomScrollView) {
+      return CustomScrollView(
+        controller: _config.customScrollViewScrollController,
+        slivers: [
+          SliverToBoxAdapter(
+            child: child,
+          ),
+        ],
+      );
+    }
+    return child;
   }
 
   /// Builds a [SuperEditor] widget based on the configuration of the given
@@ -474,6 +505,9 @@ class SuperEditorTestConfiguration {
   final plugins = <SuperEditorPlugin>{};
 
   WidgetTreeBuilder? widgetTreeBuilder;
+
+  bool insideCustomScrollView = false;
+  ScrollController? customScrollViewScrollController;
 }
 
 /// Must return a widget tree containing the given [superEditor]

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -304,9 +304,10 @@ class TestSuperEditorConfigurator {
   /// Configures the [SuperEditor] to be displayed inside a [CustomScrollView].
   ///
   /// The [CustomScrollView] is constrained by the size provided in [withEditorSize].
-  TestSuperEditorConfigurator insideCustomScrollView([ScrollController? scrollController]) {
+  ///
+  /// Use [withScrollController] to define the [ScrollController] of the [CustomScrollView].
+  TestSuperEditorConfigurator insideCustomScrollView() {
     _config.insideCustomScrollView = true;
-    _config.customScrollViewScrollController = scrollController;
     return this;
   }
 
@@ -415,7 +416,7 @@ class TestSuperEditorConfigurator {
     }
 
     return CustomScrollView(
-      controller: _config.customScrollViewScrollController,
+      controller: _config.scrollController,
       slivers: [
         SliverToBoxAdapter(
           child: child,
@@ -482,7 +483,6 @@ class SuperEditorTestConfiguration {
   Stylesheet? stylesheet;
   ScrollController? scrollController;
   bool insideCustomScrollView = false;
-  ScrollController? customScrollViewScrollController;
   DocumentGestureMode? gestureMode;
   TextInputSource? inputSource;
   SuperEditorSelectionPolicies? selectionPolicies;

--- a/super_editor/test/super_reader/reader_test_tools.dart
+++ b/super_editor/test/super_reader/reader_test_tools.dart
@@ -91,12 +91,11 @@ class TestDocumentConfigurator {
   List<ComponentBuilder>? _componentBuilders;
   WidgetTreeBuilder? _widgetTreeBuilder;
   ScrollController? _scrollController;
+  bool _insideCustomScrollView = false;
   FocusNode? _focusNode;
   DocumentSelection? _selection;
   WidgetBuilder? _androidToolbarBuilder;
   DocumentFloatingToolbarBuilder? _iOSToolbarBuilder;
-  bool _insideCustomScrollView = false;
-  ScrollController? _customScrollViewController;
 
   /// Configures the [SuperReader] for standard desktop interactions,
   /// e.g., mouse and keyboard input.
@@ -227,16 +226,10 @@ class TestDocumentConfigurator {
   /// Configures the [SuperReader] to be displayed inside a [CustomScrollView].
   ///
   /// The [CustomScrollView] is constrained by the size provided in [withEditorSize].
+  ///
+  /// Use [withScrollController] to define the [ScrollController] of the [CustomScrollView].
   TestDocumentConfigurator insideCustomScrollView() {
     _insideCustomScrollView = true;
-    return this;
-  }
-
-  /// Configures the ancestor [CustomScrollView] to use the given [scrollController].
-  ///
-  /// The [CustomScrollView] must be added to the configuration by calling [insideCustomScrollView].
-  TestDocumentConfigurator withCustomScrollViewScrollController(ScrollController? scrollController) {
-    _customScrollViewController = scrollController;
     return this;
   }
 
@@ -308,17 +301,18 @@ class TestDocumentConfigurator {
 
   /// Places [child] inside a [CustomScrollView], based on configurations in this class.
   Widget _buildAncestorScrollable({required Widget child}) {
-    if (_insideCustomScrollView) {
-      return CustomScrollView(
-        controller: _customScrollViewController,
-        slivers: [
-          SliverToBoxAdapter(
-            child: child,
-          ),
-        ],
-      );
+    if (!_insideCustomScrollView) {
+      return child;
     }
-    return child;
+
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        SliverToBoxAdapter(
+          child: child,
+        ),
+      ],
+    );
   }
 
   Widget _buildWidgetTree(Widget superReader) {

--- a/super_editor/test/super_reader/reader_test_tools.dart
+++ b/super_editor/test/super_reader/reader_test_tools.dart
@@ -225,6 +225,8 @@ class TestDocumentConfigurator {
   }
 
   /// Configures the [SuperReader] to be displayed inside a [CustomScrollView].
+  ///
+  /// The [CustomScrollView] is constrained by the size provided in [withEditorSize].
   TestDocumentConfigurator insideCustomScrollView() {
     _insideCustomScrollView = true;
     return this;

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -245,7 +245,7 @@ void main() {
       // End the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
     });
 
@@ -273,7 +273,7 @@ void main() {
       // End the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
     });
 
@@ -302,7 +302,7 @@ void main() {
       // Release the pointer to end the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the top.
@@ -336,7 +336,7 @@ void main() {
       // Release the pointer to end the gesture.
       await dragGesture.up();
 
-      // Let any pending timers resolve.
+      // Wait for the long-press timer to resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the end.
@@ -588,7 +588,7 @@ void main() {
         // End the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
       });
 
@@ -632,7 +632,7 @@ void main() {
         // End the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
       });
 
@@ -679,7 +679,7 @@ void main() {
         // Release the pointer to end the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the top.
@@ -730,7 +730,7 @@ void main() {
         // Release the pointer to end the gesture.
         await dragGesture.up();
 
-        // Let any pending timers resolve.
+        // Wait for the long-press timer to resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the end.

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -445,23 +445,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -500,23 +486,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -554,23 +526,8 @@ void main() {
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -595,26 +552,14 @@ void main() {
       testWidgetsOnAndroid("doesn't overscroll when dragging up", (tester) async {
         final scrollController = ScrollController();
 
+        // Pump a reader inside a CustomScrollView without enough room to display
+        // the whole content.
         await tester
             .createDocument()
             .withSingleParagraph()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.
@@ -639,28 +584,11 @@ void main() {
       testWidgetsOnIos('overscrolls when dragging down', (tester) async {
         final scrollController = ScrollController();
 
-        // Pump a reader inside a CustomScrollView without enough room to display
-        // the whole content.
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -694,23 +622,9 @@ void main() {
         await tester
             .createDocument() //
             .withLongTextContent()
-            .withCustomWidgetTreeBuilder(
-              (superReader) => MaterialApp(
-                home: Scaffold(
-                  body: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: CustomScrollView(
-                      controller: scrollController,
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: superReader,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            )
+            .withEditorSize(const Size(200, 200))
+            .insideCustomScrollView()
+            .withCustomScrollViewScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_reader_test.dart';
 
+import '../test_tools.dart';
 import 'reader_test_tools.dart';
 import 'test_documents.dart';
 
@@ -223,95 +224,79 @@ void main() {
     testWidgetsOnAndroid("doesn't overscroll when dragging down", (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
-      // Ensure the scrollview didn't start scrolled.
+      // Ensure the reader didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      final editorRect = tester.getRect(find.byType(SuperReader));
+      // Drag an amount of pixels chosen experimentally from the top of the reader.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getTopLeft(find.byType(SuperReader)),
+        dragAmount: const Offset(0, 200.0),
+        frameCount: 10,
+      );
 
-      const dragFrameCount = 10;
-      final dragAmountPerFrame = editorRect.height / dragFrameCount;
-
-      // Drag from the top all the way up to the bottom of the editor.
-      final dragGesture = await tester.startGesture(editorRect.topCenter);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(Offset(0, dragAmountPerFrame));
-        await tester.pump();
-
-        // Ensure we don't scroll.
-        expect(scrollController.offset, 0);
-      }
+      // Ensure we don't scroll.
+      expect(scrollController.offset, 0);
 
       // End the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
     });
 
     testWidgetsOnAndroid("doesn't overscroll when dragging up", (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
       // Jump to the bottom.
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-      final readerRect = tester.getRect(find.byType(SuperReader));
+      // Drag an amount of pixels chosen experimentally from the bottom of the reader.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getBottomLeft(find.byType(SuperReader)) - const Offset(0, 5),
+        dragAmount: const Offset(0, -200.0),
+        frameCount: 10,
+      );
 
-      const dragFrameCount = 10;
-      final dragAmountPerFrame = readerRect.height / dragFrameCount;
-
-      // Drag from the bottom all the way up to the top of the reader.
-      final dragGesture = await tester.startGesture(readerRect.topCenter);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
-        await tester.pump();
-
-        // Ensure we don't scroll.
-        expect(scrollController.offset, scrollController.position.maxScrollExtent);
-      }
+      // Ensure we don't scroll.
+      expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
       // End the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
     });
 
     testWidgetsOnIos('overscrolls when dragging down', (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
       // Ensure the scrollview didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Start a drag gesture a few pixels below the top of the reader.
-      final dragGesture =
-          await tester.startGesture(tester.getRect(find.byType(SuperReader)).topCenter + const Offset(0, 5));
-
-      // Drag an arbitrary amount, smaller than the reader size.
-      const dragFrameCount = 10;
-      const dragAmountPerFrame = (80 / dragFrameCount);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(const Offset(0, dragAmountPerFrame));
-        await tester.pump();
-      }
+      // Drag an amount of pixels chosen experimentally a few pixels below the top of the reader.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getRect(find.byType(SuperReader)).topCenter + const Offset(0, 5),
+        dragAmount: const Offset(0, 80.0),
+        frameCount: 10,
+      );
 
       // Ensure we are overscrolling while holding the pointer down.
       await tester.pumpAndSettle();
@@ -319,7 +304,8 @@ void main() {
 
       // Release the pointer to end the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the top.
@@ -329,10 +315,9 @@ void main() {
     testWidgetsOnIos('overscrolls when dragging up', (tester) async {
       final scrollController = ScrollController();
 
-      await tester
+      await tester //
           .createDocument()
           .withSingleParagraph()
-          .withEditorSize(const Size(300, 300))
           .withScrollController(scrollController)
           .pump();
 
@@ -340,17 +325,13 @@ void main() {
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
       await tester.pumpAndSettle();
 
-      // Start a drag gesture a few pixels above the top of the reader.
-      final dragGesture =
-          await tester.startGesture(tester.getRect(find.byType(SuperReader)).bottomCenter - const Offset(0, 5));
-
-      // Drag up an arbitrary amount, smaller than the reader size.
-      const dragFrameCount = 10;
-      const dragAmountPerFrame = (200 / dragFrameCount);
-      for (int i = 0; i < dragFrameCount; i += 1) {
-        await dragGesture.moveBy(const Offset(0, -dragAmountPerFrame));
-        await tester.pump();
-      }
+      // Drag an amount of pixels chosen experimentally from the bottom of the reader.
+      // The gesture starts with a small margin from the bottom, also chosen experimentally.
+      final dragGesture = await tester.dragInMultipleFrames(
+        startLocation: tester.getRect(find.byType(SuperReader)).bottomCenter - const Offset(0, 5),
+        dragAmount: const Offset(0, -200.0),
+        frameCount: 10,
+      );
 
       // Ensure we are overscrolling while holding the pointer down.
       await tester.pumpAndSettle();
@@ -358,7 +339,8 @@ void main() {
 
       // Release the pointer to end the gesture.
       await dragGesture.up();
-      await dragGesture.removePointer();
+
+      // Let any pending timers resolve.
       await tester.pumpAndSettle();
 
       // Ensure the we scrolled back to the end.
@@ -598,24 +580,20 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        final readerRect = tester.getRect(find.byType(SuperReader));
+        // Drag an amount of pixels chosen experimentally from the top of the reader.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getRect(find.byType(SuperReader)).topCenter,
+          dragAmount: const Offset(0, 400.0),
+          frameCount: 10,
+        );
 
-        const dragFrameCount = 10;
-        final dragAmountPerFrame = readerRect.height / dragFrameCount;
-
-        // Drag from the top all the way up to the bottom of the reader.
-        final dragGesture = await tester.startGesture(readerRect.topCenter);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(Offset(0, dragAmountPerFrame));
-          await tester.pump();
-
-          // Ensure we don't scroll.
-          expect(scrollController.offset, 0);
-        }
+        // Ensure we don't scroll.
+        expect(scrollController.offset, 0);
 
         // End the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
       });
 
@@ -647,25 +625,20 @@ void main() {
         // Jump to the bottom.
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-        final readerRect = tester.getRect(find.byType(SuperReader));
+        // Drag an amount of pixels chosen experimentally from the bottom of the reader.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getBottomLeft(find.byType(CustomScrollView)) - const Offset(0, 5),
+          dragAmount: const Offset(0, -400.0),
+          frameCount: 10,
+        );
 
-        const dragFrameCount = 10;
-        final dragAmountPerFrame = readerRect.height / dragFrameCount;
-
-        // Drag from the bottom all the way up to the top of the reader.
-        final dragGesture = await tester.startGesture(readerRect.topCenter);
-        addTearDown(() => dragGesture.removePointer());
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(Offset(0, -dragAmountPerFrame));
-          await tester.pump();
-
-          // Ensure we don't scroll.
-          expect(scrollController.offset, scrollController.position.maxScrollExtent);
-        }
+        // Ensure we don't scroll.
+        expect(scrollController.offset, scrollController.position.maxScrollExtent);
 
         // End the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
       });
 
@@ -699,17 +672,13 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        // Start a drag gesture a few pixels below the top of the reader.
-        final dragGesture =
-            await tester.startGesture(tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5));
-
         // Drag an arbitrary amount, smaller than the reader size.
-        const dragFrameCount = 10;
-        const dragAmountPerFrame = (80 / dragFrameCount);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(const Offset(0, dragAmountPerFrame));
-          await tester.pump();
-        }
+        // Drag an amount of pixels chosen experimentally from the top of the reader.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5),
+          dragAmount: const Offset(0, 80.0),
+          frameCount: 10,
+        );
 
         // Ensure we are overscrolling while holding the pointer down.
         await tester.pumpAndSettle();
@@ -717,7 +686,8 @@ void main() {
 
         // Release the pointer to end the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the top.
@@ -755,17 +725,13 @@ void main() {
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
         await tester.pumpAndSettle();
 
-        // Start a drag gesture a few pixels above the top of the reader.
-        final dragGesture =
-            await tester.startGesture(tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5));
-
         // Drag up an arbitrary amount, smaller than the reader size.
-        const dragFrameCount = 10;
-        const dragAmountPerFrame = (200 / dragFrameCount);
-        for (int i = 0; i < dragFrameCount; i += 1) {
-          await dragGesture.moveBy(const Offset(0, -dragAmountPerFrame));
-          await tester.pump();
-        }
+        // Drag an amount of pixels chosen experimentally from the top of the reader.
+        final dragGesture = await tester.dragInMultipleFrames(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5),
+          dragAmount: const Offset(0, -100.0),
+          frameCount: 10,
+        );
 
         // Ensure we are overscrolling while holding the pointer down.
         await tester.pumpAndSettle();
@@ -773,7 +739,8 @@ void main() {
 
         // Release the pointer to end the gesture.
         await dragGesture.up();
-        await dragGesture.removePointer();
+
+        // Let any pending timers resolve.
         await tester.pumpAndSettle();
 
         // Ensure the we scrolled back to the end.

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -233,11 +233,10 @@ void main() {
       // Ensure the reader didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Drag an amount of pixels chosen experimentally from the top of the reader.
-      final dragGesture = await tester.dragInMultipleFrames(
-        startLocation: tester.getTopLeft(find.byType(SuperReader)),
-        dragAmount: const Offset(0, 200.0),
-        frameCount: 10,
+      // Drag an arbitrary amount of pixels from the top of the reader.
+      final dragGesture = await tester.dragByFrameCount(
+        startLocation: tester.getRect(find.byType(SuperReader)).topCenter + const Offset(0, 5),
+        totalDragOffset: const Offset(0, 200.0),
       );
 
       // Ensure we don't scroll.
@@ -262,11 +261,10 @@ void main() {
       // Jump to the bottom.
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-      // Drag an amount of pixels chosen experimentally from the bottom of the reader.
-      final dragGesture = await tester.dragInMultipleFrames(
-        startLocation: tester.getBottomLeft(find.byType(SuperReader)) - const Offset(0, 5),
-        dragAmount: const Offset(0, -200.0),
-        frameCount: 10,
+      // Drag an arbitrary amount of pixels from the bottom of the reader.
+      final dragGesture = await tester.dragByFrameCount(
+        startLocation: tester.getRect(find.byType(SuperReader)).bottomCenter - const Offset(0, 5),
+        totalDragOffset: const Offset(0, -200.0),
       );
 
       // Ensure we don't scroll.
@@ -291,11 +289,10 @@ void main() {
       // Ensure the scrollview didn't start scrolled.
       expect(scrollController.offset, 0);
 
-      // Drag an amount of pixels chosen experimentally a few pixels below the top of the reader.
-      final dragGesture = await tester.dragInMultipleFrames(
+      // Drag an arbitrary amount of pixels a few pixels below the top of the reader.
+      final dragGesture = await tester.dragByFrameCount(
         startLocation: tester.getRect(find.byType(SuperReader)).topCenter + const Offset(0, 5),
-        dragAmount: const Offset(0, 80.0),
-        frameCount: 10,
+        totalDragOffset: const Offset(0, 80.0),
       );
 
       // Ensure we are overscrolling while holding the pointer down.
@@ -325,12 +322,11 @@ void main() {
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
       await tester.pumpAndSettle();
 
-      // Drag an amount of pixels chosen experimentally from the bottom of the reader.
-      // The gesture starts with a small margin from the bottom, also chosen experimentally.
-      final dragGesture = await tester.dragInMultipleFrames(
+      // Drag an arbitrary amount of pixels from the bottom of the reader.
+      // The gesture starts with an arbitrary margin from the bottom.
+      final dragGesture = await tester.dragByFrameCount(
         startLocation: tester.getRect(find.byType(SuperReader)).bottomCenter - const Offset(0, 5),
-        dragAmount: const Offset(0, -200.0),
-        frameCount: 10,
+        totalDragOffset: const Offset(0, -200.0),
       );
 
       // Ensure we are overscrolling while holding the pointer down.
@@ -580,11 +576,10 @@ void main() {
         // Ensure the scrollview didn't start scrolled.
         expect(scrollController.offset, 0);
 
-        // Drag an amount of pixels chosen experimentally from the top of the reader.
-        final dragGesture = await tester.dragInMultipleFrames(
-          startLocation: tester.getRect(find.byType(SuperReader)).topCenter,
-          dragAmount: const Offset(0, 400.0),
-          frameCount: 10,
+        // Drag an arbitrary amount of pixels from the top of the reader.
+        final dragGesture = await tester.dragByFrameCount(
+          startLocation: tester.getRect(find.byType(SuperReader)).topCenter + const Offset(0, 5),
+          totalDragOffset: const Offset(0, 400.0),
         );
 
         // Ensure we don't scroll.
@@ -625,11 +620,10 @@ void main() {
         // Jump to the bottom.
         scrollController.jumpTo(scrollController.position.maxScrollExtent);
 
-        // Drag an amount of pixels chosen experimentally from the bottom of the reader.
-        final dragGesture = await tester.dragInMultipleFrames(
-          startLocation: tester.getBottomLeft(find.byType(CustomScrollView)) - const Offset(0, 5),
-          dragAmount: const Offset(0, -400.0),
-          frameCount: 10,
+        // Drag an arbitrary amount of pixels from the bottom of the reader.
+        final dragGesture = await tester.dragByFrameCount(
+          startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5),
+          totalDragOffset: const Offset(0, -400.0),
         );
 
         // Ensure we don't scroll.
@@ -673,11 +667,9 @@ void main() {
         expect(scrollController.offset, 0);
 
         // Drag an arbitrary amount, smaller than the reader size.
-        // Drag an amount of pixels chosen experimentally from the top of the reader.
-        final dragGesture = await tester.dragInMultipleFrames(
+        final dragGesture = await tester.dragByFrameCount(
           startLocation: tester.getRect(find.byType(CustomScrollView)).topCenter + const Offset(0, 5),
-          dragAmount: const Offset(0, 80.0),
-          frameCount: 10,
+          totalDragOffset: const Offset(0, 80.0),
         );
 
         // Ensure we are overscrolling while holding the pointer down.
@@ -726,11 +718,9 @@ void main() {
         await tester.pumpAndSettle();
 
         // Drag up an arbitrary amount, smaller than the reader size.
-        // Drag an amount of pixels chosen experimentally from the top of the reader.
-        final dragGesture = await tester.dragInMultipleFrames(
+        final dragGesture = await tester.dragByFrameCount(
           startLocation: tester.getRect(find.byType(CustomScrollView)).bottomCenter - const Offset(0, 5),
-          dragAmount: const Offset(0, -100.0),
-          frameCount: 10,
+          totalDragOffset: const Offset(0, -100.0),
         );
 
         // Ensure we are overscrolling while holding the pointer down.

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -447,7 +447,7 @@ void main() {
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -488,7 +488,7 @@ void main() {
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -527,7 +527,7 @@ void main() {
             .createDocument()
             .withSingleParagraph()
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -559,7 +559,7 @@ void main() {
             .withSingleParagraph()
             .withEditorSize(const Size(200, 200))
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.
@@ -588,7 +588,7 @@ void main() {
             .createDocument() //
             .withLongTextContent()
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Ensure the scrollview didn't start scrolled.
@@ -624,7 +624,7 @@ void main() {
             .withLongTextContent()
             .withEditorSize(const Size(200, 200))
             .insideCustomScrollView()
-            .withCustomScrollViewScrollController(scrollController)
+            .withScrollController(scrollController)
             .pump();
 
         // Jump to the bottom.

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -19,17 +19,23 @@ class TestUrlLauncher implements UrlLauncher {
 
 /// Extension on [WidgetTester] to make it easier to perform drag gestures.
 extension DragExtensions on WidgetTester {
-  /// Drags from the [startLocation] by [dragAmount] in multiple frames.
+  /// Simulates a user drag from [startLocation] to `startLocation + totalDragOffset`.
   ///
-  /// The [dragAmount] is distributed evenly between [frameCount] frames.
+  /// Starts a gesture at [startLocation] and repeatedly drags the gesture
+  /// across [frameCount] frames, pumping a frame between each drag.
+  /// The gesture moves a distance each frame that's calculated as
+  /// `totalDragOffset / frameCount`.
   ///
-  /// The caller must end the gesture by calling [TestGesture.up].
-  Future<TestGesture> dragInMultipleFrames({
+  /// This method does not call `pumpAndSettle()`, so that the client can inspect
+  /// the app state immediately after the drag completes.
+  ///
+  /// The client must call [TestGesture.up] on the returned [TestGesture].
+  Future<TestGesture> dragByFrameCount({
     required Offset startLocation,
-    required Offset dragAmount,
-    required int frameCount,
+    required Offset totalDragOffset,
+    int frameCount = 10,
   }) async {
-    final dragPerFrame = Offset(dragAmount.dx / frameCount, dragAmount.dy / frameCount);
+    final dragPerFrame = Offset(totalDragOffset.dx / frameCount, totalDragOffset.dy / frameCount);
 
     final dragGesture = await startGesture(startLocation);
     for (int i = 0; i < frameCount; i += 1) {

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -16,3 +16,27 @@ class TestUrlLauncher implements UrlLauncher {
     return true;
   }
 }
+
+/// Extension on [WidgetTester] to make it easier to perform drag gestures.
+extension DragExtensions on WidgetTester {
+  /// Drags from the [startLocation] by [dragAmount] in multiple frames.
+  ///
+  /// The [dragAmount] is distributed evenly between [frameCount] frames.
+  ///
+  /// The caller must end the gesture by calling [TestGesture.up].
+  Future<TestGesture> dragInMultipleFrames({
+    required Offset startLocation,
+    required Offset dragAmount,
+    required int frameCount,
+  }) async {
+    final dragPerFrame = Offset(dragAmount.dx / frameCount, dragAmount.dy / frameCount);
+
+    final dragGesture = await startGesture(startLocation);
+    for (int i = 0; i < frameCount; i += 1) {
+      await dragGesture.moveBy(dragPerFrame);
+      await pump();
+    }
+
+    return dragGesture;
+  }
+}


### PR DESCRIPTION
[SuperEditor][SuperReader][Android] Fix scroll physics. Resolves #1539

On Android, we are noticing underscroll/overscroll with the editor being pinned at the position where the drag ended:

https://github.com/superlistapp/super_editor/assets/6467808/1f16b98d-4c38-4c32-9d30-108f664220a3

Android uses `ClampingScrollPhysics`, so it shouldn't even allow for underscroll/overscroll. It seems that the way we handle scrolling doesn't honor the scroll physics correctly. 

I replaced the call to `jumpTo` with a call to `pointerScroll` and the issue seems to be solved: 

[android.webm](https://github.com/superlistapp/super_editor/assets/7597082/57b339f5-a84c-466d-bcdd-bd013e58c94a)

The difference between `jumpTo` and `pointerScroll` is that `pointerScroll` calls `forcePixels` clamping the jump offset between `minScrollExtent` and `maxScrollExtent`, whereas `jumpTo` calls it with the given jump offset.  `jumpTo`  also updates the `userScrollDirection`.

I'm not sure that using `pointerScroll` is the right way for us to handle scrolling. I also tried using `ScrollPosition.drag` at `onPanStart` and then `Drag.update` at `onPanUpdate`, but doing so caused the following exception:

```console
════════ Exception caught by gesture ═══════════════════════════════════════════
The following assertion was thrown while handling a gesture:
'package:flutter/src/widgets/scroll_activity.dart': Failed assertion: line 370 pos 12: 'details.primaryDelta != null': is not true.
scroll_activity.dart:370

When the exception was thrown, this was the stack
#2      ScrollDragController.update scroll_activity.dart:370
#3      _AndroidDocumentTouchInteractorState._onPanUpdate document_gestures_touch_android.dart:785
#4      DragGestureRecognizer._checkUpdate.<anonymous closure> monodrag.dart:548
```
 
I'm open to other ideas to fix this issue.