### PR TITLE
Added SuperTextField entrypoint, includes Mac OS selectors and Actions example

### DIFF
--- a/super_editor/.run/Super Text Field (debug).run.xml
+++ b/super_editor/.run/Super Text Field (debug).run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Super Text Field (debug)" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/lib/main_super_text_field.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/super_editor/example/lib/main_super_text_field.dart
+++ b/super_editor/example/lib/main_super_text_field.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_text_field.dart';
 
+/// An app that demos [SuperTextField].
 void main() {
   runApp(
     MaterialApp(
@@ -23,33 +22,17 @@ class _SuperTextFieldDemoState extends State<_SuperTextFieldDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Shortcuts(
-        shortcuts: {
-          SingleActivator(LogicalKeyboardKey.escape): ExceptionIntent("This should never execute!"),
-        },
-        child: Actions(
-          actions: {
-            DismissIntent: CallbackAction<DismissIntent>(onInvoke: (DismissIntent intent) {
-              print("Action executed for dismiss intent");
-              return null;
-            }),
-            ExceptionIntent: CallbackAction<ExceptionIntent>(onInvoke: (ExceptionIntent intent) {
-              throw Exception(intent.message);
-            }),
-          },
-          child: Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: 500),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  SingleLineTextField(),
-                  const SizedBox(height: 16),
-                  MultiLineTextField(),
-                ],
-              ),
-            ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: 500),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _SingleLineTextField(),
+              const SizedBox(height: 16),
+              _MultiLineTextField(),
+            ],
           ),
         ),
       ),
@@ -57,16 +40,16 @@ class _SuperTextFieldDemoState extends State<_SuperTextFieldDemo> {
   }
 }
 
