### PR TITLE
Fixed SuperTextField single-line auto-scroll and scrolling bugs on iOS and Android (Resolves #1673)

### DIFF
--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -54,7 +54,7 @@ Future<void> main() async {
     // textFieldLog,
     // editorUserTagsLog,
     // contentLayersLog,
-    appLog,
+    // appLog,
   });
 
   runApp(SuperEditorDemoApp());

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -314,7 +314,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _updateSelectionForDragHandleAfterScrollChange() {
     _needToSyncSelectionWithHandleLocation = true;
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    onNextFrame((timeStamp) {
       if (!_needToSyncSelectionWithHandleLocation) {
         return;
       }

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -47,6 +47,7 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
     required this.editingOverlayController,
     required this.textScrollController,
     required this.textKey,
+    required this.getGlobalCaretRect,
     required this.isMultiline,
     required this.handleColor,
     this.showDebugPaint = false,
@@ -80,6 +81,10 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
   /// this [AndroidTextFieldTouchInteractor].
   final GlobalKey<ProseTextState> textKey;
 
+  /// A function that returns the current caret global rect, or `null` if no
+  /// caret exists.
+  final Rect? Function() getGlobalCaretRect;
+
   /// Whether the text field that owns this [AndroidTextFieldInteractor] is
   /// a multiline text field.
   final bool isMultiline;
@@ -112,6 +117,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void initState() {
     super.initState();
 
+    widget.textController.addListener(_onTextOrSelectionChange);
     widget.textScrollController.addListener(_onScrollChange);
   }
 
@@ -119,6 +125,10 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void didUpdateWidget(AndroidTextFieldTouchInteractor oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    if (widget.textController != oldWidget.textController) {
+      oldWidget.textController.removeListener(_onTextOrSelectionChange);
+      widget.textController.addListener(_onTextOrSelectionChange);
+    }
     if (widget.textScrollController != oldWidget.textScrollController) {
       oldWidget.textScrollController.removeListener(_onScrollChange);
       widget.textScrollController.addListener(_onScrollChange);
@@ -127,11 +137,24 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
   @override
   void dispose() {
+    widget.textController.removeListener(_onTextOrSelectionChange);
     widget.textScrollController.removeListener(_onScrollChange);
     super.dispose();
   }
 
   ProseTextLayout get _textLayout => widget.textKey.currentState!.textLayout;
+
+  void _onTextOrSelectionChange() {
+    if (!_isDraggingCaret) {
+      // The user isn't dragging the caret. Ensure the current selection is visible. The
+      // user may have typed beyond the viewport, or something may have changed the controller's
+      // selection to sit beyond the viewport.
+      //
+      // We don't do this when the user is dragging the caret because the user's finger position
+      // and the auto-scrolling system should control the scroll offset in that case.
+      widget.textScrollController.ensureExtentIsVisible();
+    }
+  }
 
   void _onTapDown(TapDownDetails details) {
     _log.fine("User tapped down");
@@ -144,12 +167,12 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     // A drag can begin with a tap down, so we hide the toolbar
     // preemptively.
     widget.editingOverlayController.hideToolbar();
-
-    _selectAtOffset(details.localPosition);
   }
 
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
+
+    _selectAtOffset(details.localPosition);
 
     if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
       widget.textController.showKeyboard();
@@ -264,8 +287,19 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     }
   }
 
-  void _onTextPanStart(DragStartDetails details) {
+  void _onPanStart(DragStartDetails details) {
     _log.fine("User started a pan");
+
+    final globalCaretRect = widget.getGlobalCaretRect();
+    if (globalCaretRect == null) {
+      // There's no caret, therefore the user shouldn't be able to drag the caret. Fizzle.
+      return;
+    }
+    if ((globalCaretRect.center - details.globalPosition).dx.abs() > 48) {
+      // There's a caret, but the user's drag offset is far away. Fizzle.
+      return;
+    }
+
     setState(() {
       _isDraggingCaret = true;
       _globalDragOffset = details.globalPosition;
@@ -279,11 +313,13 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void _onPanUpdate(DragUpdateDetails details) {
     _log.finer("User panned to new offset");
 
-    if (_isDraggingCaret) {
-      widget.textController.selection = TextSelection.collapsed(
-        offset: _globalOffsetToTextPosition(details.globalPosition).offset,
-      );
+    if (!_isDraggingCaret) {
+      return;
     }
+
+    widget.textController.selection = TextSelection.collapsed(
+      offset: _globalOffsetToTextPosition(details.globalPosition).offset,
+    );
 
     setState(() {
       _globalDragOffset = _globalDragOffset! + details.delta;
@@ -453,7 +489,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
             () => PanGestureRecognizer(),
             (PanGestureRecognizer recognizer) {
               recognizer
-                ..onStart = widget.focusNode.hasFocus ? _onTextPanStart : null
+                ..onStart = widget.focusNode.hasFocus ? _onPanStart : null
                 ..onUpdate = widget.focusNode.hasFocus ? _onPanUpdate : null
                 ..onEnd = widget.focusNode.hasFocus || _isDraggingCaret ? _onPanEnd : null
                 ..onCancel = widget.focusNode.hasFocus || _isDraggingCaret ? _onPanCancel : null

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -104,6 +104,10 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
 
 class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchInteractor>
     with TickerProviderStateMixin {
+  /// The maximum horizontal distance that a user can press near the caret to enable
+  /// a caret drag.
+  static const _closeEnoughToDragCaret = 48.0;
+
   final _textViewportOffsetLink = LayerLink();
 
   // Whether the user is dragging a collapsed selection.
@@ -295,7 +299,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       // There's no caret, therefore the user shouldn't be able to drag the caret. Fizzle.
       return;
     }
-    if ((globalCaretRect.center - details.globalPosition).dx.abs() > 48) {
+    if ((globalCaretRect.center - details.globalPosition).dx.abs() > _closeEnoughToDragCaret) {
       // There's a caret, but the user's drag offset is far away. Fizzle.
       return;
     }

--- a/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
@@ -572,7 +572,6 @@ class TextScrollController with ChangeNotifier {
   /// If auto-scrolling to the start, that auto-scroll is
   /// cancelled and replaced by auto-scrolling to the end.
   void startScrollingToEnd() {
-    print("startScrollingToEnd()");
     if (_autoScrollDirection == _AutoScrollDirection.end) {
       // Already scrolling to end. Return.
       return;
@@ -603,7 +602,6 @@ class TextScrollController with ChangeNotifier {
   /// If a line is scrolled, resets the time until the next
   /// auto scroll movement.
   void _autoScrollTick(Duration elapsedTime) {
-    print("_autoScrollTick() - elapsed time: $elapsedTime");
     if (_delegate == null) {
       _log.warning('auto-scroll delegate was null in _autoScrollTick()');
       stopScrolling();
@@ -635,7 +633,6 @@ class TextScrollController with ChangeNotifier {
       if (_autoScrollDirection == _AutoScrollDirection.start) {
         _autoScrollOneCharacterLeft();
       } else {
-        print("Auto-scrolling one character to the right");
         _autoScrollOneCharacterRight();
       }
     }
@@ -790,7 +787,6 @@ class TextScrollController with ChangeNotifier {
   ///
   /// Does nothing if the extent position is already visible.
   void ensureExtentIsVisible() {
-    print("Text scrollview - ensureExtentIsVisible()");
     if (_delegate == null) {
       _log.warning("Can't make extent selection visible. The scroll delegate is null.");
       return;
@@ -813,7 +809,6 @@ class TextScrollController with ChangeNotifier {
     final extentCharacterRectInContentSpace =
         _delegate!.getCharacterRectAtPosition(TextPosition(offset: characterIndex));
 
-    print("Character index: $characterIndex, extent rect: $extentCharacterRectInContentSpace");
     _ensureRectIsVisible(extentCharacterRectInContentSpace);
   }
 
@@ -830,7 +825,6 @@ class TextScrollController with ChangeNotifier {
           _delegate!.getCharacterRectAtPosition(TextPosition(offset: _textController.text.text.length - 1));
       final isAtLastLine = rectInContentSpace.top == lastCharRect.top;
       final extraSpacingBelowBottom = (isAtLastLine ? rectInContentSpace.height / 2 : 0);
-
       if (rectInContentSpace.top - extraSpacingAboveTop - _scrollOffset < 0) {
         // The character is entirely or partially above the top of the viewport.
         // Scroll the content down.
@@ -849,12 +843,11 @@ class TextScrollController with ChangeNotifier {
         // Scroll the content right.
         _scrollOffset = rectInContentSpace.left;
         _log.finer(' - updated _scrollOffset to $_scrollOffset');
-      } else if (rectInContentSpace.right > _delegate!.viewportWidth!) {
+      } else if (rectInContentSpace.right - _scrollOffset > _delegate!.viewportWidth!) {
         // The character is entirely or partially after the end of the viewport.
         // Scroll the content left.
         _scrollOffset = rectInContentSpace.right - _delegate!.viewportWidth!;
         _log.finer(' - updated _scrollOffset to $_scrollOffset');
-        print("Scrolled to the right to $_scrollOffset");
       }
     }
 

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -99,6 +99,10 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
 }
 
 class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor> with TickerProviderStateMixin {
+  /// The maximum horizontal distance that a user can press near the caret to enable
+  /// a caret drag.
+  static const _closeEnoughToDragCaret = 48.0;
+
   final _textViewportOffsetLink = LayerLink();
 
   // Whether the user is dragging a collapsed selection.
@@ -168,9 +172,6 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       _log.finer("Field isn't focused. Ignoring press.");
       return;
     }
-
-    // _selectionBeforeTap = widget.textController.selection;
-    // _selectAtOffset(details.localPosition);
   }
 
   void _onTapUp(TapUpDetails details) {
@@ -275,7 +276,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       // There's no caret, therefore the user shouldn't be able to drag the caret. Fizzle.
       return;
     }
-    if ((globalCaretRect.center - details.globalPosition).dx.abs() > 48) {
+    if ((globalCaretRect.center - details.globalPosition).dx.abs() > _closeEnoughToDragCaret) {
       // There's a caret, but the user's drag offset is far away. Fizzle.
       return;
     }

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -251,6 +251,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanStart(DragStartDetails details) {
+    print("iOS text field - _onPanStart()");
     _log.fine('_onPanStart()');
     setState(() {
       _isDraggingCaret = true;
@@ -263,6 +264,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
+    print("iOS text field - _onPanUpdate(): ${details.delta}");
     _log.fine('_onPanUpdate handle mode');
 
     if (_isDraggingCaret) {
@@ -284,6 +286,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanEnd(DragEndDetails details) {
+    print("iOS text field - _onPanEnd()");
     _log.fine('_onPanEnd()');
     _onHandleDragEnd();
   }

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -14,8 +14,7 @@ final _log = iosTextFieldLog;
 
 /// iOS text field touch interaction surface.
 ///
-/// This widget is intended to be displayed in the foreground of
-/// a [SuperSelectableText] widget.
+/// This widget is intended to be displayed in the foreground of a [SuperText] widget.
 ///
 /// This widget recognizes and acts upon various user interactions:
 ///
@@ -44,6 +43,7 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
     required this.editingOverlayController,
     required this.textScrollController,
     required this.selectableTextKey,
+    required this.getGlobalCaretRect,
     required this.isMultiline,
     required this.handleColor,
     this.showDebugPaint = false,
@@ -76,6 +76,10 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
   /// [GlobalKey] that references the widget that contains the field's
   /// text.
   final GlobalKey<ProseTextState> selectableTextKey;
+
+  /// A function that returns the current caret global rect, or `null` if no
+  /// caret exists.
+  final Rect? Function() getGlobalCaretRect;
 
   /// Whether the text field that owns this [IOSTextFieldInteractor] is
   /// a multiline text field.
@@ -113,7 +117,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   void initState() {
     super.initState();
 
-    widget.textController.addListener(_onSelectionChange);
+    widget.textController.addListener(_onTextOrSelectionChange);
     widget.textScrollController.addListener(_onScrollChange);
   }
 
@@ -122,8 +126,8 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     super.didUpdateWidget(oldWidget);
 
     if (widget.textController != oldWidget.textController) {
-      oldWidget.textController.removeListener(_onSelectionChange);
-      widget.textController.addListener(_onSelectionChange);
+      oldWidget.textController.removeListener(_onTextOrSelectionChange);
+      widget.textController.addListener(_onTextOrSelectionChange);
     }
     if (widget.textScrollController != oldWidget.textScrollController) {
       oldWidget.textScrollController.removeListener(_onScrollChange);
@@ -134,17 +138,27 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   @override
   void dispose() {
     _toolbarFocusSelectionRect.dispose();
-    widget.textController.removeListener(_onSelectionChange);
+    widget.textController.removeListener(_onTextOrSelectionChange);
     widget.textScrollController.removeListener(_onScrollChange);
     super.dispose();
   }
 
   ProseTextLayout get _textLayout => widget.selectableTextKey.currentState!.textLayout;
 
-  void _onSelectionChange() {
+  void _onTextOrSelectionChange() {
     if (widget.textController.selection != _previousToolbarFocusSelection) {
       // Update the selection bounds focal point
       WidgetsBinding.instance.runAsSoonAsPossible(_computeSelectionRect);
+    }
+
+    if (!_isDraggingCaret) {
+      // The user isn't dragging the caret. Ensure the current selection is visible. The
+      // user may have typed beyond the viewport, or something may have changed the controller's
+      // selection to sit beyond the viewport.
+      //
+      // We don't do this when the user is dragging the caret because the user's finger position
+      // and the auto-scrolling system should control the scroll offset in that case.
+      widget.textScrollController.ensureExtentIsVisible();
     }
   }
 
@@ -155,12 +169,15 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       return;
     }
 
-    _selectionBeforeTap = widget.textController.selection;
-    _selectAtOffset(details.localPosition);
+    // _selectionBeforeTap = widget.textController.selection;
+    // _selectAtOffset(details.localPosition);
   }
 
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
+
+    _selectionBeforeTap = widget.textController.selection;
+    _selectAtOffset(details.localPosition);
 
     if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
       widget.textController.showKeyboard();
@@ -251,8 +268,19 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanStart(DragStartDetails details) {
-    print("iOS text field - _onPanStart()");
     _log.fine('_onPanStart()');
+
+    final globalCaretRect = widget.getGlobalCaretRect();
+    if (globalCaretRect == null) {
+      // There's no caret, therefore the user shouldn't be able to drag the caret. Fizzle.
+      return;
+    }
+    if ((globalCaretRect.center - details.globalPosition).dx.abs() > 48) {
+      // There's a caret, but the user's drag offset is far away. Fizzle.
+      return;
+    }
+
+    // Let the user drag the caret around.
     setState(() {
       _isDraggingCaret = true;
       _globalDragOffset = details.globalPosition;
@@ -264,16 +292,17 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
-    print("iOS text field - _onPanUpdate(): ${details.delta}");
     _log.fine('_onPanUpdate handle mode');
 
-    if (_isDraggingCaret) {
-      widget.textController.selection = TextSelection.collapsed(
-        offset: _globalOffsetToTextPosition(details.globalPosition).offset,
-      );
+    if (!_isDraggingCaret) {
+      return;
     }
 
     setState(() {
+      widget.textController.selection = TextSelection.collapsed(
+        offset: _globalOffsetToTextPosition(details.globalPosition).offset,
+      );
+
       _globalDragOffset = _globalDragOffset! + details.delta;
       _dragOffset = _dragOffset! + details.delta;
 
@@ -286,7 +315,6 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   }
 
   void _onPanEnd(DragEndDetails details) {
-    print("iOS text field - _onPanEnd()");
     _log.fine('_onPanEnd()');
     _onHandleDragEnd();
   }

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -354,6 +354,22 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   @override
   ProseTextLayout get textLayout => _textContentKey.currentState!.textLayout;
 
+  Rect? _getGlobalCaretRect() {
+    if (!_textEditingController.selection.isValid || !_textEditingController.selection.isCollapsed) {
+      // Either there's no selection, or the selection is expanded. In either case, there's no caret.
+      return null;
+    }
+
+    final globalTextOffset =
+        (_textContentKey.currentContext!.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
+
+    final caretPosition = _textEditingController.selection.extent;
+    final caretOffset = textLayout.getOffsetForCaret(caretPosition) + globalTextOffset;
+    final caretHeight = textLayout.getHeightForCaret(caretPosition)!;
+
+    return Rect.fromLTWH(caretOffset.dx, caretOffset.dy, 1, caretHeight);
+  }
+
   bool get _isMultiline => (widget.minLines ?? 1) != 1 || widget.maxLines != 1;
 
   @override
@@ -506,6 +522,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
           child: IOSTextFieldTouchInteractor(
             focusNode: _focusNode,
             selectableTextKey: _textContentKey,
+            getGlobalCaretRect: _getGlobalCaretRect,
             textFieldLayerLink: _textFieldLayerLink,
             textController: _textEditingController,
             editingOverlayController: _editingOverlayController,

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -225,6 +225,12 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       // The given FocusNode already has focus, we need to update selection and attach to IME.
       onNextFrame((_) => _updateSelectionAndImeConnectionOnFocusChange());
     }
+
+    if (_textEditingController.selection.isValid) {
+      // The text field was initialized with a selection - immediately ensure that the
+      // extent is visible.
+      onNextFrame((_) => _textScrollController.ensureExtentIsVisible());
+    }
   }
 
   @override
@@ -389,7 +395,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     if (_textEditingController.selection.isCollapsed) {
       _editingOverlayController.hideToolbar();
     }
-    _textScrollController.ensureExtentIsVisible();
+    // _textScrollController.ensureExtentIsVisible();
   }
 
   void _onTextScrollChange() {

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -411,7 +411,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     if (_textEditingController.selection.isCollapsed) {
       _editingOverlayController.hideToolbar();
     }
-    // _textScrollController.ensureExtentIsVisible();
   }
 
   void _onTextScrollChange() {

--- a/super_editor/lib/src/super_textfield/super_text_field_keys.dart
+++ b/super_editor/lib/src/super_textfield/super_text_field_keys.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+class SuperTextFieldKeys {
+  static const caret = ValueKey("supertextfield_caret");
+
+  const SuperTextFieldKeys._();
+}

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -33,6 +33,8 @@ export 'super_textfield_context.dart';
 /// instead of regular `String`s or `InlineSpan`s, which makes it easier to style
 /// text and edit other text metadata.
 
+export "super_text_field_keys.dart";
+
 /// Text field that supports styled text.
 ///
 /// [SuperTextField] adapts to the expectations of the current platform, or

--- a/super_editor/lib/src/super_textfield/super_textfield.dart
+++ b/super_editor/lib/src/super_textfield/super_textfield.dart
@@ -210,11 +210,14 @@ class SuperTextField extends StatefulWidget {
 
 class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner {
   final _platformFieldKey = GlobalKey();
+  late FocusNode _focusNode;
   late ImeAttributedTextEditingController _controller;
 
   @override
   void initState() {
     super.initState();
+
+    _focusNode = widget.focusNode ?? FocusNode();
 
     _controller = widget.textController != null
         ? widget.textController is ImeAttributedTextEditingController
@@ -227,6 +230,13 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
   void didUpdateWidget(SuperTextField oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    if (widget.focusNode != oldWidget.focusNode) {
+      if (oldWidget.focusNode == null) {
+        _focusNode.dispose();
+      }
+      _focusNode = widget.focusNode ?? FocusNode();
+    }
+
     if (widget.textController != oldWidget.textController) {
       _controller = widget.textController != null
           ? widget.textController is ImeAttributedTextEditingController
@@ -235,6 +245,18 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           : ImeAttributedTextEditingController();
     }
   }
+
+  @override
+  void dispose() {
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
+
+    super.dispose();
+  }
+
+  @visibleForTesting
+  bool get hasFocus => _focusNode.hasFocus;
 
   @visibleForTesting
   AttributedTextEditingController get controller => _controller;
@@ -321,7 +343,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
       case SuperTextFieldPlatformConfiguration.desktop:
         return SuperDesktopTextField(
           key: _platformFieldKey,
-          focusNode: widget.focusNode,
+          focusNode: _focusNode,
           tapRegionGroupId: widget.tapRegionGroupId,
           textController: _controller,
           textAlign: widget.textAlign,
@@ -353,7 +375,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           shortcuts: _scrollShortcutOverrides,
           child: SuperAndroidTextField(
             key: _platformFieldKey,
-            focusNode: widget.focusNode,
+            focusNode: _focusNode,
             tapRegionGroupId: widget.tapRegionGroupId,
             textController: _controller,
             textAlign: widget.textAlign,
@@ -381,7 +403,7 @@ class SuperTextFieldState extends State<SuperTextField> implements ImeInputOwner
           shortcuts: _scrollShortcutOverrides,
           child: SuperIOSTextField(
             key: _platformFieldKey,
-            focusNode: widget.focusNode,
+            focusNode: _focusNode,
             tapRegionGroupId: widget.tapRegionGroupId,
             textController: _controller,
             textAlign: widget.textAlign,

--- a/super_editor/test/super_textfield/android/super_textfield_android_scrolling_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_scrolling_test.dart
@@ -17,7 +17,7 @@ void main() {
       controller.selection = TextSelection.collapsed(offset: controller.text.length);
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -38,7 +38,7 @@ void main() {
       );
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -53,7 +53,7 @@ void main() {
       expect(controller.selection.extentOffset, 0);
 
       // Drag caret from left side of text field to right side of text field, into the
-      // right auto-scroll regin.
+      // right auto-scroll region.
       final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(190, 0));
 
       // Pump a few more frames and ensure that every frame moves the caret further.
@@ -98,7 +98,7 @@ void main() {
       );
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -113,7 +113,7 @@ void main() {
       expect(controller.selection.extentOffset, 0);
 
       // Drag handle from left side of text field to right side of text field, into the
-      // right auto-scroll regin.
+      // right auto-scroll region.
       final gesture = await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(190, 0));
 
       // Pump a few more frames and ensure that every frame moves the caret further.
@@ -165,7 +165,7 @@ void main() {
       controller.selection = TextSelection.collapsed(offset: startCaretPosition);
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -178,13 +178,12 @@ void main() {
 
       // Begin with the caret at the end of the text, scrolled all the way to the right.
       expect(controller.selection.extentOffset, startCaretPosition);
-      // expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
 
       // Tap on the text field to give it focus, so that the caret appears.
       await tester.placeCaretInSuperTextField(startCaretPosition);
 
       // Drag caret from right side of text field to left side of text field, into the
-      // left auto-scroll regin.
+      // left auto-scroll region.
       final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-190, 0));
 
       // Pump a few more frames and ensure that every frame moves the caret further.
@@ -252,6 +251,7 @@ void main() {
       expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
       expect(SuperTextFieldInspector.hasFocus(), isFalse);
 
+      // Pump with enough time to expire the tap recognizer timer.
       await tester.pump(kTapTimeout);
     });
 
@@ -278,7 +278,7 @@ void main() {
       // Place a caret in the field.
       await tester.placeCaretInSuperTextField(0);
 
-      // Ensure there's a selection with focus
+      // Ensure there's a selection with focus.
       expect(SuperTextFieldInspector.findSelection()!.isValid, isTrue);
       expect(SuperTextFieldInspector.hasFocus(), isTrue);
 
@@ -290,6 +290,7 @@ void main() {
       expect(SuperTextFieldInspector.findScrollOffset()!, 0);
       expect(SuperTextFieldInspector.findSelection(), selectionBeforeDrag);
 
+      // Pump with enough time to expire the tap recognizer timer.
       await tester.pump(kTapTimeout);
     });
   });

--- a/super_editor/test/super_textfield/android/super_textfield_android_scrolling_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_scrolling_test.dart
@@ -1,0 +1,332 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
+import 'package:super_editor/super_text_field.dart';
+
+import '../super_textfield_inspector.dart';
+import '../super_textfield_robot.dart';
+
+void main() {
+  group("SuperTextField > scrolling >", () {
+    testWidgetsOnAndroid('auto-scrolls to caret position upon widget initialization', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+      controller.selection = TextSelection.collapsed(offset: controller.text.length);
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      // Ensure that the text field auto-scrolled to the end, where the caret should be placed.
+      expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
+    });
+
+    testWidgetsOnAndroid('single-line auto-scrolls to the right by caret', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      await tester.placeCaretInSuperTextField(0);
+      expect(controller.selection.extentOffset, 0);
+
+      // Drag caret from left side of text field to right side of text field, into the
+      // right auto-scroll regin.
+      final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(190, 0));
+
+      // Pump a few more frames and ensure that every frame moves the caret further.
+      int previousCaretPosition = controller.selection.extentOffset;
+      for (int i = 0; i < 10; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        final newCaretPosition = controller.selection.extentOffset;
+        expect(newCaretPosition, greaterThan(previousCaretPosition),
+            reason: "Caret position didn't move on drag frame $i");
+        previousCaretPosition = newCaretPosition;
+      }
+
+      // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // to the left when we move out of the auto-scroll region. This is a glitch that
+      // we saw in #1673.
+      final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+
+      // Drag back to the left to leave the auto-scroll region.
+      await gesture.moveBy(const Offset(-50, 0));
+      await tester.pump();
+
+      // Pump a few frames to ensure that the selection isn't jumping around
+      // in a glitchy manner.
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Ensure that when we moved slightly back to the left, to move out of the auto-scroll
+      // region, the scroll offset didn't jump somewhere else.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // Release the gesture.
+      await gesture.up();
+
+      // Ensure that the scroll offset didn't change after we released.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+    });
+
+    testWidgetsOnAndroid('single-line auto-scrolls to the right by handle', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      await tester.placeCaretInSuperTextField(0);
+      expect(controller.selection.extentOffset, 0);
+
+      // Drag handle from left side of text field to right side of text field, into the
+      // right auto-scroll regin.
+      final gesture = await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(190, 0));
+
+      // Pump a few more frames and ensure that every frame moves the caret further.
+      int previousCaretPosition = controller.selection.extentOffset;
+      for (int i = 0; i < 10; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        final newCaretPosition = controller.selection.extentOffset;
+        expect(newCaretPosition, greaterThan(previousCaretPosition),
+            reason: "Caret position didn't move on drag frame $i");
+        previousCaretPosition = newCaretPosition;
+      }
+
+      // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // to the left when we move out of the auto-scroll region. This is a glitch that
+      // we saw in #1673.
+      final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+
+      // Drag back to the left to leave the auto-scroll region.
+      await gesture.moveBy(const Offset(-50, 0));
+      await tester.pump();
+
+      // Pump a few frames to ensure that the selection isn't jumping around
+      // in a glitchy manner.
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Ensure that when we moved slightly back to the left, to move out of the auto-scroll
+      // region, the scroll offset didn't jump somewhere else.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // Release the gesture.
+      await gesture.up();
+
+      // Ensure that the scroll offset didn't change after we released.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // When working on #1673 I found that specifically when dragging to the right using
+      // the handle (not caret), the text field jumps all the way to the end of the text.
+      // Make sure we're not at the end of the text.
+      expect(SuperTextFieldInspector.isScrolledToEnd(), isFalse);
+    });
+
+    testWidgetsOnAndroid('single-line auto-scrolls to the left', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+      final startCaretPosition = controller.text.length - 3;
+      controller.selection = TextSelection.collapsed(offset: startCaretPosition);
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      // Begin with the caret at the end of the text, scrolled all the way to the right.
+      expect(controller.selection.extentOffset, startCaretPosition);
+      // expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
+
+      // Tap on the text field to give it focus, so that the caret appears.
+      await tester.placeCaretInSuperTextField(startCaretPosition);
+
+      // Drag caret from right side of text field to left side of text field, into the
+      // left auto-scroll regin.
+      final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-190, 0));
+
+      // Pump a few more frames and ensure that every frame moves the caret further.
+      int previousCaretPosition = controller.selection.extentOffset;
+      for (int i = 0; i < 10; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        final newCaretPosition = controller.selection.extentOffset;
+        expect(newCaretPosition, lessThan(previousCaretPosition),
+            reason: "Caret position didn't move on drag frame $i");
+        previousCaretPosition = newCaretPosition;
+      }
+
+      // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // to the left when we move out of the auto-scroll region. This is a glitch that
+      // we saw in #1673.
+      final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+
+      // Drag back to the right to leave the auto-scroll region.
+      await gesture.moveBy(const Offset(50, 0));
+      await tester.pump();
+
+      // Pump a few frames to ensure that we're the selection isn't jumping around
+      // in a glitchy manner.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that when we moved slightly back to the right, to move out of the auto-scroll
+      // region, the scroll offset didn't jump somewhere else.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // Release the gesture.
+      await gesture.up();
+    });
+
+    testWidgetsOnAndroid('single-line drag does nothing without a selection', (tester) async {
+      // Test explanation: I experimented with single-line text fields in a few iOS apps
+      // and I found that dragging in an area away from the caret doesn't have any effect.
+      // It doesn't scroll the text field, it doesn't move the caret, nothing.
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width.
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines whether the text fits, or
+        // if scrolling is available.
+        maxWidth: 200,
+      );
+
+      // Ensure there's no selection and no focus.
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
+      expect(SuperTextFieldInspector.hasFocus(), isFalse);
+
+      // Drag from right to left.
+      await tester.drag(find.byType(SuperTextField), const Offset(-100, 0));
+
+      // Ensure the scroll offset didn't change and there's still no selection or focus.
+      expect(SuperTextFieldInspector.findScrollOffset()!, 0);
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
+      expect(SuperTextFieldInspector.hasFocus(), isFalse);
+
+      await tester.pump(kTapTimeout);
+    });
+
+    testWidgetsOnAndroid('single-line drag does nothing with collapsed selection', (tester) async {
+      // Test explanation: I experimented with single-line text fields in a few iOS apps
+      // and I found that dragging in an area away from the caret doesn't have any effect.
+      // It doesn't scroll the text field, it doesn't move the caret, nothing.
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width.
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines whether the text fits, or
+        // if scrolling is available.
+        maxWidth: 200,
+      );
+
+      // Place a caret in the field.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Ensure there's a selection with focus
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isTrue);
+      expect(SuperTextFieldInspector.hasFocus(), isTrue);
+
+      // Drag from right to left, far away from the caret.
+      final selectionBeforeDrag = SuperTextFieldInspector.findSelection();
+      await tester.drag(find.byType(SuperTextField), const Offset(100, 0));
+
+      // Ensure the scroll offset and the selection didn't change.
+      expect(SuperTextFieldInspector.findScrollOffset()!, 0);
+      expect(SuperTextFieldInspector.findSelection(), selectionBeforeDrag);
+
+      await tester.pump(kTapTimeout);
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required AttributedTextEditingController textController,
+  required int minLines,
+  required int maxLines,
+  double? maxWidth,
+  double? maxHeight,
+  EdgeInsets? padding,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: maxWidth ?? double.infinity,
+              maxHeight: maxHeight ?? double.infinity,
+            ),
+            child: SuperTextField(
+              textController: textController,
+              lineHeight: 20,
+              textStyleBuilder: (_) => const TextStyle(fontSize: 20),
+              minLines: minLines,
+              maxLines: maxLines,
+              padding: padding,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // The first frame might have a zero viewport height. Pump a second frame to account for the final viewport size.
+  await tester.pump();
+}

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
@@ -2,6 +2,7 @@ import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/super_text_field.dart';
 
 import '../super_textfield_inspector.dart';
@@ -26,9 +27,6 @@ void main() {
         // to the right to enter the auto-scroll region.
         maxWidth: 200,
       );
-
-      print(
-          "Controller extent: ${controller.selection.extentOffset}, scroll offset: ${SuperTextFieldInspector.findScrollOffset()}");
 
       // Ensure that the text field auto-scrolled to the end, where the caret should be placed.
       expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
@@ -63,22 +61,21 @@ void main() {
       for (int i = 0; i < 10; i += 1) {
         await tester.pump(const Duration(milliseconds: 50));
         final newCaretPosition = controller.selection.extentOffset;
-        expect(newCaretPosition, greaterThan(previousCaretPosition));
+        expect(newCaretPosition, greaterThan(previousCaretPosition),
+            reason: "Caret position didn't move on drag frame $i");
         previousCaretPosition = newCaretPosition;
       }
-      print("Caret offset after auto-scroll: ${SuperTextFieldInspector.findSelection()}");
 
       // Log the scroll offset to make sure that the scroll offset doesn't jump back
       // to the left when we move out of the auto-scroll region. This is a glitch that
       // we saw in #1673.
       final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
-      print("Scroll offset after auto-scroll: $scrollOffsetAfterAutoScroll");
 
       // Drag back to the left to leave the auto-scroll region.
       await gesture.moveBy(const Offset(-50, 0));
       await tester.pump();
 
-      // Pump a few frames to ensure that we're the selection isn't jumping around
+      // Pump a few frames to ensure that the selection isn't jumping around
       // in a glitchy manner.
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
@@ -91,7 +88,8 @@ void main() {
       // Release the gesture.
       await gesture.up();
 
-      print("Final caret offset: ${SuperTextFieldInspector.findSelection()}");
+      // Ensure that the scroll offset didn't change after we released.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
     });
 
     testWidgetsOnIos('single-line auto-scrolls to the left', (tester) async {
@@ -113,9 +111,6 @@ void main() {
         maxWidth: 200,
       );
 
-      print(
-          "Controller extent: ${controller.selection.extentOffset}, scroll offset: ${SuperTextFieldInspector.findScrollOffset()}");
-
       // Begin with the caret at the end of the text, scrolled all the way to the right.
       expect(controller.selection.extentOffset, startCaretPosition);
       // expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
@@ -132,35 +127,105 @@ void main() {
       for (int i = 0; i < 10; i += 1) {
         await tester.pump(const Duration(milliseconds: 50));
         final newCaretPosition = controller.selection.extentOffset;
-        expect(newCaretPosition, lessThan(previousCaretPosition));
+        expect(newCaretPosition, lessThan(previousCaretPosition),
+            reason: "Caret position didn't move on drag frame $i");
         previousCaretPosition = newCaretPosition;
       }
-      print("Caret offset after auto-scroll: ${SuperTextFieldInspector.findSelection()}");
 
-      // // Log the scroll offset to make sure that the scroll offset doesn't jump back
-      // // to the left when we move out of the auto-scroll region. This is a glitch that
-      // // we saw in #1673.
-      // final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
-      // print("Scroll offset after auto-scroll: $scrollOffsetAfterAutoScroll");
-      //
-      // // Drag back to the left to leave the auto-scroll region.
-      // await gesture.moveBy(const Offset(-50, 0));
-      // await tester.pump();
-      //
-      // // Pump a few frames to ensure that we're the selection isn't jumping around
-      // // in a glitchy manner.
-      // await tester.pump();
-      // await tester.pump();
-      // await tester.pump();
-      //
-      // // Ensure that when we moved slightly back to the left, to move out of the auto-scroll
-      // // region, the scroll offset didn't jump somewhere else.
-      // expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
-      //
-      // // Release the gesture.
-      // await gesture.up();
-      //
-      // print("Final caret offset: ${SuperTextFieldInspector.findSelection()}");
+      // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // to the left when we move out of the auto-scroll region. This is a glitch that
+      // we saw in #1673.
+      final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+
+      // Drag back to the right to leave the auto-scroll region.
+      await gesture.moveBy(const Offset(50, 0));
+      await tester.pump();
+
+      // Pump a few frames to ensure that we're the selection isn't jumping around
+      // in a glitchy manner.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // Ensure that when we moved slightly back to the right, to move out of the auto-scroll
+      // region, the scroll offset didn't jump somewhere else.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // Release the gesture.
+      await gesture.up();
+    });
+
+    testWidgetsOnIos('single-line drag does nothing without a selection', (tester) async {
+      // Test explanation: I experimented with single-line text fields in a few iOS apps
+      // and I found that dragging in an area away from the caret doesn't have any effect.
+      // It doesn't scroll the text field, it doesn't move the caret, nothing.
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width.
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines whether the text fits, or
+        // if scrolling is available.
+        maxWidth: 200,
+      );
+
+      // Ensure there's no selection and no focus.
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
+      expect(SuperTextFieldInspector.hasFocus(), isFalse);
+
+      // Drag from right to left.
+      await tester.drag(find.byType(SuperTextField), const Offset(-100, 0));
+
+      // Ensure the scroll offset didn't change and there's still no selection or focus.
+      expect(SuperTextFieldInspector.findScrollOffset()!, 0);
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
+      expect(SuperTextFieldInspector.hasFocus(), isFalse);
+
+      await tester.pump(kTapTimeout);
+    });
+
+    testWidgetsOnIos('single-line drag does nothing with collapsed selection', (tester) async {
+      // Test explanation: I experimented with single-line text fields in a few iOS apps
+      // and I found that dragging in an area away from the caret doesn't have any effect.
+      // It doesn't scroll the text field, it doesn't move the caret, nothing.
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width.
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines whether the text fits, or
+        // if scrolling is available.
+        maxWidth: 200,
+      );
+
+      // Place a caret in the field.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Ensure there's a selection with focus
+      expect(SuperTextFieldInspector.findSelection()!.isValid, isTrue);
+      expect(SuperTextFieldInspector.hasFocus(), isTrue);
+
+      // Drag from right to left, far away from the caret.
+      final selectionBeforeDrag = SuperTextFieldInspector.findSelection();
+      await tester.drag(find.byType(SuperTextField), const Offset(100, 0));
+
+      // Ensure the scroll offset and the selection didn't change.
+      expect(SuperTextFieldInspector.findScrollOffset()!, 0);
+      expect(SuperTextFieldInspector.findSelection(), selectionBeforeDrag);
+
+      await tester.pump(kTapTimeout);
     });
   });
 }

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
@@ -17,7 +17,7 @@ void main() {
       controller.selection = TextSelection.collapsed(offset: controller.text.length);
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -38,7 +38,7 @@ void main() {
       );
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -53,7 +53,7 @@ void main() {
       expect(controller.selection.extentOffset, 0);
 
       // Drag caret from left side of text field to right side of text field, into the
-      // right auto-scroll regin.
+      // right auto-scroll region.
       final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(190, 0));
 
       // Pump a few more frames and ensure that every frame moves the caret further.
@@ -100,7 +100,7 @@ void main() {
       controller.selection = TextSelection.collapsed(offset: startCaretPosition);
 
       // Pump the widget tree with a SuperTextField with a maxWidth smaller
-      // than the text width
+      // than the text width.
       await _pumpTestApp(
         tester,
         textController: controller,
@@ -113,13 +113,12 @@ void main() {
 
       // Begin with the caret at the end of the text, scrolled all the way to the right.
       expect(controller.selection.extentOffset, startCaretPosition);
-      // expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
 
       // Tap on the text field to give it focus, so that the caret appears.
       await tester.placeCaretInSuperTextField(startCaretPosition);
 
       // Drag caret from right side of text field to left side of text field, into the
-      // left auto-scroll regin.
+      // left auto-scroll region.
       final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-190, 0));
 
       // Pump a few more frames and ensure that every frame moves the caret further.
@@ -187,6 +186,7 @@ void main() {
       expect(SuperTextFieldInspector.findSelection()!.isValid, isFalse);
       expect(SuperTextFieldInspector.hasFocus(), isFalse);
 
+      // Pump with enough time to expire the tap recognizer timer.
       await tester.pump(kTapTimeout);
     });
 
@@ -217,7 +217,7 @@ void main() {
       expect(SuperTextFieldInspector.findSelection()!.isValid, isTrue);
       expect(SuperTextFieldInspector.hasFocus(), isTrue);
 
-      // Drag from right to left, far away from the caret.
+      // Drag from left to right, far away from the caret.
       final selectionBeforeDrag = SuperTextFieldInspector.findSelection();
       await tester.drag(find.byType(SuperTextField), const Offset(100, 0));
 
@@ -225,6 +225,7 @@ void main() {
       expect(SuperTextFieldInspector.findScrollOffset()!, 0);
       expect(SuperTextFieldInspector.findSelection(), selectionBeforeDrag);
 
+      // Pump with enough time to expire the tap recognizer timer.
       await tester.pump(kTapTimeout);
     });
   });

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_scrolling_test.dart
@@ -1,0 +1,202 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_text_field.dart';
+
+import '../super_textfield_inspector.dart';
+import '../super_textfield_robot.dart';
+
+void main() {
+  group("SuperTextField > scrolling >", () {
+    testWidgetsOnIos('auto-scrolls to caret position upon widget initialization', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+      controller.selection = TextSelection.collapsed(offset: controller.text.length);
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      print(
+          "Controller extent: ${controller.selection.extentOffset}, scroll offset: ${SuperTextFieldInspector.findScrollOffset()}");
+
+      // Ensure that the text field auto-scrolled to the end, where the caret should be placed.
+      expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
+    });
+
+    testWidgetsOnIos('single-line auto-scrolls to the right', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      await tester.placeCaretInSuperTextField(0);
+      expect(controller.selection.extentOffset, 0);
+
+      // Drag caret from left side of text field to right side of text field, into the
+      // right auto-scroll regin.
+      final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(190, 0));
+
+      // Pump a few more frames and ensure that every frame moves the caret further.
+      int previousCaretPosition = controller.selection.extentOffset;
+      for (int i = 0; i < 10; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        final newCaretPosition = controller.selection.extentOffset;
+        expect(newCaretPosition, greaterThan(previousCaretPosition));
+        previousCaretPosition = newCaretPosition;
+      }
+      print("Caret offset after auto-scroll: ${SuperTextFieldInspector.findSelection()}");
+
+      // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // to the left when we move out of the auto-scroll region. This is a glitch that
+      // we saw in #1673.
+      final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+      print("Scroll offset after auto-scroll: $scrollOffsetAfterAutoScroll");
+
+      // Drag back to the left to leave the auto-scroll region.
+      await gesture.moveBy(const Offset(-50, 0));
+      await tester.pump();
+
+      // Pump a few frames to ensure that we're the selection isn't jumping around
+      // in a glitchy manner.
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      // Ensure that when we moved slightly back to the left, to move out of the auto-scroll
+      // region, the scroll offset didn't jump somewhere else.
+      expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+
+      // Release the gesture.
+      await gesture.up();
+
+      print("Final caret offset: ${SuperTextFieldInspector.findSelection()}");
+    });
+
+    testWidgetsOnIos('single-line auto-scrolls to the left', (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText("This is long text that extends beyond the right side of the text field."),
+      );
+      final startCaretPosition = controller.text.length - 3;
+      controller.selection = TextSelection.collapsed(offset: startCaretPosition);
+
+      // Pump the widget tree with a SuperTextField with a maxWidth smaller
+      // than the text width
+      await _pumpTestApp(
+        tester,
+        textController: controller,
+        minLines: 1,
+        maxLines: 1,
+        // This width is important because it determines how far we need to drag the caret
+        // to the right to enter the auto-scroll region.
+        maxWidth: 200,
+      );
+
+      print(
+          "Controller extent: ${controller.selection.extentOffset}, scroll offset: ${SuperTextFieldInspector.findScrollOffset()}");
+
+      // Begin with the caret at the end of the text, scrolled all the way to the right.
+      expect(controller.selection.extentOffset, startCaretPosition);
+      // expect(SuperTextFieldInspector.isScrolledToEnd(), isTrue);
+
+      // Tap on the text field to give it focus, so that the caret appears.
+      await tester.placeCaretInSuperTextField(startCaretPosition);
+
+      // Drag caret from right side of text field to left side of text field, into the
+      // left auto-scroll regin.
+      final gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-190, 0));
+
+      // Pump a few more frames and ensure that every frame moves the caret further.
+      int previousCaretPosition = controller.selection.extentOffset;
+      for (int i = 0; i < 10; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        final newCaretPosition = controller.selection.extentOffset;
+        expect(newCaretPosition, lessThan(previousCaretPosition));
+        previousCaretPosition = newCaretPosition;
+      }
+      print("Caret offset after auto-scroll: ${SuperTextFieldInspector.findSelection()}");
+
+      // // Log the scroll offset to make sure that the scroll offset doesn't jump back
+      // // to the left when we move out of the auto-scroll region. This is a glitch that
+      // // we saw in #1673.
+      // final scrollOffsetAfterAutoScroll = SuperTextFieldInspector.findScrollOffset();
+      // print("Scroll offset after auto-scroll: $scrollOffsetAfterAutoScroll");
+      //
+      // // Drag back to the left to leave the auto-scroll region.
+      // await gesture.moveBy(const Offset(-50, 0));
+      // await tester.pump();
+      //
+      // // Pump a few frames to ensure that we're the selection isn't jumping around
+      // // in a glitchy manner.
+      // await tester.pump();
+      // await tester.pump();
+      // await tester.pump();
+      //
+      // // Ensure that when we moved slightly back to the left, to move out of the auto-scroll
+      // // region, the scroll offset didn't jump somewhere else.
+      // expect(SuperTextFieldInspector.findScrollOffset(), scrollOffsetAfterAutoScroll);
+      //
+      // // Release the gesture.
+      // await gesture.up();
+      //
+      // print("Final caret offset: ${SuperTextFieldInspector.findSelection()}");
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required AttributedTextEditingController textController,
+  required int minLines,
+  required int maxLines,
+  double? maxWidth,
+  double? maxHeight,
+  EdgeInsets? padding,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: maxWidth ?? double.infinity,
+              maxHeight: maxHeight ?? double.infinity,
+            ),
+            child: SuperTextField(
+              textController: textController,
+              lineHeight: 20,
+              textStyleBuilder: (_) => const TextStyle(fontSize: 20),
+              minLines: minLines,
+              maxLines: maxLines,
+              padding: padding,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // The first frame might have a zero viewport height. Pump a second frame to account for the final viewport size.
+  await tester.pump();
+}

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -9,8 +9,8 @@ import 'package:super_editor/super_text_field.dart';
 import '../super_textfield_inspector.dart';
 
 void main() {
-  group("SuperTextField iOS selection >", () {
-    testWidgetsOnIos("tapping in empty space shows the toolbar", (tester) async {
+  group("SuperTextField > selection >", () {
+    testWidgetsOnIos("tapping on caret toggles the toolbar", (tester) async {
       await _pumpTestApp(tester);
 
       // Ensure there's no selection to begin with, and no toolbar is displayed.

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -505,7 +505,7 @@ a scrollbar
         expect(SuperTextFieldInspector.findSelection()!.isValid, true);
       });
 
-      testWidgetsOnMobile("tap down in focused field moves the caret", (tester) async {
+      testWidgetsOnMobile("tap down in focused field does nothing", (tester) async {
         await _pumpTestApp(tester);
 
         // Tap in empty space to place the caret at the end of the text.
@@ -519,6 +519,25 @@ a scrollbar
         addTearDown(() => gesture.removePointer());
         await tester.pumpAndSettle();
 
+        // Ensure the caret didn't move.
+        expect(SuperTextFieldInspector.findSelection()!.extent.offset, 3);
+      });
+
+      testWidgetsOnMobile("tap up in focused field moves the caret", (tester) async {
+        await _pumpTestApp(tester);
+
+        // Tap in empty space to place the caret at the end of the text.
+        await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
+        // Without this 'delay' onTapDown is not called the second time
+        await tester.pumpAndSettle(const Duration(milliseconds: 200));
+        expect(SuperTextFieldInspector.findSelection()!.extent.offset, greaterThan(0));
+
+        // Tap DOWN at beginning of text to move the caret.
+        final gesture = await tester.startGesture(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump(kTapTimeout);
+
         // Ensure the caret moved to the beginning of the text.
         expect(SuperTextFieldInspector.findSelection()!.extent.offset, 0);
       });
@@ -526,6 +545,10 @@ a scrollbar
       // mobile only because precise input (mouse) doesn't use touch slop
       testWidgetsOnMobile("MediaQuery gesture settings are respected", (tester) async {
         bool horizontalDragStartCalled = false;
+        final controller = AttributedTextEditingController(
+          text: AttributedText('a b c'),
+        );
+
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -545,9 +568,7 @@ a scrollbar
                   return MediaQuery(
                     data: data,
                     child: SuperTextField(
-                      textController: AttributedTextEditingController(
-                        text: AttributedText('a b c'),
-                      ),
+                      textController: controller,
                     ),
                   );
                 }),
@@ -564,9 +585,8 @@ a scrollbar
           const TextSelection.collapsed(offset: 0),
         );
 
-        // The gesture should trigger the selection PanGestureRecognizer instead
-        // the HorizontalDragGestureRecognizer below.
-
+        // The following gesture should trigger the selection PanGestureRecognizer instead
+        // of the HorizontalDragGestureRecognizer, thereby moving the caret.
         final gesture = await tester.startGesture(tester.getTopLeft(find.byType(SuperTextField)));
         addTearDown(() => gesture.removePointer());
         await gesture.moveBy(const Offset(19, 0));
@@ -579,6 +599,7 @@ a scrollbar
           const TextSelection.collapsed(offset: 1),
         );
 
+        // Pump an update with a larger pan slop.
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -598,9 +619,7 @@ a scrollbar
                   return MediaQuery(
                     data: data,
                     child: SuperTextField(
-                      textController: AttributedTextEditingController(
-                        text: AttributedText('a b c'),
-                      ),
+                      textController: controller,
                     ),
                   );
                 }),
@@ -609,18 +628,22 @@ a scrollbar
           ),
         );
 
+        // The following gesture, which moves as much as the previous gesture, should
+        // have no effect on the selection because the pan slop was increased.
         final gesture2 = await tester.startGesture(tester.getTopLeft(find.byType(SuperTextField)));
         addTearDown(() => gesture2.removePointer());
         await gesture2.moveBy(const Offset(19, 0));
         await gesture2.up();
         await tester.pumpAndSettle();
 
-        // With default gesture settings the horizontal drag recognizer will
-        // win instead of the selection PanGestureRecognizer.
+        // Ensure that the selection didn't change because the larger pan slop prevented
+        // the selection pan from winning in the gesture arena. Also, ensure that because
+        // the selection pan didn't take the gesture, the horizontal drag detector won
+        // out, instead.
         expect(horizontalDragStartCalled, isTrue);
         expect(
           SuperTextFieldInspector.findSelection(),
-          const TextSelection.collapsed(offset: 0),
+          const TextSelection.collapsed(offset: 1),
         );
       });
 

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -528,7 +528,7 @@ a scrollbar
 
         // Tap in empty space to place the caret at the end of the text.
         await tester.tapAt(tester.getBottomRight(find.byType(SuperTextField)) - const Offset(10, 10));
-        // Without this 'delay' onTapDown is not called the second time
+        // Without this 'delay' onTapDown is not called the second time.
         await tester.pumpAndSettle(const Duration(milliseconds: 200));
         expect(SuperTextFieldInspector.findSelection()!.extent.offset, greaterThan(0));
 

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -216,6 +216,14 @@ class SuperTextFieldInspector {
     return textScrollView.textScrollController;
   }
 
+  static bool isAndroidCollapsedHandleVisible([Finder? superTextFieldFinder]) {
+    final fieldFinder =
+        SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
+    final match = (fieldFinder.evaluate().single as StatefulElement).state as SuperAndroidTextFieldState;
+
+    return match.isCollapsedHandleVisible;
+  }
+
   /// Finds and returns the platform textfield within a [SuperTextField].
   ///
   /// {@macro supertextfield_finder}

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -75,7 +75,60 @@ class SuperTextFieldInspector {
     return state.controller.selection;
   }
 
-  /// Finds and returns the scroll offset within a [SuperTextField].
+  /// Returns `true` if the given [SuperTextField] is a single-line text field.
+  ///
+  /// {@macro supertextfield_finder}
+  static bool isSingleLine([Finder? superTextFieldFinder]) {
+    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
+
+    final fieldFinder = findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().single.widget;
+
+    switch (match.runtimeType) {
+      case SuperDesktopTextField:
+        return (match as SuperDesktopTextField).maxLines == 1;
+      case SuperAndroidTextField:
+        return (match as SuperAndroidTextField).maxLines == 1;
+      case SuperIOSTextField:
+        return (match as SuperIOSTextField).maxLines == 1;
+      default:
+        throw Exception("Found unknown SuperTextField platform widget: $match");
+    }
+  }
+
+  /// Returns `true` if the given [SuperTextField] is a multi-line text field.
+  ///
+  /// {@macro supertextfield_finder}
+  static bool isMultiLine([Finder? superTextFieldFinder]) {
+    return !isSingleLine(superTextFieldFinder);
+  }
+
+  /// Returns `true` if the given [SuperTextField] has a scroll offset of zero, i.e.,
+  /// is scrolled to the beginning of the viewport.
+  ///
+  /// This inspection applies to both horizontal and vertical scrolling text fields.
+  ///
+  /// {@macro supertextfield_finder}
+  static bool isScrolledToBeginning([Finder? superTextFieldFinder]) {
+    return findScrollOffset(superTextFieldFinder) == 0.0;
+  }
+
+  /// Returns `true` if the given [SuperTextField] is scrolled all the away to the
+  /// end of the viewport.
+  ///
+  /// This inspection applies to both horizontal and vertical scrolling text fields.
+  ///
+  /// {@macro supertextfield_finder}
+  static bool isScrolledToEnd([Finder? superTextFieldFinder]) {
+    final maxScrollOffset = findDesktopScrollController(superTextFieldFinder)?.position.maxScrollExtent ??
+        findMobileScrollController(superTextFieldFinder)?.endScrollOffset;
+    assert(maxScrollOffset != null,
+        "Couldn't check if SuperTextField is scrolled to the end because no SuperTextField was found.");
+    return findScrollOffset(superTextFieldFinder) == maxScrollOffset;
+  }
+
+  /// Finds and returns the scroll offset, in the direction of scrolling,
+  /// within a [SuperTextField].
   ///
   /// {@macro supertextfield_finder}
   static double? findScrollOffset([Finder? superTextFieldFinder]) {
@@ -108,6 +161,49 @@ class SuperTextFieldInspector {
     final textScrollView = textScrollViewElement.widget as TextScrollView;
 
     return textScrollView.textScrollController.scrollOffset;
+  }
+
+  static ScrollController? findDesktopScrollController([Finder? superTextFieldFinder]) {
+    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
+
+    final fieldFinder = findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().single.widget;
+    if (match is! SuperDesktopTextField) {
+      return null;
+    }
+
+    final textScrollViewElement = find
+        .descendant(
+          of: finder,
+          matching: find.byType(SuperTextFieldScrollview),
+        )
+        .evaluate()
+        .single as StatefulElement;
+    final textScrollView = textScrollViewElement.widget as SuperTextFieldScrollview;
+
+    return textScrollView.scrollController;
+  }
+
+  static TextScrollController? findMobileScrollController([Finder? superTextFieldFinder]) {
+    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
+
+    final fieldFinder = findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().single.widget;
+    if (match is! SuperAndroidTextField && match is! SuperIOSTextField) {
+      return null;
+    }
+
+    // Both mobile textfields use TextScrollView.
+    final textScrollViewElement = find
+        .descendant(
+          of: finder,
+          matching: find.byType(TextScrollView),
+        )
+        .evaluate()
+        .single as StatefulElement;
+    final textScrollView = textScrollViewElement.widget as TextScrollView;
+
+    return textScrollView.textScrollController;
   }
 
   /// Finds and returns the platform textfield within a [SuperTextField].

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -75,6 +75,16 @@ class SuperTextFieldInspector {
     return state.controller.selection;
   }
 
+  /// Returns `true` if the [SuperTextField] currently has focus.
+  ///
+  /// {@macro supertextfield_finder}
+  static bool hasFocus([Finder? superTextFieldFinder]) {
+    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
+    final element = finder.evaluate().single as StatefulElement;
+    final state = element.state as SuperTextFieldState;
+    return state.hasFocus;
+  }
+
   /// Returns `true` if the given [SuperTextField] is a single-line text field.
   ///
   /// {@macro supertextfield_finder}

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -49,7 +49,7 @@ extension SuperTextFieldRobot on WidgetTester {
     }
 
     if (found) {
-      await pumpAndSettle();
+      await pumpAndSettle(kTapTimeout);
     } else {
       throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
     }
@@ -66,7 +66,6 @@ extension SuperTextFieldRobot on WidgetTester {
     final caretLayerState = caretLayerElement.state as TextLayoutCaretState;
     final caretGeometry = caretLayerState.globalCaretGeometry!;
 
-    print("Caret geometry: $caretGeometry");
     final gesture = await startGesture(caretGeometry.center);
     await pump(kTapMinTime);
 
@@ -191,19 +190,6 @@ extension SuperTextFieldRobot on WidgetTester {
     final textPositionOffset = textLayout.getOffsetForCaret(
       TextPosition(offset: offset, affinity: textAffinity),
     );
-
-    print("Text position $offset, offset: ${textLayout.getOffsetForCaret(
-      TextPosition(offset: offset, affinity: textAffinity),
-    )}");
-    print("Text position ${offset + 1}, offset: ${textLayout.getOffsetForCaret(
-      TextPosition(offset: offset + 1, affinity: textAffinity),
-    )}");
-    print("Text position ${offset + 2}, offset: ${textLayout.getOffsetForCaret(
-      TextPosition(offset: offset + 2, affinity: textAffinity),
-    )}");
-    print("Text position ${offset + 3}, offset: ${textLayout.getOffsetForCaret(
-      TextPosition(offset: offset + 3, affinity: textAffinity),
-    )}");
 
     // Adjust the text offset from text layout coordinates to text field viewport coordinates
     // by adding the scroll offset.

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -21,23 +21,27 @@ extension SuperTextFieldRobot on WidgetTester {
         SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
     final match = fieldFinder.evaluate().single.widget;
     bool found = false;
+    final scrollDelta = SuperTextFieldInspector.findScrollOffset(superTextFieldFinder)!;
+    final scrollOffset =
+        SuperTextFieldInspector.isSingleLine(superTextFieldFinder) ? Offset(scrollDelta, 0) : Offset(0, scrollDelta);
 
     if (match is SuperDesktopTextField) {
-      final didTap =
-          await _tapAtTextPositionOnDesktop(state<SuperDesktopTextFieldState>(fieldFinder), offset, affinity);
+      final didTap = await _tapAtTextPositionOnDesktop(
+          state<SuperDesktopTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       found = true;
     } else if (match is SuperAndroidTextField) {
-      final didTap =
-          await _tapAtTextPositionOnAndroid(state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity);
+      final didTap = await _tapAtTextPositionOnAndroid(
+          state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       found = true;
     } else if (match is SuperIOSTextField) {
-      final didTap = await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity);
+      final didTap =
+          await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
@@ -51,6 +55,29 @@ extension SuperTextFieldRobot on WidgetTester {
     }
   }
 
+  Future<TestGesture> dragCaretByDistanceInSuperTextField(Offset delta, [Finder? superTextFieldFinder]) async {
+    final caretLayerFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperTextField),
+      matching: find.byType(TextLayoutCaret),
+    );
+    expect(caretLayerFinder, findsOne);
+
+    final caretLayerElement = caretLayerFinder.evaluate().first as StatefulElement;
+    final caretLayerState = caretLayerElement.state as TextLayoutCaretState;
+    final caretGeometry = caretLayerState.globalCaretGeometry!;
+
+    print("Caret geometry: $caretGeometry");
+    final gesture = await startGesture(caretGeometry.center);
+    await pump(kTapMinTime);
+
+    for (int i = 0; i < 50; i += 1) {
+      await gesture.moveBy(delta / 50);
+      await pump(const Duration(milliseconds: 50));
+    }
+
+    return gesture;
+  }
+
   /// Double taps in a [SuperTextField] at the given [offset]
   ///
   /// {@macro supertextfield_finder}
@@ -60,17 +87,20 @@ extension SuperTextFieldRobot on WidgetTester {
     final fieldFinder =
         SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
     final match = fieldFinder.evaluate().single.widget;
+    final scrollDelta = SuperTextFieldInspector.findScrollOffset(superTextFieldFinder)!;
+    final scrollOffset =
+        SuperTextFieldInspector.isSingleLine(superTextFieldFinder) ? Offset(scrollDelta, 0) : Offset(0, scrollDelta);
 
     if (match is SuperDesktopTextField) {
       final superDesktopTextField = state<SuperDesktopTextFieldState>(fieldFinder);
 
-      bool didTap = await _tapAtTextPositionOnDesktop(superDesktopTextField, offset, affinity);
+      bool didTap = await _tapAtTextPositionOnDesktop(superDesktopTextField, offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       await pump(kDoubleTapMinTime);
 
-      didTap = await _tapAtTextPositionOnDesktop(superDesktopTextField, offset, affinity);
+      didTap = await _tapAtTextPositionOnDesktop(superDesktopTextField, offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
@@ -81,13 +111,15 @@ extension SuperTextFieldRobot on WidgetTester {
     }
 
     if (match is SuperAndroidTextField) {
-      bool didTap = await _tapAtTextPositionOnAndroid(state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity);
+      bool didTap = await _tapAtTextPositionOnAndroid(
+          state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       await pump(kDoubleTapMinTime);
 
-      didTap = await _tapAtTextPositionOnAndroid(state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity);
+      didTap = await _tapAtTextPositionOnAndroid(
+          state<SuperAndroidTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
@@ -98,13 +130,15 @@ extension SuperTextFieldRobot on WidgetTester {
     }
 
     if (match is SuperIOSTextField) {
-      bool didTap = await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity);
+      bool didTap =
+          await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
       await pump(kDoubleTapMinTime);
 
-      didTap = await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity);
+      didTap =
+          await _tapAtTextPositionOnIOS(state<SuperIOSTextFieldState>(fieldFinder), offset, affinity, scrollOffset);
       if (!didTap) {
         throw Exception("The desired text offset wasn't tappable in SuperTextField: $offset");
       }
@@ -117,35 +151,69 @@ extension SuperTextFieldRobot on WidgetTester {
     throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
   }
 
-  Future<bool> _tapAtTextPositionOnDesktop(SuperDesktopTextFieldState textField, int offset,
-      [TextAffinity textAffinity = TextAffinity.downstream]) async {
+  Future<bool> _tapAtTextPositionOnDesktop(
+    SuperDesktopTextFieldState textField,
+    int offset, [
+    TextAffinity textAffinity = TextAffinity.downstream,
+    Offset scrollOffset = Offset.zero,
+  ]) async {
     final textFieldBox = textField.context.findRenderObject() as RenderBox;
-    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity);
+    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity, scrollOffset);
   }
 
-  Future<bool> _tapAtTextPositionOnAndroid(SuperAndroidTextFieldState textField, int offset,
-      [TextAffinity textAffinity = TextAffinity.downstream]) async {
+  Future<bool> _tapAtTextPositionOnAndroid(
+    SuperAndroidTextFieldState textField,
+    int offset, [
+    TextAffinity textAffinity = TextAffinity.downstream,
+    Offset scrollOffset = Offset.zero,
+  ]) async {
     final textFieldBox = textField.context.findRenderObject() as RenderBox;
-    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity);
+    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity, scrollOffset);
   }
 
-  Future<bool> _tapAtTextPositionOnIOS(SuperIOSTextFieldState textField, int offset,
-      [TextAffinity textAffinity = TextAffinity.downstream]) async {
+  Future<bool> _tapAtTextPositionOnIOS(
+    SuperIOSTextFieldState textField,
+    int offset, [
+    TextAffinity textAffinity = TextAffinity.downstream,
+    Offset scrollOffset = Offset.zero,
+  ]) async {
     final textFieldBox = textField.context.findRenderObject() as RenderBox;
-    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity);
+    return await _tapAtTextPositionInTextLayout(textField.textLayout, textFieldBox, offset, textAffinity, scrollOffset);
   }
 
-  Future<bool> _tapAtTextPositionInTextLayout(TextLayout textLayout, RenderBox textFieldBox, int offset,
-      [TextAffinity textAffinity = TextAffinity.downstream]) async {
+  Future<bool> _tapAtTextPositionInTextLayout(
+    TextLayout textLayout,
+    RenderBox textFieldBox,
+    int offset, [
+    TextAffinity textAffinity = TextAffinity.downstream,
+    Offset scrollOffset = Offset.zero,
+  ]) async {
     final textPositionOffset = textLayout.getOffsetForCaret(
       TextPosition(offset: offset, affinity: textAffinity),
     );
+
+    print("Text position $offset, offset: ${textLayout.getOffsetForCaret(
+      TextPosition(offset: offset, affinity: textAffinity),
+    )}");
+    print("Text position ${offset + 1}, offset: ${textLayout.getOffsetForCaret(
+      TextPosition(offset: offset + 1, affinity: textAffinity),
+    )}");
+    print("Text position ${offset + 2}, offset: ${textLayout.getOffsetForCaret(
+      TextPosition(offset: offset + 2, affinity: textAffinity),
+    )}");
+    print("Text position ${offset + 3}, offset: ${textLayout.getOffsetForCaret(
+      TextPosition(offset: offset + 3, affinity: textAffinity),
+    )}");
+
+    // Adjust the text offset from text layout coordinates to text field viewport coordinates
+    // by adding the scroll offset.
+    Offset adjustedOffset = textPositionOffset - scrollOffset;
 
     // When upgrading Superlist to Flutter 3, some tests showed a caret offset
     // dy of -0.2. This didn't happen everywhere, but it did happen some places.
     // Until we get to the bottom of this issue, we'll add a constant offset to
     // make up for this.
-    Offset adjustedOffset = textPositionOffset + const Offset(0, 0.2);
+    adjustedOffset += const Offset(0, 0.2);
 
     // There's a problem on Windows and Linux where we get -0.0 instead of 0.0.
     // We adjust the offset to get rid of the -0.0, because a -0.0 fails the
@@ -163,9 +231,9 @@ extension SuperTextFieldRobot on WidgetTester {
     }
 
     if (!textFieldBox.size.contains(adjustedOffset)) {
-      // ignore: avoid_print
-      print("Couldn't tap at $adjustedOffset in text field with size ${textFieldBox.size}");
-      return false;
+      throw Exception(
+        "Couldn't tap at text position because it's not visible. Text field viewport size: ${textFieldBox.size}, text offset in viewport $adjustedOffset. Raw text offset: $textPositionOffset). Text field scroll offset: $scrollOffset",
+      );
     }
 
     final globalTapOffset = adjustedOffset + textFieldBox.localToGlobal(Offset.zero);

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -91,13 +91,31 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
   @visibleForTesting
   bool get isCaretPresent => widget.position != null && widget.position!.offset >= 0;
 
+  @visibleForTesting
+  Offset? get caretOffset => isCaretPresent ? widget.textLayout.getOffsetForCaret(widget.position!) : null;
+
+  @visibleForTesting
+  double? get caretHeight => isCaretPresent
+      ? widget.textLayout.getHeightForCaret(widget.position!) ??
+      widget.textLayout.getLineHeightAtPosition(widget.position!)
+      : null;
+
+  @visibleForTesting
+  Rect? get localCaretGeometry => isCaretPresent ? caretOffset! & Size(widget.style.width, caretHeight!) : null;
+
+  Rect? get globalCaretGeometry {
+    if (!isCaretPresent) {
+      return null;
+    }
+
+    final topLeftInGlobalSpace = (context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
+    return localCaretGeometry!.translate(topLeftInGlobalSpace.dx, topLeftInGlobalSpace.dy);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final offset = isCaretPresent ? widget.textLayout.getOffsetForCaret(widget.position!) : null;
-    final height = isCaretPresent
-        ? widget.textLayout.getHeightForCaret(widget.position!) ??
-            widget.textLayout.getLineHeightAtPosition(widget.position!)
-        : null;
+    final offset = caretOffset;
+    final height = caretHeight;
 
     return Stack(
       clipBehavior: Clip.none,


### PR DESCRIPTION
Fixed SuperTextField single-line auto-scroll and scrolling bugs on iOS and Android (Resolves #1673)

There were a number of problems with iOS and Android single-line `SuperTextField`s:

- When dragging to the edge to auto-scroll, when the user let go, the selection would jump somewhere else.
- On Android, auto-scrolling to the right would almost immediately jump to the end of the text.
- Pressing and dragging anywhere would place and drag the caret - the caret should only drag when the user presses near it.

To test these behaviors, I added a number of test tools for `SuperTextField`.

The root issue was mostly about the timing of certain behaviors. Adjusting when certain things happen was able to resolve these glitches. There were also a few logical errors in the code - for example, when we were checking if the caret was beyond the right side of the viewport, we weren't accounting for the scroll offset.