### PR TITLE
[SuperEditor] Add constants for style metadata (Resolves #825)

### DIFF
--- a/super_editor/README.md
+++ b/super_editor/README.md
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> {
                             }
 
                             return {
-                                "padding": const CascadingPadding.only(top: 24),
+                                Styles.padding: const CascadingPadding.only(top: 24),
                             };
                         },
                     )

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -502,7 +502,7 @@ final _darkModeStyles = [
     BlockSelector.all,
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFFCCCCCC),
         ),
       };
@@ -512,7 +512,7 @@ final _darkModeStyles = [
     const BlockSelector("header1"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
         ),
       };
@@ -522,7 +522,7 @@ final _darkModeStyles = [
     const BlockSelector("header2"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
         ),
       };

--- a/super_editor/example/lib/demos/in_the_lab/in_the_lab_scaffold.dart
+++ b/super_editor/example/lib/demos/in_the_lab/in_the_lab_scaffold.dart
@@ -90,7 +90,7 @@ final darkModeStyles = [
     BlockSelector.all,
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFFCCCCCC),
           fontSize: 32,
         ),
@@ -101,7 +101,7 @@ final darkModeStyles = [
     const BlockSelector("header1"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 48,
         ),
@@ -112,7 +112,7 @@ final darkModeStyles = [
     const BlockSelector("header2"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 42,
         ),
@@ -123,7 +123,7 @@ final darkModeStyles = [
     const BlockSelector("header3"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 36,
         ),

--- a/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
+++ b/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
@@ -82,7 +82,7 @@ class _SelectedTextColorsDemoState extends State<SelectedTextColorsDemo> {
             BlockSelector.all,
             (doc, docNode) {
               return {
-                "textStyle": TextStyle(
+                Styles.textStyle: TextStyle(
                   color: _regularTextColor,
                 ),
               };

--- a/super_editor/example/lib/demos/interaction_spot_checks/spot_check_scaffold.dart
+++ b/super_editor/example/lib/demos/interaction_spot_checks/spot_check_scaffold.dart
@@ -90,7 +90,7 @@ final darkModeStyles = [
     BlockSelector.all,
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFFCCCCCC),
           fontSize: 32,
         ),
@@ -101,7 +101,7 @@ final darkModeStyles = [
     const BlockSelector("header1"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 48,
         ),
@@ -112,7 +112,7 @@ final darkModeStyles = [
     const BlockSelector("header2"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 42,
         ),
@@ -123,7 +123,7 @@ final darkModeStyles = [
     const BlockSelector("header3"),
     (doc, docNode) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Color(0xFF888888),
           fontSize: 36,
         ),

--- a/super_editor/example/lib/demos/styles/demo_doc_styles.dart
+++ b/super_editor/example/lib/demos/styles/demo_doc_styles.dart
@@ -31,9 +31,9 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           BlockSelector.all,
           (doc, docNode) {
             return {
-              "maxWidth": 640.0,
-              "padding": const CascadingPadding.symmetric(horizontal: 24),
-              "textStyle": const TextStyle(
+              Styles.maxWidth: 640.0,
+              Styles.padding: const CascadingPadding.symmetric(horizontal: 24),
+              Styles.textStyle: const TextStyle(
                 color: Colors.black,
                 fontSize: 18,
                 height: 1.4,
@@ -45,8 +45,8 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("header1"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 40),
-              "textStyle": const TextStyle(
+              Styles.padding: const CascadingPadding.only(top: 40),
+              Styles.textStyle: const TextStyle(
                 color: Color(0xFF333333),
                 fontSize: 38,
                 fontWeight: FontWeight.bold,
@@ -58,8 +58,8 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("header2"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 32),
-              "textStyle": const TextStyle(
+              Styles.padding: const CascadingPadding.only(top: 32),
+              Styles.textStyle: const TextStyle(
                 color: Color(0xFF333333),
                 fontSize: 26,
                 fontWeight: FontWeight.bold,
@@ -71,8 +71,8 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("header3"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 28),
-              "textStyle": const TextStyle(
+              Styles.padding: const CascadingPadding.only(top: 28),
+              Styles.textStyle: const TextStyle(
                 color: Color(0xFF333333),
                 fontSize: 22,
                 fontWeight: FontWeight.bold,
@@ -84,7 +84,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("paragraph"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 24),
+              Styles.padding: const CascadingPadding.only(top: 24),
             };
           },
         ),
@@ -92,7 +92,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("paragraph").after("header1"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 0),
+              Styles.padding: const CascadingPadding.only(top: 0),
             };
           },
         ),
@@ -100,7 +100,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("paragraph").after("header2"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 0),
+              Styles.padding: const CascadingPadding.only(top: 0),
             };
           },
         ),
@@ -108,7 +108,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("paragraph").after("header3"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 0),
+              Styles.padding: const CascadingPadding.only(top: 0),
             };
           },
         ),
@@ -116,7 +116,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           const BlockSelector("listItem"),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(top: 24),
+              Styles.padding: const CascadingPadding.only(top: 24),
             };
           },
         ),
@@ -124,7 +124,7 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
           BlockSelector.all.last(),
           (doc, docNode) {
             return {
-              "padding": const CascadingPadding.only(bottom: 96),
+              Styles.padding: const CascadingPadding.only(bottom: 96),
             };
           },
         ),

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -208,7 +208,7 @@ class _MarketingVideoState extends State<MarketingVideo> {
               StyleRule(
                   BlockSelector.all,
                   (doc, node) => {
-                        "padding": const CascadingPadding.all(0.0),
+                        Styles.padding: const CascadingPadding.all(0.0),
                       }),
             ],
             inlineTextStyler: (attributions, style) => _textStyleBuilder(attributions),

--- a/super_editor/lib/src/core/styles.dart
+++ b/super_editor/lib/src/core/styles.dart
@@ -92,6 +92,8 @@ class StyleRule {
 }
 
 /// Generates style metadata for the given [DocumentNode] within the [Document].
+///
+/// See [Styles] for the list of available keys.
 typedef Styler = Map<String, dynamic> Function(Document, DocumentNode);
 
 /// Selects blocks in a document that matches a given rule.
@@ -315,4 +317,16 @@ class SelectionStyles {
 
   @override
   int get hashCode => selectionColor.hashCode ^ highlightEmptyTextBlocks.hashCode;
+}
+
+/// The keys to the style metadata used by a [StyleRule].
+class Styles {
+  /// Key to apply a [TextStyle] to the content.
+  static const String textStyle = 'textStyle';
+
+  /// Key to apply a [CascadingPadding] around the content.
+  static const String padding = 'padding';
+
+  /// Key to a `double` that defines the maximum width of the node.
+  static const String maxWidth = 'maxWidth';
 }

--- a/super_editor/lib/src/core/styles.dart
+++ b/super_editor/lib/src/core/styles.dart
@@ -321,12 +321,24 @@ class SelectionStyles {
 
 /// The keys to the style metadata used by a [StyleRule].
 class Styles {
-  /// Key to apply a [TextStyle] to the content.
+  /// Applies a [TextStyle] to the content.
   static const String textStyle = 'textStyle';
 
-  /// Key to apply a [CascadingPadding] around the content.
+  /// Applies a [CascadingPadding] around the content.
   static const String padding = 'padding';
 
   /// Key to a `double` that defines the maximum width of the node.
   static const String maxWidth = 'maxWidth';
+
+  /// Applies a background [Color] to a blockquote.
+  static const String backgroundColor = 'backgroundColor';
+
+  /// Applies a [BorderRadius] to a blockquote.
+  static const String borderRadius = 'borderRadius';
+
+  /// Applies a [TextAlign] to a text node.
+  static const String textAlign = 'textAlign';
+
+  /// Applies a [AttributionStyleAdjuster] to a text node.
+  static const String inlineTextStyler = 'inlineTextStyler';
 }

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
@@ -125,8 +126,8 @@ class BlockquoteComponentViewModel extends SingleColumnLayoutComponentViewModel 
   @override
   void applyStyles(Map<String, dynamic> styles) {
     super.applyStyles(styles);
-    backgroundColor = styles["backgroundColor"] ?? Colors.transparent;
-    borderRadius = styles["borderRadius"] ?? BorderRadius.zero;
+    backgroundColor = styles[Styles.backgroundColor] ?? Colors.transparent;
+    borderRadius = styles[Styles.borderRadius] ?? BorderRadius.zero;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
@@ -465,8 +465,8 @@ abstract class SingleColumnLayoutComponentViewModel {
   EdgeInsetsGeometry padding;
 
   void applyStyles(Map<String, dynamic> styles) {
-    maxWidth = styles["maxWidth"] ?? double.infinity;
-    padding = (styles["padding"] as CascadingPadding?)?.toEdgeInsets() ?? EdgeInsets.zero;
+    maxWidth = styles[Styles.maxWidth] ?? double.infinity;
+    padding = (styles[Styles.padding] as CascadingPadding?)?.toEdgeInsets() ?? EdgeInsets.zero;
   }
 
   SingleColumnLayoutComponentViewModel copy();

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1287,9 +1287,9 @@ final defaultStylesheet = Stylesheet(
       BlockSelector.all,
       (doc, docNode) {
         return {
-          "maxWidth": 640.0,
-          "padding": const CascadingPadding.symmetric(horizontal: 24),
-          "textStyle": const TextStyle(
+          Styles.maxWidth: 640.0,
+          Styles.padding: const CascadingPadding.symmetric(horizontal: 24),
+          Styles.textStyle: const TextStyle(
             color: Colors.black,
             fontSize: 18,
             height: 1.4,
@@ -1301,8 +1301,8 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("header1"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 40),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 40),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 38,
             fontWeight: FontWeight.bold,
@@ -1314,8 +1314,8 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("header2"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 32),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 32),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 26,
             fontWeight: FontWeight.bold,
@@ -1327,8 +1327,8 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("header3"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 28),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 28),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 22,
             fontWeight: FontWeight.bold,
@@ -1340,7 +1340,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("paragraph"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 24),
+          Styles.padding: const CascadingPadding.only(top: 24),
         };
       },
     ),
@@ -1348,7 +1348,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header1"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -1356,7 +1356,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header2"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -1364,7 +1364,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header3"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -1372,7 +1372,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("listItem"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 24),
+          Styles.padding: const CascadingPadding.only(top: 24),
         };
       },
     ),