-class SingleLineTextField extends StatefulWidget {
-  const SingleLineTextField({super.key});
+class _SingleLineTextField extends StatefulWidget {
+  const _SingleLineTextField();
 
   @override
-  State<SingleLineTextField> createState() => _SingleLineTextFieldState();
+  State<_SingleLineTextField> createState() => _SingleLineTextFieldState();
 }
 
-class _SingleLineTextFieldState extends State<SingleLineTextField> {
+class _SingleLineTextFieldState extends State<_SingleLineTextField> {
   final _focusNode = FocusNode();
-  late final _textController = ImeAttributedTextEditingController(
+  final _textController = ImeAttributedTextEditingController(
     controller: AttributedTextEditingController(),
   );
 
@@ -80,62 +63,36 @@ class _SingleLineTextFieldState extends State<SingleLineTextField> {
   @override
   Widget build(BuildContext context) {
     return TapRegion(
+      groupId: "textfields",
       onTapOutside: (_) => _focusNode.unfocus(),
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) {
-          return Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(4),
-              border: Border.all(
-                color: _focusNode.hasFocus ? Colors.blue : Colors.grey.shade300,
-                width: 1,
-              ),
-            ),
-            child: child,
-          );
-        },
+      child: TextFieldBorder(
+        focusNode: _focusNode,
+        borderBuilder: _borderBuilder,
         child: SuperTextField(
           focusNode: _focusNode,
           textController: _textController,
-          textStyleBuilder: (attributions) {
-            return defaultTextFieldStyleBuilder(attributions).copyWith(
-              color: Colors.black,
-            );
-          },
-          hintBuilder: (_) => Text(
-            "Type some text...",
-            style: TextStyle(color: Colors.grey),
-          ),
+          textStyleBuilder: _textStyleBuilder,
+          hintBuilder: _createHintBuilder("Enter single line text..."),
+          padding: const EdgeInsets.all(4),
           minLines: 1,
           maxLines: 1,
           inputSource: TextInputSource.ime,
-          imeConfiguration: TextInputConfiguration(keyboardAppearance: Brightness.light),
-          selectorHandlers: {
-            ...defaultTextFieldSelectorHandlers,
-            MacOsSelectors.cancelOperation: ({
-              required SuperTextFieldContext textFieldContext,
-            }) {
-              print("Intercepted ESC selector");
-              Actions.maybeInvoke(context, DismissIntent());
-            },
-          },
         ),
       ),
     );
   }
 }
 
-class MultiLineTextField extends StatefulWidget {
-  const MultiLineTextField({super.key});
+class _MultiLineTextField extends StatefulWidget {
+  const _MultiLineTextField();
 
   @override
-  State<MultiLineTextField> createState() => _MultiLineTextFieldState();
+  State<_MultiLineTextField> createState() => _MultiLineTextFieldState();
 }
 
-class _MultiLineTextFieldState extends State<MultiLineTextField> {
+class _MultiLineTextFieldState extends State<_MultiLineTextField> {
   final _focusNode = FocusNode();
-  late final _textController = ImeAttributedTextEditingController(
+  final _textController = ImeAttributedTextEditingController(
     controller: AttributedTextEditingController(),
   );
 
@@ -149,48 +106,51 @@ class _MultiLineTextFieldState extends State<MultiLineTextField> {
   @override
   Widget build(BuildContext context) {
     return TapRegion(
+      groupId: "textfields",
       onTapOutside: (_) => _focusNode.unfocus(),
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (context, child) {
-          return Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(4),
-              border: Border.all(
-                color: _focusNode.hasFocus ? Colors.blue : Colors.grey.shade300,
-                width: 1,
-              ),
-            ),
-            child: child,
-          );
-        },
+      child: TextFieldBorder(
+        focusNode: _focusNode,
+        borderBuilder: _borderBuilder,
         child: SuperTextField(
           focusNode: _focusNode,
           textController: _textController,
-          textStyleBuilder: (attributions) {
-            return defaultTextFieldStyleBuilder(attributions).copyWith(
-              color: Colors.black,
-            );
-          },
-          hintBuilder: (_) => Text(
-            "Type some text...",
-            style: TextStyle(color: Colors.grey),
-          ),
+          textStyleBuilder: _textStyleBuilder,
+          hintBuilder: _createHintBuilder("Type some text..."),
+          padding: const EdgeInsets.all(4),
           minLines: 5,
           maxLines: 5,
           inputSource: TextInputSource.ime,
-          imeConfiguration: TextInputConfiguration(keyboardAppearance: Brightness.light),
-          selectorHandlers: {
-            ...defaultTextFieldSelectorHandlers,
-          },
         ),
       ),
     );
   }
 }
 
-class ExceptionIntent extends Intent {
-  const ExceptionIntent(this.message);
+BoxDecoration _borderBuilder(TextFieldBorderState borderState) {
+  return BoxDecoration(
+    borderRadius: BorderRadius.circular(4),
+    border: Border.all(
+      color: borderState.hasError //
+          ? Colors.red
+          : borderState.hasFocus
+              ? Colors.blue
+              : Colors.grey.shade300,
+      width: borderState.hasError ? 2 : 1,
+    ),
+  );
+}
 
-  final String message;
+TextStyle _textStyleBuilder(Set<Attribution> attributions) {
+  return defaultTextFieldStyleBuilder(attributions).copyWith(
+    color: Colors.black,
+  );
+}
+
+WidgetBuilder _createHintBuilder(String hintText) {
+  return (BuildContext context) {
+    return Text(
+      hintText,
+      style: TextStyle(color: Colors.grey),
+    );
+  };
 }

--- a/super_editor/example/lib/main_super_text_field.dart
+++ b/super_editor/example/lib/main_super_text_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_text_field.dart';
 
@@ -22,24 +23,32 @@ class _SuperTextFieldDemoState extends State<_SuperTextFieldDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Actions(
-        actions: {
-          DismissIntent: CallbackAction<DismissIntent>(onInvoke: (DismissIntent intent) {
-            print("Action executed for dismiss intent");
-            return null;
-          }),
+      body: Shortcuts(
+        shortcuts: {
+          SingleActivator(LogicalKeyboardKey.escape): ExceptionIntent("This should never execute!"),
         },
-        child: Center(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(maxWidth: 500),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                SingleLineTextField(),
-                const SizedBox(height: 16),
-                MultiLineTextField(),
-              ],
+        child: Actions(
+          actions: {
+            DismissIntent: CallbackAction<DismissIntent>(onInvoke: (DismissIntent intent) {
+              print("Action executed for dismiss intent");
+              return null;
+            }),
+            ExceptionIntent: CallbackAction<ExceptionIntent>(onInvoke: (ExceptionIntent intent) {
+              throw Exception(intent.message);
+            }),
+          },
+          child: Center(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: 500),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  SingleLineTextField(),
+                  const SizedBox(height: 16),
+                  MultiLineTextField(),
+                ],
+              ),
             ),
           ),
         ),
@@ -178,4 +187,10 @@ class _MultiLineTextFieldState extends State<MultiLineTextField> {
       ),
     );
   }
+}
+
+class ExceptionIntent extends Intent {
+  const ExceptionIntent(this.message);
+
+  final String message;
 }

