### PR TITLE
[SuperEditor] Add em-dash conversion reaction (Resolves #1177)

### DIFF
--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -217,5 +217,6 @@ final defaultEditorReactions = List.unmodifiable([
   const BlockquoteConversionReaction(),
   const HorizontalRuleConversionReaction(),
   const ImageUrlConversionReaction(),
+  const DashConversionReaction(),
   //---- End Content Conversions ---
 ]);

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -67,7 +67,7 @@ class HeaderConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     final prefixLength = match.length - 1; // -1 for the space on the end
@@ -130,7 +130,7 @@ class UnorderedListItemConversionReaction extends ParagraphPrefixConversionReact
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an unordered list item pattern.
@@ -172,7 +172,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an ordered list item pattern.
@@ -214,7 +214,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with blockquote pattern.
@@ -321,9 +321,9 @@ class HorizontalRuleConversionReaction implements EditReaction {
 }
 
 /// Base class for [EditReaction]s that want to take action when the user types text at
-/// the beginning of a [TextNode], which matches a given [RegExp].
-abstract class TextNodePrefixConversionReaction implements EditReaction {
-  const TextNodePrefixConversionReaction({
+/// the beginning of a paragraph, which matches a given [RegExp].
+abstract class ParagraphPrefixConversionReaction implements EditReaction {
+  const ParagraphPrefixConversionReaction({
     bool requireSpaceInsertion = true,
   }) : _requireSpaceInsertion = requireSpaceInsertion;
 
@@ -334,7 +334,7 @@ abstract class TextNodePrefixConversionReaction implements EditReaction {
   /// user didn't insert a space into the paragraph.
   final bool _requireSpaceInsertion;
 
-  /// Pattern that is matched at the beginning of a node and then passed to
+  /// Pattern that is matched at the beginning of a paragraph and then passed to
   /// sub-classes for processing.
   RegExp get pattern;
 
@@ -348,61 +348,25 @@ abstract class TextNodePrefixConversionReaction implements EditReaction {
 
     final edit = changeList[changeList.length - 2] as DocumentEdit;
     final textInsertionEvent = edit.change as TextInsertionEvent;
-
-    final textNode = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
-    if (!acceptsNode(textNode)) {
-      // The subclass doesn't accept this type of node. Fizzle.
-      return;
-    }
-
-    final match = pattern.firstMatch(textNode.text.text)?.group(0);
+    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
+    final match = pattern.firstMatch(paragraph.text.text)?.group(0);
     if (match == null) {
       return;
     }
 
-    // The user started a node with the desired pattern. Delegate to the subclass
+    // The user started a paragraph with the desired pattern. Delegate to the subclass
     // to do whatever it wants.
-    onPrefixMatched(editContext, requestDispatcher, changeList, textNode, match);
+    onPrefixMatched(editContext, requestDispatcher, changeList, paragraph, match);
   }
-
-  /// Hook called by the superclass, before evaluating the [pattern], to check if a
-  /// given [node] is acceptable for this reaction.
-  ///
-  /// For example, a reaction that only runs for [ParagraphNode]s should return `true`
-  /// only if [node] is a [ParagraphNode].
-  @protected
-  bool acceptsNode(TextNode node);
-
-  /// Hook, called by the superclass, when the user starts the given [node] with
-  /// the given [match], which fits the desired [pattern].
-  @protected
-  void onPrefixMatched(
-    EditContext editContext,
-    RequestDispatcher requestDispatcher,
-    List<EditEvent> changeList,
-    TextNode node,
-    String match,
-  );
-}
-
-/// A [TextNodePrefixConversionReaction] that only runs for [ParagraphNode]s.
-///
-/// This reaction runs when the user types text at the beginning of a [ParagraphNode],
-/// which matches a given [RegExp].
-abstract class ParagraphPrefixConversionReaction extends TextNodePrefixConversionReaction {
-  const ParagraphPrefixConversionReaction();
-
-  @override
-  bool acceptsNode(TextNode node) => node is ParagraphNode;
 
   /// Hook, called by the superclass, when the user starts the given [paragraph] with
   /// the given [match], which fits the desired [pattern].
-  @override
+  @protected
   void onPrefixMatched(
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    covariant ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   );
 }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -67,7 +67,7 @@ class HeaderConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     final prefixLength = match.length - 1; // -1 for the space on the end
@@ -130,7 +130,7 @@ class UnorderedListItemConversionReaction extends ParagraphPrefixConversionReact
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an unordered list item pattern.
@@ -172,7 +172,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an ordered list item pattern.
@@ -214,7 +214,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with blockquote pattern.
@@ -321,9 +321,9 @@ class HorizontalRuleConversionReaction implements EditReaction {
 }
 
 /// Base class for [EditReaction]s that want to take action when the user types text at
-/// the beginning of a paragraph, which matches a given [RegExp].
-abstract class ParagraphPrefixConversionReaction implements EditReaction {
-  const ParagraphPrefixConversionReaction({
+/// the beginning of a [TextNode], which matches a given [RegExp].
+abstract class TextNodePrefixConversionReaction implements EditReaction {
+  const TextNodePrefixConversionReaction({
     bool requireSpaceInsertion = true,
   }) : _requireSpaceInsertion = requireSpaceInsertion;
 
@@ -334,7 +334,7 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
   /// user didn't insert a space into the paragraph.
   final bool _requireSpaceInsertion;
 
-  /// Pattern that is matched at the beginning of a paragraph and then passed to
+  /// Pattern that is matched at the beginning of a node and then passed to
   /// sub-classes for processing.
   RegExp get pattern;
 
@@ -348,25 +348,61 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
 
     final edit = changeList[changeList.length - 2] as DocumentEdit;
     final textInsertionEvent = edit.change as TextInsertionEvent;
-    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
-    final match = pattern.firstMatch(paragraph.text.text)?.group(0);
+
+    final textNode = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
+    if (!acceptsNode(textNode)) {
+      // The subclass doesn't accept this type of node. Fizzle.
+      return;
+    }
+
+    final match = pattern.firstMatch(textNode.text.text)?.group(0);
     if (match == null) {
       return;
     }
 
-    // The user started a paragraph with the desired pattern. Delegate to the subclass
+    // The user started a node with the desired pattern. Delegate to the subclass
     // to do whatever it wants.
-    onPrefixMatched(editContext, requestDispatcher, changeList, paragraph, match);
+    onPrefixMatched(editContext, requestDispatcher, changeList, textNode, match);
   }
 
-  /// Hook, called by the superclass, when the user starts the given [paragraph] with
+  /// Hook called by the superclass, before evaluating the [pattern], to check if a
+  /// given [node] is acceptable for this reaction.
+  ///
+  /// For example, a reaction that only runs for [ParagraphNode]s should return `true`
+  /// only if [node] is a [ParagraphNode].
+  @protected
+  bool acceptsNode(TextNode node);
+
+  /// Hook, called by the superclass, when the user starts the given [node] with
   /// the given [match], which fits the desired [pattern].
   @protected
   void onPrefixMatched(
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    TextNode node,
+    String match,
+  );
+}
+
+/// A [TextNodePrefixConversionReaction] that only runs for [ParagraphNode]s.
+///
+/// This reaction runs when the user types text at the beginning of a [ParagraphNode],
+/// which matches a given [RegExp].
+abstract class ParagraphPrefixConversionReaction extends TextNodePrefixConversionReaction {
+  const ParagraphPrefixConversionReaction();
+
+  @override
+  bool acceptsNode(TextNode node) => node is ParagraphNode;
+
+  /// Hook, called by the superclass, when the user starts the given [paragraph] with
+  /// the given [match], which fits the desired [pattern].
+  @override
+  void onPrefixMatched(
+    EditContext editContext,
+    RequestDispatcher requestDispatcher,
+    List<EditEvent> changeList,
+    covariant ParagraphNode paragraph,
     String match,
   );
 }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -67,7 +67,7 @@ class HeaderConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     final prefixLength = match.length - 1; // -1 for the space on the end
@@ -130,7 +130,7 @@ class UnorderedListItemConversionReaction extends ParagraphPrefixConversionReact
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an unordered list item pattern.
@@ -172,7 +172,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an ordered list item pattern.
@@ -214,7 +214,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   ) {
     // The user started a paragraph with blockquote pattern.
@@ -250,7 +250,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
 /// The horizontal rule is inserted before the current node and the remainder of
 /// the node's text is kept.
 ///
-/// Applied only to [ParagraphNode]s.
+/// Applied only to all [TextNode]s.
 class HorizontalRuleConversionReaction implements EditReaction {
   // Matches "---" or "—-" (an em-dash followed by a regular dash) at the beginning of a line,
   // followed by a space.
@@ -348,7 +348,10 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
 
     final edit = changeList[changeList.length - 2] as DocumentEdit;
     final textInsertionEvent = edit.change as TextInsertionEvent;
-    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
+    final paragraph = document.getNodeById(textInsertionEvent.nodeId);
+    if (paragraph is! ParagraphNode) {
+      return;
+    }
     final match = pattern.firstMatch(paragraph.text.text)?.group(0);
     if (match == null) {
       return;
@@ -366,7 +369,7 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    TextNode paragraph,
+    ParagraphNode paragraph,
     String match,
   );
 }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -67,7 +67,7 @@ class HeaderConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     final prefixLength = match.length - 1; // -1 for the space on the end
@@ -130,7 +130,7 @@ class UnorderedListItemConversionReaction extends ParagraphPrefixConversionReact
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an unordered list item pattern.
@@ -172,7 +172,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with an ordered list item pattern.
@@ -214,7 +214,7 @@ class BlockquoteConversionReaction extends ParagraphPrefixConversionReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   ) {
     // The user started a paragraph with blockquote pattern.
@@ -269,7 +269,7 @@ class HorizontalRuleConversionReaction implements EditReaction {
 
     final edit = changeList[changeList.length - 2] as DocumentEdit;
     final textInsertionEvent = edit.change as TextInsertionEvent;
-    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as ParagraphNode;
+    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
     final match = _hrPattern.firstMatch(paragraph.text.text)?.group(0);
     if (match == null) {
       return;
@@ -334,7 +334,7 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
 
     final edit = changeList[changeList.length - 2] as DocumentEdit;
     final textInsertionEvent = edit.change as TextInsertionEvent;
-    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as ParagraphNode;
+    final paragraph = document.getNodeById(textInsertionEvent.nodeId) as TextNode;
     final match = pattern.firstMatch(paragraph.text.text)?.group(0);
     if (match == null) {
       return;
@@ -352,7 +352,7 @@ abstract class ParagraphPrefixConversionReaction implements EditReaction {
     EditContext editContext,
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
-    ParagraphNode paragraph,
+    TextNode paragraph,
     String match,
   );
 }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -654,6 +654,10 @@ class LinkifyReaction implements EditReaction {
 
 /// An [EditReaction] which converts two dashes (--) to an em-dash (—).
 ///
+/// This reaction only applies when the user enters a dash (-) after
+/// another dash in the same node. The upstream dash and the newly inserted
+/// dash are removed and an em-dash (—) is inserted.
+///
 /// This reaction applies to all [TextNode]s in the document.
 class DashConversionReaction implements EditReaction {
   const DashConversionReaction();

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -142,3 +142,5 @@ extension CharacterMovement on String {
     return range.current.length;
   }
 }
+
+const emDash = '—';

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -143,7 +143,9 @@ extension CharacterMovement on String {
   }
 }
 
-/// Holds constants for special characters using within the package.
+/// Characters that are difficult to represent literally, and therefore are provided as constants.
 class SpecialCharacters {
   static const emDash = '—';
+
+  const SpecialCharacters._();
 }

--- a/super_editor/lib/src/infrastructure/strings.dart
+++ b/super_editor/lib/src/infrastructure/strings.dart
@@ -143,4 +143,7 @@ extension CharacterMovement on String {
   }
 }
 
-const emDash = '—';
+/// Holds constants for special characters using within the package.
+class SpecialCharacters {
+  static const emDash = '—';
+}

--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -344,6 +344,22 @@ extension SuperEditorRobot on WidgetTester {
     return gesture;
   }
 
+  /// Simulates typing [text], either as keyboard keys, or as insertion deltas of
+  /// a software keyboard.
+  ///
+  /// Provide an [imeOwnerFinder] if there are multiple [ImeOwner]s in the current
+  /// widget tree.
+  Future<void> typeTextAdaptive(String text, [Finder? imeOwnerFinder]) async {
+    if (!testTextInput.hasAnyClients) {
+      // There isn't any IME connections.
+      // Type using the hardware keyboard.
+      await typeKeyboardText(text);
+      return;
+    }
+
+    await ime.typeText(text, getter: () => imeClientGetter(imeOwnerFinder));
+  }
+
   /// Types the given [text] into a [SuperEditor] by simulating IME text deltas from
   /// the platform.
   ///

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -5,9 +5,6 @@ import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/default_document_editor.dart';
 
-import 'package:super_editor/src/default_editor/default_document_editor_reactions.dart';
-import 'package:super_editor/src/default_editor/horizontal_rule.dart';
-import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
@@ -26,7 +23,6 @@ void main() {
         final context = await tester //
             .createDocument()
             .withSingleEmptyParagraph()
-            .withAddedReactions([const DashConversionReaction()]) //
             .withInputSource(inputSource)
             .pump();
 
@@ -61,7 +57,6 @@ void main() {
             .createDocument()
             .fromMarkdown('was inserted')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -97,7 +92,6 @@ void main() {
             .createDocument()
             .fromMarkdown('Inserting with a reaction')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -142,7 +136,6 @@ void main() {
             .createDocument()
             .fromMarkdown('Inserting')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -181,7 +174,6 @@ void main() {
             .createDocument()
             .fromMarkdown('* ')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -217,7 +209,6 @@ void main() {
             .createDocument()
             .fromMarkdown('* was inserted')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -260,7 +251,6 @@ void main() {
             .createDocument()
             .fromMarkdown('* Inserting with a reaction')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -305,7 +295,6 @@ void main() {
             .createDocument()
             .fromMarkdown('* Inserting')
             .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
             .pump();
 
         final nodeId = context.document.nodes.first.id;
@@ -346,7 +335,7 @@ void main() {
           ],
         );
         final composer = MutableDocumentComposer();
-        final editor = _createTestEditor(document: document, composer: composer);
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -399,7 +388,7 @@ void main() {
           ],
         );
         final composer = MutableDocumentComposer();
-        final editor = _createTestEditor(document: document, composer: composer);
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -457,7 +446,7 @@ void main() {
           ],
         );
         final composer = MutableDocumentComposer();
-        final editor = _createTestEditor(document: document, composer: composer);
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -515,7 +504,7 @@ void main() {
           ],
         );
         final composer = MutableDocumentComposer();
-        final editor = _createTestEditor(document: document, composer: composer);
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -559,96 +548,5 @@ void main() {
         expect((document.nodes.first as TaskNode).text.text, 'Inserting — by typing two dashes');
       });
     });
-
-    group('converts three dashes to a horizontal rule', () {
-      testAllInputsOnAllPlatforms('at the beginning of an empty paragraph', (
-        tester, {
-        required TextInputSource inputSource,
-      }) async {
-        final context = await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
-            .pump();
-
-        // Place the caret at the beginning of the document.
-        await tester.placeCaretInParagraph('1', 0);
-
-        // Type the first dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure no conversion was performed.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '-');
-
-        // Type the second dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure the two dashes were converted to an em-dash.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '—');
-
-        // Type the third dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure the paragraph was converted to a horizontal rule.
-        expect(context.document.nodes.length, 2);
-        expect(context.document.nodes.first, isA<HorizontalRuleNode>());
-        expect(context.document.nodes.last, isA<ParagraphNode>());
-        expect((context.document.nodes.last as ParagraphNode).text.text, '');
-      });
-
-      testAllInputsOnAllPlatforms('at the beginning of a non-empty paragraph', (
-        tester, {
-        required TextInputSource inputSource,
-      }) async {
-        final context = await tester //
-            .createDocument()
-            .fromMarkdown('Existing paragraph')
-            .withInputSource(inputSource)
-            .withAddedReactions([const DashConversionReaction()]) //
-            .pump();
-
-        // Place the caret at the beginning of the document.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 0);
-
-        // Type the first dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure no conversion was performed.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '-Existing paragraph');
-
-        // Type the second dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure the two dashes were converted to an em-dash.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '—Existing paragraph');
-
-        // Type the third dash.
-        await tester.typeTextAdaptive('-');
-
-        // Ensure a horizontal rule was inserted before the existing paragraph.
-        expect(context.document.nodes.length, 2);
-        expect(context.document.nodes.first, isA<HorizontalRuleNode>());
-        expect(context.document.nodes.last, isA<ParagraphNode>());
-        expect((context.document.nodes.last as ParagraphNode).text.text, 'Existing paragraph');
-      });
-    });
   });
-}
-
-/// Creates an [Editor] with the default reaction pipeline plus the [DashConversionReaction].
-Editor _createTestEditor({
-  required MutableDocument document,
-  required MutableDocumentComposer composer,
-}) {
-  final editor = Editor(
-    editables: {
-      Editor.documentKey: document,
-      Editor.composerKey: composer,
-    },
-    requestHandlers: List.from(defaultRequestHandlers),
-    reactionPipeline: [...defaultEditorReactions, const DashConversionReaction()],
-  );
-
-  return editor;
 }

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -41,7 +41,7 @@ void main() {
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph('1').text, emDash);
+        expect(SuperEditorInspector.findTextInParagraph('1').text, SpecialCharacters.emDash);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' is an em-dash');

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/default_editor/default_document_editor.dart';
 
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
+import 'package:super_editor/src/infrastructure/strings.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -40,7 +41,7 @@ void main() {
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph('1').text, '—');
+        expect(SuperEditorInspector.findTextInParagraph('1').text, emDash);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' is an em-dash');

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -1,0 +1,654 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/default_document_editor.dart';
+
+import 'package:super_editor/src/default_editor/default_document_editor_reactions.dart';
+import 'package:super_editor/src/default_editor/horizontal_rule.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/super_editor.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../../test_runners.dart';
+import '../supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor dash conversion', () {
+    group('converts two dashes to an em dash', () {
+      testAllInputsOnAllPlatforms('at the beginning of an empty paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withAddedReactions([const DashConversionReaction()]) //
+            .withInputSource(inputSource)
+            .pump();
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph('1').text, '-');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph('1').text, '—');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' is an em-dash');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph('1').text, '— is an em-dash');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of a non-empty paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('was inserted')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at the beginning of a paragraph.
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-was inserted');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—was inserted');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive('(em-dash) ');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—(em-dash) was inserted');
+      });
+
+      testAllInputsOnAllPlatforms('at the middle of a paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('Inserting with a reaction')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at "|with".
+        await tester.placeCaretInParagraph(nodeId, 10);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -with a reaction');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —with a reaction');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' typing two dashes ');
+
+        // Type three dashes. The first two should be converted to an em-dash
+        // and the second should be inserted as is.
+        await tester.typeTextAdaptive('---');
+        expect(
+            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
+
+        // Type another dash. The previously inserted dash and the current one
+        // should be converted to an em-dash.
+        await tester.typeTextAdaptive('-');
+        expect(
+            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
+      });
+
+      testAllInputsOnAllPlatforms('at the end of a paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('Inserting')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at the end of the paragraph and add a space
+        // just to separate the first word from the dash.
+        // Converting from markdown removes the trailing spaces.
+        await tester.placeCaretInParagraph(nodeId, 9);
+        await tester.typeTextAdaptive(' ');
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' by typing two dashes');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — by typing two dashes');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of an empty list item', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* ')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' is an em-dash');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '— is an em-dash');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of a non-empty list item', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* was inserted')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-was inserted');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—was inserted');
+
+        // Type a third dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure a dash was inserted and no other nodes were added.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—-was inserted');
+        expect(context.document.nodes.length, 1);
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive('(em-dash) ');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—-(em-dash) was inserted');
+      });
+
+      testAllInputsOnAllPlatforms('at the middle of a list item', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Inserting with a reaction')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at "|with".
+        await tester.placeCaretInParagraph(nodeId, 10);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -with a reaction');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —with a reaction');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' typing two dashes ');
+
+        // Type three dashes. The first two should be converted to an em-dash
+        // and the second should be inserted as is.
+        await tester.typeTextAdaptive('---');
+        expect(
+            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
+
+        // Type another dash. The previously inserted dash and the current one
+        // should be converted to an em-dash.
+        await tester.typeTextAdaptive('-');
+        expect(
+            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
+      });
+
+      testAllInputsOnAllPlatforms('at the end of a list item', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Inserting')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        final nodeId = context.document.nodes.first.id;
+
+        // Place the caret at the end of the list item and add a space
+        // just to separate the first word from the dash.
+        // Converting from markdown removes the trailing spaces.
+        await tester.placeCaretInParagraph(nodeId, 9);
+        await tester.typeTextAdaptive(' ');
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(context.document.nodes.length, 1);
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' by typing two dashes');
+
+        // Ensure the text was inserted.
+        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — by typing two dashes');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of an empty task', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText(""), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = _createTestEditor(document: document, composer: composer);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final nodeId = document.nodes.first.id;
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect((document.nodes.first as TaskNode).text.text, '-');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(document.nodes.length, 1);
+        expect((document.nodes.first as TaskNode).text.text, '—');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' is an em-dash');
+
+        // Ensure the text was inserted.
+        expect((document.nodes.first as TaskNode).text.text, '— is an em-dash');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of a non-empty task', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("was inserted"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = _createTestEditor(document: document, composer: composer);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect((document.nodes.first as TaskNode).text.text, '-was inserted');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(document.nodes.length, 1);
+        expect((document.nodes.first as TaskNode).text.text, '—was inserted');
+
+        // Type a third dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure a dash was inserted and no other nodes were added.
+        expect((document.nodes.first as TaskNode).text.text, '—-was inserted');
+        expect(document.nodes.length, 1);
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive('(em-dash) ');
+
+        // Ensure the text was inserted.
+        expect((document.nodes.first as TaskNode).text.text, '—-(em-dash) was inserted');
+      });
+
+      testAllInputsOnAllPlatforms('at the middle of a task', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("Inserting with a reaction"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = _createTestEditor(document: document, composer: composer);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Place the caret at "|with".
+        await tester.placeCaretInParagraph(document.nodes.first.id, 10);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting -with a reaction');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(document.nodes.length, 1);
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting —with a reaction');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' typing two dashes ');
+
+        // Type three dashes. The first two should be converted to an em-dash
+        // and the second should be inserted as is.
+        await tester.typeTextAdaptive('---');
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting — typing two dashes —-with a reaction');
+
+        // Type another dash. The previously inserted dash and the current one
+        // should be converted to an em-dash.
+        await tester.typeTextAdaptive('-');
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting — typing two dashes ——with a reaction');
+      });
+
+      testAllInputsOnAllPlatforms('at the end of a task', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("Inserting"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = _createTestEditor(document: document, composer: composer);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Place the caret at the end of the task and add a space
+        // just to separate the first word from the dash.
+        // Converting from markdown removes the trailing spaces.
+        await tester.placeCaretInParagraph(document.nodes.first.id, 9);
+        await tester.typeTextAdaptive(' ');
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion happened.
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting -');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect(document.nodes.length, 1);
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting —');
+
+        // Type some arbitrary text.
+        await tester.typeTextAdaptive(' by typing two dashes');
+
+        // Ensure the text was inserted.
+        expect((document.nodes.first as TaskNode).text.text, 'Inserting — by typing two dashes');
+      });
+    });
+
+    group('converts three dashes to a horizontal rule', () {
+      testAllInputsOnAllPlatforms('at the beginning of an empty paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion was performed.
+        expect((context.document.nodes.first as ParagraphNode).text.text, '-');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect((context.document.nodes.first as ParagraphNode).text.text, '—');
+
+        // Type the third dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the paragraph was converted to a horizontal rule.
+        expect(context.document.nodes.length, 2);
+        expect(context.document.nodes.first, isA<HorizontalRuleNode>());
+        expect(context.document.nodes.last, isA<ParagraphNode>());
+        expect((context.document.nodes.last as ParagraphNode).text.text, '');
+      });
+
+      testAllInputsOnAllPlatforms('at the beginning of a non-empty paragraph', (
+        tester, {
+        required TextInputSource inputSource,
+      }) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('Existing paragraph')
+            .withInputSource(inputSource)
+            .withAddedReactions([const DashConversionReaction()]) //
+            .pump();
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph(context.document.nodes.first.id, 0);
+
+        // Type the first dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure no conversion was performed.
+        expect((context.document.nodes.first as ParagraphNode).text.text, '-Existing paragraph');
+
+        // Type the second dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure the two dashes were converted to an em-dash.
+        expect((context.document.nodes.first as ParagraphNode).text.text, '—Existing paragraph');
+
+        // Type the third dash.
+        await tester.typeTextAdaptive('-');
+
+        // Ensure a horizontal rule was inserted before the existing paragraph.
+        expect(context.document.nodes.length, 2);
+        expect(context.document.nodes.first, isA<HorizontalRuleNode>());
+        expect(context.document.nodes.last, isA<ParagraphNode>());
+        expect((context.document.nodes.last as ParagraphNode).text.text, 'Existing paragraph');
+      });
+    });
+  });
+}
+
+/// Creates an [Editor] with the default reaction pipeline plus the [DashConversionReaction].
+Editor _createTestEditor({
+  required MutableDocument document,
+  required MutableDocumentComposer composer,
+}) {
+  final editor = Editor(
+    editables: {
+      Editor.documentKey: document,
+      Editor.composerKey: composer,
+    },
+    requestHandlers: List.from(defaultRequestHandlers),
+    reactionPipeline: [...defaultEditorReactions, const DashConversionReaction()],
+  );
+
+  return editor;
+}