@@ -1380,7 +1380,7 @@ final defaultStylesheet = Stylesheet(
       const BlockSelector("blockquote"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.grey,
             fontSize: 20,
             fontWeight: FontWeight.bold,
@@ -1393,7 +1393,7 @@ final defaultStylesheet = Stylesheet(
       BlockSelector.all.last(),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(bottom: 96),
+          Styles.padding: const CascadingPadding.only(bottom: 96),
         };
       },
     ),

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -64,7 +64,7 @@ final taskStyles = StyleRule(
     }
 
     return {
-      "padding": const CascadingPadding.only(top: 24),
+      Styles.padding: const CascadingPadding.only(top: 24),
     };
   },
 );

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -383,11 +383,11 @@ mixin TextComponentViewModel on SingleColumnLayoutComponentViewModel {
   void applyStyles(Map<String, dynamic> styles) {
     super.applyStyles(styles);
 
-    textAlignment = styles["textAlign"] ?? textAlignment;
+    textAlignment = styles[Styles.textAlign] ?? textAlignment;
 
     textStyleBuilder = (attributions) {
-      final baseStyle = styles["textStyle"] ?? noStyleBuilder({});
-      final inlineTextStyler = styles["inlineTextStyler"] as AttributionStyleAdjuster;
+      final baseStyle = styles[Styles.textStyle] ?? noStyleBuilder({});
+      final inlineTextStyler = styles[Styles.inlineTextStyler] as AttributionStyleAdjuster;
 
       return inlineTextStyler(attributions, baseStyle);
     };

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -717,9 +717,9 @@ final readOnlyDefaultStylesheet = Stylesheet(
       BlockSelector.all,
       (doc, docNode) {
         return {
-          "maxWidth": 640.0,
-          "padding": const CascadingPadding.symmetric(horizontal: 24),
-          "textStyle": const TextStyle(
+          Styles.maxWidth: 640.0,
+          Styles.padding: const CascadingPadding.symmetric(horizontal: 24),
+          Styles.textStyle: const TextStyle(
             color: Colors.black,
             fontSize: 18,
             height: 1.4,
@@ -731,8 +731,8 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("header1"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 40),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 40),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 38,
             fontWeight: FontWeight.bold,
@@ -744,8 +744,8 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("header2"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 32),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 32),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 26,
             fontWeight: FontWeight.bold,
@@ -757,8 +757,8 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("header3"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 28),
-          "textStyle": const TextStyle(
+          Styles.padding: const CascadingPadding.only(top: 28),
+          Styles.textStyle: const TextStyle(
             color: Color(0xFF333333),
             fontSize: 22,
             fontWeight: FontWeight.bold,
@@ -770,7 +770,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("paragraph"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 24),
+          Styles.padding: const CascadingPadding.only(top: 24),
         };
       },
     ),
@@ -778,7 +778,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header1"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -786,7 +786,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header2"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -794,7 +794,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("paragraph").after("header3"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 0),
         };
       },
     ),
@@ -802,7 +802,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("listItem"),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(top: 24),
+          Styles.padding: const CascadingPadding.only(top: 24),
         };
       },
     ),
