### PR TITLE
[DemoApp] Fix link visual styles when applying by the toolbar (Resolves #1632)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -383,10 +383,22 @@ class _EditorToolbarState extends State<EditorToolbar> {
     final trimmedRange = _trimTextRangeWhitespace(text, selectionRange);
 
     final linkAttribution = LinkAttribution(url: Uri.parse(url));
-    text.addAttribution(
-      linkAttribution,
-      trimmedRange,
-    );
+
+    widget.editor!.execute([
+      AddTextAttributionsRequest(
+        documentRange: DocumentRange(
+          start: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: TextNodePosition(offset: trimmedRange.start),
+          ),
+          end: DocumentPosition(
+            nodeId: textNode.id,
+            nodePosition: TextNodePosition(offset: trimmedRange.end),
+          ),
+        ),
+        attributions: {linkAttribution},
+      ),
+    ]);
 
     // Clear the field and hide the URL bar
     _urlController!.clear();
@@ -411,7 +423,8 @@ class _EditorToolbarState extends State<EditorToolbar> {
       endOffset -= 1;
     }
 
-    return SpanRange(startOffset, endOffset);
+    // Add 1 to the end offset because SpanRange treats the end offset to be exclusive.
+    return SpanRange(startOffset, endOffset + 1);
   }
 
   /// Changes the alignment of the current selected text node


### PR DESCRIPTION
[DemoApp] Fix link visual styles when applying by the toolbar. Resolves #1632

Applying a link to a text using the editor toolbar isn't updating the layout immediately.

https://github.com/superlistapp/super_editor/assets/7597082/ec2eb472-e447-4c88-8d64-5444acdb40eb

The issue is on the demo app itself, which is directly applying the link attribution instead of using the request/command pipeline.

This PR changes the demo app to apply the links by executing a `AddTextAttributionsRequest`.