### PR TITLE
[SuperEditor] Linkify on Enter (Resolves #1600)

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -701,14 +701,22 @@ class SplitListItemCommand implements EditCommand {
     _log.log('SplitListItemCommand', ' - inserted new node: ${newNode.id} after old one: ${node.id}');
 
     executor.logChanges([
+      SplitListItemIntention.start(),
       DocumentEdit(
         NodeChangeEvent(nodeId),
       ),
       DocumentEdit(
         NodeInsertedEvent(newNodeId, document.getNodeIndexById(newNodeId)),
       ),
+      SplitListItemIntention.end(),
     ]);
   }
+}
+
+class SplitListItemIntention extends Intention {
+  SplitListItemIntention.start() : super.start();
+
+  SplitListItemIntention.end() : super.end();
 }
 
 ExecutionInstruction tabToIndentListItem({

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -542,6 +542,7 @@ class SplitExistingTaskCommand implements EditCommand {
     composer.setComposingRegion(null);
 
     executor.logChanges([
+      SplitTaskIntention.start(),
       DocumentEdit(
         NodeChangeEvent(node.id),
       ),
@@ -556,6 +557,13 @@ class SplitExistingTaskCommand implements EditCommand {
         changeType: SelectionChangeType.pushCaret,
         reason: SelectionReason.userInteraction,
       ),
+      SplitTaskIntention.end(),
     ]);
   }
+}
+
+class SplitTaskIntention extends Intention {
+  SplitTaskIntention.start() : super.start();
+
+  SplitTaskIntention.end() : super.end();
 }


### PR DESCRIPTION
[SuperEditor] Linkify on Enter. Resolves #1600 

Currently, we only linkify an URL if the user types a space after it. So, typing an URL and pressing ENTER isn't linkifying the URL.

This PR changes the `LinkifyReaction` to look for `SubmitParagraphIntention` and `SplitParagraphIntention`, so it can linkify the URL on ENTER.  As both `SubmitParagraphIntention` and `SplitParagraphIntention` don't have the node id, I had to look at the next change in the change list. We could also modify those objects to store the node id.

To also make it work for list items and tasks,  this PR adds the `SplitListItemIntention` and `SplitTaskIntention` to follow the same pattern.

https://github.com/superlistapp/super_editor/assets/7597082/b8b95da8-8595-4728-9bc2-ac4abc5778e5

We have some duplication on the tests because we basically need to run the same test three times, with the only difference being the signal we use to trigger a new line:

1. Simulate an ENTER key press on a hardware keyboard.
2. Simulate a "\n" insertion delta.
3. Simulate a newline action.