### PR TITLE
Remove unused parameters on private classes

### DIFF
--- a/super_editor/test/infrastructure/content_layers_test.dart
+++ b/super_editor/test/infrastructure/content_layers_test.dart
@@ -542,9 +542,7 @@ class _RebuildableWidget extends StatefulWidget {
     Key? key,
     this.rebuildSignal,
     this.buildTracker,
-    this.elementTracker,
     this.onBuildScheduled,
-    this.onBuild,
     this.builder,
     this.child,
   })  : assert(child != null || builder != null, "Must provide either a child OR a builder."),
@@ -557,14 +555,8 @@ class _RebuildableWidget extends StatefulWidget {
   /// The number of times this widget has run `build()`.
   final ValueNotifier<int>? buildTracker;
 
-  /// The [Element] that currently owns this `Widget` and its `State`.
-  final ValueNotifier<Element?>? elementTracker;
-
   /// Callback that's invoked when this widget calls `setState()`.
   final VoidCallback? onBuildScheduled;
-
-  /// Callback that's invoked during this widget's `build()` method.
-  final VoidCallback? onBuild;
 
   final WidgetBuilder? builder;
   final Widget? child;
@@ -623,10 +615,6 @@ class _RebuildableWidgetState extends State<_RebuildableWidget> {
   @override
   Widget build(BuildContext context) {
     widget.buildTracker?.value += 1;
-    widget.elementTracker?.value = context as Element;
-
-    widget.onBuild?.call();
-
     return widget.child != null ? widget.child! : widget.builder!.call(context);
   }
 }
@@ -638,7 +626,6 @@ class _RebuildableContentLayerWidget extends ContentLayerStatefulWidget {
     this.rebuildSignal,
     this.buildTracker,
     this.elementTracker,
-    this.onBuildScheduled,
     this.onBuild,
     this.builder,
     this.child,
@@ -654,9 +641,6 @@ class _RebuildableContentLayerWidget extends ContentLayerStatefulWidget {
 
   /// The [Element] that currently owns this `Widget` and its `State`.
   final ValueNotifier<Element?>? elementTracker;
-
-  /// Callback that's invoked when this widget calls `setState()`.
-  final VoidCallback? onBuildScheduled;
 
   /// Callback that's invoked during this widget's `build()` method.
   final VoidCallback? onBuild;
@@ -702,17 +686,6 @@ class _RebuildableContentLayerWidgetState extends ContentLayerState<_Rebuildable
     // layout pass so that our tests can inspect the order of operations and ensure that
     // when the content layout changes, the content is always laid out before layers.
     context.findRenderObject()?.markNeedsLayout();
-  }
-
-  // This override is a regrettable requirement for ContentLayers, which is needed so
-  // that ContentLayers can remove the layers to prevent them from building during a
-  // regular build phase when the content changes. This is the result of Flutter making
-  // it impossible to monitor dirty subtrees, and making it impossible to control build
-  // order.
-  @override
-  void setState(VoidCallback fn) {
-    super.setState(fn);
-    widget.onBuildScheduled?.call();
   }
 
   @override


### PR DESCRIPTION
## Description

This removes unused parameters from some private classes in `content_layers_test.dart`, since there is currently a bug in `dart fix --apply` where it will remove the parameters that are unused, but not the associated members.

## Related Issues
 - https://github.com/dart-lang/sdk/issues/54190

## Related PRs
 - https://github.com/flutter/tests/pull/316