### PR TITLE
Fix: Caret not blinking on iOS after dragging to scroll (Resolves #1549)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -580,7 +580,9 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     // Stop waiting for a long-press to start.
     _globalTapDownOffset = null;
     _tapDownLongPressTimer?.cancel();
-    _controlsController!.hideMagnifier();
+    _controlsController!
+      ..hideMagnifier()
+      ..blinkCaret();
 
     if (_wasScrollingOnTapDown) {
       // The scrollable was scrolling when the user touched down. We expect that the
@@ -588,8 +590,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       // action on this touch event. The user will tap again to change the selection.
       return;
     }
-
-    _controlsController!.blinkCaret();
 
     final selection = widget.selection.value;
     if (selection != null &&
@@ -986,7 +986,9 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _onPanEnd(DragEndDetails details) {
     _magnifierOffset.value = null;
-    _controlsController!.hideMagnifier();
+    _controlsController!
+      ..hideMagnifier()
+      ..blinkCaret();
 
     if (_dragMode == null) {
       // User was dragging the scroll area. Go ballistic.
@@ -1021,7 +1023,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       _onHandleDragEnd();
     }
 
-    _controlsController!.blinkCaret();
     _handleAutoScrolling.stopAutoScrollHandleMonitoring();
     scrollPosition.removeListener(_onAutoScrollChange);
   }


### PR DESCRIPTION
Fix: Caret not blinking on iOS after dragging to scroll (Resolves #1549)

The root cause was that we were disabling blinking on touch down, and on pan start, but we weren't re-enabling blinking on pan end in the case that the user was scrolling.

There wasn't any great way to add tests for this fix because we purposefully prevent caret blinking during tests so that `pumpAndSettle()` doesn't throw an exception.