### PR TITLE
[Infrastructure] Store golden test failures as workflow artifacts (Resolves #1658)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -93,6 +93,13 @@ jobs:
       # Run all golden tests
       - run: flutter test test_goldens
 
+      # Archive golden failures
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: golden-failures
+          path: "**/failures/**/*.png"
+
   test_super_editor_markdown:
     runs-on: ubuntu-latest
     defaults:
@@ -159,6 +166,13 @@ jobs:
 
       # Run all golden tests
       - run: flutter test test_goldens
+
+      # Archive golden failures
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: golden-failures
+          path: "**/failures/**/*.png"
 
   test_attributed_text:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Infrastructure] Store golden test failures as workflow artifacts. Resolves #1658

Currently, if a golden test fails only on CI, we have no way to inspect the failure because we cannot access the generated images.

This PR adds a step to the `test_goldens_super_editor` and `test_super_editor_markdown` jobs to store the failures as as artifacts in the test workflow.

If a golden test fails, a `golden-failures.zip` will be generated containing all images that are inside all "failures" directories.

It's possible to configure a retention period. If not set, it uses the retention limit set by the repository, organization, or enterprise