### PR TITLE
[SuperEditor][iOS] Add tests for drag to select (Resolves #1613)

### DIFF
--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -156,10 +157,14 @@ extension SuperEditorRobot on WidgetTester {
   /// to ensure that the drag rectangle never has a zero-width or a
   /// zero-height, because such a drag rectangle wouldn't be seen as
   /// intersecting any content.
+  ///
+  /// Provide a [pointerDeviceKind] to override the device kind used in the gesture.
+  /// If [pointerDeviceKind] is `null`, it defaults to [PointerDeviceKind.touch]
+  /// on mobile, and [PointerDeviceKind.mouse] on other platforms.
   Future<void> dragSelectDocumentFromPositionByOffset({
     required DocumentPosition from,
     required Offset delta,
-    PointerDeviceKind pointerDeviceKind = PointerDeviceKind.mouse,
+    PointerDeviceKind? pointerDeviceKind,
     Finder? superEditorFinder,
   }) async {
     final documentLayout = _findDocumentLayout(superEditorFinder);
@@ -197,8 +202,13 @@ extension SuperEditorRobot on WidgetTester {
       }
     }
 
+    final deviceKind = pointerDeviceKind ??
+        (defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android
+            ? PointerDeviceKind.touch
+            : PointerDeviceKind.mouse);
+
     // Simulate the drag.
-    final gesture = await startGesture(dragStartOffset, kind: pointerDeviceKind);
+    final gesture = await startGesture(dragStartOffset, kind: deviceKind);
 
     // Move slightly so that a "pan start" is reported.
     //

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -159,6 +159,7 @@ extension SuperEditorRobot on WidgetTester {
   Future<void> dragSelectDocumentFromPositionByOffset({
     required DocumentPosition from,
     required Offset delta,
+    PointerDeviceKind pointerDeviceKind = PointerDeviceKind.mouse,
     Finder? superEditorFinder,
   }) async {
     final documentLayout = _findDocumentLayout(superEditorFinder);
@@ -197,7 +198,7 @@ extension SuperEditorRobot on WidgetTester {
     }
 
     // Simulate the drag.
-    final gesture = await startGesture(dragStartOffset, kind: PointerDeviceKind.mouse);
+    final gesture = await startGesture(dragStartOffset, kind: pointerDeviceKind);
 
     // Move slightly so that a "pan start" is reported.
     //

--- a/super_editor/lib/src/test/super_reader_test/super_reader_robot.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_robot.dart
@@ -85,6 +85,7 @@ extension SuperReaderRobot on WidgetTester {
   Future<void> dragSelectDocumentFromPositionByOffset({
     required DocumentPosition from,
     required Offset delta,
+    PointerDeviceKind pointerDeviceKind = PointerDeviceKind.mouse,
     Finder? superReaderFinder,
   }) async {
     final documentLayout = _findDocumentLayout(superReaderFinder);
@@ -123,7 +124,7 @@ extension SuperReaderRobot on WidgetTester {
     }
 
     // Simulate the drag.
-    final gesture = await startGesture(dragStartOffset, kind: PointerDeviceKind.mouse);
+    final gesture = await startGesture(dragStartOffset, kind: pointerDeviceKind);
 
     // Move slightly so that a "pan start" is reported.
     //

--- a/super_editor/lib/src/test/super_reader_test/super_reader_robot.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_robot.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -82,10 +83,14 @@ extension SuperReaderRobot on WidgetTester {
   /// to ensure that the drag rectangle never has a zero-width or a
   /// zero-height, because such a drag rectangle wouldn't be seen as
   /// intersecting any content.
+  ///
+  /// Provide a [pointerDeviceKind] to override the device kind used in the gesture.
+  /// If [pointerDeviceKind] is `null`, it defaults to [PointerDeviceKind.touch]
+  /// on mobile, and [PointerDeviceKind.mouse] on other platforms.
   Future<void> dragSelectDocumentFromPositionByOffset({
     required DocumentPosition from,
     required Offset delta,
-    PointerDeviceKind pointerDeviceKind = PointerDeviceKind.mouse,
+    PointerDeviceKind? pointerDeviceKind,
     Finder? superReaderFinder,
   }) async {
     final documentLayout = _findDocumentLayout(superReaderFinder);
@@ -123,8 +128,13 @@ extension SuperReaderRobot on WidgetTester {
       }
     }
 
+    final deviceKind = pointerDeviceKind ??
+        (defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android
+            ? PointerDeviceKind.touch
+            : PointerDeviceKind.mouse);
+
     // Simulate the drag.
-    final gesture = await startGesture(dragStartOffset, kind: pointerDeviceKind);
+    final gesture = await startGesture(dragStartOffset, kind: deviceKind);
 
     // Move slightly so that a "pan start" is reported.
     //

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -230,16 +230,12 @@ multiple lines.''',
         await tester.doubleTapInParagraph(paragraphNode.id, 0);
 
         // Drag from "SuperEdito|r" a distance long enough to go through the entire first line.
-        //
-        // Explicitly use "PointerDeviceKind.touch" because "PointerDeviceKind.mouse" isn't
-        // considered a drag device on mobile.
         await tester.dragSelectDocumentFromPositionByOffset(
           from: DocumentPosition(
             nodeId: paragraphNode.id,
             nodePosition: const TextNodePosition(offset: 10),
           ),
           delta: const Offset(300, 0),
-          pointerDeviceKind: PointerDeviceKind.touch,
         );
 
         // Ensure the first line is selected.
@@ -278,22 +274,18 @@ multiple lines.''',
         await tester.doubleTapInParagraph(paragraphNode.id, 0);
 
         // Drag from "SuperEdito|r" a distance long enough to go to the last line.
-        //
-        // Explicitly use "PointerDeviceKind.touch" because "PointerDeviceKind.mouse" isn't
-        // considered a drag device on mobile.
         await tester.dragSelectDocumentFromPositionByOffset(
           from: DocumentPosition(
             nodeId: paragraphNode.id,
             nodePosition: const TextNodePosition(offset: 10),
           ),
           delta: const Offset(0, 40),
-          pointerDeviceKind: PointerDeviceKind.touch,
         );
 
         // Ensure the selection starts at the beginning and end at "multiple l|ines".
         expect(
           SuperEditorInspector.findDocumentSelection(),
-          equals(
+          selectionEquivalentTo(
             DocumentSelection(
               base: DocumentPosition(
                 nodeId: paragraphNode.id,

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
+import '../../test_tools.dart';
 import '../supereditor_test_tools.dart';
 
 void main() {
@@ -206,6 +208,104 @@ void main() {
           // Release the gesture so the test system doesn't complain.
           await gesture.up();
         });
+      });
+    });
+
+    group('within ancestor scrollable', () {
+      testWidgetsOnIos("expands selection when dragging horizontally", (tester) async {
+        final testContext = await tester
+            .createDocument()
+            .fromMarkdown(
+              '''
+SuperEditor containing a
+paragraph that spans 
+multiple lines.''',
+            )
+            .insideCustomScrollView()
+            .pump();
+
+        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+
+        // Double tap to select "SuperEditor".
+        await tester.doubleTapInParagraph(paragraphNode.id, 0);
+
+        // Drag from "SuperEdito|r" a distance long enough to go through the entire first line.
+        //
+        // Explicitly use "PointerDeviceKind.touch" because "PointerDeviceKind.mouse" isn't
+        // considered a drag device on mobile.
+        await tester.dragSelectDocumentFromPositionByOffset(
+          from: DocumentPosition(
+            nodeId: paragraphNode.id,
+            nodePosition: const TextNodePosition(offset: 10),
+          ),
+          delta: const Offset(300, 0),
+          pointerDeviceKind: PointerDeviceKind.touch,
+        );
+
+        // Ensure the first line is selected.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 24),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("expands selection when dragging vertically", (tester) async {
+        final testContext = await tester
+            .createDocument()
+            .fromMarkdown(
+              '''
+SuperEditor containing a
+paragraph that spans 
+multiple lines.''',
+            )
+            .insideCustomScrollView()
+            .pump();
+
+        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+
+        // Double tap to select "SuperEditor".
+        await tester.doubleTapInParagraph(paragraphNode.id, 0);
+
+        // Drag from "SuperEdito|r" a distance long enough to go to the last line.
+        //
+        // Explicitly use "PointerDeviceKind.touch" because "PointerDeviceKind.mouse" isn't
+        // considered a drag device on mobile.
+        await tester.dragSelectDocumentFromPositionByOffset(
+          from: DocumentPosition(
+            nodeId: paragraphNode.id,
+            nodePosition: const TextNodePosition(offset: 10),
+          ),
+          delta: const Offset(0, 40),
+          pointerDeviceKind: PointerDeviceKind.touch,
+        );
+
+        // Ensure the selection starts at the beginning and end at "multiple l|ines".
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          equals(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 57),
+              ),
+            ),
+          ),
+        );
       });
     });
   });

--- a/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
+++ b/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
@@ -5,6 +6,7 @@ import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_reader_test.dart';
 
+import '../../test_tools.dart';
 import '../reader_test_tools.dart';
 
 void main() {
@@ -245,6 +247,98 @@ void main() {
           // Release the gesture so the test system doesn't complain.
           gesture.up();
         });
+      });
+    });
+
+    group('within ancestor scrollable', () {
+      testWidgetsOnIos("expands selection when dragging horizontally", (tester) async {
+        final testContext = await tester
+            .createDocument()
+            .fromMarkdown(
+              '''
+SuperEditor containing a
+paragraph that spans 
+multiple lines.''',
+            )
+            .insideCustomScrollView()
+            .pump();
+
+        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+
+        // Double tap to select "SuperEditor".
+        await SuperReaderRobot(tester).doubleTapInParagraph(paragraphNode.id, 0);
+
+        // Drag from "SuperEdito|r" a distance long enough to go through the entire first line.
+        await SuperReaderRobot(tester).dragSelectDocumentFromPositionByOffset(
+          from: DocumentPosition(
+            nodeId: paragraphNode.id,
+            nodePosition: const TextNodePosition(offset: 10),
+          ),
+          delta: const Offset(300, 0),
+          pointerDeviceKind: PointerDeviceKind.touch,
+        );
+
+        // Ensure the first line is selected.
+        expect(
+          SuperReaderInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 24),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnIos("expands selection when dragging vertically", (tester) async {
+        final testContext = await tester
+            .createDocument()
+            .fromMarkdown(
+              '''
+SuperEditor containing a
+paragraph that spans 
+multiple lines.''',
+            )
+            .insideCustomScrollView()
+            .pump();
+
+        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+
+        // Double tap to select "SuperEditor".
+        await SuperReaderRobot(tester).doubleTapInParagraph(paragraphNode.id, 0);
+
+        // Drag from "SuperEdito|r" a distance long enough to go to the last line.
+        await SuperReaderRobot(tester).dragSelectDocumentFromPositionByOffset(
+          from: DocumentPosition(
+            nodeId: paragraphNode.id,
+            nodePosition: const TextNodePosition(offset: 10),
+          ),
+          delta: const Offset(0, 40),
+          pointerDeviceKind: PointerDeviceKind.touch,
+        );
+
+        // Ensure the selection starts at the beginning and end at "multiple l|ines".
+        expect(
+          SuperReaderInspector.findDocumentSelection(),
+          equals(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: paragraphNode.id,
+                nodePosition: const TextNodePosition(offset: 57),
+              ),
+            ),
+          ),
+        );
       });
     });
   });

