### PR TITLE
[SuperEditor] Don't execute keyboard handlers without primary focus (Resolves #183)

### DIFF
--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_physical_keyboard.dart
@@ -69,6 +69,14 @@ class _SuperEditorHardwareKeyHandlerState extends State<SuperEditorHardwareKeyHa
   }
 
   KeyEventResult _onKeyPressed(FocusNode node, KeyEvent keyEvent) {
+    if (!node.hasPrimaryFocus) {
+      // The editor is focused, but doesn't have primary focus. For example:
+      // - The editor has a node with a focused widget.
+      // - There is a focused widget somewhere else in the tree which shares
+      //   focus with the editor, typically a popover toolbar.
+      // Don't run any of the editor key handlers and let the event bubble up.
+      return KeyEventResult.ignored;
+    }
     editorKeyLog.info("Handling key press: $keyEvent");
     ExecutionInstruction instruction = ExecutionInstruction.continueExecution;
     int index = 0;

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
@@ -6,7 +7,9 @@ import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
 import '../test_runners.dart';
+import '../test_tools.dart';
 import 'supereditor_test_tools.dart';
+import 'test_documents.dart';
 
 void main() {
   group('SuperEditor keyboard', () {
@@ -279,6 +282,103 @@ void main() {
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 41, to: 58));
         });
       });
+    });
+
+    testAllInputsOnAllPlatforms('does nothing without primary focus', (
+      tester, {
+      required TextInputSource inputSource,
+    }) async {
+      final editorFocusNode = FocusNode();
+      final popoverFocusNode = FocusNode();
+      final textFieldFocusNode = FocusNode();
+      final overlayController = OverlayPortalController();
+
+      bool keyHandlerCalled = false;
+
+      // Pump a tree with an OverlayPortal that displays a SuperTextField.
+      // The textfield shares focus with SuperEditor, simulating a popover toolbar.
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withFocusNode(editorFocusNode)
+          .withInputSource(inputSource)
+          .withAddedKeyboardActions(append: [
+            ({required editContext, required keyEvent}) {
+              keyHandlerCalled = true;
+              return ExecutionInstruction.continueExecution;
+            }
+          ])
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: Scaffold(
+                body: OverlayPortal(
+                  controller: overlayController,
+                  overlayChildBuilder: (context) => Focus(
+                    focusNode: popoverFocusNode,
+                    parentNode: editorFocusNode,
+                    child: SuperTextField(
+                      focusNode: textFieldFocusNode,
+                      inputSource: inputSource,
+                    ),
+                  ),
+                  child: superEditor,
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      // Double tap to select the word "Lorem".
+      await tester.doubleTapInParagraph('1', 0);
+
+      // Show the popover and request focus to the textfield.
+      overlayController.show();
+      textFieldFocusNode.requestFocus();
+      await tester.pump();
+
+      // Press cmd + shift + alt + ctrl + space.
+      // This isn't a default shortcut in any platform.
+      // Therefore, if the editor is handling key events, our custom handler
+      // will be called.
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.meta);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.alt);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.space);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.space);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.alt);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.meta);
+      await tester.pumpAndSettle();
+
+      // Ensure the custom handler wasn't called.
+      expect(keyHandlerCalled, false);
+
+      // Press enter, which by default inserts a new line,
+      // to check if the document will change.
+      await tester.pressEnter();
+
+      // Ensure the document doesn't change.
+      expect(
+        SuperEditorInspector.findTextInParagraph('1').text,
+        (singleParagraphDoc().nodes.first as TextNode).text.text,
+      );
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(
+          const DocumentSelection(
+            base: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 5),
+            ),
+          ),
+        ),
+      );
     });
   });
 

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -206,6 +206,23 @@ void testAllInputsOnDesktop(
   }, skip: skip);
 }
 
+/// A widget test that runs a variant for every platform
+/// and for all [TextInputSource]s.
+@isTestGroup
+void testAllInputsOnAllPlatforms(
+  String description,
+  InputModeTesterCallback test, {
+  bool skip = false,
+}) {
+  testWidgetsOnAllPlatforms("$description (keyboard)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.keyboard);
+  }, skip: skip);
+
+  testWidgetsOnAllPlatforms("$description (IME)", (WidgetTester tester) async {
+    await test(tester, inputSource: TextInputSource.ime);
+  }, skip: skip);
+}
+
 /// A widget test that runs as a Mac, and for all [TextInputSource]s.
 @isTestGroup
 void testAllInputsOnMac(


### PR DESCRIPTION
[SuperEditor] Don't execute keyboard handlers without primary focus. Resolves #183

In the demo app, pressing ENTER on the toolbar's URL field causes a new line to be inserted, instead of applying the link attribution.

The cause is that the editor keyboard handlers (`enterToInsertBlockNewline` in this case) are running even if the editor doesn't have primary focus. This prevents the key event to bubble up to the OS to generate an `onPerformAction` call.

This PR changes the shortcut system to avoid calling any keyboard handler if the editor doesn't have primary focus.