### PR TITLE
[SuperEditor][Android] Make selection focal point debug visuals hidden by default (Resolves #1722)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1263,6 +1263,7 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
     required this.scrollChangeSignal,
     required this.dragHandleAutoScroller,
     this.defaultToolbarBuilder,
+    this.showDebugPaint = false,
     this.child,
   });
 
@@ -1276,6 +1277,10 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
   final ValueListenable<DragHandleAutoScroller?> dragHandleAutoScroller;
 
   final DocumentFloatingToolbarBuilder? defaultToolbarBuilder;
+
+  /// Paints some extra visual ornamentation to help with
+  /// debugging, when `true`.
+  final bool showDebugPaint;
 
   final Widget? child;
 
@@ -1515,7 +1520,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     return Stack(
       children: [
         _buildMagnifierFocalPoint(),
-        _buildDebugSelectionFocalPoint(),
+        if (widget.showDebugPaint) //
+          _buildDebugSelectionFocalPoint(),
         _buildMagnifier(),
         // Handles and toolbar are built after the magnifier so that they don't appear in the magnifier.
         _buildCollapsedHandle(),

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1531,7 +1531,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       valueListenable: _controlsController!.shouldShowCollapsedHandle,
       builder: (context, shouldShow, child) {
         final selection = widget.selection.value;
-        if (selection == null || selection.isCollapsed) {
+        if (selection == null || !selection.isCollapsed) {
           // When the user double taps we first place a collapsed selection
           // and then an expanded selection.
           // Return a SizedBox to avoid flashing the collapsed drag handle.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -1529,13 +1530,20 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     return ValueListenableBuilder(
       valueListenable: _controlsController!.shouldShowCollapsedHandle,
       builder: (context, shouldShow, child) {
+        final selection = widget.selection.value;
+        if (selection == null || selection.isCollapsed) {
+          // When the user double taps we first place a collapsed selection
+          // and then an expanded selection.
+          // Return a SizedBox to avoid flashing the collapsed drag handle.
+          return const SizedBox();
+        }
+
         // Note: If we pass this widget as the `child` property, it causes repeated starts and stops
         // of the pan gesture. By building it here, pan events work as expected.
         return Follower.withOffset(
           link: _controlsController!.collapsedHandleFocalPoint,
           leaderAnchor: Alignment.bottomCenter,
           followerAnchor: Alignment.topCenter,
-          showWhenUnlinked: false,
           child: AnimatedOpacity(
             // When the controller doesn't want the handle to be visible, hide it.
             opacity: shouldShow ? 1.0 : 0.0,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1535,6 +1535,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
           link: _controlsController!.collapsedHandleFocalPoint,
           leaderAnchor: Alignment.bottomCenter,
           followerAnchor: Alignment.topCenter,
+          showWhenUnlinked: false,
           child: AnimatedOpacity(
             // When the controller doesn't want the handle to be visible, hide it.
             opacity: shouldShow ? 1.0 : 0.0,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
[SuperEditor][Android] Make selection focal point debug visuals hidden by default (Resolves #1722)

On Android, dragging a handle is causing a red dot to appear. 

https://github.com/superlistapp/super_editor/assets/6467808/57f75372-e2a1-4360-b456-e8d3b43157e8

This is because we are always adding a debug paint information.

This PR adds a `showDebugPaint` to control whether or not we want that debug information. 