### PR TITLE
[SuperEditor][Desktop] Keep selection base while dragging (Resolves #1393)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -88,14 +88,16 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
   // Tracks user drag gestures for selection purposes.
   SelectionType _selectionType = SelectionType.position;
   Offset? _dragStartGlobal;
+  // The selection's document position where the user started dragging an expanded selection.
+  // The selection base is cached instead of continuously re-computed because components
+  // can change size and position during selection.
+  DocumentPosition? _dragSelectionBase;
   Offset? _dragEndGlobal;
   bool _expandSelectionDuringDrag = false;
   // When selecting by word, this is the initial word's upstream position.
   DocumentPosition? _wordSelectionUpstream;
   // When selecting by word, this is the initial word's downstream position.
   DocumentPosition? _wordSelectionDownstream;
-  // Holds the first selection base of a drag gesture.
-  DocumentPosition? _startingSelectionBase;
 
   /// Holds which kind of device started a pan gesture, e.g., a mouse or a trackpad.
   PointerDeviceKind? _panGestureDevice;
@@ -551,7 +553,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       _expandSelectionDuringDrag = false;
       _wordSelectionUpstream = null;
       _wordSelectionDownstream = null;
-      _startingSelectionBase = null;
+      _dragSelectionBase = null;
     });
 
     widget.autoScroller.disableAutoScrolling();
@@ -624,15 +626,9 @@ Updating drag selection:
       extentOffsetInDocument,
     );
 
-    // If a component resizes itself depending on whether or not it's selected,
-    // we might end up in a situation where the starting drag offset points
-    // to a different component than the component it was pointing at
-    // the start of the gesture.
-    // Cache and reuse the first selection base of the drag gesture,
-    // so the selection base never changes during a single drag gesture.
-    _startingSelectionBase ??= selection?.base;
+    _dragSelectionBase ??= selection?.base;
 
-    DocumentPosition? basePosition = _startingSelectionBase;
+    DocumentPosition? basePosition = _dragSelectionBase;
     DocumentPosition? extentPosition = selection?.extent;
     editorGesturesLog.fine(" - base: $basePosition, extent: $extentPosition");
 

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -94,6 +94,8 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
   DocumentPosition? _wordSelectionUpstream;
   // When selecting by word, this is the initial word's downstream position.
   DocumentPosition? _wordSelectionDownstream;
+  // Holds the first selection base of a drag gesture.
+  DocumentPosition? _startingSelectionBase;
 
   /// Holds which kind of device started a pan gesture, e.g., a mouse or a trackpad.
   PointerDeviceKind? _panGestureDevice;
@@ -549,6 +551,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       _expandSelectionDuringDrag = false;
       _wordSelectionUpstream = null;
       _wordSelectionDownstream = null;
+      _startingSelectionBase = null;
     });
 
     widget.autoScroller.disableAutoScrolling();
@@ -620,7 +623,16 @@ Updating drag selection:
       baseOffsetInDocument,
       extentOffsetInDocument,
     );
