### PR TITLE
[SuperReader][SuperTextField] Applies color attribution on textstyle created through default style builder (Resolves #1579)

### DIFF
--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -859,6 +859,10 @@ TextStyle readOnlyDefaultStyleBuilder(Set<Attribution> attributions) {
             ? TextDecoration.lineThrough
             : TextDecoration.combine([TextDecoration.lineThrough, newStyle.decoration!]),
       );
+    } else if (attribution is ColorAttribution) {
+      newStyle = newStyle.copyWith(
+        color: attribution.color,
+      );
     } else if (attribution is LinkAttribution) {
       newStyle = newStyle.copyWith(
         color: Colors.lightBlue,

--- a/super_editor/lib/src/super_textfield/styles.dart
+++ b/super_editor/lib/src/super_textfield/styles.dart
@@ -37,6 +37,10 @@ TextStyle defaultTextFieldStyleBuilder(Set<Attribution> attributions) {
             ? TextDecoration.lineThrough
             : TextDecoration.combine([TextDecoration.lineThrough, newStyle.decoration!]),
       );
+    } else if (attribution is ColorAttribution) {
+      newStyle = newStyle.copyWith(
+        color: attribution.color,
+      );
     } else if (attribution is LinkAttribution) {
       newStyle = newStyle.copyWith(
         color: Colors.lightBlue,

--- a/super_editor/lib/src/super_textfield/styles.dart
+++ b/super_editor/lib/src/super_textfield/styles.dart
@@ -14,6 +14,7 @@ TextStyle defaultTextFieldStyleBuilder(Set<Attribution> attributions) {
   TextStyle newStyle = const TextStyle(
     fontSize: 16,
     height: 1,
+    color: Colors.black,
   );
 
   for (final attribution in attributions) {

--- a/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
@@ -118,12 +118,12 @@ class SuperReaderInspector {
     final documentLayout = _findDocumentLayout(superReaderFinder);
 
     final textComponentState = documentLayout.getComponentByNodeId(nodeId) as TextComponentState;
-    final superTextWithSelection = find
+    final superText = find
         .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperText))
         .evaluate()
         .single
         .widget as SuperText;
-    return superTextWithSelection.richText as TextSpan;
+    return superText.richText as TextSpan;
   }
 
   /// Finds and returns the [TextStyle] that's applied to the top-level of the [TextSpan]

--- a/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
@@ -119,10 +119,10 @@ class SuperReaderInspector {
 
     final textComponentState = documentLayout.getComponentByNodeId(nodeId) as TextComponentState;
     final superTextWithSelection = find
-        .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperTextWithSelection))
+        .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperText))
         .evaluate()
         .single
-        .widget as SuperTextWithSelection;
+        .widget as SuperText;
     return superTextWithSelection.richText as TextSpan;
   }
 

--- a/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
@@ -108,6 +108,24 @@ class SuperReaderInspector {
     return (documentLayout.getComponentByNodeId(nodeId) as TextComponentState).widget.text;
   }
 
+  /// Finds the paragraph with the given [nodeId] and returns the paragraph's content as a [TextSpan].
+  ///
+  /// A [TextSpan] is the fundamental way that Flutter styles text. It's the lowest level reflection
+  /// of what the user will see, short of rendering the actual UI.
+  ///
+  /// {@macro super_reader_finder}
+  static TextSpan findRichTextInParagraph(String nodeId, [Finder? superReaderFinder]) {
+    final documentLayout = _findDocumentLayout(superReaderFinder);
+
+    final textComponentState = documentLayout.getComponentByNodeId(nodeId) as TextComponentState;
+    final superTextWithSelection = find
+        .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperTextWithSelection))
+        .evaluate()
+        .single
+        .widget as SuperTextWithSelection;
+    return superTextWithSelection.richText as TextSpan;
+  }
+
   /// Finds and returns the [TextStyle] that's applied to the top-level of the [TextSpan]
   /// in the paragraph with the given [nodeId].
   ///

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -3,16 +3,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
-import 'package:super_editor/src/default_editor/attributions.dart';
-import 'package:super_editor/src/default_editor/text.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/src/test/ime.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
 import 'package:super_editor/super_editor.dart';
-import 'package:super_text_layout/super_text_layout.dart';
 
-import '../super_textfield/super_textfield_inspector.dart';
 import 'supereditor_test_tools.dart';
 import 'test_documents.dart';
 
@@ -199,7 +194,7 @@ void main() {
 
         // Ensure the text is colored orange.
         expect(
-          SuperTextFieldInspector.findRichText().style?.color,
+          SuperEditorInspector.findRichTextInParagraph("1").style?.color,
           Colors.orange,
         );
       });
