### PR TITLE
[SuperEditor][Android] Fix drag handle flashing on double tap (Resolves #1690)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1531,7 +1531,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       valueListenable: _controlsController!.shouldShowCollapsedHandle,
       builder: (context, shouldShow, child) {
         final selection = widget.selection.value;
-        if (selection == null || selection.isCollapsed) {
+        if (selection == null || !selection.isCollapsed) {
           // When the user double taps we first place a collapsed selection
           // and then an expanded selection.
           // Return a SizedBox to avoid flashing the collapsed drag handle.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -1529,13 +1530,20 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     return ValueListenableBuilder(
       valueListenable: _controlsController!.shouldShowCollapsedHandle,
       builder: (context, shouldShow, child) {
+        final selection = widget.selection.value;
+        if (selection == null || selection.isCollapsed) {
+          // When the user double taps we first place a collapsed selection
+          // and then an expanded selection.
+          // Return a SizedBox to avoid flashing the collapsed drag handle.
+          return const SizedBox();
+        }
+
         // Note: If we pass this widget as the `child` property, it causes repeated starts and stops
         // of the pan gesture. By building it here, pan events work as expected.
         return Follower.withOffset(
           link: _controlsController!.collapsedHandleFocalPoint,
           leaderAnchor: Alignment.bottomCenter,
           followerAnchor: Alignment.topCenter,
-          showWhenUnlinked: false,
           child: AnimatedOpacity(
             // When the controller doesn't want the handle to be visible, hide it.
             opacity: shouldShow ? 1.0 : 0.0,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1535,6 +1535,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
           link: _controlsController!.collapsedHandleFocalPoint,
           leaderAnchor: Alignment.bottomCenter,
           followerAnchor: Alignment.topCenter,
+          showWhenUnlinked: false,
           child: AnimatedOpacity(
             // When the controller doesn't want the handle to be visible, hide it.
             opacity: shouldShow ? 1.0 : 0.0,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
[SuperEditor][Android] Fix drag handle flashing on double tap. Resolves #1690

Upon double tap, the drag handle quickly flashes at the top-left corner of the screen:

https://github.com/superlistapp/super_editor/assets/31278849/92af387f-a242-48e0-a1f0-0995851b280e

This happens because of the following:

- The `TapSequenceGestureRecognizer` reports both `onTapDown` and `onDoubleTapDown` (as expected), so we first show the collapsed drag handle, then we hide the collapsed drag handle and show the expanded handles.
- The `Follower` is configured to `showWhenUnlinked` (because it defaults to `true`), so when the `Leader` is unlinked, it's placed at the top-left corner. 
- The collapsed handle uses a `AnimatedOpacity` to fade in and out.

So, on double tap, the drag handle is positioned at the top-left corner and it's visible for a brief moment, while the animation is running.

This PR sets `showWhenUnlinked` to false, so when the `Leader` is unlinked, the drag handle is immediately hidden.

Another option is to keep the `Leader` for the collapsed drag handle on the widget tree even when we have an expanded selection. 