### PR TITLE
[SuperEditor][SuperReader][iOS] Fix horizontal text selection inside a CustomScrollView (Resolves #1610)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1275,12 +1275,27 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
               ..gestureSettings = gestureSettings;
           },
         ),
-        // We use a VerticalDragGestureRecognizer instead of a PanGestureRecognizer
-        // because `Scrollable` also uses a VerticalDragGestureRecognizer and we
-        // need to beat out any ancestor `Scrollable` in the gesture arena.
+        // We use a combination of a VerticalDragGestureRecognizer and a HorizontalDragGestureRecognizer
+        // instead of a PanGestureRecognizer because `Scrollable` also uses a VerticalDragGestureRecognizer
+        // and we need to beat out any ancestor `Scrollable` in the gesture arena.
+        // Without the HorizontalDragGestureRecognizer, horizontal drags aren't reported here
+        // when the editor has an ancestor `Scrollable`.
         VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
           () => VerticalDragGestureRecognizer(),
           (VerticalDragGestureRecognizer instance) {
+            instance
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onDown = _onPanDown
+              ..onStart = _onPanStart
+              ..onUpdate = _onPanUpdate
+              ..onEnd = _onPanEnd
+              ..onCancel = _onPanCancel
+              ..gestureSettings = gestureSettings;
+          },
+        ),
+        HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+          () => HorizontalDragGestureRecognizer(),
+          (HorizontalDragGestureRecognizer instance) {
             instance
               ..dragStartBehavior = DragStartBehavior.down
               ..onDown = _onPanDown

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -972,12 +972,27 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
               ..gestureSettings = gestureSettings;
           },
         ),
-        // We use a VerticalDragGestureRecognizer instead of a PanGestureRecognizer
-        // because `Scrollable` also uses a VerticalDragGestureRecognizer and we
-        // need to beat out any ancestor `Scrollable` in the gesture arena.
+        // We use a combination of a VerticalDragGestureRecognizer and a HorizontalDragGestureRecognizer
+        // instead of a PanGestureRecognizer because `Scrollable` also uses a VerticalDragGestureRecognizer
+        // and we need to beat out any ancestor `Scrollable` in the gesture arena.
+        // Without the HorizontalDragGestureRecognizer, horizontal drags aren't reported here
+        // when the reader has an ancestor `Scrollable`.
         VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
           () => VerticalDragGestureRecognizer(),
           (VerticalDragGestureRecognizer instance) {
+            instance
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onDown = _onPanDown
+              ..onStart = _onPanStart
+              ..onUpdate = _onPanUpdate
+              ..onEnd = _onPanEnd
+              ..onCancel = _onPanCancel
+              ..gestureSettings = gestureSettings;
+          },
+        ),
+        HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+          () => HorizontalDragGestureRecognizer(),
+          (HorizontalDragGestureRecognizer instance) {
             instance
               ..dragStartBehavior = DragStartBehavior.down
               ..onDown = _onPanDown


### PR DESCRIPTION
[SuperEditor][SuperReader][iOS] Fix horizontal text selection inside a CustomScrollView. Resolves #1610

Performing a horizontal drag isn't changing the selection when the editor is inside a `CustomScrollView`.

The reason seems to be that the `VerticalDragGestureRecognizer` is losing in the gesture arena when inside an ancestor scrollable. Adding a `HorizontalDragGestureRecognizer` to the `RawGestureDetector` seems to fix the issue.

This PR doesn't add tests because so far I wasn't able to write a failing test with the current implementation. I'll file a ticket to write tests for this.

https://github.com/superlistapp/super_editor/assets/7597082/7bda2411-6374-4631-a5cf-81c23cde0879