@@ -214,13 +209,19 @@ void main() {
 
         // Ensure the first span is colored black.
         expect(
-          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          SuperEditorInspector.findRichTextInParagraph("1")
+              .getSpanForPosition(const TextPosition(offset: 0))!
+              .style!
+              .color,
           Colors.black,
         );
 
         // Ensure the second span is colored orange.
         expect(
-          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          SuperEditorInspector.findRichTextInParagraph("1")
+              .getSpanForPosition(const TextPosition(offset: 5))!
+              .style!
+              .color,
           Colors.orange,
         );
       });

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -12,6 +12,7 @@ import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import '../super_textfield/super_textfield_inspector.dart';
 import 'supereditor_test_tools.dart';
 import 'test_documents.dart';
 
@@ -196,11 +197,9 @@ void main() {
             )
             .pump();
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the text is colored orange.
         expect(
-          superText.richText.style!.color,
+          SuperTextFieldInspector.findRichText().style?.color,
           Colors.orange,
         );
       });
@@ -213,17 +212,15 @@ void main() {
             )
             .pump();
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the first span is colored black.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
           Colors.black,
         );
 
         // Ensure the second span is colored orange.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
           Colors.orange,
         );
       });

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -216,7 +216,6 @@ void main() {
                 ],
               ),
             )
-            .withInputSource(TextInputSource.ime)
             .pump();
 
         final superText = tester.widget<SuperText>(find.byType(SuperText));
@@ -227,6 +226,7 @@ void main() {
           Colors.orange,
         );
       });
+
       testWidgetsOnAllPlatforms("to partial text", (tester) async {
         await tester //
             .createDocument()
@@ -256,7 +256,6 @@ void main() {
                 ],
               ),
             )
-            .withInputSource(TextInputSource.ime)
             .pump();
 
         final superText = tester.widget<SuperText>(find.byType(SuperText));

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -13,6 +13,7 @@ import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import 'supereditor_test_tools.dart';
+import 'test_documents.dart';
 
 void main() {
   group("SuperEditor", () {
@@ -191,30 +192,7 @@ void main() {
         await tester //
             .createDocument()
             .withCustomContent(
-              MutableDocument(
-                nodes: [
-                  ParagraphNode(
-                    id: '1',
-                    text: AttributedText(
-                      'abcdefghij',
-                      AttributedSpans(
-                        attributions: [
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 0,
-                            markerType: SpanMarkerType.start,
-                          ),
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 9,
-                            markerType: SpanMarkerType.end,
-                          ),
-                        ],
-                      ),
-                    ),
-                  )
-                ],
-              ),
+              singleParagraphFullColor(),
             )
             .pump();
 
@@ -231,30 +209,7 @@ void main() {
         await tester //
             .createDocument()
             .withCustomContent(
-              MutableDocument(
-                nodes: [
-                  ParagraphNode(
-                    id: '1',
-                    text: AttributedText(
-                      'abcdefghij',
-                      AttributedSpans(
-                        attributions: [
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 5,
-                            markerType: SpanMarkerType.start,
-                          ),
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 9,
-                            markerType: SpanMarkerType.end,
-                          ),
-                        ],
-                      ),
-                    ),
-                  )
-                ],
-              ),
+              singleParagraphWithPartialColor(),
             )
             .pump();
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
@@ -8,6 +9,8 @@ import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/src/test/ime.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import 'supereditor_test_tools.dart';
 
@@ -180,6 +183,95 @@ void main() {
           // Ensure the link attribution was applied to the inserted text.
           expect(doc, equalsMarkdown("[This is a linnk](https://google.com) pointing to google"));
         });
+      });
+    });
+
+    group("applies color attributions", () {
+      testWidgetsOnAllPlatforms("to full text", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              MutableDocument(
+                nodes: [
+                  ParagraphNode(
+                    id: '1',
+                    text: AttributedText(
+                      'abcdefghij',
+                      AttributedSpans(
+                        attributions: [
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 0,
+                            markerType: SpanMarkerType.start,
+                          ),
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 9,
+                            markerType: SpanMarkerType.end,
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            )
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the text is colored orange.
+        expect(
+          superText.richText.style!.color,
+          Colors.orange,
+        );
+      });
+      testWidgetsOnAllPlatforms("to partial text", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              MutableDocument(
+                nodes: [
+                  ParagraphNode(
+                    id: '1',
+                    text: AttributedText(
+                      'abcdefghij',
+                      AttributedSpans(
+                        attributions: [
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 5,
+                            markerType: SpanMarkerType.start,
+                          ),
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 9,
+                            markerType: SpanMarkerType.end,
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            )
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the first span is colored black.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          Colors.black,
+        );
+
+        // Ensure the second span is colored orange.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          Colors.orange,
+        );
       });
     });
 

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:super_editor/super_editor.dart';
 
 MutableDocument paragraphThenHrThenParagraphDoc() => MutableDocument(
@@ -228,5 +229,55 @@ MutableDocument longDoc() => MutableDocument(
             'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
           ),
         ),
+      ],
+    );
+
+MutableDocument singleParagraphWithPartialColor() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: '1',
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 5,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+
+MutableDocument singleParagraphFullColor() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: '1',
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        )
       ],
     );

