### PR TITLE
[DRAFT][SuperTextField] Support light and dark mode

### DIFF
--- a/super_editor/example/lib/main_super_text_field.dart
+++ b/super_editor/example/lib/main_super_text_field.dart
@@ -6,6 +6,7 @@ import 'package:super_editor/super_text_field.dart';
 void main() {
   runApp(
     MaterialApp(
+      debugShowCheckedModeBanner: false,
       home: _SuperTextFieldDemo(),
     ),
   );
@@ -19,23 +20,81 @@ class _SuperTextFieldDemo extends StatefulWidget {
 }
 
 class _SuperTextFieldDemoState extends State<_SuperTextFieldDemo> {
+  final _darkBackground = const Color(0xFF222222);
+  final _lightBackground = Colors.white;
+  final _brightness = ValueNotifier<Brightness>(Brightness.light);
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: 500),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+    return ValueListenableBuilder(
+      valueListenable: _brightness,
+      builder: (context, brightness, child) {
+        return Theme(
+          data: ThemeData(brightness: brightness),
+          child: child!,
+        );
+      },
+      child: Builder(builder: (context) {
+        final isLight = Theme.of(context).brightness == Brightness.light;
+
+        return Scaffold(
+            body: ColoredBox(
+          color: isLight ? _lightBackground : _darkBackground,
+          child: Stack(
             children: [
-              _SingleLineTextField(),
-              const SizedBox(height: 16),
-              _MultiLineTextField(),
+              Center(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: 500),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _SingleLineTextField(),
+                      const SizedBox(height: 16),
+                      _MultiLineTextField(),
+                    ],
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomRight,
+                child: ListenableBuilder(
+                  listenable: _brightness,
+                  builder: (context, child) {
+                    return child!;
+                  },
+                  child: _buildCornerFabs(),
+                ),
+              ),
             ],
           ),
-        ),
-      ),
+        ));
+      }),
+    );
+  }
+
+  Widget _buildCornerFabs() {
+    return Padding(
+      padding: const EdgeInsets.only(right: 16, bottom: 16),
+      child: _buildLightAndDarkModeToggle(),
+    );
+  }
+
+  Widget _buildLightAndDarkModeToggle() {
+    return FloatingActionButton(
+      backgroundColor: _brightness.value == Brightness.light ? _darkBackground : _lightBackground,
+      foregroundColor: _brightness.value == Brightness.light ? _lightBackground : _darkBackground,
+      elevation: 5,
+      onPressed: () {
+        _brightness.value = _brightness.value == Brightness.light ? Brightness.dark : Brightness.light;
+      },
+      child: _brightness.value == Brightness.light
+          ? const Icon(
+              Icons.dark_mode,
+            )
+          : const Icon(
+              Icons.light_mode,
+            ),
     );
   }
 }
@@ -62,6 +121,8 @@ class _SingleLineTextFieldState extends State<_SingleLineTextField> {
 
   @override
   Widget build(BuildContext context) {
+    final isLight = Theme.of(context).brightness == Brightness.light;
+
     return TapRegion(
       groupId: "textfields",
       onTapOutside: (_) => _focusNode.unfocus(),
@@ -71,7 +132,8 @@ class _SingleLineTextFieldState extends State<_SingleLineTextField> {
         child: SuperTextField(
           focusNode: _focusNode,
           textController: _textController,
-          textStyleBuilder: _textStyleBuilder,
+          controlsColor: isLight ? Colors.black : Colors.white,
+          textStyleBuilder: (_) => _textStyleBuilder(_, isLight),
           hintBuilder: _createHintBuilder("Enter single line text..."),
           padding: const EdgeInsets.all(4),
           minLines: 1,
@@ -105,6 +167,8 @@ class _MultiLineTextFieldState extends State<_MultiLineTextField> {
 
   @override
   Widget build(BuildContext context) {
+    final isLight = Theme.of(context).brightness == Brightness.light;
+
     return TapRegion(
       groupId: "textfields",
       onTapOutside: (_) => _focusNode.unfocus(),
@@ -113,8 +177,9 @@ class _MultiLineTextFieldState extends State<_MultiLineTextField> {
         borderBuilder: _borderBuilder,
         child: SuperTextField(
           focusNode: _focusNode,
+          controlsColor: isLight ? Colors.black : Colors.white,
           textController: _textController,
-          textStyleBuilder: _textStyleBuilder,
+          textStyleBuilder: (_) => _textStyleBuilder(_, isLight),
           hintBuilder: _createHintBuilder("Type some text..."),
           padding: const EdgeInsets.all(4),
           minLines: 5,
@@ -140,9 +205,9 @@ BoxDecoration _borderBuilder(TextFieldBorderState borderState) {
   );
 }
 
-TextStyle _textStyleBuilder(Set<Attribution> attributions) {
+TextStyle _textStyleBuilder(Set<Attribution> attributions, bool isLight) {
   return defaultTextFieldStyleBuilder(attributions).copyWith(
-    color: Colors.black,
+    color: isLight ? Colors.black : Colors.white,
   );
 }
 


### PR DESCRIPTION
NOTE: This is a work-in-progress PR that fixes issue #1598 

Here is the progress made so far on this PR:

- [x] Toggleable light mode and dark mode, which is respected by the SuperTextFields
- [ ] Start with a single text field of a single line. Make it possible to add more SuperTextFields in a vertical column.
- [ ] Make it possible to select a SuperTextField and alter various characteristics in a settings pane, e.g., line count, border color, etc.
- [ ] Adapts the overall layout for mobile vs desktop