--- a/super_editor/example/lib/main_super_text_field.dart
+++ b/super_editor/example/lib/main_super_text_field.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_text_field.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: _SuperTextFieldDemo(),
+    ),
+  );
+}
+
+class _SuperTextFieldDemo extends StatefulWidget {
+  const _SuperTextFieldDemo();
+
+  @override
+  State<_SuperTextFieldDemo> createState() => _SuperTextFieldDemoState();
+}
+
+class _SuperTextFieldDemoState extends State<_SuperTextFieldDemo> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Actions(
+        actions: {
+          DismissIntent: CallbackAction<DismissIntent>(onInvoke: (DismissIntent intent) {
+            print("Action executed for dismiss intent");
+            return null;
+          }),
+        },
+        child: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: 500),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SingleLineTextField(),
+                const SizedBox(height: 16),
+                MultiLineTextField(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SingleLineTextField extends StatefulWidget {
+  const SingleLineTextField({super.key});
+
+  @override
+  State<SingleLineTextField> createState() => _SingleLineTextFieldState();
+}
+
+class _SingleLineTextFieldState extends State<SingleLineTextField> {
+  final _focusNode = FocusNode();
+  late final _textController = ImeAttributedTextEditingController(
+    controller: AttributedTextEditingController(),
+  );
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TapRegion(
+      onTapOutside: (_) => _focusNode.unfocus(),
+      child: ListenableBuilder(
+        listenable: _focusNode,
+        builder: (context, child) {
+          return Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(
+                color: _focusNode.hasFocus ? Colors.blue : Colors.grey.shade300,
+                width: 1,
+              ),
+            ),
+            child: child,
+          );
+        },
+        child: SuperTextField(
+          focusNode: _focusNode,
+          textController: _textController,
+          textStyleBuilder: (attributions) {
+            return defaultTextFieldStyleBuilder(attributions).copyWith(
+              color: Colors.black,
+            );
+          },
+          hintBuilder: (_) => Text(
+            "Type some text...",
+            style: TextStyle(color: Colors.grey),
+          ),
+          minLines: 1,
+          maxLines: 1,
+          inputSource: TextInputSource.ime,
+          imeConfiguration: TextInputConfiguration(keyboardAppearance: Brightness.light),
+          selectorHandlers: {
+            ...defaultTextFieldSelectorHandlers,
+            MacOsSelectors.cancelOperation: ({
+              required SuperTextFieldContext textFieldContext,
+            }) {
+              print("Intercepted ESC selector");
+              Actions.maybeInvoke(context, DismissIntent());
+            },
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class MultiLineTextField extends StatefulWidget {
+  const MultiLineTextField({super.key});
+
+  @override
+  State<MultiLineTextField> createState() => _MultiLineTextFieldState();
+}
+
+class _MultiLineTextFieldState extends State<MultiLineTextField> {
+  final _focusNode = FocusNode();
+  late final _textController = ImeAttributedTextEditingController(
+    controller: AttributedTextEditingController(),
+  );
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TapRegion(
+      onTapOutside: (_) => _focusNode.unfocus(),
+      child: ListenableBuilder(
+        listenable: _focusNode,
+        builder: (context, child) {
+          return Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(
+                color: _focusNode.hasFocus ? Colors.blue : Colors.grey.shade300,
+                width: 1,
+              ),
+            ),
+            child: child,
+          );
+        },
+        child: SuperTextField(
+          focusNode: _focusNode,
+          textController: _textController,
+          textStyleBuilder: (attributions) {
+            return defaultTextFieldStyleBuilder(attributions).copyWith(
+              color: Colors.black,
+            );
+          },
+          hintBuilder: (_) => Text(
+            "Type some text...",
+            style: TextStyle(color: Colors.grey),
+          ),
+          minLines: 5,
+          maxLines: 5,
+          inputSource: TextInputSource.ime,
+          imeConfiguration: TextInputConfiguration(keyboardAppearance: Brightness.light),
+          selectorHandlers: {
+            ...defaultTextFieldSelectorHandlers,
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -244,6 +244,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   void _createTextFieldContext() {
     _textFieldContext = SuperTextFieldContext(
       textFieldBuildContext: context,
+      focusNode: _focusNode,
       controller: _controller,
       getTextLayout: () => textLayout,
       scroller: _textFieldScroller,
@@ -1295,6 +1296,7 @@ class _SuperTextFieldImeInteractorState extends State<SuperTextFieldImeInteracto
   }
 
   void _onPerformSelector(String selectorName) {
+    print("_onPerformSelector: $selectorName");
     final handler = widget.selectorHandlers[selectorName];
     if (handler == null) {
       editorImeLog.warning("No handler found for $selectorName");
@@ -2251,6 +2253,10 @@ typedef SuperTextFieldSelectorHandler = void Function({
 });
 
 const defaultTextFieldSelectorHandlers = <String, SuperTextFieldSelectorHandler>{
+  // Control.
+  MacOsSelectors.insertTab: _moveFocusNext,
+  MacOsSelectors.cancelOperation: _giveUpFocus,
+
   // Caret movement.
   MacOsSelectors.moveLeft: _moveCaretUpstream,
   MacOsSelectors.moveRight: _moveCaretDownstream,
@@ -2282,6 +2288,18 @@ const defaultTextFieldSelectorHandlers = <String, SuperTextFieldSelectorHandler>
   MacOsSelectors.deleteToEndOfLine: _deleteToEndOfLine,
   MacOsSelectors.deleteBackwardByDecomposingPreviousCharacter: _deleteUpstream,
 };
+
+void _giveUpFocus({
+  required SuperTextFieldContext textFieldContext,
+}) {
+  textFieldContext.focusNode.unfocus();
+}
+
+void _moveFocusNext({
+  required SuperTextFieldContext textFieldContext,
+}) {
+  textFieldContext.focusNode.nextFocus();
+}
 
 void _moveCaretUpstream({
   required SuperTextFieldContext textFieldContext,

--- a/super_editor/lib/src/super_textfield/infrastructure/text_field_border.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_field_border.dart
@@ -3,6 +3,9 @@ import 'package:flutter/widgets.dart';
 
 /// A border that displays with different colors based on common text field states, e.g.,
 /// non-focused, focused, error.
+///
+/// The border visuals are chosen by a provided [borderBuilder]. The border state is refreshed,
+/// and the [borderBuilder] is re-run, every time focus changes, or the error state changes.
 class TextFieldBorder extends StatelessWidget {
   const TextFieldBorder({
     super.key,
@@ -13,14 +16,20 @@ class TextFieldBorder extends StatelessWidget {
     required this.child,
   });
 
+  /// The [FocusNode] associated with the [child] text field.
   final FocusNode focusNode;
 
+  /// Whether the [child] text field is currently in an error state.
   final ValueListenable<bool>? hasError;
 
+  /// Creates a visual border decoration based on a given [TextFieldBorderState].
   final TextFieldBorderBuilder borderBuilder;
 
+  /// Clipping strategy, which defaults to [Clip.none], and can be used to clip [child]
+  /// text field content when rounded corners are used for the border.
   final Clip clipBehavior;
 
+  /// The widget subtree that displays a text field, to which this border applies.
   final Widget child;
 
   @override
@@ -51,6 +60,10 @@ class TextFieldBorder extends StatelessWidget {
       );
 }
 
+/// Properties that might impact the visual appearance of a text field border.
+///
+/// [TextFieldBorder] provides a [TextFieldBorderState] to a [TextFieldBorderBuilder]
+/// to create the desired visual border for a text field.
 class TextFieldBorderState {
   const TextFieldBorderState({
     required this.hasFocus,

--- a/super_editor/lib/src/super_textfield/infrastructure/text_field_border.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_field_border.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// A border that displays with different colors based on common text field states, e.g.,
+/// non-focused, focused, error.
+class TextFieldBorder extends StatelessWidget {
+  const TextFieldBorder({
+    super.key,
+    required this.focusNode,
+    this.hasError,
+    required this.borderBuilder,
+    this.clipBehavior = Clip.none,
+    required this.child,
+  });
+
+  final FocusNode focusNode;
+
+  final ValueListenable<bool>? hasError;
+
+  final TextFieldBorderBuilder borderBuilder;
+
+  final Clip clipBehavior;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: hasError ?? ValueNotifier<bool>(false),
+      builder: (context, hasError, child) {
+        return ListenableBuilder(
+          listenable: focusNode,
+          builder: (context, child) {
+            return Container(
+              decoration: borderBuilder(_borderState),
+              clipBehavior: clipBehavior,
+              child: child,
+            );
+          },
+          child: child,
+        );
+      },
+      child: child,
+    );
+  }
+
+  TextFieldBorderState get _borderState => TextFieldBorderState(
+        hasFocus: focusNode.hasFocus,
+        hasPrimaryFocus: focusNode.hasPrimaryFocus,
+        hasError: hasError?.value ?? false,
+      );
+}
+
+class TextFieldBorderState {
+  const TextFieldBorderState({
+    required this.hasFocus,
+    required this.hasPrimaryFocus,
+    required this.hasError,
+  });
+
+  final bool hasFocus;
+  final bool hasPrimaryFocus;
+  final bool hasError;
+}
+
+typedef TextFieldBorderBuilder = BoxDecoration Function(TextFieldBorderState borderState);

--- a/super_editor/lib/src/super_textfield/super_textfield_context.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield_context.dart
@@ -8,6 +8,7 @@ import 'package:super_text_layout/super_text_layout.dart';
 class SuperTextFieldContext {
   SuperTextFieldContext({
     required this.textFieldBuildContext,
+    required this.focusNode,
     required this.controller,
     required this.getTextLayout,
     required this.scroller,
@@ -22,6 +23,9 @@ class SuperTextFieldContext {
   /// said, it will point to an [Element] near the root of the text field, and the
   /// associated render object will match the outer bounds of the text field.
   final BuildContext textFieldBuildContext;
+
+  /// The [FocusNode] associated with the text field.
+  final FocusNode focusNode;
 
   /// Controller that owns the text content, selection, composing region and any
   /// other text-editing state for the associated text field.

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -77,6 +77,7 @@ export 'src/infrastructure/platforms/ios/ios_document_controls.dart';
 export 'src/infrastructure/platforms/ios/floating_cursor.dart';
 export 'src/infrastructure/platforms/ios/toolbar.dart';
 export 'src/infrastructure/platforms/ios/magnifier.dart';
+export 'src/infrastructure/platforms/mac/mac_ime.dart';
 export 'src/infrastructure/platforms/mobile_documents.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';
 export 'src/infrastructure/signal_notifier.dart';

--- a/super_editor/lib/super_text_field.dart
+++ b/super_editor/lib/super_text_field.dart
@@ -1,3 +1,7 @@
 library super_text_field;
 
+// The whole text field.
 export 'src/super_textfield/super_textfield.dart';
+
+// Tools for building new text fields.
+export 'src/super_textfield/infrastructure/text_field_border.dart';

--- a/super_editor/test/super_textfield/mac/super_textfield_mac_selectors_test.dart
+++ b/super_editor/test/super_textfield/mac/super_textfield_mac_selectors_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../super_textfield_inspector.dart';
+import '../super_textfield_robot.dart';
+
+void main() {
+  group("SuperTextField > Mac > Selectors > ", () {
+    testWidgetsOnMac('allows apps to handle selectors in their own way', (tester) async {
+      bool customHandlerCalled = false;
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText('Selectors test'),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+            inputSource: TextInputSource.ime,
+            selectorHandlers: {
+              MacOsSelectors.moveRight: ({
+                required SuperTextFieldContext textFieldContext,
+              }) {
+                customHandlerCalled = true;
+              }
+            },
+          ),
+        ),
+      );
+
+      // Place the caret at the beginning of the text field.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Press right arrow key to trigger the MacOsSelectors.moveRight selector.
+      await tester.pressRightArrow();
+
+      // Ensure the custom handler was called.
+      expect(customHandlerCalled, isTrue);
+
+      // Ensure that the textfield didn't execute the default handler for the MacOsSelectors.moveRight selector.
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 0),
+      );
+    });
+  });
+
+  testWidgetsOnMac('prevents surrounding widgets from consuming control keys that trigger OS selectors',
+      (tester) async {
+    // Explanation: Mac OS selectors are only generated for a given key event, if that key event
+    // isn't handled by anything within Flutter code. Some key events are almost always tied to
+    // Shortcuts higher up in the tree, e.g., ESC to generate a DismissIntent. Therefore, SuperTextField
+    // needs to explicitly tell Flutter to stop propagating any key event that's expected to generate a
+    // selector on the OS side.
+    bool receivedOsSelector = false;
+
+    await tester.pumpWidget(
+      _buildScaffold(
+        child: Shortcuts(
+          shortcuts: const {
+            SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
+          },
+          child: Actions(
+            actions: {
+              DismissIntent: CallbackAction<DismissIntent>(onInvoke: (DismissIntent intent) {
+                fail("Received a DismissIntent from Shortcuts but that shortcut should never have been activated.");
+              }),
+            },
+            child: SuperTextField(
+              inputSource: TextInputSource.ime,
+              selectorHandlers: {
+                MacOsSelectors.cancelOperation: ({
+                  required SuperTextFieldContext textFieldContext,
+                }) {
+                  receivedOsSelector = true;
+                }
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Give focus to the text field so that it handles key presses.
+    await tester.placeCaretInSuperTextField(0);
+
+    // Press ESC, which we expect to make it all the way to the OS.
+    await tester.pressEscape();
+
+    // Ensure that the key event skipped the Flutter tree Shortcuts and Actions and
+    // made it back to us as an OS selector.
+    expect(receivedOsSelector, isTrue);
+  });
+}
+
+Widget _buildScaffold({
+  required Widget child,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 300,
+        child: child,
+      ),
+    ),
+  );
+}

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -527,45 +527,6 @@ void main() {
       expect(enableDeltaModel, true);
       expect(keyboardAppearance, 'Brightness.dark');
     });
-
-    testWidgetsOnMac('allows apps to handle selectors in their own way', (tester) async {
-      bool customHandlerCalled = false;
-
-      final controller = AttributedTextEditingController(
-        text: AttributedText('Selectors test'),
-      );
-
-      await tester.pumpWidget(
-        _buildScaffold(
-          child: SuperTextField(
-            textController: controller,
-            inputSource: TextInputSource.ime,
-            selectorHandlers: {
-              MacOsSelectors.moveRight: ({
-                required SuperTextFieldContext textFieldContext,
-              }) {
-                customHandlerCalled = true;
-              }
-            },
-          ),
-        ),
-      );
-
-      // Place the caret at the beginning of the text field.
-      await tester.placeCaretInSuperTextField(0);
-
-      // Press right arrow key to trigger the MacOsSelectors.moveRight selector.
-      await tester.pressRightArrow();
-
-      // Ensure the custom handler was called.
-      expect(customHandlerCalled, isTrue);
-
-      // Ensure that the textfield didn't execute the default handler for the MacOsSelectors.moveRight selector.
-      expect(
-        SuperTextFieldInspector.findSelection(),
-        const TextSelection.collapsed(offset: 0),
-      );
-    });
   });
 
   group('SuperTextField on some bad Android software keyboards', () {


### PR DESCRIPTION
By default, `SuperTextField` on Mac now blocks all key events and sends them directly to the OS, in case they need to be turned into selectors. Apps can alter this behavior by placing higher priority key handlers above that one, or completely replacing the key handlers in the text field.

By forcibly bypassing all Flutter focus nodes, key events like ESC will go directly to the OS, generate a selector, like "cancel operation", which will be sent to the IME and received by the text field.

`SuperTextField` has a map of default selector behaviors. **If the defaults should be changed, please let me know.**

Apps can customize selector actions by providing their own entries in the selector action map. They can add to the default actions, or completely replace the default actions.