--- a/super_editor/test/super_reader/superreader_attributions_test.dart
+++ b/super_editor/test/super_reader/superreader_attributions_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import 'reader_test_tools.dart';
+
+void main() {
+  group("SuperReader", () {
+    group("applies color attributions", () {
+      testWidgetsOnAllPlatforms("to full text", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              MutableDocument(
+                nodes: [
+                  ParagraphNode(
+                    id: '1',
+                    text: AttributedText(
+                      'abcdefghij',
+                      AttributedSpans(
+                        attributions: [
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 0,
+                            markerType: SpanMarkerType.start,
+                          ),
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 9,
+                            markerType: SpanMarkerType.end,
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            )
+            .pump();
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the text is colored orange.
+        expect(
+          superText.richText.style!.color,
+          Colors.orange,
+        );
+      });
+
+      testWidgetsOnAllPlatforms("to partial text", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              MutableDocument(
+                nodes: [
+                  ParagraphNode(
+                    id: '1',
+                    text: AttributedText(
+                      'abcdefghij',
+                      AttributedSpans(
+                        attributions: [
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 5,
+                            markerType: SpanMarkerType.start,
+                          ),
+                          const SpanMarker(
+                            attribution: ColorAttribution(Colors.orange),
+                            offset: 9,
+                            markerType: SpanMarkerType.end,
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            )
+            .pump();
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the first span is colored black.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          Colors.black,
+        );
+
+        // Ensure the second span is colored orange.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          Colors.orange,
+        );
+      });
+    });
+  });
+}

--- a/super_editor/test/super_reader/superreader_attributions_test.dart
+++ b/super_editor/test/super_reader/superreader_attributions_test.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
-import 'package:super_editor/super_editor.dart';
-import 'package:super_text_layout/super_text_layout.dart';
+import 'package:super_editor/src/test/super_reader_test/super_reader_inspector.dart';
 
 import '../super_editor/test_documents.dart';
-import '../super_textfield/super_textfield_inspector.dart';
 import 'reader_test_tools.dart';
 
 void main() {
@@ -21,7 +19,7 @@ void main() {
 
         // Ensure the text is colored orange.
         expect(
-          SuperTextFieldInspector.findRichText().style!.color,
+          SuperReaderInspector.findRichTextInParagraph("1").style!.color,
           Colors.orange,
         );
       });
@@ -36,13 +34,19 @@ void main() {
 
         // Ensure the first span is colored black.
         expect(
-          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          SuperReaderInspector.findRichTextInParagraph("1")
+              .getSpanForPosition(const TextPosition(offset: 0))!
+              .style!
+              .color,
           Colors.black,
         );
 
         // Ensure the second span is colored orange.
         expect(
-          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          SuperReaderInspector.findRichTextInParagraph("1")
+              .getSpanForPosition(const TextPosition(offset: 5))!
+              .style!
+              .color,
           Colors.orange,
         );
       });

--- a/super_editor/test/super_reader/superreader_attributions_test.dart
+++ b/super_editor/test/super_reader/superreader_attributions_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import '../super_editor/test_documents.dart';
+import '../super_textfield/super_textfield_inspector.dart';
 import 'reader_test_tools.dart';
 
 void main() {
@@ -13,38 +15,13 @@ void main() {
         await tester //
             .createDocument()
             .withCustomContent(
-              MutableDocument(
-                nodes: [
-                  ParagraphNode(
-                    id: '1',
-                    text: AttributedText(
-                      'abcdefghij',
-                      AttributedSpans(
-                        attributions: [
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 0,
-                            markerType: SpanMarkerType.start,
-                          ),
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 9,
-                            markerType: SpanMarkerType.end,
-                          ),
-                        ],
-                      ),
-                    ),
-                  )
-                ],
-              ),
+              singleParagraphFullColor(),
             )
             .pump();
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the text is colored orange.
         expect(
-          superText.richText.style!.color,
+          SuperTextFieldInspector.findRichText().style!.color,
           Colors.orange,
         );
       });
@@ -53,44 +30,19 @@ void main() {
         await tester //
             .createDocument()
             .withCustomContent(
-              MutableDocument(
-                nodes: [
-                  ParagraphNode(
-                    id: '1',
-                    text: AttributedText(
-                      'abcdefghij',
-                      AttributedSpans(
-                        attributions: [
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 5,
-                            markerType: SpanMarkerType.start,
-                          ),
-                          const SpanMarker(
-                            attribution: ColorAttribution(Colors.orange),
-                            offset: 9,
-                            markerType: SpanMarkerType.end,
-                          ),
-                        ],
-                      ),
-                    ),
-                  )
-                ],
-              ),
+              singleParagraphWithPartialColor(),
             )
             .pump();
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the first span is colored black.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
           Colors.black,
         );
 
         // Ensure the second span is colored orange.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
           Colors.orange,
         );
       });

