### PR TITLE
Add dependency_overrides snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 <p align="center">Super Editor was initiated by <a href="https://superlist.com">Superlist</a> and is implemented and maintained by the <a href="https://flutterbountyhunters.com">Flutter Bounty Hunters</a>, Superlist, and the contributors.</p>
 
-
-
 <hr>
 
 <p align="center">Do you use Flutter's <b>stable</b> branch? Be sure to checkout <code>super_editor</code>'s <b><a href="https://github.com/superlistapp/super_editor/commits/stable">stable</a></b> branch, for compatibility.<br>Do you use Flutter's <b>master</b> branch? Be sure to checkout <code>super_editor</code>'s <b><a href="https://github.com/superlistapp/super_editor/commits/main">main</a></b> branch, for compabitility.</p>
@@ -19,9 +17,9 @@
 
 <h2 align="center">Super Editor & Super Text Field</h2>
 
-Please see the [SuperEditor README](super_editor/README.md) about how to use the packages, or run the [sample editor](super_editor/example/README.md). 
+Please see the [SuperEditor README](super_editor/README.md) about how to use the packages, or run the [sample editor](super_editor/example/README.md).
 
-A web demo is accessible at [https://superlist.com/SuperEditor](https://superlist.com/SuperEditor/). 
+A web demo is accessible at [https://superlist.com/SuperEditor](https://superlist.com/SuperEditor/).
 
 <hr>
 
@@ -34,3 +32,30 @@ You might notice that this is a mono-repo, which includes multiple projects. Tha
   <a href="attributed_text/README.md"><img src="https://user-images.githubusercontent.com/7259036/170845473-268655ac-3fec-47c1-86ab-41a1391aa1e0.png" width="300" alt="Attributed Text"></a>
 </p>
 
+<h2 align="center">Releases</h2>
+Sometimes we make changes to multiple packages before cutting new releases. If you see compilation errors
+while using the pub.dev version, please consider overriding the dependencies in your pubspec.yaml:
+
+```yaml
+dependency_overrides:
+  super_editor:
+    git:
+      url: https://github.com/superlistapp/super_editor
+      path: super_editor
+      ref: stable
+  super_editor_markdown:
+    git:
+      url: https://github.com/superlistapp/super_editor
+      path: super_editor_markdown
+      ref: stable
+  super_text_layout:
+    git:
+      url: https://github.com/superlistapp/super_editor
+      path: super_text_layout
+      ref: stable
+  attributed_text:
+    git:
+      url: https://github.com/superlistapp/super_editor
+      path: attributed_text
+      ref: stable
+```

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ You might notice that this is a mono-repo, which includes multiple projects. Tha
   <a href="attributed_text/README.md"><img src="https://user-images.githubusercontent.com/7259036/170845473-268655ac-3fec-47c1-86ab-41a1391aa1e0.png" width="300" alt="Attributed Text"></a>
 </p>
 
-<h2 align="center">Releases</h2>
-Sometimes we make changes to multiple packages before cutting new releases. If you see compilation errors
-while using the pub.dev version, please consider overriding the dependencies in your pubspec.yaml:
+<h2 align="center">Mono-repo Versioning</h2>
+If you have compilation errors when using the GitHub version of super_editor, try overriding dependencies for the other packages in this mono-repo, e.g., super_editor_markdown, super_text_layout, and attributed_text. This project often makes changes to multiple packages within the mono-repo, which requires that you use the latest main or stable version of every package.
+
+You can override your dependencies as follows:
 
 ```yaml
 dependency_overrides:
@@ -42,7 +43,7 @@ dependency_overrides:
     git:
       url: https://github.com/superlistapp/super_editor
       path: super_editor
-      ref: stable
+      ref: stable # or "main"
   super_editor_markdown:
     git:
       url: https://github.com/superlistapp/super_editor


### PR DESCRIPTION
Add dependency_overrides snippet

Sometimes we make changes breaking changes in packages like super_text_layout or attributed_text. When it happens, depending on super_editor from pub causes compilation errors.

This PR adds a snippet to the README explaining how to fix the compilation errors by overriding the dependencies.