### PR TITLE
Fix: iOS and magnifier not appearing when expected (Resolves #1550)

### DIFF
--- a/super_editor/example/lib/main_super_editor.dart
+++ b/super_editor/example/lib/main_super_editor.dart
@@ -1,3 +1,4 @@
+import 'package:example/demos/example_editor/_example_document.dart';
 import 'package:example/demos/example_editor/example_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -45,4 +46,53 @@ void main() {
       debugShowCheckedModeBanner: false,
     ),
   );
+}
+
+class _StandardEditor extends StatefulWidget {
+  const _StandardEditor();
+
+  @override
+  State<_StandardEditor> createState() => _StandardEditorState();
+}
+
+class _StandardEditorState extends State<_StandardEditor> {
+  final GlobalKey _docLayoutKey = GlobalKey();
+
+  late MutableDocument _doc;
+  late MutableDocumentComposer _composer;
+  late Editor _docEditor;
+
+  late FocusNode _editorFocusNode;
+
+  late ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _doc = createInitialDocument();
+    _composer = MutableDocumentComposer();
+    _docEditor = createDefaultDocumentEditor(document: _doc, composer: _composer);
+    _editorFocusNode = FocusNode();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    _editorFocusNode.dispose();
+    _composer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditor(
+      editor: _docEditor,
+      document: _doc,
+      composer: _composer,
+      focusNode: _editorFocusNode,
+      scrollController: _scrollController,
+      documentLayoutKey: _docLayoutKey,
+    );
+  }
 }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -830,9 +830,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       return;
     }
 
-    _controlsController!.doNotBlinkCaret();
-    _controlsController!.hideToolbar();
-    _controlsController!.showToolbar();
+    _controlsController!
+      ..doNotBlinkCaret()
+      ..hideToolbar()
+      ..showMagnifier();
 
     _globalStartDragOffset = details.globalPosition;
     final interactorBox = context.findRenderObject() as RenderBox;

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/super_editor_test.dart';
 
 import '../../test_runners.dart';
@@ -7,9 +9,93 @@ import '../supereditor_test_tools.dart';
 
 void main() {
   group("SuperEditor > iOS > overlay controls >", () {
+    testWidgetsOnIos("hides all controls when placing the caret", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret.
+      await tester.tapInParagraph("1", 200);
+
+      // Ensure all controls are hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("shows magnifier when dragging the caret", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret.
+      await tester.tapInParagraph("1", 200);
+
+      // Press and drag the caret somewhere else in the paragraph.
+      final gesture = await tester.tapDownInParagraph("1", 200);
+      for (int i = 0; i < 5; i += 1) {
+        await gesture.moveBy(const Offset(24, 0));
+        await tester.pump();
+      }
+
+      // Ensure magnifier is visible and toolbar is hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Resolve the gesture so that we don't have pending gesture timers.
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 100));
+    });
+
+    testWidgetsOnIos("shows toolbar when selection is expanded", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Select a word.
+      await tester.doubleTapInParagraph("1", 200);
+
+      // Ensure toolbar is visible and magnifier is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("hides toolbar when tapping on expanded selection", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Select a word.
+      await tester.doubleTapInParagraph("1", 200);
+
+      // Ensure toolbar is visible and magnifier is hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+
+      // Tap on the selected text.
+      await tester.tapInParagraph("1", 200);
+
+      // Ensure that all controls are now hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("shows magnifier when dragging expanded handle", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Select a word.
+      await tester.doubleTapInParagraph("1", 250);
+
+      // Press and drag upstream handle
+      final gesture = await tester.pressDownOnUpstreamMobileHandle();
+      for (int i = 0; i < 5; i += 1) {
+        await gesture.moveBy(const Offset(-24, 0));
+        await tester.pump();
+      }
+
+      // Ensure that the magnifier is visible.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Resolve the gesture so that we don't have pending gesture timers.
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 100));
+    });
+
     group("on device and web > shows ", () {
       testWidgetsOnIosDeviceAndWeb("caret", (tester) async {
-        await _pumpApp(tester);
+        await _pumpSingleParagraphApp(tester);
 
         // Create a collapsed selection.
         await tester.tapInParagraph("1", 1);
@@ -24,7 +110,7 @@ void main() {
       });
 
       testWidgetsOnIosDeviceAndWeb("upstream and downstream handles", (tester) async {
-        await _pumpApp(tester);
+        await _pumpSingleParagraphApp(tester);
 
         // Create an expanded selection.
         await tester.doubleTapInParagraph("1", 1);
@@ -43,7 +129,7 @@ void main() {
     group("on device >", () {
       group("shows", () {
         testWidgetsOnIos("the magnifier", (tester) async {
-          await _pumpApp(tester);
+          await _pumpSingleParagraphApp(tester);
 
           // Long press, and hold, so that the magnifier appears.
           await tester.longPressDownInParagraph("1", 1);
@@ -54,7 +140,7 @@ void main() {
         });
 
         testWidgetsOnIos("the floating toolbar", (tester) async {
-          await _pumpApp(tester);
+          await _pumpSingleParagraphApp(tester);
 
           // Create an expanded selection.
           await tester.doubleTapInParagraph("1", 1);
@@ -73,7 +159,7 @@ void main() {
     group("on web >", () {
       group("defers to browser to show", () {
         testWidgetsOnWebIos("the magnifier", (tester) async {
-          await _pumpApp(tester);
+          await _pumpSingleParagraphApp(tester);
 
           // Long press, and hold, so that the magnifier appears.
           await tester.longPressDownInParagraph("1", 1);
@@ -84,7 +170,7 @@ void main() {
         });
 
         testWidgetsOnWebIos("the floating toolbar", (tester) async {
-          await _pumpApp(tester);
+          await _pumpSingleParagraphApp(tester);
 
           // Create an expanded selection.
           await tester.doubleTapInParagraph("1", 1);
@@ -102,7 +188,7 @@ void main() {
   });
 }
 
-Future<void> _pumpApp(WidgetTester tester) async {
+Future<void> _pumpSingleParagraphApp(WidgetTester tester) async {
   await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...


### PR DESCRIPTION
Fix: iOS and magnifier not appearing when expected (Resolves #1550)

There were a couple places where we weren't triggering the hiding and showing of the iOS floating toolbar and magnifier appropriately. This PR fixes that.

This PR also adds tests for their appearance under various conditions.

This PR also adds a barebones `SuperEditor` demo so that we can verify default `SuperEditor` behavior in addition to the customized behavior in the Example app.