### PR TITLE
Fix: reporting IME geometry crashes when  is true in SuperEditor, caret doesn't blink when placed by 'autofocus' in SuperEditor (Resolves #1566)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -129,7 +129,7 @@ class SuperEditorIosControlsController {
 
   /// Whether the caret (collapsed handle) should blink right now.
   ValueListenable<bool> get shouldCaretBlink => _shouldCaretBlink;
-  final _shouldCaretBlink = ValueNotifier<bool>(false);
+  final _shouldCaretBlink = ValueNotifier<bool>(true);
 
   /// Tells the caret to blink by setting [shouldCaretBlink] to `true`.
   void blinkCaret() => _shouldCaretBlink.value = true;

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -293,9 +293,12 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
       return;
     }
 
-    _reportSizeAndTransformToIme();
-    _reportCaretRectToIme();
-    _reportTextStyleToIme();
+    final myRenderBox = context.findRenderObject() as RenderBox?;
+    if (myRenderBox != null && myRenderBox.hasSize) {
+      _reportSizeAndTransformToIme();
+      _reportCaretRectToIme();
+      _reportTextStyleToIme();
+    }
 
     // There are some operations that might affect our transform, size and the caret rect,
     // but we can't react to them.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -554,7 +554,8 @@ class SuperEditorState extends State<SuperEditor> {
             editor: widget.editor,
             document: widget.document,
             selection: _composer.selectionNotifier,
-            isDocumentLayoutAvailable: () => _docLayoutKey.currentContext != null,
+            isDocumentLayoutAvailable: () =>
+                (_docLayoutKey.currentContext?.findRenderObject() as RenderBox?)?.hasSize == true,
             getDocumentLayout: () => editContext.documentLayout,
             placeCaretAtEndOfDocumentOnGainFocus: widget.selectionPolicies.placeCaretAtEndOfDocumentOnGainFocus,
             restorePreviousSelectionOnGainFocus: widget.selectionPolicies.restorePreviousSelectionOnGainFocus,


### PR DESCRIPTION
Fix: reporting IME geometry crashes when  is true in SuperEditor, caret doesn't blink when placed by 'autofocus' in SuperEditor (Resolves #1566)

One of the bugs is that with `autofocus` `true`, we apparently attempt to report IME geometry before the associated widget has run layout. I'm not sure why this is coming up now. Perhaps we never tried using `autofocus` since we implemented reporting IME geometry. I added a check to only report geometry if we have a layout size.

Also, when using `autofocus`, the caret appears immediately, but doesn't blink. To solve that, I changed the initial caret blinking `bool` in the controller from `false` to `true`. That might have unintended consequences, but I wasn't sure. It solved the blink problem without causing any obvious other problems. We should keep an eye out.