### PR TITLE
[SuperEditor][Android] Make selection focal point debug visuals hidden by default (Resolves #1722)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1271,6 +1271,7 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
     required this.scrollChangeSignal,
     required this.dragHandleAutoScroller,
     this.defaultToolbarBuilder,
+    this.showDebugPaint = false,
     this.child,
   });
 
@@ -1287,6 +1288,10 @@ class SuperEditorAndroidControlsOverlayManager extends StatefulWidget {
   final ValueListenable<DragHandleAutoScroller?> dragHandleAutoScroller;
 
   final DocumentFloatingToolbarBuilder? defaultToolbarBuilder;
+
+  /// Paints some extra visual ornamentation to help with
+  /// debugging, when `true`.
+  final bool showDebugPaint;
 
   final Widget? child;
 
@@ -1528,7 +1533,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       child: Stack(
         children: [
           _buildMagnifierFocalPoint(),
-          _buildDebugSelectionFocalPoint(),
+          if (widget.showDebugPaint) //
+            _buildDebugSelectionFocalPoint(),
           _buildMagnifier(),
           // Handles and toolbar are built after the magnifier so that they don't appear in the magnifier.
           _buildCollapsedHandle(),


### PR DESCRIPTION
[SuperEditor][Android] Make selection focal point debug visuals hidden by default (Resolves #1722)

On Android, dragging a handle is causing a red dot to appear. 

https://github.com/superlistapp/super_editor/assets/6467808/57f75372-e2a1-4360-b456-e8d3b43157e8

This is because we are always adding a debug paint information.

This PR adds a `showDebugPaint` to control whether or not we want that debug information. 