@@ -810,7 +810,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       const BlockSelector("blockquote"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.grey,
             fontSize: 20,
             fontWeight: FontWeight.bold,
@@ -823,7 +823,7 @@ final readOnlyDefaultStylesheet = Stylesheet(
       BlockSelector.all.last(),
       (doc, docNode) {
         return {
-          "padding": const CascadingPadding.only(bottom: 96),
+          Styles.padding: const CascadingPadding.only(bottom: 96),
         };
       },
     ),

--- a/super_editor/test/super_editor/components/block_node_test.dart
+++ b/super_editor/test/super_editor/components/block_node_test.dart
@@ -643,7 +643,7 @@ Widget _buildHardwareKeyboardEditor(MutableDocument document, MutableDocumentCom
           addRulesAfter: [
             StyleRule(BlockSelector.all, (doc, node) {
               return {
-                "textStyle": const TextStyle(
+                Styles.textStyle: const TextStyle(
                   fontSize: 12,
                 ),
               };

--- a/super_editor/test/super_editor/components/blockquote_test.dart
+++ b/super_editor/test/super_editor/components/blockquote_test.dart
@@ -40,7 +40,7 @@ final _styleSheet = Stylesheet(
       const BlockSelector("blockquote"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(color: Colors.blue, fontSize: 16),
+          Styles.textStyle: const TextStyle(color: Colors.blue, fontSize: 16),
         };
       },
     ),

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -850,7 +850,7 @@ final _styleSheet = Stylesheet(
       const BlockSelector("paragraph"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.red,
             fontSize: 16,
           ),
@@ -861,7 +861,7 @@ final _styleSheet = Stylesheet(
       const BlockSelector("listItem"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.blue,
             fontSize: 16,
           ),

--- a/super_editor/test/super_editor/supereditor_component_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_component_selection_test.dart
@@ -611,7 +611,7 @@ final _testStylesheet = defaultStylesheet.copyWith(
   addRulesAfter: [
     StyleRule(BlockSelector.all, (doc, node) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           fontSize: 12,
         ),
       };

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -258,7 +258,7 @@ void main() {
               rules: [
                 StyleRule(BlockSelector.all, (document, node) {
                   return {
-                    "textStyle": const TextStyle(
+                    Styles.textStyle: const TextStyle(
                       color: Colors.black,
                     ),
                   };
@@ -301,7 +301,7 @@ void main() {
               rules: [
                 StyleRule(BlockSelector.all, (document, node) {
                   return {
-                    "textStyle": const TextStyle(
+                    Styles.textStyle: const TextStyle(
                       color: Colors.black,
                     ),
                   };

--- a/super_editor/test/super_editor/supereditor_style_test.dart
+++ b/super_editor/test/super_editor/supereditor_style_test.dart
@@ -94,7 +94,7 @@ A paragraph
                 const BlockSelector("listItem"),
                 (doc, docNode) {
                   return {
-                    "textStyle": const TextStyle(
+                    Styles.textStyle: const TextStyle(
                       color: Colors.blue,
                       fontSize: 16,
                     ),
@@ -105,7 +105,7 @@ A paragraph
                 const BlockSelector("paragraph"),
                 (doc, docNode) {
                   return {
-                    "textStyle": const TextStyle(
+                    Styles.textStyle: const TextStyle(
                       color: Colors.red,
                       fontSize: 16,
                     ),
@@ -260,7 +260,7 @@ final _stylesheetWithNodePositionRule = Stylesheet(
       const BlockSelector("paragraph"),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.red,
           ),
         };
@@ -270,7 +270,7 @@ final _stylesheetWithNodePositionRule = Stylesheet(
       const BlockSelector("paragraph").last(),
       (doc, docNode) {
         return {
-          "textStyle": const TextStyle(
+          Styles.textStyle: const TextStyle(
             color: Colors.blue,
           )
         };
@@ -284,7 +284,7 @@ final _stylesheetWithBlackText = Stylesheet(
   rules: [
     StyleRule(BlockSelector.all, (document, node) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Colors.black,
         ),
       };
@@ -297,7 +297,7 @@ final _stylesheetWithWhiteText = Stylesheet(
   rules: [
     StyleRule(BlockSelector.all, (document, node) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           color: Colors.white,
         ),
       };

--- a/super_editor/test_goldens/editor/supereditor_text_layout_test.dart
+++ b/super_editor/test_goldens/editor/supereditor_text_layout_test.dart
@@ -231,7 +231,7 @@ final _stylesheet = defaultStylesheet.copyWith(
   addRulesAfter: [
     StyleRule(BlockSelector.all, (doc, node) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           fontFamily: 'Roboto',
         ),
       };

--- a/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
+++ b/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
@@ -194,7 +194,7 @@ final _stylesheet = defaultStylesheet.copyWith(
   addRulesAfter: [
     StyleRule(BlockSelector.all, (doc, node) {
       return {
-        "textStyle": const TextStyle(
+        Styles.textStyle: const TextStyle(
           fontFamily: 'Roboto',
         ),
       };

--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -312,13 +312,13 @@ final _compactStylesheet = defaultStylesheet.copyWith(
     StyleRule(BlockSelector.all, (doc, docNode) => {'textStyle': _baseTextStyle}),
     StyleRule(
       BlockSelector.all.after(header1Attribution.name),
-      (doc, docNode) => {'padding': const CascadingPadding.only(top: 24)},
+      (doc, docNode) => {Styles.padding: const CascadingPadding.only(top: 24)},
     ),
     StyleRule(
       BlockSelector(header1Attribution.name),
       (doc, docNode) {
         return {
-          'textStyle': _baseTextStyle.copyWith(
+          Styles.textStyle: _baseTextStyle.copyWith(
             fontSize: 32,
             fontWeight: FontWeight.w700,
             height: 1.2,
@@ -328,7 +328,7 @@ final _compactStylesheet = defaultStylesheet.copyWith(
     ),
     StyleRule(BlockSelector(header2Attribution.name), (doc, docNode) {
       return {
-        'textStyle': _baseTextStyle.copyWith(
+        Styles.textStyle: _baseTextStyle.copyWith(
           fontSize: 32,
           fontWeight: FontWeight.w700,
           height: 1.2,
@@ -337,7 +337,7 @@ final _compactStylesheet = defaultStylesheet.copyWith(
     }),
     StyleRule(BlockSelector(header3Attribution.name), (doc, docNode) {
       return {
-        'textStyle': _baseTextStyle.copyWith(
+        Styles.textStyle: _baseTextStyle.copyWith(
           fontSize: 26,
           fontWeight: FontWeight.w700,
           height: 1.2,
@@ -346,7 +346,7 @@ final _compactStylesheet = defaultStylesheet.copyWith(
     }),
     StyleRule(BlockSelector(blockquoteAttribution.name), (doc, docNode) {
       return {
-        'textStyle': _baseTextStyle.copyWith(
+        Styles.textStyle: _baseTextStyle.copyWith(
           fontSize: 20,
           fontWeight: FontWeight.bold,
           color: Colors.black54,
@@ -360,16 +360,16 @@ final _compactStylesheet = defaultStylesheet.copyWith(
 final _wideStylesheet = defaultStylesheet.copyWith(
   documentPadding: const EdgeInsets.symmetric(horizontal: 54, vertical: 60),
   addRulesAfter: [
-    StyleRule(BlockSelector.all, (doc, docNode) => {'textStyle': _baseTextStyle}),
+    StyleRule(BlockSelector.all, (doc, docNode) => {Styles.textStyle: _baseTextStyle}),
     StyleRule(
       BlockSelector.all.after(header1Attribution.name),
-      (doc, docNode) => {'padding': const CascadingPadding.only(top: 48)},
+      (doc, docNode) => {Styles.padding: const CascadingPadding.only(top: 48)},
     ),
     StyleRule(
       BlockSelector(header1Attribution.name),
       (doc, docNode) {
         return {
-          'textStyle': _baseTextStyle.copyWith(
+          Styles.textStyle: _baseTextStyle.copyWith(
             fontSize: 40,
             fontWeight: FontWeight.w700,
             height: 1.2,
@@ -381,7 +381,7 @@ final _wideStylesheet = defaultStylesheet.copyWith(
       BlockSelector(header2Attribution.name),
       (doc, docNode) {
         return {
-          'textStyle': _baseTextStyle.copyWith(
+          Styles.textStyle: _baseTextStyle.copyWith(
             fontSize: 32,
             fontWeight: FontWeight.w700,
             height: 1.2,
@@ -393,7 +393,7 @@ final _wideStylesheet = defaultStylesheet.copyWith(
       BlockSelector(header3Attribution.name),
       (doc, docNode) {
         return {
-          'textStyle': _baseTextStyle.copyWith(
+          Styles.textStyle: _baseTextStyle.copyWith(
             fontSize: 36,
             fontWeight: FontWeight.w700,
             height: 1.2,
@@ -405,7 +405,7 @@ final _wideStylesheet = defaultStylesheet.copyWith(
       BlockSelector(blockquoteAttribution.name),
       (doc, docNode) {
         return {
-          'textStyle': _baseTextStyle.copyWith(
+          Styles.textStyle: _baseTextStyle.copyWith(
             fontSize: 20,
             fontWeight: FontWeight.bold,
             color: Colors.black54,


### PR DESCRIPTION
[SuperEditor] Add constants for style metadata. Resolves #825

Currently, we use hardcoded strings for the stylesheet properties.

This PR adds constants to the available properties, so developers can use intelisense to discover them.

We could also add constants for node's metadata.