### PR TITLE
Fixed double-tap and drag by word upstream (Resolves #1480)

### DIFF
--- a/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
+++ b/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
@@ -180,7 +180,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     if (tracker == null && _firstTap != null && _firstTap!.pointer == pointer) {
       tracker = _firstTap;
     }
-    // If tracker is still null, check if this is the first tap tracker
+    // If tracker is still null, check if this is the second tap tracker
     if (tracker == null && _secondTap != null && _secondTap!.pointer == pointer) {
       tracker = _secondTap;
     }
@@ -191,6 +191,10 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
   }
 
   void _reject(_TapTracker tracker) {
+    if (!_trackers.containsKey(tracker.pointer)) {
+      return;
+    }
+
     _trackers.remove(tracker.pointer);
     tracker.entry.resolve(GestureDisposition.rejected);
     _freezeTracker(tracker);

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -61,6 +61,26 @@ extension SuperEditorRobot on WidgetTester {
     return await startGesture(globalTapOffset);
   }
 
+  Future<TestGesture> doubleTapDownInParagraph(
+    String nodeId,
+    int offset, {
+    TextAffinity affinity = TextAffinity.downstream,
+    Finder? superEditorFinder,
+  }) async {
+    // Calculate the global tap position based on the TextLayout and desired TextPosition.
+    final globalTapOffset = _findGlobalOffsetForTextPosition(nodeId, offset, affinity, superEditorFinder);
+
+    final gesture = await startGesture(globalTapOffset);
+    await gesture.up();
+    await pump(kTapMinTime + const Duration(milliseconds: 1));
+
+    await gesture.down(globalTapOffset);
+    await pump(kTapMinTime + const Duration(milliseconds: 1));
+    await pump();
+
+    return gesture;
+  }
+
   /// Simulates a long-press at the given text [offset] within the paragraph
   /// with the given [nodeId].
   Future<void> longPressInParagraph(

--- a/super_editor/test/super_editor/desktop/super_editor_desktop_selection_test.dart
+++ b/super_editor/test/super_editor/desktop/super_editor_desktop_selection_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../supereditor_test_tools.dart';
+
+void main() {
+  group("Super Editor > desktop >", () {
+    testWidgetsOnDesktop("selects by word when double tap and dragging downstream", (tester) async {
+      // "Lorem ipsum |dolor sit| amet, consectetur adipiscing elit, sed do eiusmod tempor..."
+      //              ^  ^      ^
+      //             12  14    21
+      await _pumpSingleParagraphScaffold(tester);
+
+      final gesture = await tester.doubleTapDownInParagraph("1", 14);
+
+      for (int i = 0; i < 10; i += 1) {
+        await gesture.moveBy(const Offset(10, 0));
+        await tester.pump();
+      }
+
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection(
+          base: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 12),
+          ),
+          extent: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 21),
+          ),
+        ),
+      );
+
+      await gesture.up();
+    });
+
+    testWidgetsOnDesktop("selects by word when double tap and dragging upstream", (tester) async {
+      // "Lorem |ipsum dolor| sit amet, consectetur adipiscing elit, sed do eiusmod tempor..."
+      //        ^        ^  ^
+      //        6       14  17
+      await _pumpSingleParagraphScaffold(tester);
+
+      final gesture = await tester.doubleTapDownInParagraph("1", 14);
+
+      for (int i = 0; i < 10; i += 1) {
+        await gesture.moveBy(const Offset(-10, 0));
+        await tester.pump();
+      }
+
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection(
+          base: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 17),
+          ),
+          extent: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 6),
+          ),
+        ),
+      );
+
+      await gesture.up();
+    });
+  });
+}
+
+Future<void> _pumpSingleParagraphScaffold(WidgetTester tester) async {
+  await tester //
+      .createDocument()
+      .withSingleParagraph()
+      .pump();
+}


### PR DESCRIPTION
Fixed double-tap and drag by word upstream (Resolves #1480)

The root issue is that our double tap selection behavior was always treating the start of a word as the base of a selection. That works when dragging downstream. However, when dragging upstream, the base of the selection should be the end of the word, not the beginning.

This PR also adds a test tool to simulate a double tap and drag. Creating this test tool uncovered some kind of issue within our multi-tap gesture recognizer. I made a change that avoids the crash, but I don't have any idea why it's needed. The problem is tied to Flutter's gesture arena protocol, which I still don't understand.