### PR TITLE
Fix caret visible during expanded selection in SuperTextField for iOS and Android (Resolves #1671)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -594,7 +594,9 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           return TextLayoutCaret(
             textLayout: textLayout,
             style: widget.caretStyle,
-            position: _textEditingController.selection.extent,
+            position: _textEditingController.selection.isCollapsed //
+                ? _textEditingController.selection.extent
+                : null,
             blinkTimingMode: widget.blinkTimingMode,
           );
         },

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -611,7 +611,9 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           return TextLayoutCaret(
             textLayout: textLayout,
             style: widget.caretStyle,
-            position: _textEditingController.selection.extent,
+            position: _textEditingController.selection.isCollapsed //
+                ? _textEditingController.selection.extent
+                : null,
             blinkTimingMode: widget.blinkTimingMode,
           );
         },

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -101,7 +101,7 @@ void main() {
       expect(_isCaretPresent(tester), isFalse);
     });
 
-    testWidgetsOnAllPlatforms("is displayed with focus and a text selection", (tester) async {
+    testWidgetsOnAllPlatforms("is displayed with focus and a collapsed text selection", (tester) async {
       final controller = AttributedTextEditingController(
         selection: const TextSelection.collapsed(offset: 0),
       );
@@ -117,6 +117,25 @@ void main() {
       await tester.pump();
 
       expect(_isCaretPresent(tester), isTrue);
+    });
+
+    testWidgetsOnMobile("is NOT displayed with focus and an expanded text selection", (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("Hello, world!"),
+        selection: const TextSelection(baseOffset: 0, extentOffset: 5),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            focusNode: FocusNode()..requestFocus(),
+            textController: controller,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(_isCaretPresent(tester), isFalse);
     });
 
     testWidgetsOnAllPlatforms("uses the given caretStyle", (tester) async {


### PR DESCRIPTION
Fix caret visible during expanded selection in SuperTextField for iOS and Android (Resolves #1671)