### PR TITLE
[SuperEditor] Make composing region underline continuous (Resolves #1684)

### DIFF
--- a/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
@@ -886,7 +886,11 @@ class _NoOpTextLayout implements ProseTextLayout {
   }
 
   @override
-  List<TextBox> getBoxesForSelection(TextSelection selection) {
+  List<TextBox> getBoxesForSelection(
+    TextSelection selection, {
+    BoxHeightStyle boxHeightStyle = BoxHeightStyle.tight,
+    BoxWidthStyle boxWidthStyle = BoxWidthStyle.tight,
+  }) {
     throw UnimplementedError();
   }
 

--- a/super_text_layout/lib/src/text_layout.dart
+++ b/super_text_layout/lib/src/text_layout.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 import 'super_text.dart';
@@ -47,7 +48,11 @@ abstract class TextLayout {
   double? getHeightForCaret(TextPosition position);
 
   /// Returns a [List] of [TextBox]es that contain the given [selection].
-  List<TextBox> getBoxesForSelection(TextSelection selection);
+  List<TextBox> getBoxesForSelection(
+    TextSelection selection, {
+    BoxHeightStyle boxHeightStyle = BoxHeightStyle.tight,
+    BoxWidthStyle boxWidthStyle = BoxWidthStyle.tight,
+  });
 
   /// Returns a bounding [TextBox] for the character at the given [position] or `null`
   /// if a character box couldn't be found.
@@ -295,12 +300,20 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
   }
 
   @override
-  List<TextBox> getBoxesForSelection(TextSelection selection) {
+  List<TextBox> getBoxesForSelection(
+    TextSelection selection, {
+    BoxHeightStyle boxHeightStyle = BoxHeightStyle.tight,
+    BoxWidthStyle boxWidthStyle = BoxWidthStyle.tight,
+  }) {
     if (_renderParagraph.needsLayout) {
       return [];
     }
 
-    return _renderParagraph.getBoxesForSelection(selection);
+    return _renderParagraph.getBoxesForSelection(
+      selection,
+      boxHeightStyle: boxHeightStyle,
+      boxWidthStyle: boxWidthStyle,
+    );
   }
 
   @override

--- a/super_text_layout/lib/src/text_underline_layer.dart
+++ b/super_text_layout/lib/src/text_underline_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 
@@ -32,6 +34,7 @@ class TextUnderlineLayerState extends State<TextUnderlineLayer> with TickerProvi
       // Convert selection bounding boxes into underline paths.
       final boxes = widget.textLayout.getBoxesForSelection(
         TextSelection(baseOffset: underline.range.start, extentOffset: underline.range.end),
+        boxHeightStyle: BoxHeightStyle.max,
       );
       final lines = <Path>[];
       for (final box in boxes) {


### PR DESCRIPTION
[SuperEditor] Make composing region underline continuous. Resolves #1684

Steps To Reproduce

1. Go to SuperEditor demo
2. Use Japanese-Romanji keyboad layout
3. Place the selection in the text (not specific position needed)
4. In the physical English keyboard, type "as"

With these steps the underlines aren't aligned:

![tight](https://github.com/superlistapp/super_editor/assets/7597082/6492ee94-d18e-4534-82f2-d64f57f82042)

We use `getBoxesForSelection` to determine the position of the underline, which internally calls a `RenderParagraph` method of the same name. This method takes a `boxHeightStyle` parameter, which the default value (`BoxHeightStyle.tight`) has the following doc:

```dart
/// Provide tight bounding boxes that fit heights per run. This style may result
/// in uneven bounding boxes that do not nicely connect with adjacent boxes.
```

This is how it's rendered with the other styles:

`BoxHeightStyle.includeLineSpacingBottom`
![includeLineSpacingBottom](https://github.com/superlistapp/super_editor/assets/7597082/da6aff0f-22ff-41c3-b18a-51f0689ea1a6)

`BoxHeightStyle.includeLineSpacingMiddle`
![includeLineSpacingMiddle](https://github.com/superlistapp/super_editor/assets/7597082/c47d9b4f-302f-42cc-8625-c6ce978fb68e)

`BoxHeightStyle.includeLineSpacingTop`
![includeLineSpacingTop](https://github.com/superlistapp/super_editor/assets/7597082/7978442d-2ba3-4e2f-98e1-2ce752ef1f27)

`BoxHeightStyle.max`
![max](https://github.com/superlistapp/super_editor/assets/7597082/3c9d930a-a782-44a3-a9bc-7d5922c0a539)

`BoxHeightStyle.strut`
![strut](https://github.com/superlistapp/super_editor/assets/7597082/84ad24f1-4e98-4d14-a5f3-cc881e7c3baa)

Modifying `TextUnderlineLayer` to use `BoxHeightStyle.max` as the `boxHeightStyle` solves the alignment issue. However, it's noticeable that the gap between the text and the underline becomes much bigger, even if we set the `TextLayoutUnderline` gap to zero:

![zero_gap](https://github.com/superlistapp/super_editor/assets/7597082/b588bf3a-4d24-4e74-974b-f6458f1427a6)

This PR exposes the `boxHeightStyle` and `boxWidthStyle` parameters in  the `TextLayout` interface and changes the `TextUnderlineLayer` to use `BoxHeightStyle.max`.

To make the gap smaller, we could manually expand the selection boxes, using the bottom of the first box of each line:

```dart
final selectionBoxes = widget.textLayout.getBoxesForSelection(
  TextSelection(baseOffset: underline.range.start, extentOffset: underline.range.end),
);

for (int i = 0; i < selectionBoxes.length; i++) {
  final box = selectionBoxes[i];

  if (paintBoxes.isEmpty) {
    // This is the first box, just add it.
    paintBoxes.add(box);
  } else if (box.top >= paintBoxes.last.bottom) {
    // This box belong to another line.
    // This is a naive check and we should be able to find a better way to do it.
    paintBoxes.add(box);
  } else {
    final lastBox = paintBoxes.last;
    paintBoxes[paintBoxes.length - 1] = TextBox.fromLTRBD(
      lastBox.left,
      lastBox.top,
      box.right, // extend here
      lastBox.bottom,
      lastBox.direction,
    );
  }
}
```

With this approach we get a much smaller gap:

![Captura de Tela 2023-12-14 às 11 44 37](https://github.com/superlistapp/super_editor/assets/7597082/790ca657-b44e-4051-9dab-3e793e2a6707)


This PR doesn't include golden tests because I couldn't manage to render the Japanese correctly in the tests:
![Captura de Tela 2023-12-14 às 11 36 37](https://github.com/superlistapp/super_editor/assets/7597082/4967ba19-dee6-470d-8b86-c81bf035c5da)
