### PR TITLE
Feat: added support for iOS in isPrimaryShortcutKeyPressed

### DIFF
--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -32,7 +32,11 @@ enum ExecutionInstruction {
 
 extension PrimaryShortcutKey on RawKeyEvent {
   bool get isPrimaryShortcutKeyPressed =>
-      (defaultTargetPlatform == TargetPlatform.macOS && isMetaPressed) ||
+      ([
+            TargetPlatform.macOS,
+            TargetPlatform.iOS,
+          ].contains(defaultTargetPlatform) &&
+          isMetaPressed) ||
       (defaultTargetPlatform != TargetPlatform.macOS && isControlPressed);
 }
 
@@ -59,7 +63,9 @@ bool isKeyEventCharacterBlacklisted(String? character) {
 /// Examples of what's prohibited: "F1", "Scroll Lock"
 @visibleForTesting
 bool isCharacterBlacklisted(String character) {
-  return character.length > 1 && _isUpperCase(character.codeUnits.first) && _isAllAlphaNumeric(character.codeUnits);
+  return character.length > 1 &&
+      _isUpperCase(character.codeUnits.first) &&
+      _isAllAlphaNumeric(character.codeUnits);
 }
 
 const _ascii_A = 0x41;


### PR DESCRIPTION
This PR fixes some minor issues we're facing at CampaignComposer (@jmatth can say more), but, basically when on iPad, it can't detect the Meta key pressed for shortcuts.

This PR Closes #1625 

As explained in the issue, when adding the `TagetPlatform.iOS` to the clause, it will allow the keybindings, which was previously compatible with macOS, be used also on iOS.