### PR TITLE
Fixed tap to show toolbar on iOS when tapping on caret a second time (Resolves #1567)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -626,7 +626,9 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     }
 
     if (docPosition != null) {
-      final didTapOnExistingSelection = selection != null && selection.isCollapsed && selection.extent == docPosition;
+      final didTapOnExistingSelection = selection != null &&
+          selection.isCollapsed &&
+          selection.extent.nodePosition.isEquivalentTo(docPosition.nodePosition);
 
       if (didTapOnExistingSelection) {
         // Toggle the toolbar display when the user taps on the collapsed caret,

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -441,6 +441,7 @@ class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<I
       // The selection didn't change from what it was the last time we calculated selection bounds.
       return;
     }
+    _selectionUsedForMostRecentLayout = selection;
 
     // The selection changed, which means the selection bounds changed, we need to recalculate the
     // toolbar focal point bounds.

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:overlord/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -410,7 +409,7 @@ class IosToolbarFocalPointDocumentLayer extends DocumentLayoutLayerStatefulWidge
 
 class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<IosToolbarFocalPointDocumentLayer, Rect>
     with SingleTickerProviderStateMixin {
-  bool _wasSelectionExpanded = false;
+  DocumentSelection? _selectionUsedForMostRecentLayout;
 
   @override
   void initState() {
@@ -438,24 +437,13 @@ class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<I
 
   void _onSelectionChange() {
     final selection = widget.selection.value;
-    _wasSelectionExpanded = !(selection?.isCollapsed == true);
-
-    if (selection == null && !_wasSelectionExpanded) {
-      // There's no selection now, and in the previous frame there either was no selection,
-      // or a collapsed selection. We don't need to worry about re-calculating or rebuilding
-      // our bounds.
-      return;
-    }
-    if (selection != null && selection.isCollapsed && !_wasSelectionExpanded) {
-      // The current selection is collapsed, and the selection in the previous frame was
-      // either null, or was also collapsed. We only need to position bounds when the selection
-      // is expanded, or goes from expanded to collapsed, or from collapsed to expanded.
+    if (selection == _selectionUsedForMostRecentLayout) {
+      // The selection didn't change from what it was the last time we calculated selection bounds.
       return;
     }
 
-    // The current selection is expanded, or we went from expanded in the previous frame
-    // to non-expanded in this frame. Either way, we need to recalculate the toolbar focal
-    // point bounds.
+    // The selection changed, which means the selection bounds changed, we need to recalculate the
+    // toolbar focal point bounds.
     setStateAsSoonAsPossible(() {
       // The selection bounds, and Leader build, will take place in methods that
       // run in response to setState().
@@ -477,10 +465,6 @@ class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<I
       return null;
     }
 
-    if (documentSelection.isCollapsed) {
-      return null;
-    }
-
     return documentLayout.getRectForSelection(
       documentSelection.base,
       documentSelection.extent,
@@ -488,8 +472,8 @@ class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<I
   }
 
   @override
-  Widget doBuild(BuildContext context, Rect? expandedSelectionBounds) {
-    if (expandedSelectionBounds == null) {
+  Widget doBuild(BuildContext context, Rect? selectionBounds) {
+    if (selectionBounds == null) {
       return const SizedBox();
     }
 
@@ -497,7 +481,7 @@ class _IosToolbarFocalPointDocumentLayerState extends DocumentLayoutLayerState<I
       child: Stack(
         children: [
           Positioned.fromRect(
-            rect: expandedSelectionBounds,
+            rect: selectionBounds,
             child: Leader(
               link: widget.toolbarFocalPointLink,
               child: widget.showDebugLeaderBounds

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
-import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/super_editor_test.dart';
 
 import '../../test_runners.dart';
@@ -18,6 +16,24 @@ void main() {
       // Ensure all controls are hidden.
       expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
+    testWidgetsOnIos("shows toolbar when tapping on caret", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret.
+      await tester.tapInParagraph("1", 200);
+
+      // Ensure all controls are hidden.
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap again on the caret.
+      await tester.tapInParagraph("1", 200);
+
+      // Ensure that the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
     });
 
     testWidgetsOnIos("shows magnifier when dragging the caret", (tester) async {


### PR DESCRIPTION
Fixed tap to show toolbar on iOS when tapping on caret a second time (Resolves #1567)

There were a few things that lead to this issue:

- The toolbar focal point layer was explicitly ignoring collapsed selections, now it places a leader when the selection is collapsed, too.
- The check for tapping on the same selection was giving false negatives due to differences in text affinity based on where the user taps. Now we use a different comparison method to avoid those mismatches.
- We didn't have a test for this, as far as I could tell, so I added one. However, this new test was passing even before I made the other changes in this PR. Therefore, this test is probably useless, but I can't figure out why.