--- a/super_editor/test/super_textfield/super_textfield_attributions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_attributions_test.dart
@@ -64,8 +64,8 @@ void main() {
 
         // Ensure the first span is colored black.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style?.color,
-          null,
+          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          Colors.black,
         );
 
         // Ensure the second span is colored orange.

--- a/super_editor/test/super_textfield/super_textfield_attributions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_attributions_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
+import 'super_textfield_inspector.dart';
+
 void main() {
   group("SuperTextField", () {
     group("applies color attributions", () {
@@ -29,11 +31,9 @@ void main() {
           ),
         );
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the text is colored orange.
         expect(
-          superText.richText.style!.color,
+          SuperTextFieldInspector.findRichText().style!.color,
           Colors.orange,
         );
       });
@@ -60,17 +60,15 @@ void main() {
           ),
         );
 
-        final superText = tester.widget<SuperText>(find.byType(SuperText));
-
         // Ensure the first span is colored black.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 0))!.style!.color,
           Colors.black,
         );
 
         // Ensure the second span is colored orange.
         expect(
-          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          SuperTextFieldInspector.findRichText().getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
           Colors.orange,
         );
       });

--- a/super_editor/test/super_textfield/super_textfield_attributions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_attributions_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+void main() {
+  group("SuperTextField", () {
+    group("applies color attributions", () {
+      testWidgetsOnAllPlatforms("to full text", (tester) async {
+        await _pumpTestApp(
+          tester,
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the text is colored orange.
+        expect(
+          superText.richText.style!.color,
+          Colors.orange,
+        );
+      });
+
+      testWidgetsOnAllPlatforms("to partial text", (tester) async {
+        await _pumpTestApp(
+          tester,
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 5,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final superText = tester.widget<SuperText>(find.byType(SuperText));
+
+        // Ensure the first span is colored black.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 0))!.style?.color,
+          null,
+        );
+
+        // Ensure the second span is colored orange.
+        expect(
+          superText.richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color,
+          Colors.orange,
+        );
+      });
+    });
+  });
+}
+
+/// Pumps a [SuperTextField] with the given attributed [text].
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required AttributedText text,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperTextField(
+          textController: AttributedTextEditingController(
+            text: text,
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // A SuperTextField configured with maxLines can't render in the first frame.
+  // Ask another frame, so the text field can be found by the finder.
+  await tester.pump();
+}

--- a/super_editor/test/super_textfield/super_textfield_attributions_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_attributions_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
-import 'package:super_text_layout/super_text_layout.dart';
 
 import 'super_textfield_inspector.dart';
 

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -24,6 +24,17 @@ class SuperTextFieldInspector {
     return state.controller.text;
   }
 
+  /// Finds and returns the [RichText] within a [SuperTextField].
+  ///
+  /// {@macro supertextfield_finder}
+  static InlineSpan findRichText([Finder? superTextFieldFinder]) {
+    final resolvedSuperTextFieldFinder = superTextFieldFinder ?? find.byType(SuperTextField);
+    final superText = find.descendant(of: resolvedSuperTextFieldFinder, matching: find.byType(SuperText));
+    final element = superText.evaluate().single as StatefulElement;
+    final state = element.state as SuperTextState;
+    return state.widget.richText;
+  }
+
   /// Finds and returns the [TextSelection] within a [SuperTextField].
   ///
   /// {@macro supertextfield_finder}

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -29,10 +29,40 @@ class SuperTextFieldInspector {
   /// {@macro supertextfield_finder}
   static InlineSpan findRichText([Finder? superTextFieldFinder]) {
     final resolvedSuperTextFieldFinder = superTextFieldFinder ?? find.byType(SuperTextField);
-    final superText = find.descendant(of: resolvedSuperTextFieldFinder, matching: find.byType(SuperText));
-    final element = superText.evaluate().single as StatefulElement;
-    final state = element.state as SuperTextState;
-    return state.widget.richText;
+
+    // Try to find a SuperTextField that contains a SuperText. It's possible
+    // that a SuperTextField uses a SuperTextWithSelection instead of a SuperText,
+    // that condition is handled later.
+    final superTextFinder = find.descendant(of: resolvedSuperTextFieldFinder, matching: find.byType(SuperText));
+    final superTextElements = superTextFinder.evaluate();
+
+    if (superTextElements.length > 1) {
+      throw Exception("Found more than 1 super text field match with finder: $resolvedSuperTextFieldFinder");
+    }
+
+    if (superTextElements.length == 1) {
+      final element = superTextFinder.evaluate().single as StatefulElement;
+      final state = element.state as SuperTextState;
+      return state.widget.richText;
+    }
+
+    // We didn't find a SuperTextField with a SuperText. Now we'll search for a
+    // SuperTextField with a selection.
+    final superTextWithSelectionFinder =
+        find.descendant(of: resolvedSuperTextFieldFinder, matching: find.byType(SuperTextWithSelection));
+    final superTextWithSelectionElements = superTextWithSelectionFinder.evaluate();
+
+    if (superTextWithSelectionElements.length > 1) {
+      throw Exception("Found more than 1 super text field match with finder: $resolvedSuperTextFieldFinder");
+    }
+
+    if (superTextWithSelectionElements.length == 1) {
+      final element = superTextWithSelectionFinder.evaluate().single as StatefulElement;
+      final state = element.state as SuperTextState;
+      return state.widget.richText;
+    }
+
+    throw Exception("Couldn't find a super text field variant with the given finder: $resolvedSuperTextFieldFinder");
   }
 
   /// Finds and returns the [TextSelection] within a [SuperTextField].


### PR DESCRIPTION
[SuperReader][SuperTextField] Applies color attribution on textstyle created through default style builder (Resolves #1579)

### **The Issue:** 

Colored attributions set on text passed to `SuperReader` and `SuperTextField` aren't applied to the final rendered text within the document. 

With following attributed text passed to both `SuperReader` and `SuperTextField`, 

```
AttributedText(
    'My text colored in orange',
    AttributedSpans(
      attributions: const [
        SpanMarker(
          attribution: ColorAttribution(
            Colors.orange,
          ),
          offset: 0,
          markerType: SpanMarkerType.start,
        ),
        SpanMarker(
          attribution: ColorAttribution(
            Colors.orange,
          ),
          offset: 24,
          markerType: SpanMarkerType.end,
        ),
      ],
    ),
  ),
```
<br>

`SuperReader` output:

<img width="457" alt="Screenshot 2023-11-29 at 2 44 24 AM" src="https://github.com/superlistapp/super_editor/assets/65209850/08ab67e1-f32d-4f1c-8069-9feeb139c865">
<br>
<br>

`SuperTextField` output(on Desktop):

<img width="679" alt="Screenshot 2023-11-30 at 1 41 35 PM" src="https://github.com/superlistapp/super_editor/assets/65209850/83374e95-2f3e-46ca-a203-be2bcc10bdfb">

<br>
<br>

### **Solution:**

Turns out that the `readOnlyDefaultStyleBuilder` used by `SuperReader` and `defaultTextFieldStyleBuilder` used by `SuperTextField` which are responsible for creating a text style based on set of text attributions weren't applying the passed color attribution to the created text style.

This PR updates `readOnlyDefaultStyleBuilder` and `defaultTextFieldStyleBuilder` to include a check to see if incoming `Attribution` is of type `ColorAttribution`, if it's then updates text style color with color set within `ColorAttribution`.

`SuperReader` output:

<img width="457" alt="Screenshot 2023-11-29 at 2 44 10 AM" src="https://github.com/superlistapp/super_editor/assets/65209850/c973dfb7-082d-42c1-b2bf-88b987b7d951">

<br>

`SuperTextField` output(on Desktop):

<img width="679" alt="Screenshot 2023-11-30 at 1 42 24 PM" src="https://github.com/superlistapp/super_editor/assets/65209850/9aeb7a34-4cb1-438e-b0f8-0822b6b5c92a">

