### PR TITLE
[SuperTextField][mobile] Migrate popover toolbars to OverlayPortal (Resolves #1602)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -491,57 +491,61 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     return OverlayPortal(
       controller: _popoverController,
       overlayChildBuilder: _buildPopoverToolbar,
-      child: TapRegion(
-        groupId: widget.tapRegionGroupId,
-        child: NonReparentingFocus(
-          key: _textFieldKey,
-          focusNode: _focusNode,
-          onKey: _onKeyPressed,
-          child: CompositedTransformTarget(
-            link: _textFieldLayerLink,
-            child: AndroidTextFieldTouchInteractor(
-              focusNode: _focusNode,
-              textKey: _textContentKey,
-              textFieldLayerLink: _textFieldLayerLink,
-              textController: _textEditingController,
-              editingOverlayController: _editingOverlayController,
-              textScrollController: _textScrollController,
-              isMultiline: _isMultiline,
-              handleColor: widget.handlesColor,
-              showDebugPaint: widget.showDebugPaint,
-              child: TextScrollView(
-                key: _scrollKey,
-                textScrollController: _textScrollController,
-                textKey: _textContentKey,
-                textEditingController: _textEditingController,
-                textAlign: widget.textAlign,
-                minLines: widget.minLines,
-                maxLines: widget.maxLines,
-                lineHeight: widget.lineHeight,
-                perLineAutoScrollDuration: const Duration(milliseconds: 100),
-                showDebugPaint: widget.showDebugPaint,
-                padding: widget.padding,
-                child: ListenableBuilder(
-                  listenable: _textEditingController,
-                  builder: (context, _) {
-                    final isTextEmpty = _textEditingController.text.text.isEmpty;
-                    final showHint = widget.hintBuilder != null &&
-                        ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
-                            (isTextEmpty &&
-                                !_focusNode.hasFocus &&
-                                widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+      child: _buildTextField(),
+    );
+  }
 
-                    return CompositedTransformTarget(
-                      link: _textContentLayerLink,
-                      child: Stack(
-                        children: [
-                          if (showHint) widget.hintBuilder!(context),
-                          _buildSelectableText(),
-                        ],
-                      ),
-                    );
-                  },
-                ),
+  Widget _buildTextField() {
+    return TapRegion(
+      groupId: widget.tapRegionGroupId,
+      child: NonReparentingFocus(
+        key: _textFieldKey,
+        focusNode: _focusNode,
+        onKey: _onKeyPressed,
+        child: CompositedTransformTarget(
+          link: _textFieldLayerLink,
+          child: AndroidTextFieldTouchInteractor(
+            focusNode: _focusNode,
+            textKey: _textContentKey,
+            textFieldLayerLink: _textFieldLayerLink,
+            textController: _textEditingController,
+            editingOverlayController: _editingOverlayController,
+            textScrollController: _textScrollController,
+            isMultiline: _isMultiline,
+            handleColor: widget.handlesColor,
+            showDebugPaint: widget.showDebugPaint,
+            child: TextScrollView(
+              key: _scrollKey,
+              textScrollController: _textScrollController,
+              textKey: _textContentKey,
+              textEditingController: _textEditingController,
+              textAlign: widget.textAlign,
+              minLines: widget.minLines,
+              maxLines: widget.maxLines,
+              lineHeight: widget.lineHeight,
+              perLineAutoScrollDuration: const Duration(milliseconds: 100),
+              showDebugPaint: widget.showDebugPaint,
+              padding: widget.padding,
+              child: ListenableBuilder(
+                listenable: _textEditingController,
+                builder: (context, _) {
+                  final isTextEmpty = _textEditingController.text.text.isEmpty;
+                  final showHint = widget.hintBuilder != null &&
+                      ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
+                          (isTextEmpty &&
+                              !_focusNode.hasFocus &&
+                              widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+
+                  return CompositedTransformTarget(
+                    link: _textContentLayerLink,
+                    child: Stack(
+                      children: [
+                        if (showHint) widget.hintBuilder!(context),
+                        _buildSelectableText(),
+                      ],
+                    ),
+                  );
+                },
               ),
             ),
           ),

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -493,65 +493,69 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     return OverlayPortal(
       controller: _popoverController,
       overlayChildBuilder: _buildPopoverToolbar,
-      child: TapRegion(
-        groupId: widget.tapRegionGroupId,
-        child: NonReparentingFocus(
-          key: _textFieldKey,
-          focusNode: _focusNode,
-          child: CompositedTransformTarget(
-            link: _textFieldLayerLink,
-            child: IOSTextFieldTouchInteractor(
-              focusNode: _focusNode,
-              selectableTextKey: _textContentKey,
-              textFieldLayerLink: _textFieldLayerLink,
-              textController: _textEditingController,
-              editingOverlayController: _editingOverlayController,
-              textScrollController: _textScrollController,
-              isMultiline: _isMultiline,
-              handleColor: widget.handlesColor,
-              showDebugPaint: widget.showDebugPaint,
-              child: TextScrollView(
-                key: _scrollKey,
-                textScrollController: _textScrollController,
-                textKey: _textContentKey,
-                textEditingController: _textEditingController,
-                textAlign: widget.textAlign,
-                minLines: widget.minLines,
-                maxLines: widget.maxLines,
-                lineHeight: widget.lineHeight,
-                perLineAutoScrollDuration: const Duration(milliseconds: 100),
-                showDebugPaint: widget.showDebugPaint,
-                padding: widget.padding,
-                child: ListenableBuilder(
-                  listenable: _textEditingController,
-                  builder: (context, _) {
-                    final isTextEmpty = _textEditingController.text.text.isEmpty;
-                    final showHint = widget.hintBuilder != null &&
-                        ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
-                            (isTextEmpty &&
-                                !_focusNode.hasFocus &&
-                                widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+      child: _buildTextField(),
+    );
+  }
 
-                    return CompositedTransformTarget(
-                      link: _textContentLayerLink,
-                      child: Stack(
-                        children: [
-                          if (showHint) widget.hintBuilder!(context),
-                          _buildSelectableText(),
-                          Positioned(
-                            left: 0,
-                            top: 0,
-                            right: 0,
-                            bottom: 0,
-                            child: IOSFloatingCursor(
-                              controller: _floatingCursorController,
-                            ),
+  Widget _buildTextField() {
+    return TapRegion(
+      groupId: widget.tapRegionGroupId,
+      child: NonReparentingFocus(
+        key: _textFieldKey,
+        focusNode: _focusNode,
+        child: CompositedTransformTarget(
+          link: _textFieldLayerLink,
+          child: IOSTextFieldTouchInteractor(
+            focusNode: _focusNode,
+            selectableTextKey: _textContentKey,
+            textFieldLayerLink: _textFieldLayerLink,
+            textController: _textEditingController,
+            editingOverlayController: _editingOverlayController,
+            textScrollController: _textScrollController,
+            isMultiline: _isMultiline,
+            handleColor: widget.handlesColor,
+            showDebugPaint: widget.showDebugPaint,
+            child: TextScrollView(
+              key: _scrollKey,
+              textScrollController: _textScrollController,
+              textKey: _textContentKey,
+              textEditingController: _textEditingController,
+              textAlign: widget.textAlign,
+              minLines: widget.minLines,
+              maxLines: widget.maxLines,
+              lineHeight: widget.lineHeight,
+              perLineAutoScrollDuration: const Duration(milliseconds: 100),
+              showDebugPaint: widget.showDebugPaint,
+              padding: widget.padding,
+              child: ListenableBuilder(
+                listenable: _textEditingController,
+                builder: (context, _) {
+                  final isTextEmpty = _textEditingController.text.text.isEmpty;
+                  final showHint = widget.hintBuilder != null &&
+                      ((isTextEmpty && widget.hintBehavior == HintBehavior.displayHintUntilTextEntered) ||
+                          (isTextEmpty &&
+                              !_focusNode.hasFocus &&
+                              widget.hintBehavior == HintBehavior.displayHintUntilFocus));
+
+                  return CompositedTransformTarget(
+                    link: _textContentLayerLink,
+                    child: Stack(
+                      children: [
+                        if (showHint) widget.hintBuilder!(context),
+                        _buildSelectableText(),
+                        Positioned(
+                          left: 0,
+                          top: 0,
+                          right: 0,
+                          bottom: 0,
+                          child: IOSFloatingCursor(
+                            controller: _floatingCursorController,
                           ),
-                        ],
-                      ),
-                    );
-                  },
-                ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
               ),
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -550,8 +550,7 @@ Second paragraph"""). //
         );
       });
 
-      testWidgetsOnIos(
-          'when the user presses the newline button on the software keyboard at the end of an image (on iOS)',
+      testWidgetsOnIos('when the user presses the newline button on the software keyboard at the end of an image',
           (tester) async {
         final testContext = await tester
             .createDocument()

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -468,7 +468,7 @@ spans multiple lines.''',
       expect(find.byType(AndroidSelectionHandle), findsOneWidget);
     });
 
-    testWidgetsOnIos('configures default gesture mode (on iOS)', (tester) async {
+    testWidgetsOnIos('configures default gesture mode', (tester) async {
       await tester //
           .createDocument()
           .withSingleParagraph()

--- a/super_editor/test/super_textfield/super_textfield_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_test.dart
@@ -97,76 +97,73 @@ void main() {
     });
 
     group("on mobile", () {
-      group("configures inner textfield textInputAction for newline when it's multiline", () {
-        testWidgetsOnAndroid('(on Android)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                minLines: 10,
-                maxLines: 10,
-              ),
+      testWidgetsOnAndroid("configures inner textfield textInputAction for newline when it's multiline",
+          (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 10,
+              maxLines: 10,
             ),
-          );
+          ),
+        );
 
-          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
 
-          // Ensure inner textfield action is configured to newline
-          // so we are able to receive new lines
-          expect(innerTextField.textInputAction, TextInputAction.newline);
-        });
-
-        testWidgetsOnIos('(on iOS)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                minLines: 10,
-                maxLines: 10,
-              ),
-            ),
-          );
-
-          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
-
-          // Ensure inner textfield action is configured to newline
-          // so we are able to receive new lines
-          expect(innerTextField.textInputAction, TextInputAction.newline);
-        });
+        // Ensure inner textfield action is configured to newline
+        // so we are able to receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.newline);
       });
 
-      group("configures inner textfield textInputAction for done when it's singleline", () {
-        testWidgetsOnAndroid('(on Android)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                minLines: 1,
-                maxLines: 1,
-              ),
+      testWidgetsOnIos("configures inner textfield textInputAction for newline when it's multiline", (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 10,
+              maxLines: 10,
             ),
-          );
+          ),
+        );
 
-          final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
+        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
 
-          // Ensure inner textfield action is configured to done
-          // because we should NOT receive new lines
-          expect(innerTextField.textInputAction, TextInputAction.done);
-        });
+        // Ensure inner textfield action is configured to newline
+        // so we are able to receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.newline);
+      });
 
-        testWidgetsOnIos('(on iOS)', (tester) async {
-          await tester.pumpWidget(
-            _buildScaffold(
-              child: const SuperTextField(
-                minLines: 1,
-                maxLines: 1,
-              ),
+      testWidgetsOnAndroid("configures inner textfield textInputAction for done when it's singleline", (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 1,
+              maxLines: 1,
             ),
-          );
+          ),
+        );
 
-          final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+        final innerTextField = tester.widget<SuperAndroidTextField>(find.byType(SuperAndroidTextField).first);
 
-          // Ensure inner textfield action is configured to done
-          // because we should NOT receive new lines
-          expect(innerTextField.textInputAction, TextInputAction.done);
-        });
+        // Ensure inner textfield action is configured to done
+        // because we should NOT receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.done);
+      });
+
+      testWidgetsOnIos("configures inner textfield textInputAction for done when it's singleline", (tester) async {
+        await tester.pumpWidget(
+          _buildScaffold(
+            child: const SuperTextField(
+              minLines: 1,
+              maxLines: 1,
+            ),
+          ),
+        );
+
+        final innerTextField = tester.widget<SuperIOSTextField>(find.byType(SuperIOSTextField).first);
+
+        // Ensure inner textfield action is configured to done
+        // because we should NOT receive new lines
+        expect(innerTextField.textInputAction, TextInputAction.done);
       });
 
       testWidgetsOnIos('applies keyboard appearance', (tester) async {

--- a/super_editor/test/super_textfield/super_textfield_theme_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_theme_test.dart
@@ -13,7 +13,7 @@ import 'super_textfield_robot.dart';
 
 void main() {
   group('SuperTextField', () {
-    testWidgetsOnIos('applies app theme to the popover toolbar (on iOS)', (tester) async {
+    testWidgetsOnIos('applies app theme to the popover toolbar', (tester) async {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText('A single line textfield'),

--- a/super_editor/test/super_textfield/super_textfield_theme_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_theme_test.dart
@@ -1,0 +1,130 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/super_textfield/android/android_textfield.dart';
+import 'package:super_editor/src/super_textfield/infrastructure/attributed_text_editing_controller.dart';
+import 'package:super_editor/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart';
+import 'package:super_editor/src/super_textfield/ios/ios_textfield.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import 'super_textfield_robot.dart';
+
+void main() {
+  group('SuperTextField', () {
+    testWidgetsOnIos('applies app theme to the popover toolbar (on iOS)', (tester) async {
+      final controller = ImeAttributedTextEditingController(
+        controller: AttributedTextEditingController(
+          text: AttributedText('A single line textfield'),
+        ),
+      );
+
+      // Used to switch between dark/light mode.
+      ValueNotifier<ThemeData> themeData = ValueNotifier(ThemeData.dark());
+
+      // Holds the popover theme's brightness.
+      Brightness? popoverBrightness;
+
+      await _pumpTestAppScaffold(
+        tester,
+        theme: themeData,
+        child: SuperIOSTextField(
+          textController: controller,
+          caretStyle: const CaretStyle(),
+          selectionColor: Colors.blue,
+          handlesColor: Colors.blue,
+          popoverToolbarBuilder: (context, overlayController) {
+            popoverBrightness = Theme.of(context).brightness;
+            return const SizedBox();
+          },
+        ),
+      );
+
+      // Double tap to show the toolbar.
+      await tester.doubleTapAtSuperTextField(0, find.byType(SuperIOSTextField));
+
+      // Ensure the toolbar has a dark theme.
+      expect(popoverBrightness, Brightness.dark);
+
+      // Switch the theme to light.
+      themeData.value = ThemeData.light();
+      await tester.pump();
+
+      // Ensure the toolbar also switched to a light theme.
+      expect(popoverBrightness, Brightness.light);
+    });
+
+    testWidgetsOnAndroid('applies app theme to the popover toolbar (on Android)', (tester) async {
+      final controller = ImeAttributedTextEditingController(
+        controller: AttributedTextEditingController(
+          text: AttributedText('A single line textfield'),
+        ),
+      );
+
+      // Used to switch between dark/light mode.
+      ValueNotifier<ThemeData> themeData = ValueNotifier(ThemeData.dark());
+
+      // Holds the popover theme's brightness.
+      Brightness? popoverBrightness;
+
+      await _pumpTestAppScaffold(
+        tester,
+        theme: themeData,
+        child: SuperAndroidTextField(
+          textController: controller,
+          caretStyle: const CaretStyle(),
+          selectionColor: Colors.blue,
+          handlesColor: Colors.blue,
+          popoverToolbarBuilder: (context, overlayController, config) {
+            popoverBrightness = Theme.of(context).brightness;
+            return const SizedBox();
+          },
+        ),
+      );
+
+      // Double tap to show the toolbar.
+      await tester.doubleTapAtSuperTextField(0, find.byType(SuperAndroidTextField));
+
+      // Ensure the toolbar has a dark theme.
+      expect(popoverBrightness, Brightness.dark);
+
+      // Switch the theme to light.
+      themeData.value = ThemeData.light();
+      await tester.pump();
+
+      // Ensure the toolbar also switched to a light theme.
+      expect(popoverBrightness, Brightness.light);
+    });
+  });
+}
+
+/// Pumps a [Scaffold] which applies the given [theme]'s value to its body.
+///
+/// The body rebuilds itself whenever the [theme]'s value changes.
+Future<void> _pumpTestAppScaffold(
+  WidgetTester tester, {
+  required ValueListenable<ThemeData> theme,
+  required Widget child,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ValueListenableBuilder(
+          valueListenable: theme,
+          builder: (context, _, __) {
+            // The theme must be placed below the MaterialApp
+            // so it isn't applied to the app's Overlay.
+            return Theme(
+              data: theme.value,
+              child: SizedBox(
+                width: 300,
+                child: child,
+              ),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
[SuperTextField][mobile] Migrate popover toolbar to OverlayPortal (Resolves #1602)

Currently, the mobile toolbars are displayed in the app `Overlay`. Because of that, it doesn't have access to  `InheritedWidgets` placed below `MaterialApp`. 

As a result, if an app adds a `Theme` widget above `SuperTextField`, the `SuperTextField` uses this `Theme`, but the popover toolbar uses the `MaterialApp`'s theme.

This PR changes the popover toolbars to be displayed in an `OverlayPortal` instead of an `Overlay`. By doing so, the popovers "see" the same `InheritedWidgets` that the `SuperTextField` sees.

In the tests, I had to use the platform textfields directly, as `SuperTextField` doesn't expose the `popoverToolbarBuilder` in its public API.

I also noticed that the iOS textfield is always using the `_defaultPopoverToolbarBuilder` instead of the given `popoverToolbarBuilder`. This PR fixes that.