### PR TITLE
Adds paragraph alignment request and command (Resolves #1587)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -438,8 +438,14 @@ class _EditorToolbarState extends State<EditorToolbar> {
         break;
     }
 
-    final selectedNode = widget.document.getNodeById(widget.composer.selection!.extent.nodeId) as ParagraphNode;
-    selectedNode.putMetadataValue('textAlign', newAlignmentValue);
+    widget.editor!.execute([
+      ChangeParagraphAlignmentRequest(
+        nodeId: widget.composer.selection!.extent.nodeId,
+        textAlign: newAlignmentValue,
+      ),
+    ]);
+
+    widget.closeToolbar();
   }
 
   /// Returns the localized name for the given [_TextType], e.g.,

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -415,6 +415,10 @@ class _ExampleEditorState extends State<ExampleEditor> {
               keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
               androidToolbarBuilder: (_) => _buildAndroidFloatingToolbar(),
               overlayController: _overlayController,
+              selectionPolicies: SuperEditorSelectionPolicies(
+                clearSelectionWhenEditorLosesFocus: false,
+                clearSelectionWhenImeConnectionCloses: false,
+              ),
             ),
           ),
         ),

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -195,6 +195,12 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
           composer: request.composer,
         )
       : null,
+  (request) => request is ChangeParagraphAlignmentRequest
+      ? ChangeParagraphAlignmentCommand(
+          nodeId: request.nodeId,
+          textAlign: request.textAlign,
+        )
+      : null,
 ]);
 
 final defaultEditorReactions = List.unmodifiable([

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -1,6 +1,7 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';
@@ -227,6 +228,53 @@ class ChangeParagraphBlockTypeCommand implements EditCommand {
       DocumentEdit(
         NodeChangeEvent(nodeId),
       ),
+    ]);
+  }
+}
+
+/// [EditRequest] to change the alignment of the [ParagraphNode] to [textAlign].
+class ChangeParagraphAlignmentRequest implements EditRequest {
+  ChangeParagraphAlignmentRequest({
+    required this.nodeId,
+    required this.textAlign,
+  });
+
+  final String nodeId;
+  final String? textAlign;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChangeParagraphAlignmentRequest &&
+          runtimeType == other.runtimeType &&
+          nodeId == other.nodeId &&
+          textAlign == other.textAlign;
+
+  @override
+  int get hashCode => nodeId.hashCode ^ textAlign.hashCode;
+}
+
+/// Updates alignment of the [ParagraphNode] with the given [textAlign].
+class ChangeParagraphAlignmentCommand implements EditCommand {
+  const ChangeParagraphAlignmentCommand({
+    required this.nodeId,
+    required this.textAlign,
+  });
+
+  final String nodeId;
+  final String? textAlign;
+
+  @override
+  void execute(EditContext context, CommandExecutor executor) {
+    final document = context.find<MutableDocument>(Editor.documentKey);
+
+    final existingNode = document.getNodeById(nodeId)! as ParagraphNode;
+    existingNode.putMetadataValue('textAlign', textAlign);
+
+    executor.logChanges([
+      DocumentEdit(
+        NodeChangeEvent(nodeId),
+      )
     ]);
   }
 }

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -1,7 +1,6 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_layout.dart';

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -533,6 +533,23 @@ class TextComponentState extends State<TextComponent> with DocumentComponent imp
   }
 
   @override
+  void didUpdateWidget(covariant TextComponent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.textAlign != widget.textAlign) {
+      // Text alignment has changed, force a re-layout.
+      invalidateLayout();
+    }
+  }
+
+  /// Invalidates layout for this widget to force a rebuild on the
+  /// parent widget.
+  void invalidateLayout() {
+    final renderObject = context.findRenderObject();
+    renderObject!.markNeedsLayout();
+  }
+
+  @override
   Offset getOffsetForPosition(dynamic nodePosition) {
     if (nodePosition is! TextPosition) {
       throw Exception('Expected nodePosition of type TextPosition but received: $nodePosition');

--- a/super_text_layout/lib/src/super_text.dart
+++ b/super_text_layout/lib/src/super_text.dart
@@ -392,6 +392,15 @@ class RenderLayoutAwareParagraph extends RenderParagraph {
   bool _needsLayout = true;
 
   @override
+  set textAlign(TextAlign value) {
+    if (super.textAlign == value) {
+      return;
+    }
+    super.textAlign = value;
+    markNeedsLayout();
+  }
+
+  @override
   void markNeedsLayout() {
     super.markNeedsLayout();
     _needsLayout = true;

--- a/super_text_layout/lib/src/super_text.dart
+++ b/super_text_layout/lib/src/super_text.dart
@@ -392,15 +392,6 @@ class RenderLayoutAwareParagraph extends RenderParagraph {
   bool _needsLayout = true;
 
   @override
-  set textAlign(TextAlign value) {
-    if (super.textAlign == value) {
-      return;
-    }
-    super.textAlign = value;
-    markNeedsLayout();
-  }
-
-  @override
   void markNeedsLayout() {
     super.markNeedsLayout();
     _needsLayout = true;


### PR DESCRIPTION
Adds paragraph alignment request and command (Resolves #1587)

### **The Issue:** 

Changing text alignment of a paragraph node doesn't reflect the alignment change immediately in the document. This change is reflected only after I make any other edits to the document.  Reason seems to be due to the way we're updating the paragraph alignment. 

Sometime back ago, we introduced a request/command system to make changes to the document. The request/command to change the paragraph alignment was left out back then, and right now we seem to only update the node's metadata when trying to update the alignment of the paragraph through the toolbar alignment dropdown.

Demo:

https://github.com/superlistapp/super_editor/assets/65209850/47c44e02-5988-4922-a3e5-17f3c1eeb780

### **Solution:** 

This PR adds `ChangeParagraphAlignmentRequest` and `ChangeParagraphAlignmentCommand` to change the alignment of the paragraph with the request/command flow in `super_editor`. 

### **Remarks:** 

1. Adds `ChangeParagraphAlignmentRequest` and `ChangeParagraphAlignmentCommand` to handle paragraph alignment change request and execution.
2. Adds alignment request check for `ChangeParagraphAlignmentRequest` within existing `defaultRequestHandlers`.
3. `EditorToolbar` alignment change toggle function updated to make the alignment request with `ChangeParagraphAlignmentRequest` to the `Editor`.
4. Adds `selectionPolicies` to `ExampleEditor` super editor to persist the toolbar overlay when clicked.