--- a/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
+++ b/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
@@ -275,7 +275,6 @@ multiple lines.''',
             nodePosition: const TextNodePosition(offset: 10),
           ),
           delta: const Offset(300, 0),
-          pointerDeviceKind: PointerDeviceKind.touch,
         );
 
         // Ensure the first line is selected.
@@ -320,13 +319,12 @@ multiple lines.''',
             nodePosition: const TextNodePosition(offset: 10),
           ),
           delta: const Offset(0, 40),
-          pointerDeviceKind: PointerDeviceKind.touch,
         );
 
         // Ensure the selection starts at the beginning and end at "multiple l|ines".
         expect(
           SuperReaderInspector.findDocumentSelection(),
-          equals(
+          selectionEquivalentTo(
             DocumentSelection(
               base: DocumentPosition(
                 nodeId: paragraphNode.id,

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
 
 /// A [UrlLauncher] that logs each attempt to launch a URL, but doesn't
@@ -44,5 +45,76 @@ extension DragExtensions on WidgetTester {
     }
 
     return dragGesture;
+  }
+}
+
+/// Compares two selections, ignoring selection affinities.
+///
+/// Some node positions, like [TextNodePosition], have a concept of affinity (upstream/downstream),
+/// which is used when making particular selection decisions, but doesn't impact equivalency.
+Matcher selectionEquivalentTo(DocumentSelection expectedSelection) => EquivalentSelectionMatcher(expectedSelection);
+
+/// A [Matcher] that compares two selections, ignoring selection affinities.
+///
+/// Some node positions, like [TextNodePosition], have a concept of affinity (upstream/downstream),
+/// which is used when making particular selection decisions, but doesn't impact equivalency.
+class EquivalentSelectionMatcher extends Matcher {
+  EquivalentSelectionMatcher(
+    this.expectedSelection,
+  );
+
+  final DocumentSelection expectedSelection;
+
+  @override
+  Description describe(Description description) {
+    return description.add("given selection is equivalent to expected selection");
+  }
+
+  @override
+  bool matches(covariant Object target, Map<dynamic, dynamic> matchState) {
+    return _calculateMismatchReason(target, matchState) == null;
+  }
+
+  @override
+  Description describeMismatch(
+    covariant Object target,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    final mismatchReason = _calculateMismatchReason(target, matchState);
+    if (mismatchReason != null) {
+      mismatchDescription.add(mismatchReason);
+    }
+    return mismatchDescription;
+  }
+
+  String? _calculateMismatchReason(
+    Object target,
+    Map<dynamic, dynamic> matchState,
+  ) {
+    if (target is! DocumentSelection) {
+      return "the given target isn't a DocumentSelection";
+    }
+
+    if (target.base.nodeId != expectedSelection.base.nodeId) {
+      return "The selection doesn't start at the expected node.\nExpected: $expectedSelection\nActual: $target";
+    }
+
+    if (target.extent.nodeId != expectedSelection.extent.nodeId) {
+      return "The selection doesn't end at the expected node.\nExpected: $expectedSelection\nActual: $target";
+    }
+
+    if (!target.base.nodePosition.isEquivalentTo(expectedSelection.base.nodePosition)) {
+      // The base node positions aren't the same.
+      return 'The selection starts at the correct node, but at a wrong position.\nExpected: $expectedSelection\nActual: $target';
+    }
+
+    if (!target.extent.nodePosition.isEquivalentTo(expectedSelection.extent.nodePosition)) {
+      // The extent node positions aren't the same.
+      return 'The selection ends at the correct node, but at a wrong position.\nExpected: $expectedSelection\nActual: $target';
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
[SuperEditor][iOS] Add tests for drag to select. Resolves #1613

It was reported in https://github.com/superlistapp/super_editor/issues/1610 that performing a horizontal drag isn't changing the selection. https://github.com/superlistapp/super_editor/pull/1611 fixed the bug, but didn't include any tests.

This PR adds test for horizontal dragging inside a `CustomScrollView`. During the tests I got some failures because dragging can cause an `upstream` selection affinity.  I added a custom `Matcher` to compare the selections, ignoring the affinity. We have something similar to this in `NodePosition.isEquivalentTo`. 

Initially, these tests weren't failing, even without the fix. The reason is that `dragSelectDocumentFromPositionByOffset` always uses `PointerDeviceKind.mouse` as the device kind when starting the gesture. As this device kind isn't considered a drag device in mobile, the `CustomScrollView` didn't try to accept the gesture.

This PR adds a `pointerDeviceKind` parameter to `dragSelectDocumentFromPositionByOffset`, so we can override the device kind. 

We should consider changing all `dragXX` methods to default the device kind depending on the platform