### PR TITLE
Fix Linux golden test dirty paint failures by upgrading follow_the_leader (Resolves #1490)

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
     git:
       url: https://github.com/superlistapp/super_editor.git
       path: super_text_layout
-  follow_the_leader: ^0.0.4+5
+  follow_the_leader: ^0.0.4+6
   overlord: ^0.0.3+4
 
 dependency_overrides:

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   attributed_text: ^0.2.2
   characters: ^1.2.0
   collection: ^1.15.0
-  follow_the_leader: ^0.0.4+3
+  follow_the_leader: ^0.0.4+6
   http: ">=0.13.1 <2.0.0"
   linkify: ^5.0.0
   logging: ^1.0.1


### PR DESCRIPTION
Fix Linux golden test dirty paint failures by upgrading follow_the_leader (Resolves #1490)

Tests are still failing, but these are legitimate failures related to mobile handles, toolbar, etc. They'll be fixed in other work coming up immediately.