--- a/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
+++ b/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
@@ -155,7 +155,7 @@ void main() {
     });
 
     group("paragraph to horizontal rule >", () {
-      testAllInputsOnAllPlatforms("with --- in an empty paragraph", (
+      testAllInputsOnAllPlatforms("with --- at the beginning of an empty paragraph", (
         tester, {
         required TextInputSource inputSource,
       }) async {
@@ -177,7 +177,7 @@ void main() {
         expect((document.nodes.last as ParagraphNode).text.text.isEmpty, isTrue);
       });
 
-      testAllInputsOnAllPlatforms('with --- in an non-empty paragraph', (
+      testAllInputsOnAllPlatforms('with --- at the beginning of an non-empty paragraph', (
         tester, {
         required TextInputSource inputSource,
       }) async {

--- a/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
+++ b/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
@@ -220,12 +220,15 @@ void main() {
             .autoFocus(true)
             .pump();
 
-        final nonHrInput = _nonHrVariant.currentValue!;
-        await tester.typeImeText(nonHrInput);
+        final nonHrInputAndResult = _nonHrVariant.currentValue!;
+        final input = nonHrInputAndResult.input;
+        final expectedResult = nonHrInputAndResult.expectedResult;
+
+        await tester.typeImeText(input);
 
         final paragraphNode = context.findEditContext().document.nodes.first;
         expect(paragraphNode, isA<ParagraphNode>());
-        expect((paragraphNode as ParagraphNode).text.text, nonHrInput);
+        expect((paragraphNode as ParagraphNode).text.text, expectedResult);
       }, variant: _nonHrVariant);
     });
 
@@ -386,9 +389,28 @@ final _orderedListVariant = ValueVariant({
   " 1) ",
 });
 
-final _nonHrVariant = ValueVariant({
+/// Holds sequence of character that shouldn't produce a horizontal rule
+/// and the expected resulting text after running the editor reactions.
+final _nonHrVariant = ValueVariant(const {
   // We ignore " - " because that is a conversion for unordered list items
-  "— ",
-  "—— ",
-  " —- ",
+  _TestInput(input: "-- ", expectedResult: "— "),
+  _TestInput(input: "---- ", expectedResult: "—— "),
+  _TestInput(input: " --- ", expectedResult: " —- "),
 });
+
+/// A test text input and the expected resulting text after running
+/// the editor reactions.
+class _TestInput {
+  const _TestInput({
+    required this.input,
+    required this.expectedResult,
+  });
+
+  final String input;
+  final String expectedResult;
+
+  @override
+  String toString() {
+    return "[input: $input, expectedResult: $expectedResult]";
+  }
+}

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -305,7 +305,7 @@ class _MarkdownToDocument implements md.NodeVisitor {
   }) {
     late String content;
 
-    if (element.children != null && element.children!.first is md.UnparsedContent) {
+    if (element.children != null && element.children!.isNotEmpty && element.children!.first is md.UnparsedContent) {
       // The list item might contain another sub-list. In that case, the textContent
       // contains the text for the whole list instead of just the current list item.
       // Use the textContent for the first child, which contains only the text

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -977,6 +977,16 @@ This is some code
         expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
       });
 
+      test('empty unordered list item', () {
+        const markdown = '* ';
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 1);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes.first as ListItemNode).text.text, isEmpty);
+      });
+
       test('unordered list with empty lines between items', () {
         const markdown = '''
  * list item 1
@@ -1028,6 +1038,16 @@ This is some code
 
         expect((document.nodes[4] as ListItemNode).indent, 0);
         expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
+      });
+
+      test('empty ordered list item', () {
+        const markdown = '1. ';
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 1);
+        expect(document.nodes.first, isA<ListItemNode>());
+        expect((document.nodes.first as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes.first as ListItemNode).text.text, isEmpty);
       });
 
       test('ordered list with empty lines between items', () {


### PR DESCRIPTION
[SuperEditor] Addem-dash conversion reaction. Resolves #1177 

This PR adds a reaction to convert 2 dashes ("--") to an em dash ("—"). 

It also allows typing three dashes at the beginning of the paragraph.  In this case, the first two dashes are converted to an em dash and after typing the third dash a horizontal rule is added before the current paragraph and the dashes are removed.

https://github.com/superlistapp/super_editor/assets/7597082/e69106be-9f26-423b-8290-7e799b7f0772

