### PR TITLE
[SuperEditor] Enable Mac shortcuts for iOS (Resolves #1609)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -24,12 +24,12 @@ import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_contr
 import 'package:super_editor/src/infrastructure/platforms/ios/long_press_selection.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/magnifier.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/signal_notifier.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 
 import '../infrastructure/document_gestures.dart';
 import '../infrastructure/document_gestures_interaction_overrides.dart';
-import '../infrastructure/text_input.dart';
 import 'selection_upstream_downstream.dart';
 
 /// An [InheritedWidget] that provides shared access to a [SuperEditorIosControlsController],
@@ -1459,7 +1459,7 @@ class SuperEditorIosMagnifierOverlayManagerState extends State<SuperEditorIosMag
   }
 
   Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink magnifierFocalPoint) {
-    if (isWeb) {
+    if (CurrentPlatform.isWeb) {
       // Defer to the browser to display overlay controls on mobile.
       return const SizedBox();
     }

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -79,13 +79,11 @@ ExecutionInstruction scrollOnCtrlOrCmdAndHomeKeyPress({
     return ExecutionInstruction.continueExecution;
   }
 
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-  if (isMacOrIos && !HardwareKeyboard.instance.isMetaPressed) {
+  if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isMacOrIos && !HardwareKeyboard.instance.isControlPressed) {
+  if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -114,13 +112,11 @@ ExecutionInstruction scrollOnCtrlOrCmdAndEndKeyPress({
     return ExecutionInstruction.continueExecution;
   }
 
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-  if (isMacOrIos && !HardwareKeyboard.instance.isMetaPressed) {
+  if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isMacOrIos && !HardwareKeyboard.instance.isControlPressed) {
+  if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -221,9 +217,7 @@ ExecutionInstruction deleteDownstreamCharacterWithCtrlDeleteOnMac({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,
 }) {
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-  if (!isMacOrIos) {
+  if (!isApple) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -525,28 +519,26 @@ ExecutionInstruction moveUpAndDownWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
   bool didMove = false;
   if (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp) {
-    if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
+    if (isApple && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretUpstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
+    } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
       didMove =
           editContext.commonOps.moveSelectionToBeginningOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretUp(expand: HardwareKeyboard.instance.isShiftPressed);
     }
   } else {
-    if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
+    if (isApple && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretDownstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
+    } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
       didMove = editContext.commonOps.moveSelectionToEndOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretDown(expand: HardwareKeyboard.instance.isShiftPressed);
@@ -585,16 +577,14 @@ ExecutionInstruction moveLeftAndRightWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
   bool didMove = false;
   MovementModifier? movementModifier;
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     movementModifier = MovementModifier.word;
-  } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
     movementModifier = MovementModifier.line;
-  } else if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
+  } else if (isApple && HardwareKeyboard.instance.isAltPressed) {
     movementModifier = MovementModifier.word;
   }
 
@@ -769,9 +759,7 @@ ExecutionInstruction deleteToStartOfLineWithCmdBackspaceOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-  if (!isMacOrIos) {
+  if (!isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -803,9 +791,8 @@ ExecutionInstruction deleteToEndOfLineWithCmdDeleteOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (!isMacOrIos) {
+  if (!isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {
@@ -837,9 +824,8 @@ ExecutionInstruction deleteWordUpstreamWithAltBackspaceOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (!isMacOrIos) {
+  if (!isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -904,9 +890,8 @@ ExecutionInstruction deleteWordDownstreamWithAltDeleteOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (!isMacOrIos) {
+  if (!isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -221,7 +221,9 @@ ExecutionInstruction deleteDownstreamCharacterWithCtrlDeleteOnMac({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,
 }) {
-  if (defaultTargetPlatform != TargetPlatform.macOS) {
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
+  if (!isMacOrIos) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -523,25 +525,28 @@ ExecutionInstruction moveUpAndDownWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
   bool didMove = false;
   if (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp) {
-    if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isAltPressed) {
+    if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretUpstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isMetaPressed) {
-      didMove = editContext.commonOps.moveSelectionToBeginningOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
+    } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
+      didMove =
+          editContext.commonOps.moveSelectionToBeginningOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretUp(expand: HardwareKeyboard.instance.isShiftPressed);
     }
   } else {
-    if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isAltPressed) {
+    if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretDownstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isMetaPressed) {
+    } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
       didMove = editContext.commonOps.moveSelectionToEndOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretDown(expand: HardwareKeyboard.instance.isShiftPressed);
@@ -580,14 +585,16 @@ ExecutionInstruction moveLeftAndRightWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
   bool didMove = false;
   MovementModifier? movementModifier;
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     movementModifier = MovementModifier.word;
-  } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
     movementModifier = MovementModifier.line;
-  } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isAltPressed) {
+  } else if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
     movementModifier = MovementModifier.word;
   }
 
@@ -762,7 +769,9 @@ ExecutionInstruction deleteToStartOfLineWithCmdBackspaceOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (defaultTargetPlatform != TargetPlatform.macOS) {
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
+  if (!isMacOrIos) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -794,8 +803,9 @@ ExecutionInstruction deleteToEndOfLineWithCmdDeleteOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (defaultTargetPlatform != TargetPlatform.macOS) {
+  if (!isMacOrIos) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {
@@ -827,8 +837,9 @@ ExecutionInstruction deleteWordUpstreamWithAltBackspaceOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (defaultTargetPlatform != TargetPlatform.macOS) {
+  if (!isMacOrIos) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -893,8 +904,9 @@ ExecutionInstruction deleteWordDownstreamWithAltDeleteOnMac({
   if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
     return ExecutionInstruction.continueExecution;
   }
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-  if (defaultTargetPlatform != TargetPlatform.macOS) {
+  if (!isMacOrIos) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -13,7 +13,7 @@ import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 /// Scrolls up by the viewport height, or as high as possible,
 /// when the user presses the Page Up key.
@@ -79,11 +79,11 @@ ExecutionInstruction scrollOnCtrlOrCmdAndHomeKeyPress({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
+  if (CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
+  if (!CurrentPlatform.isApple && !HardwareKeyboard.instance.isControlPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -112,11 +112,11 @@ ExecutionInstruction scrollOnCtrlOrCmdAndEndKeyPress({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
+  if (CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
+  if (!CurrentPlatform.isApple && !HardwareKeyboard.instance.isControlPressed) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -200,7 +200,7 @@ ExecutionInstruction sendKeyEventToMacOs({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,
 }) {
-  if (defaultTargetPlatform == TargetPlatform.macOS && !isWeb) {
+  if (defaultTargetPlatform == TargetPlatform.macOS && !CurrentPlatform.isWeb) {
     // On macOS, we let the IME handle all key events. Then, the IME might generate
     // selectors which express the user intent, e.g, moveLeftAndModifySelection:.
     //
@@ -217,7 +217,7 @@ ExecutionInstruction deleteDownstreamCharacterWithCtrlDeleteOnMac({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,
 }) {
-  if (!isApple) {
+  if (!CurrentPlatform.isApple) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -502,7 +502,7 @@ ExecutionInstruction moveUpAndDownWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isWeb && (editContext.composer.composingRegion.value != null)) {
+  if (CurrentPlatform.isWeb && (editContext.composer.composingRegion.value != null)) {
     // We are composing a character on web. It's possible that a native element is being displayed,
     // like an emoji picker or a character selection panel.
     // We need to let the OS handle the key so the user can navigate
@@ -521,24 +521,24 @@ ExecutionInstruction moveUpAndDownWithArrowKeys({
 
   bool didMove = false;
   if (keyEvent.logicalKey == LogicalKeyboardKey.arrowUp) {
-    if (isApple && HardwareKeyboard.instance.isAltPressed) {
+    if (CurrentPlatform.isApple && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretUpstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
+    } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) {
       didMove =
           editContext.commonOps.moveSelectionToBeginningOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretUp(expand: HardwareKeyboard.instance.isShiftPressed);
     }
   } else {
-    if (isApple && HardwareKeyboard.instance.isAltPressed) {
+    if (CurrentPlatform.isApple && HardwareKeyboard.instance.isAltPressed) {
       didMove = editContext.commonOps.moveCaretDownstream(
         expand: HardwareKeyboard.instance.isShiftPressed,
         movementModifier: MovementModifier.paragraph,
       );
-    } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
+    } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) {
       didMove = editContext.commonOps.moveSelectionToEndOfDocument(expand: HardwareKeyboard.instance.isShiftPressed);
     } else {
       didMove = editContext.commonOps.moveCaretDown(expand: HardwareKeyboard.instance.isShiftPressed);
@@ -564,7 +564,7 @@ ExecutionInstruction moveLeftAndRightWithArrowKeys({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isWeb && (editContext.composer.composingRegion.value != null)) {
+  if (CurrentPlatform.isWeb && (editContext.composer.composingRegion.value != null)) {
     // We are composing a character on web. It's possible that a native element is being displayed,
     // like an emoji picker or a character selection panel.
     // We need to let the OS handle the key so the user can navigate
@@ -582,9 +582,9 @@ ExecutionInstruction moveLeftAndRightWithArrowKeys({
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     movementModifier = MovementModifier.word;
-  } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) {
     movementModifier = MovementModifier.line;
-  } else if (isApple && HardwareKeyboard.instance.isAltPressed) {
+  } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isAltPressed) {
     movementModifier = MovementModifier.word;
   }
 
@@ -609,7 +609,7 @@ ExecutionInstruction doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,
 }) {
-  if (!isWeb) {
+  if (!CurrentPlatform.isWeb) {
     return ExecutionInstruction.continueExecution;
   }
 
@@ -759,7 +759,7 @@ ExecutionInstruction deleteToStartOfLineWithCmdBackspaceOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple) {
+  if (!CurrentPlatform.isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -792,7 +792,7 @@ ExecutionInstruction deleteToEndOfLineWithCmdDeleteOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple) {
+  if (!CurrentPlatform.isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {
@@ -825,7 +825,7 @@ ExecutionInstruction deleteWordUpstreamWithAltBackspaceOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple) {
+  if (!CurrentPlatform.isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.backspace) {
@@ -891,7 +891,7 @@ ExecutionInstruction deleteWordDownstreamWithAltDeleteOnMac({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (!isApple) {
+  if (!CurrentPlatform.isApple) {
     return ExecutionInstruction.continueExecution;
   }
   if (!HardwareKeyboard.instance.isAltPressed || keyEvent.logicalKey != LogicalKeyboardKey.delete) {

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -13,7 +13,7 @@ import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/ime_input_owner.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 import '../document_hardware_keyboard/document_input_keyboard.dart';
 import 'document_delta_editing.dart';
@@ -315,7 +315,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
     late Size size;
     late Matrix4 transform;
 
-    if (isWeb) {
+    if (CurrentPlatform.isWeb) {
       // On web, we can't set the caret rect.
       // To display the IME panels at the correct position,
       // instead of reporting the whole editor size and transform,
@@ -337,7 +337,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   }
 
   void _reportCaretRectToIme() {
-    if (isWeb) {
+    if (CurrentPlatform.isWeb) {
       // On web, setting the caret rect isn't supported.
       // To position the IME popovers, we report the size, transform and style
       // of the selected component and let the browser position the popovers.
@@ -359,7 +359,7 @@ class SuperEditorImeInteractorState extends State<SuperEditorImeInteractor> impl
   ///
   /// TODO: update this after https://github.com/flutter/flutter/issues/134265 is resolved.
   void _reportTextStyleToIme() {
-    if (!isWeb) {
+    if (!CurrentPlatform.isWeb) {
       // If we are not on the web, we can position the caret rect without the need
       // to send the text styles to the IME.
       return;
@@ -645,7 +645,7 @@ void unIndentListItem(SuperEditorContext context) {
 }
 
 void insertNewLine(SuperEditorContext context) {
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     return;
   }
   context.commonOps.insertBlockLevelNewline();
@@ -704,14 +704,14 @@ void deleteToEndOfLine(SuperEditorContext context) {
 }
 
 void deleteBackward(SuperEditorContext context) {
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     return;
   }
   context.commonOps.deleteUpstream();
 }
 
 void deleteForward(SuperEditorContext context) {
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     return;
   }
   context.commonOps.deleteDownstream();

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -14,7 +14,7 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/key_event_extensions.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 import 'layout_single_column/layout_single_column.dart';
 import 'text_tools.dart';
@@ -843,7 +843,7 @@ ExecutionInstruction doNothingWithEnterOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     // On web, pressing enter generates both a key event and a `TextInputAction.newline` action.
     // We handle the newline action and ignore the key event.
     // We return blocked so the OS can process it.
@@ -865,7 +865,7 @@ ExecutionInstruction doNothingWithBackspaceOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     // On web, pressing backspace generates both a key event and a deletion delta.
     // We handle the deletion delta and ignore the key event.
     // We return blocked so the OS can process it.
@@ -887,7 +887,7 @@ ExecutionInstruction doNothingWithDeleteOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     // On web, pressing delete generates both a key event and a deletion delta.
     // We handle the deletion delta and ignore the key event.
     // We return blocked so the OS can process it.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -28,6 +28,7 @@ import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/signal_notifier.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_text_layout/super_text_layout.dart';
@@ -800,7 +801,7 @@ Widget defaultIosEditorToolbarBuilder(
   CommonEditorOperations editorOps,
   SuperEditorIosControlsController editorControlsController,
 ) {
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     // On web, we defer to the browser's internal overlay controls for mobile.
     return const SizedBox();
   }

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 
-
 enum ExecutionInstruction {
   /// The handler has no relation to the key event and
   /// took no action.
@@ -34,8 +33,10 @@ enum ExecutionInstruction {
 
 extension PrimaryShortcutKey on KeyEvent {
   bool get isPrimaryShortcutKeyPressed =>
-      (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isMetaPressed) ||
-      (defaultTargetPlatform != TargetPlatform.macOS && HardwareKeyboard.instance.isControlPressed);
+      (const [TargetPlatform.macOS, TargetPlatform.iOS].contains(defaultTargetPlatform) &&
+          HardwareKeyboard.instance.isMetaPressed) ||
+      (!const [TargetPlatform.macOS, TargetPlatform.iOS].contains(defaultTargetPlatform) &&
+          HardwareKeyboard.instance.isControlPressed);
 }
 
 /// Whether the given [character] should be ignored when it's received within

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 enum ExecutionInstruction {
   /// The handler has no relation to the key event and
@@ -34,8 +34,8 @@ enum ExecutionInstruction {
 
 extension PrimaryShortcutKey on KeyEvent {
   bool get isPrimaryShortcutKeyPressed =>
-      (isApple && HardwareKeyboard.instance.isMetaPressed) || //
-      (!isApple && HardwareKeyboard.instance.isControlPressed);
+      (CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) || //
+      (!CurrentPlatform.isApple && HardwareKeyboard.instance.isControlPressed);
 }
 
 /// Whether the given [character] should be ignored when it's received within

--- a/super_editor/lib/src/infrastructure/keyboard.dart
+++ b/super_editor/lib/src/infrastructure/keyboard.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
 
 enum ExecutionInstruction {
   /// The handler has no relation to the key event and
@@ -33,10 +34,8 @@ enum ExecutionInstruction {
 
 extension PrimaryShortcutKey on KeyEvent {
   bool get isPrimaryShortcutKeyPressed =>
-      (const [TargetPlatform.macOS, TargetPlatform.iOS].contains(defaultTargetPlatform) &&
-          HardwareKeyboard.instance.isMetaPressed) ||
-      (!const [TargetPlatform.macOS, TargetPlatform.iOS].contains(defaultTargetPlatform) &&
-          HardwareKeyboard.instance.isControlPressed);
+      (isApple && HardwareKeyboard.instance.isMetaPressed) || //
+      (!isApple && HardwareKeyboard.instance.isControlPressed);
 }
 
 /// Whether the given [character] should be ignored when it's received within

--- a/super_editor/lib/src/infrastructure/platforms/platform.dart
+++ b/super_editor/lib/src/infrastructure/platforms/platform.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+
+class CurrentPlatform {
+  /// Whether or not we are running on an Apple device (MacOS or iOS).
+  static bool get isApple =>
+      defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
+  /// Whether or not we are running on web.
+  ///
+  /// By default this is the same as [kIsWeb].
+  ///
+  /// [debugIsWebOverride] may be used to override the natural value of [isWeb].
+  static bool get isWeb => debugIsWebOverride == null //
+      ? kIsWeb
+      : debugIsWebOverride == WebPlatformOverride.web;
+}
+
+/// Overrides the value of [CurrentPlatform.isWeb].
+///
+/// This is intended to be used in tests.
+///
+/// Set it to `null` to use the default value of [CurrentPlatform.isWeb].
+///
+/// Set it to [WebPlatformOverride.web] to configure to run as if we are on web.
+///
+/// Set it to [WebPlatformOverride.native] to configure to run as if we are NOT on web.
+@visibleForTesting
+WebPlatformOverride? debugIsWebOverride;
+
+@visibleForTesting
+enum WebPlatformOverride {
+  /// Configuration to run the app as if we are a native app.
+  native,
+
+  /// Configuration to run the app as if we are on web.
+  web,
+}

--- a/super_editor/lib/src/infrastructure/text_input.dart
+++ b/super_editor/lib/src/infrastructure/text_input.dart
@@ -15,6 +15,9 @@ bool get isWeb => debugIsWebOverride == null //
     ? kIsWeb
     : debugIsWebOverride == WebPlatformOverride.web;
 
+/// Whether or not we are running on an Apple device (MacOS or iOS).
+bool get isApple => defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+
 /// Overrides the value of [isWeb].
 ///
 /// This is intended to be used in tests.

--- a/super_editor/lib/src/infrastructure/text_input.dart
+++ b/super_editor/lib/src/infrastructure/text_input.dart
@@ -1,40 +1,5 @@
-import 'package:flutter/foundation.dart';
-
 /// The mode of user text input.
 enum TextInputSource {
   keyboard,
   ime,
-}
-
-/// Whether or not we are running on web.
-///
-/// By default this is the same as [kIsWeb].
-///
-/// [debugIsWebOverride] may be used to override the natural value of [isWeb].
-bool get isWeb => debugIsWebOverride == null //
-    ? kIsWeb
-    : debugIsWebOverride == WebPlatformOverride.web;
-
-/// Whether or not we are running on an Apple device (MacOS or iOS).
-bool get isApple => defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-/// Overrides the value of [isWeb].
-///
-/// This is intended to be used in tests.
-///
-/// Set it to `null` to use the default value of [isWeb].
-///
-/// Set it to [WebPlatformOverride.web] to configure to run as if we are on web.
-///
-/// Set it to [WebPlatformOverride.native] to configure to run as if we are NOT on web.
-@visibleForTesting
-WebPlatformOverride? debugIsWebOverride;
-
-@visibleForTesting
-enum WebPlatformOverride {
-  /// Configuration to run the app as if we are a native app.
-  native,
-
-  /// Configuration to run the app as if we are on web.
-  web,
 }

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -24,13 +24,12 @@ import 'package:super_editor/src/infrastructure/platforms/android/long_press_sel
 import 'package:super_editor/src/infrastructure/platforms/android/magnifier.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/signal_notifier.dart';
 import 'package:super_editor/src/infrastructure/toolbar_position_delegate.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 import 'package:super_editor/src/super_textfield/metrics.dart';
 import 'package:super_text_layout/super_text_layout.dart';
-
-import '../infrastructure/text_input.dart';
 
 /// Read-only document gesture interactor that's designed for Android touch input, e.g.,
 /// drag to scroll, and handles to control selection.
@@ -1308,7 +1307,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
                   _buildCaret(),
                   // Build the drag handles (if desired).
                   // We don't show handles on web because the browser already displays the native handles.
-                  if (!isWeb) //
+                  if (!CurrentPlatform.isWeb) //
                     ..._buildHandles(),
                   // Build the focal point for the magnifier
                   if (_isDraggingHandle || widget.longPressMagnifierGlobalOffset.value != null)
@@ -1316,10 +1315,10 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
                   // Build the magnifier (this needs to be done before building
                   // the handles so that the magnifier doesn't show the handles.
                   // We don't show magnifier on web because the browser already displays the native magnifier.
-                  if (!isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
+                  if (!CurrentPlatform.isWeb && widget.editingController.shouldDisplayMagnifier) _buildMagnifier(),
                   // Build the editing toolbar.
                   // We don't show toolbar on web because the browser already displays the native toolbar.
-                  if (!isWeb &&
+                  if (!CurrentPlatform.isWeb &&
                       widget.editingController.shouldDisplayToolbar &&
                       widget.editingController.isToolbarPositioned)
                     _buildToolbar(context),

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -20,11 +20,10 @@ import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_contr
 import 'package:super_editor/src/infrastructure/platforms/ios/long_press_selection.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/magnifier.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/touch_controls.dart';
 import 'package:super_editor/src/super_reader/reader_context.dart';
 import 'package:super_editor/src/super_reader/super_reader.dart';
-
-import '../infrastructure/text_input.dart';
 
 /// An [InheritedWidget] that provides shared access to a [SuperReaderIosControlsController],
 /// which coordinates the state of iOS controls like drag handles, magnifier, and toolbar.
@@ -1138,7 +1137,7 @@ class SuperReaderIosMagnifierOverlayManagerState extends State<SuperReaderIosMag
   }
 
   Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink magnifierFocalPoint) {
-    if (isWeb) {
+    if (CurrentPlatform.isWeb) {
       // Defer to the browser to display overlay controls on mobile.
       return const SizedBox();
     }

--- a/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
@@ -5,7 +5,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
-import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 import 'reader_context.dart';
 
@@ -240,9 +240,9 @@ MovementModifier? _getHorizontalMovementModifier(KeyEvent keyEvent) {
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     return MovementModifier.word;
-  } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) {
     return MovementModifier.line;
-  } else if (isApple && HardwareKeyboard.instance.isAltPressed) {
+  } else if (CurrentPlatform.isApple && HardwareKeyboard.instance.isAltPressed) {
     return MovementModifier.word;
   }
 

--- a/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
@@ -5,6 +5,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/keyboard.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
 
 import 'reader_context.dart';
 
@@ -236,13 +237,12 @@ final expandSelectionWithRightArrow = createShortcut(
 );
 
 MovementModifier? _getHorizontalMovementModifier(KeyEvent keyEvent) {
-  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     return MovementModifier.word;
-  } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (isApple && HardwareKeyboard.instance.isMetaPressed) {
     return MovementModifier.line;
-  } else if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
+  } else if (isApple && HardwareKeyboard.instance.isAltPressed) {
     return MovementModifier.word;
   }
 

--- a/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
@@ -236,12 +236,13 @@ final expandSelectionWithRightArrow = createShortcut(
 );
 
 MovementModifier? _getHorizontalMovementModifier(KeyEvent keyEvent) {
+  final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
   if ((defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux) &&
       HardwareKeyboard.instance.isControlPressed) {
     return MovementModifier.word;
-  } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isMetaPressed) {
+  } else if (isMacOrIos && HardwareKeyboard.instance.isMetaPressed) {
     return MovementModifier.line;
-  } else if (defaultTargetPlatform == TargetPlatform.macOS && HardwareKeyboard.instance.isAltPressed) {
+  } else if (isMacOrIos && HardwareKeyboard.instance.isAltPressed) {
     return MovementModifier.word;
   }
 

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -32,6 +32,7 @@ import 'package:super_editor/src/infrastructure/documents/selection_leader_docum
 import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 
 import '../infrastructure/platforms/mobile_documents.dart';
 import '../infrastructure/text_input.dart';
@@ -517,7 +518,7 @@ Widget defaultIosReaderToolbarBuilder(
   ValueListenable<DocumentSelection?> selection,
   SuperReaderIosControlsController editorControlsController,
 ) {
-  if (isWeb) {
+  if (CurrentPlatform.isWeb) {
     // On web, we defer to the browser's internal overlay controls for mobile.
     return const SizedBox();
   }

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -19,6 +19,7 @@ import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_editor/src/infrastructure/multi_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/src/super_textfield/infrastructure/text_field_scroller.dart';
 import 'package:super_editor/src/super_textfield/super_textfield.dart';
@@ -1332,7 +1333,7 @@ class _SuperTextFieldImeInteractorState extends State<SuperTextFieldImeInteracto
   }
 
   void _reportCaretRectToIme() {
-    if (isWeb) {
+    if (CurrentPlatform.isWeb) {
       // On web, setting the caret rect isn't supported.
       // To position the IME popovers, we report our size, transform and text style
       // and let the browser position the popovers.
@@ -2062,7 +2063,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (isWeb && (textFieldContext.controller.composingRegion.isValid)) {
+    if (CurrentPlatform.isWeb && (textFieldContext.controller.composingRegion.isValid)) {
       // We are composing a character on web. It's possible that a native element is being displayed,
       // like an emoji picker or a character selection panel.
       // We need to let the OS handle the key so the user can navigate
@@ -2359,7 +2360,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
     required SuperTextFieldContext textFieldContext,
     required KeyEvent keyEvent,
   }) {
-    if (defaultTargetPlatform == TargetPlatform.macOS && !isWeb) {
+    if (defaultTargetPlatform == TargetPlatform.macOS && !CurrentPlatform.isWeb) {
       // On macOS, we let the IME handle all key events. Then, the IME might generate
       // selectors which express the user intent, e.g, moveLeftAndModifySelection:.
       //
@@ -2437,11 +2438,11 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
+    if (CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
+    if (!CurrentPlatform.isApple && !HardwareKeyboard.instance.isControlPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
@@ -2469,11 +2470,11 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
+    if (CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
+    if (!CurrentPlatform.isApple && !HardwareKeyboard.instance.isControlPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
@@ -2501,7 +2502,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (defaultTargetPlatform != TargetPlatform.macOS && !isWeb) {
+    if (defaultTargetPlatform != TargetPlatform.macOS && !CurrentPlatform.isWeb) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
@@ -2529,7 +2530,7 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (defaultTargetPlatform != TargetPlatform.macOS && !isWeb) {
+    if (defaultTargetPlatform != TargetPlatform.macOS && !CurrentPlatform.isWeb) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -2437,13 +2437,11 @@ class DefaultSuperTextFieldKeyboardHandlers {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
-
-    if (isMacOrIos && !HardwareKeyboard.instance.isMetaPressed) {
+    if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (!isMacOrIos && !HardwareKeyboard.instance.isControlPressed) {
+    if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
@@ -2470,13 +2468,12 @@ class DefaultSuperTextFieldKeyboardHandlers {
     if (keyEvent.logicalKey != LogicalKeyboardKey.end) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
-    final isMacOrIos = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
 
-    if (isMacOrIos && !HardwareKeyboard.instance.isMetaPressed) {
+    if (isApple && !HardwareKeyboard.instance.isMetaPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 
-    if (!isMacOrIos && !HardwareKeyboard.instance.isControlPressed) {
+    if (!isApple && !HardwareKeyboard.instance.isControlPressed) {
       return TextFieldKeyboardHandlerResult.notHandled;
     }
 

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -9,7 +9,7 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor copy and paste > ', () {
-    testWidgetsOnMacAndIos('pastes within a paragraph', (tester) async {
+    testWidgetsOnApple('pastes within a paragraph', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()
@@ -34,7 +34,7 @@ void main() {
       expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
     });
 
-    testWidgetsOnMacAndIos('pastes within a list item', (tester) async {
+    testWidgetsOnApple('pastes within a list item', (tester) async {
       await tester //
           .createDocument()
           .fromMarkdown(" * Pasted text:")

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
-import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -10,7 +9,7 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor copy and paste > ', () {
-    testWidgetsOnMac('pastes within a paragraph', (tester) async {
+    testWidgetsOnMacAndIos('pastes within a paragraph', (tester) async {
       await tester //
           .createDocument()
           .withSingleEmptyParagraph()
@@ -35,7 +34,7 @@ void main() {
       expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
     });
 
-    testWidgetsOnMac('pastes within a list item', (tester) async {
+    testWidgetsOnMacAndIos('pastes within a list item', (tester) async {
       await tester //
           .createDocument()
           .fromMarkdown(" * Pasted text:")

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -7,15 +7,16 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
+import '../test_runners.dart';
 import '../test_tools_user_input.dart';
 import 'supereditor_test_tools.dart';
 
 void main() {
   group('Super Editor keyboard actions', () {
     group("movement >", () {
-      group("Mac >", () {
+      group("Mac and iOS >", () {
         group("jumps to", () {
-          testWidgetsOnMac('beginning of line with CMD + LEFT ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of line with CMD + LEFT ARROW', (tester) async {
             // Start the user's selection somewhere after the beginning of the first
             // line in the first node.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
@@ -34,7 +35,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMac('end of line with CMD + RIGHT ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of line with CMD + RIGHT ARROW', (tester) async {
             // Start the user's selection somewhere before the end of the first line
             // in the first node.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
@@ -55,7 +56,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMac('beginning of word with ALT + LEFT ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of word with ALT + LEFT ARROW', (tester) async {
             // Start the user's selection somewhere in the middle of a word.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
 
@@ -73,7 +74,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMac('end of word with ALT + RIGHT ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of word with ALT + RIGHT ARROW', (tester) async {
             // Start the user's selection somewhere in the middle of a word.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
 
@@ -91,7 +92,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMac('beginning of paragraph with OPTION + UP ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of paragraph with OPTION + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -115,7 +116,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('end of paragraph with OPTION + DOWN ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of paragraph with OPTION + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -139,7 +140,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('beginning of document with CMD + UP ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of document with CMD + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -162,7 +163,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('end of document with CMD + DOWN ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of document with CMD + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -187,7 +188,7 @@ void main() {
         });
 
         group("expands to", () {
-          testWidgetsOnMac('beginning of paragraph with SHIFT + OPTION + UP ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of paragraph with SHIFT + OPTION + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -215,7 +216,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('end of paragraph with SHIFT + OPTION + DOWN ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of paragraph with SHIFT + OPTION + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -243,7 +244,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('beginning of document with SHIFT + CMD + UP ARROW', (tester) async {
+          testWidgetsOnMacAndIos('beginning of document with SHIFT + CMD + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -270,7 +271,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMac('end of document with SHIFT + CMD + DOWN ARROW', (tester) async {
+          testWidgetsOnMacAndIos('end of document with SHIFT + CMD + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -298,7 +299,7 @@ void main() {
           }, variant: inputSourceVariant);
         });
 
-        testWidgetsOnMac("option + backspace: deletes a word upstream", (tester) async {
+        testWidgetsOnMacAndIos("option + backspace: deletes a word upstream", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -327,7 +328,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMac("option + backspace: deletes a word upstream (after a space)", (tester) async {
+        testWidgetsOnMacAndIos("option + backspace: deletes a word upstream (after a space)", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -356,7 +357,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMac("option + delete: deletes a word downstream", (tester) async {
+        testWidgetsOnMacAndIos("option + delete: deletes a word downstream", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -385,7 +386,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMac("option + delete: deletes a word downstream (before a space)", (tester) async {
+        testWidgetsOnMacAndIos("option + delete: deletes a word downstream (before a space)", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -414,7 +415,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMac("control + backspace: deletes a single upstream character", (tester) async {
+        testWidgetsOnMacAndIos("control + backspace: deletes a single upstream character", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -441,7 +442,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMac("control + delete: deletes a single downstream character", (tester) async {
+        testWidgetsOnMacAndIos("control + delete: deletes a single downstream character", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -1059,7 +1060,7 @@ void main() {
     });
 
     group('CMD + A to select all', () {
-      testWidgetsOnMac('does nothing when CMD key is pressed but A-key is not pressed', (tester) async {
+      testWidgetsOnMacAndIos('does nothing when CMD key is pressed but A-key is not pressed', (tester) async {
         await tester //
             .createDocument()
             .withSingleParagraph()
@@ -1082,7 +1083,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('does nothing when A-key is pressed but meta key is not pressed', (tester) async {
+      testWidgetsOnMacAndIos('does nothing when A-key is pressed but meta key is not pressed', (tester) async {
         await tester //
             .createDocument()
             .withSingleParagraph()
@@ -1105,7 +1106,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('does nothing when CMD+A is pressed but the document is empty', (tester) async {
+      testWidgetsOnMacAndIos('does nothing when CMD+A is pressed but the document is empty', (tester) async {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
@@ -1127,7 +1128,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('selects all when CMD+A is pressed with a single-node document', (tester) async {
+      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a single-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(MutableDocument(
@@ -1160,7 +1161,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('selects all when CMD+A is pressed with a two-node document', (tester) async {
+      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a two-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1199,7 +1200,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('selects all when CMD+A is pressed with a three-node document', (tester) async {
+      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a three-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1245,7 +1246,7 @@ void main() {
     });
 
     group('key pressed with selection', () {
-      testWidgetsOnMac('deletes selection if backspace is pressed', (tester) async {
+      testWidgetsOnMacAndIos('deletes selection if backspace is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1293,7 +1294,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('deletes selection if delete is pressed', (tester) async {
+      testWidgetsOnMacAndIos('deletes selection if delete is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1341,7 +1342,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('replaces selected content with character when character key is pressed', (tester) async {
+      testWidgetsOnMacAndIos('replaces selected content with character when character key is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1390,7 +1391,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMac('collapses selection if escape is pressed', (tester) async {
+      testWidgetsOnMacAndIos('collapses selection if escape is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1439,7 +1440,7 @@ void main() {
       });
     });
 
-    testWidgetsOnMac('does nothing when escape is pressed if the selection is collapsed', (tester) async {
+    testWidgetsOnMacAndIos('does nothing when escape is pressed if the selection is collapsed', (tester) async {
       await tester //
           .createDocument()
           .withCustomContent(

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -16,7 +16,7 @@ void main() {
     group("movement >", () {
       group("Mac and iOS >", () {
         group("jumps to", () {
-          testWidgetsOnMacAndIos('beginning of line with CMD + LEFT ARROW', (tester) async {
+          testWidgetsOnApple('beginning of line with CMD + LEFT ARROW', (tester) async {
             // Start the user's selection somewhere after the beginning of the first
             // line in the first node.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
@@ -35,7 +35,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMacAndIos('end of line with CMD + RIGHT ARROW', (tester) async {
+          testWidgetsOnApple('end of line with CMD + RIGHT ARROW', (tester) async {
             // Start the user's selection somewhere before the end of the first line
             // in the first node.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
@@ -56,7 +56,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMacAndIos('beginning of word with ALT + LEFT ARROW', (tester) async {
+          testWidgetsOnApple('beginning of word with ALT + LEFT ARROW', (tester) async {
             // Start the user's selection somewhere in the middle of a word.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
 
@@ -74,7 +74,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMacAndIos('end of word with ALT + RIGHT ARROW', (tester) async {
+          testWidgetsOnApple('end of word with ALT + RIGHT ARROW', (tester) async {
             // Start the user's selection somewhere in the middle of a word.
             await _pumpCaretMovementTestSetup(tester, textOffsetInFirstNode: 8);
 
@@ -92,7 +92,7 @@ void main() {
             );
           });
 
-          testWidgetsOnMacAndIos('beginning of paragraph with OPTION + UP ARROW', (tester) async {
+          testWidgetsOnApple('beginning of paragraph with OPTION + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -116,7 +116,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('end of paragraph with OPTION + DOWN ARROW', (tester) async {
+          testWidgetsOnApple('end of paragraph with OPTION + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -140,7 +140,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('beginning of document with CMD + UP ARROW', (tester) async {
+          testWidgetsOnApple('beginning of document with CMD + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -163,7 +163,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('end of document with CMD + DOWN ARROW', (tester) async {
+          testWidgetsOnApple('end of document with CMD + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -188,7 +188,7 @@ void main() {
         });
 
         group("expands to", () {
-          testWidgetsOnMacAndIos('beginning of paragraph with SHIFT + OPTION + UP ARROW', (tester) async {
+          testWidgetsOnApple('beginning of paragraph with SHIFT + OPTION + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -216,7 +216,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('end of paragraph with SHIFT + OPTION + DOWN ARROW', (tester) async {
+          testWidgetsOnApple('end of paragraph with SHIFT + OPTION + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -244,7 +244,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('beginning of document with SHIFT + CMD + UP ARROW', (tester) async {
+          testWidgetsOnApple('beginning of document with SHIFT + CMD + UP ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -271,7 +271,7 @@ void main() {
             );
           }, variant: inputSourceVariant);
 
-          testWidgetsOnMacAndIos('end of document with SHIFT + CMD + DOWN ARROW', (tester) async {
+          testWidgetsOnApple('end of document with SHIFT + CMD + DOWN ARROW', (tester) async {
             await _pumpTwoParagraphsTestApp(
               tester,
               inputSource: inputSourceVariant.currentValue!,
@@ -299,7 +299,7 @@ void main() {
           }, variant: inputSourceVariant);
         });
 
-        testWidgetsOnMacAndIos("option + backspace: deletes a word upstream", (tester) async {
+        testWidgetsOnApple("option + backspace: deletes a word upstream", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -328,7 +328,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMacAndIos("option + backspace: deletes a word upstream (after a space)", (tester) async {
+        testWidgetsOnApple("option + backspace: deletes a word upstream (after a space)", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -357,7 +357,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMacAndIos("option + delete: deletes a word downstream", (tester) async {
+        testWidgetsOnApple("option + delete: deletes a word downstream", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -386,7 +386,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMacAndIos("option + delete: deletes a word downstream (before a space)", (tester) async {
+        testWidgetsOnApple("option + delete: deletes a word downstream (before a space)", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -415,7 +415,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMacAndIos("control + backspace: deletes a single upstream character", (tester) async {
+        testWidgetsOnApple("control + backspace: deletes a single upstream character", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -442,7 +442,7 @@ void main() {
           );
         }, variant: inputSourceVariant);
 
-        testWidgetsOnMacAndIos("control + delete: deletes a single downstream character", (tester) async {
+        testWidgetsOnApple("control + delete: deletes a single downstream character", (tester) async {
           final testContext = await tester
               .createDocument() //
               .withSingleParagraph()
@@ -1060,7 +1060,7 @@ void main() {
     });
 
     group('CMD + A to select all', () {
-      testWidgetsOnMacAndIos('does nothing when CMD key is pressed but A-key is not pressed', (tester) async {
+      testWidgetsOnApple('does nothing when CMD key is pressed but A-key is not pressed', (tester) async {
         await tester //
             .createDocument()
             .withSingleParagraph()
@@ -1083,7 +1083,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('does nothing when A-key is pressed but meta key is not pressed', (tester) async {
+      testWidgetsOnApple('does nothing when A-key is pressed but meta key is not pressed', (tester) async {
         await tester //
             .createDocument()
             .withSingleParagraph()
@@ -1106,7 +1106,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('does nothing when CMD+A is pressed but the document is empty', (tester) async {
+      testWidgetsOnApple('does nothing when CMD+A is pressed but the document is empty', (tester) async {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
@@ -1128,7 +1128,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a single-node document', (tester) async {
+      testWidgetsOnApple('selects all when CMD+A is pressed with a single-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(MutableDocument(
@@ -1161,7 +1161,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a two-node document', (tester) async {
+      testWidgetsOnApple('selects all when CMD+A is pressed with a two-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1200,7 +1200,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('selects all when CMD+A is pressed with a three-node document', (tester) async {
+      testWidgetsOnApple('selects all when CMD+A is pressed with a three-node document', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1246,7 +1246,7 @@ void main() {
     });
 
     group('key pressed with selection', () {
-      testWidgetsOnMacAndIos('deletes selection if backspace is pressed', (tester) async {
+      testWidgetsOnApple('deletes selection if backspace is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1294,7 +1294,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('deletes selection if delete is pressed', (tester) async {
+      testWidgetsOnApple('deletes selection if delete is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1342,7 +1342,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('replaces selected content with character when character key is pressed', (tester) async {
+      testWidgetsOnApple('replaces selected content with character when character key is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1391,7 +1391,7 @@ void main() {
         );
       });
 
-      testWidgetsOnMacAndIos('collapses selection if escape is pressed', (tester) async {
+      testWidgetsOnApple('collapses selection if escape is pressed', (tester) async {
         await tester //
             .createDocument()
             .withCustomContent(
@@ -1440,7 +1440,7 @@ void main() {
       });
     });
 
-    testWidgetsOnMacAndIos('does nothing when escape is pressed if the selection is collapsed', (tester) async {
+    testWidgetsOnApple('does nothing when escape is pressed if the selection is collapsed', (tester) async {
       await tester //
           .createDocument()
           .withCustomContent(

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -56,7 +56,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 2, to: 3));
         });
 
-        testAllInputsOnMacAndIos("to beginning of word when ALT + LEFT_ARROW is pressed", (
+        testAllInputsOnApple("to beginning of word when ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -67,7 +67,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 8));
         });
 
-        testAllInputsOnMacAndIos("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
+        testAllInputsOnApple("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -78,7 +78,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 8));
         });
 
-        testAllInputsOnMacAndIos("to end of word when ALT + RIGHT_ARROW is pressed", (
+        testAllInputsOnApple("to end of word when ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -89,7 +89,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 12));
         });
 
-        testAllInputsOnMacAndIos("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
+        testAllInputsOnApple("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -100,7 +100,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 12));
         });
 
-        testAllInputsOnMacAndIos("to beginning of line when CMD + LEFT_ARROW is pressed", (
+        testAllInputsOnApple("to beginning of line when CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -111,7 +111,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 0));
         });
 
-        testAllInputsOnMacAndIos("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
+        testAllInputsOnApple("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -122,7 +122,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 0));
         });
 
-        testAllInputsOnMacAndIos("to end of line when CMD + RIGHT_ARROW is pressed", (
+        testAllInputsOnApple("to end of line when CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -133,7 +133,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 26, TextAffinity.upstream));
         });
 
-        testAllInputsOnMacAndIos("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
+        testAllInputsOnApple("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -56,7 +56,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 2, to: 3));
         });
 
-        testAllInputsOnMac("to beginning of word when ALT + LEFT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to beginning of word when ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -67,7 +67,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 8));
         });
 
-        testAllInputsOnMac("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -78,7 +78,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 8));
         });
 
-        testAllInputsOnMac("to end of word when ALT + RIGHT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to end of word when ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -89,7 +89,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 12));
         });
 
-        testAllInputsOnMac("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -100,7 +100,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 12));
         });
 
-        testAllInputsOnMac("to beginning of line when CMD + LEFT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to beginning of line when CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -111,7 +111,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 0));
         });
 
-        testAllInputsOnMac("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -122,7 +122,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 0));
         });
 
-        testAllInputsOnMac("to end of line when CMD + RIGHT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to end of line when CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
@@ -133,7 +133,7 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 26, TextAffinity.upstream));
         });
 
-        testAllInputsOnMac("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
+        testAllInputsOnMacAndIos("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {

--- a/super_editor/test/super_reader/super_reader_keyboard_test.dart
+++ b/super_editor/test/super_reader/super_reader_keyboard_test.dart
@@ -34,7 +34,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 13));
       });
 
-      testAllInputsOnMac("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
+      testAllInputsOnMacAndIos("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -58,7 +58,7 @@ void main() {
         );
       });
 
-      testAllInputsOnMac("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
+      testAllInputsOnMacAndIos("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -70,7 +70,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 20));
       });
 
-      testAllInputsOnMac("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
+      testAllInputsOnMacAndIos("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -82,7 +82,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 0));
       });
 
-      testAllInputsOnMac("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
+      testAllInputsOnMacAndIos("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -182,7 +182,7 @@ void main() {
       });
     });
 
-    testAllInputsOnMac("and removes selection when it collapses without holding the SHIFT key", (
+    testAllInputsOnMacAndIos("and removes selection when it collapses without holding the SHIFT key", (
       tester, {
       required TextInputSource inputSource,
     }) async {
@@ -224,7 +224,7 @@ void main() {
       );
     });
 
-    testAllInputsOnMac("and retains the selection when collapsed and the SHIFT key is pressed", (
+    testAllInputsOnMacAndIos("and retains the selection when collapsed and the SHIFT key is pressed", (
       tester, {
       required TextInputSource inputSource,
     }) async {

--- a/super_editor/test/super_reader/super_reader_keyboard_test.dart
+++ b/super_editor/test/super_reader/super_reader_keyboard_test.dart
@@ -34,7 +34,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 13));
       });
 
-      testAllInputsOnMacAndIos("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
+      testAllInputsOnApple("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -58,7 +58,7 @@ void main() {
         );
       });
 
-      testAllInputsOnMacAndIos("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
+      testAllInputsOnApple("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -70,7 +70,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 20));
       });
 
-      testAllInputsOnMacAndIos("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
+      testAllInputsOnApple("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -82,7 +82,7 @@ void main() {
         expect(SuperReaderInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 8, to: 0));
       });
 
-      testAllInputsOnMacAndIos("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
+      testAllInputsOnApple("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -182,7 +182,7 @@ void main() {
       });
     });
 
-    testAllInputsOnMacAndIos("and removes selection when it collapses without holding the SHIFT key", (
+    testAllInputsOnApple("and removes selection when it collapses without holding the SHIFT key", (
       tester, {
       required TextInputSource inputSource,
     }) async {
@@ -224,7 +224,7 @@ void main() {
       );
     });
 
-    testAllInputsOnMacAndIos("and retains the selection when collapsed and the SHIFT key is pressed", (
+    testAllInputsOnApple("and retains the selection when collapsed and the SHIFT key is pressed", (
       tester, {
       required TextInputSource inputSource,
     }) async {

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -81,7 +81,7 @@ void testWidgetsOnMacWeb(
 
 /// A widget test that runs a variant for Mac and iOS.
 @isTestGroup
-void testWidgetsOnMacAndIos(
+void testWidgetsOnApple(
   String description,
   WidgetTesterCallback test, {
   bool skip = false,
@@ -236,7 +236,7 @@ void testAllInputsOnMac(
 
 /// A widget test that runs as a Mac and iOS, and for all [TextInputSource]s.
 @isTestGroup
-void testAllInputsOnMacAndIos(
+void testAllInputsOnApple(
   String description,
   InputModeTesterCallback test, {
   bool skip = false,

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:meta/meta.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 
 @isTestGroup

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -79,6 +79,18 @@ void testWidgetsOnMacWeb(
   }, variant: variant, skip: skip);
 }
 
+/// A widget test that runs a variant for Mac and iOS.
+@isTestGroup
+void testWidgetsOnMacAndIos(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+  TestVariant<Object?> variant = const DefaultTestVariant(),
+}) {
+  testWidgetsOnMac(description, test, variant: variant, skip: skip);
+  testWidgetsOnIos(description, test, variant: variant, skip: skip);
+}
+
 @isTestGroup
 void testWidgetsOnIosDeviceAndWeb(
   String description,
@@ -218,6 +230,30 @@ void testAllInputsOnMac(
   }, skip: skip);
 
   testWidgetsOnMac("$description (IME)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.ime);
+  }, skip: skip);
+}
+
+/// A widget test that runs as a Mac and iOS, and for all [TextInputSource]s.
+@isTestGroup
+void testAllInputsOnMacAndIos(
+  String description,
+  InputModeTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgetsOnMac("$description (keyboard)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.keyboard);
+  }, skip: skip);
+
+  testWidgetsOnMac("$description (IME)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.ime);
+  }, skip: skip);
+
+  testWidgetsOnIos("$description (keyboard)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.keyboard);
+  }, skip: skip);
+
+  testWidgetsOnIos("$description (IME)", (WidgetTester tester) async {
     await test(tester, inputSource: TextInputSource.ime);
   }, skip: skip);
 }


### PR DESCRIPTION
[SuperEditor] Enable Mac shortcuts for iOS. Resolves #1609

Mac shortcuts, like cmd + c, don't execute for iOS. The reason is that the `isPrimaryShortcutKeyPressed` getter only checks if the current platform is mac.

This PR changes `isPrimaryShortcutKeyPressed` to consider iOS and also enable other shortcuts that are running for mac only.