-    DocumentPosition? basePosition = selection?.base;
+
+    // If a component resizes itself depending on whether or not it's selected,
+    // we might end up in a situation where the starting drag offset points
+    // to a different component than the component it was pointing at
+    // the start of the gesture.
+    // Cache and reuse the first selection base of the drag gesture,
+    // so the selection base never changes during a single drag gesture.
+    _startingSelectionBase ??= selection?.base;
+
+    DocumentPosition? basePosition = _startingSelectionBase;
     DocumentPosition? extentPosition = selection?.extent;
     editorGesturesLog.fine(" - base: $basePosition, extent: $extentPosition");
 

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -549,11 +549,11 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
   void _onDragEnd() {
     setState(() {
       _dragStartGlobal = null;
+      _dragSelectionBase = null;
       _dragEndGlobal = null;
       _expandSelectionDuringDrag = false;
       _wordSelectionUpstream = null;
       _wordSelectionDownstream = null;
-      _dragSelectionBase = null;
     });
 
     widget.autoScroller.disableAutoScrolling();

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -182,17 +182,19 @@ void main() {
       // Ensure that the entire document is selected.
       expect(
         SuperEditorInspector.findDocumentSelection(),
-        DocumentSelection(
-          base: DocumentPosition(
-            nodeId: lastParagraph.id,
-            nodePosition: TextNodePosition(
-              offset: lastParagraph.endPosition.offset,
-              affinity: TextAffinity.upstream,
+        selectionEquivalentTo(
+          DocumentSelection(
+            base: DocumentPosition(
+              nodeId: lastParagraph.id,
+              nodePosition: TextNodePosition(
+                offset: lastParagraph.endPosition.offset,
+                affinity: TextAffinity.upstream,
+              ),
             ),
-          ),
-          extent: DocumentPosition(
-            nodeId: firstParagraph.id,
-            nodePosition: firstParagraph.beginningPosition,
+            extent: DocumentPosition(
+              nodeId: firstParagraph.id,
+              nodePosition: firstParagraph.beginningPosition,
+            ),
           ),
         ),
       );

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -306,7 +306,8 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop("keeps selection base while dragging an expandable component", (tester) async {
+    testWidgetsOnArbitraryDesktop("keeps selection base while dragging a selection across components that change size",
+        (tester) async {
       final document = MutableDocument(
         nodes: [
           TaskNode(
@@ -347,7 +348,7 @@ void main() {
         ),
       );
 
-      // Start dragging from "Tas|k 3".
+      // Start dragging from "Tas|k 3" to the beginning of the document.
       final gesture = await tester.startDocumentDragFromPosition(
         from: const DocumentPosition(
           nodeId: '3',
@@ -356,7 +357,7 @@ void main() {
       );
       addTearDown(() => gesture.removePointer());
 
-      // Gradually move up.
+      // Gradually move up until the beginning of the document.
       for (int i = 0; i <= 10; i++) {
         await gesture.moveBy(const Offset(0, -30));
         await tester.pump();
@@ -1221,7 +1222,7 @@ class _UnselectableHorizontalRuleComponent extends StatelessWidget {
   }
 }
 
-/// Builds [TaskComponentViewModel]s and [_ExpandingTaskComponent]s for every
+/// Builds [TaskComponentViewModel]s and [ExpandingTaskComponent]s for every
 /// [TaskNode] in a document.
 class _ExpandingTaskComponentBuilder extends ComponentBuilder {
   @override
@@ -1248,52 +1249,9 @@ class _ExpandingTaskComponentBuilder extends ComponentBuilder {
       return null;
     }
 
-    return _ExpandingTaskComponent(
+    return ExpandingTaskComponent(
       key: componentContext.componentKey,
       viewModel: componentViewModel,
-    );
-  }
-}
-
-/// A task component which expands its height when it's selected.
-class _ExpandingTaskComponent extends StatefulWidget {
-  const _ExpandingTaskComponent({
-    super.key,
-    required this.viewModel,
-  });
-
-  final TaskComponentViewModel viewModel;
-
-  @override
-  State<_ExpandingTaskComponent> createState() => _ExpandingTaskComponentState();
-}
-
-class _ExpandingTaskComponentState extends State<_ExpandingTaskComponent>
-    with ProxyDocumentComponent<_ExpandingTaskComponent>, ProxyTextComposable {
-  final _textKey = GlobalKey();
-
-  @override
-  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => _textKey;
-
-  @override
-  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        TextComponent(
-          key: _textKey,
-          text: widget.viewModel.text,
-          textStyleBuilder: widget.viewModel.textStyleBuilder,
-          textSelection: widget.viewModel.selection,
-          selectionColor: widget.viewModel.selectionColor,
-          highlightWhenEmpty: widget.viewModel.highlightWhenEmpty,
-        ),
-        if (widget.viewModel.selection != null) //
-          const SizedBox(height: 20)
-      ],
     );
   }
 }

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -331,7 +331,7 @@ void main() {
       await tester //
           .createDocument()
           .withCustomContent(document)
-          .withAddedComponents([_ExpandingTaskComponentBuilder()]) //
+          .withAddedComponents([ExpandingTaskComponentBuilder()]) //
           .pump();
 
       // Place the caret at "Tas|k 3" to make it expand.
@@ -1218,40 +1218,6 @@ class _UnselectableHorizontalRuleComponent extends StatelessWidget {
         color: Color(0xFF000000),
         thickness: 1.0,
       ),
-    );
-  }
-}
-
-/// Builds [TaskComponentViewModel]s and [ExpandingTaskComponent]s for every
-/// [TaskNode] in a document.
-class _ExpandingTaskComponentBuilder extends ComponentBuilder {
-  @override
-  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
-    if (node is! TaskNode) {
-      return null;
-    }
-
-    return TaskComponentViewModel(
-      nodeId: node.id,
-      padding: EdgeInsets.zero,
-      isComplete: node.isComplete,
-      setComplete: (bool isComplete) {},
-      text: node.text,
-      textStyleBuilder: noStyleBuilder,
-      selectionColor: const Color(0x00000000),
-    );
-  }
-
-  @override
-  Widget? createComponent(
-      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
-    if (componentViewModel is! TaskComponentViewModel) {
-      return null;
-    }
-
-    return ExpandingTaskComponent(
-      key: componentContext.componentKey,
-      viewModel: componentViewModel,
     );
   }
 }

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -798,6 +798,40 @@ class FakeImageComponentBuilder implements ComponentBuilder {
   }
 }
 
+/// Builds [TaskComponentViewModel]s and [ExpandingTaskComponent]s for every
+/// [TaskNode] in a document.
+class ExpandingTaskComponentBuilder extends ComponentBuilder {
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! TaskNode) {
+      return null;
+    }
+
+    return TaskComponentViewModel(
+      nodeId: node.id,
+      padding: EdgeInsets.zero,
+      isComplete: node.isComplete,
+      setComplete: (bool isComplete) {},
+      text: node.text,
+      textStyleBuilder: noStyleBuilder,
+      selectionColor: const Color(0x00000000),
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! TaskComponentViewModel) {
+      return null;
+    }
+
+    return ExpandingTaskComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
 /// A task component which expands its height when it's selected.
 class ExpandingTaskComponent extends StatefulWidget {
   const ExpandingTaskComponent({

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -798,6 +798,49 @@ class FakeImageComponentBuilder implements ComponentBuilder {
   }
 }
 
+/// A task component which expands its height when it's selected.
+class ExpandingTaskComponent extends StatefulWidget {
+  const ExpandingTaskComponent({
+    super.key,
+    required this.viewModel,
+  });
+
+  final TaskComponentViewModel viewModel;
+
+  @override
+  State<ExpandingTaskComponent> createState() => _ExpandingTaskComponentState();
+}
+
+class _ExpandingTaskComponentState extends State<ExpandingTaskComponent>
+    with ProxyDocumentComponent<ExpandingTaskComponent>, ProxyTextComposable {
+  final _textKey = GlobalKey();
+
+  @override
+  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => _textKey;
+
+  @override
+  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextComponent(
+          key: _textKey,
+          text: widget.viewModel.text,
+          textStyleBuilder: widget.viewModel.textStyleBuilder,
+          textSelection: widget.viewModel.selection,
+          selectionColor: widget.viewModel.selectionColor,
+          highlightWhenEmpty: widget.viewModel.highlightWhenEmpty,
+        ),
+        if (widget.viewModel.selection != null) //
+          const SizedBox(height: 20)
+      ],
+    );
+  }
+}
+
 class StandardEditorPieces {
   StandardEditorPieces(this.document, this.composer, this.editor);
 


### PR DESCRIPTION
[SuperEditor][Desktop] Keep selection base while dragging. Resolves #1393

In the animated component demo, dragging up from a task near the bottom causes the selection base to change while the user is dragging:

https://github.com/superlistapp/super_editor/assets/7597082/fbc8a6d1-23a7-4f0a-90a3-2121c860d6a5

Currently, on each pan update, we re-compute the whole selection by checking the selection in the drag region. This is a problem if a component resizes itself, because, at the start of the drag gestures, the offset points to a component and while the user is dragging and the components are resizing, the starting offset might point to another component.

To fix that, this PR caches the starting selection base and reuses-it at each pan update. This isn't a problem on mobile, because when the user drags the expanded drag handle, we are already expanding the current selection.

https://github.com/superlistapp/super_editor/assets/7597082/c4fc6ced-12d2-417f-aaa3-128583bf2b96

This change caused one test to fail, due to a different selection affinity.


