### PR TITLE
Use the right platform test runner for golden selection tests (Resolves #1561)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -831,7 +831,11 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 ///   );
 /// }
 /// ```
-typedef DocumentFloatingToolbarBuilder = Widget Function(BuildContext, Key mobileToolbarKey, LeaderLink focalPoint);
+typedef DocumentFloatingToolbarBuilder = Widget Function(
+  BuildContext context,
+  Key mobileToolbarKey,
+  LeaderLink focalPoint,
+);
 
 /// Builds a full-screen magnifier display, with the magnifier following the given [focalPoint],
 /// and with the magnifier attached to the given [magnifierKey].


### PR DESCRIPTION
Use the right platform test runner for golden selection tests (Resolves #1561)

Our golden tests for text selection allowed for platform customization, but that platform selection wasn't being honored by the choice of test runner. The tests were always running on Android. This PR selects different test runners based on the desired gesture mode.