### PR TITLE
[SuperEditor][Android] Fix caret not blinking with autofocus (Resolves #1723)

### DIFF
--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -57,6 +57,9 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   @visibleForTesting
   bool get isCaretVisible => _blinkController.opacity == 1.0;
 
+  @visibleForTesting
+  Duration get caretFlashPeriod => _blinkController.flashPeriod;
+
   @override
   void initState() {
     super.initState();

--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -52,8 +52,10 @@ class CaretDocumentOverlay extends DocumentLayoutLayerStatefulWidget {
 @visibleForTesting
 class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOverlay, Rect?>
     with SingleTickerProviderStateMixin {
+  late final BlinkController _blinkController;
+
   @visibleForTesting
-  late final BlinkController blinkController;
+  bool get isCaretVisible => _blinkController.opacity == 1.0;
 
   @override
   void initState() {
@@ -61,9 +63,9 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
 
     switch (widget.blinkTimingMode) {
       case BlinkTimingMode.ticker:
-        blinkController = BlinkController(tickerProvider: this);
+        _blinkController = BlinkController(tickerProvider: this);
       case BlinkTimingMode.timer:
-        blinkController = BlinkController.withTimer();
+        _blinkController = BlinkController.withTimer();
     }
 
     widget.composer.selectionNotifier.addListener(_onSelectionChange);
@@ -87,7 +89,7 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   void dispose() {
     widget.composer.selectionNotifier.removeListener(_onSelectionChange);
 
-    blinkController.dispose();
+    _blinkController.dispose();
 
     super.dispose();
   }
@@ -106,27 +108,27 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
   void _startOrStopBlinking() {
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
     final wantsToBlink = widget.composer.selection != null;
-    if (wantsToBlink && blinkController.isBlinking) {
+    if (wantsToBlink && _blinkController.isBlinking) {
       return;
     }
-    if (!wantsToBlink && !blinkController.isBlinking) {
+    if (!wantsToBlink && !_blinkController.isBlinking) {
       return;
     }
 
     wantsToBlink //
-        ? blinkController.startBlinking()
-        : blinkController.stopBlinking();
+        ? _blinkController.startBlinking()
+        : _blinkController.stopBlinking();
   }
 
   void _updateCaretFlash() {
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
     final documentSelection = widget.composer.selection;
     if (documentSelection == null) {
-      blinkController.stopBlinking();
+      _blinkController.stopBlinking();
       return;
     }
 
-    blinkController.jumpToOpaque();
+    _blinkController.jumpToOpaque();
     _startOrStopBlinking();
   }
 
@@ -170,13 +172,13 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
                 left: caret.left,
                 height: caret.height,
                 child: AnimatedBuilder(
-                  animation: blinkController,
+                  animation: _blinkController,
                   builder: (context, child) {
                     return Container(
                       key: DocumentKeys.caret,
                       width: widget.caretStyle.width,
                       decoration: BoxDecoration(
-                        color: widget.caretStyle.color.withOpacity(blinkController.opacity),
+                        color: widget.caretStyle.color.withOpacity(_blinkController.opacity),
                         borderRadius: widget.caretStyle.borderRadius,
                       ),
                     );

--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -46,12 +46,14 @@ class CaretDocumentOverlay extends DocumentLayoutLayerStatefulWidget {
   final BlinkTimingMode blinkTimingMode;
 
   @override
-  DocumentLayoutLayerState<CaretDocumentOverlay, Rect?> createState() => _CaretDocumentOverlayState();
+  DocumentLayoutLayerState<CaretDocumentOverlay, Rect?> createState() => CaretDocumentOverlayState();
 }
 
-class _CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOverlay, Rect?>
+@visibleForTesting
+class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOverlay, Rect?>
     with SingleTickerProviderStateMixin {
-  late final BlinkController _blinkController;
+  @visibleForTesting
+  late final BlinkController blinkController;
 
   @override
   void initState() {
@@ -59,9 +61,9 @@ class _CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentO
 
     switch (widget.blinkTimingMode) {
       case BlinkTimingMode.ticker:
-        _blinkController = BlinkController(tickerProvider: this);
+        blinkController = BlinkController(tickerProvider: this);
       case BlinkTimingMode.timer:
-        _blinkController = BlinkController.withTimer();
+        blinkController = BlinkController.withTimer();
     }
 
     widget.composer.selectionNotifier.addListener(_onSelectionChange);
@@ -85,7 +87,7 @@ class _CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentO
   void dispose() {
     widget.composer.selectionNotifier.removeListener(_onSelectionChange);
 
-    _blinkController.dispose();
+    blinkController.dispose();
 
     super.dispose();
   }
@@ -104,27 +106,27 @@ class _CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentO
   void _startOrStopBlinking() {
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
     final wantsToBlink = widget.composer.selection != null;
-    if (wantsToBlink && _blinkController.isBlinking) {
+    if (wantsToBlink && blinkController.isBlinking) {
       return;
     }
-    if (!wantsToBlink && !_blinkController.isBlinking) {
+    if (!wantsToBlink && !blinkController.isBlinking) {
       return;
     }
 
     wantsToBlink //
-        ? _blinkController.startBlinking()
-        : _blinkController.stopBlinking();
+        ? blinkController.startBlinking()
+        : blinkController.stopBlinking();
   }
 
   void _updateCaretFlash() {
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
     final documentSelection = widget.composer.selection;
     if (documentSelection == null) {
-      _blinkController.stopBlinking();
+      blinkController.stopBlinking();
       return;
     }
 
-    _blinkController.jumpToOpaque();
+    blinkController.jumpToOpaque();
     _startOrStopBlinking();
   }
 
@@ -168,13 +170,13 @@ class _CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentO
                 left: caret.left,
                 height: caret.height,
                 child: AnimatedBuilder(
-                  animation: _blinkController,
+                  animation: blinkController,
                   builder: (context, child) {
                     return Container(
                       key: DocumentKeys.caret,
                       width: widget.caretStyle.width,
                       decoration: BoxDecoration(
-                        color: widget.caretStyle.color.withOpacity(_blinkController.opacity),
+                        color: widget.caretStyle.color.withOpacity(blinkController.opacity),
                         borderRadius: widget.caretStyle.borderRadius,
                       ),
                     );

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -133,7 +133,7 @@ class SuperEditorAndroidControlsController {
 
   /// Whether the caret should blink right now.
   ValueListenable<bool> get shouldCaretBlink => _shouldCaretBlink;
-  final _shouldCaretBlink = ValueNotifier<bool>(false);
+  final _shouldCaretBlink = ValueNotifier<bool>(true);
 
   /// Tells the caret to blink by setting [shouldCaretBlink] to `true`.
   void blinkCaret() {

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -178,7 +178,8 @@ class AndroidHandlesDocumentLayer extends DocumentLayoutLayerStatefulWidget {
 class AndroidControlsDocumentLayerState
     extends DocumentLayoutLayerState<AndroidHandlesDocumentLayer, DocumentSelectionLayout>
     with SingleTickerProviderStateMixin {
-  late BlinkController _caretBlinkController;
+  @visibleForTesting
+  late BlinkController caretBlinkController;
 
   SuperEditorAndroidControlsController? _controlsController;
 
@@ -187,7 +188,7 @@ class AndroidControlsDocumentLayerState
   @override
   void initState() {
     super.initState();
-    _caretBlinkController = BlinkController(tickerProvider: this);
+    caretBlinkController = BlinkController(tickerProvider: this);
 
     _previousSelection = widget.selection.value;
     widget.selection.addListener(_onSelectionChange);
@@ -223,7 +224,7 @@ class AndroidControlsDocumentLayerState
     widget.selection.removeListener(_onSelectionChange);
     _controlsController?.shouldCaretBlink.removeListener(_onBlinkModeChange);
 
-    _caretBlinkController.dispose();
+    caretBlinkController.dispose();
     super.dispose();
   }
 
@@ -266,14 +267,14 @@ class AndroidControlsDocumentLayerState
 
   void _onBlinkModeChange() {
     if (_controlsController!.shouldCaretBlink.value) {
-      _caretBlinkController.startBlinking();
+      caretBlinkController.startBlinking();
     } else {
-      _caretBlinkController.stopBlinking();
+      caretBlinkController.stopBlinking();
     }
   }
 
   void _caretJumpToOpaque() {
-    _caretBlinkController.jumpToOpaque();
+    caretBlinkController.jumpToOpaque();
   }
 
   @override
@@ -345,11 +346,11 @@ class AndroidControlsDocumentLayerState
       child: Leader(
         link: _controlsController!.collapsedHandleFocalPoint,
         child: ListenableBuilder(
-          listenable: _caretBlinkController,
+          listenable: caretBlinkController,
           builder: (context, child) {
             return ColoredBox(
               key: DocumentKeys.caret,
-              color: caretColor.withOpacity(_caretBlinkController.opacity),
+              color: caretColor.withOpacity(caretBlinkController.opacity),
             );
           },
         ),

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -178,8 +178,7 @@ class AndroidHandlesDocumentLayer extends DocumentLayoutLayerStatefulWidget {
 class AndroidControlsDocumentLayerState
     extends DocumentLayoutLayerState<AndroidHandlesDocumentLayer, DocumentSelectionLayout>
     with SingleTickerProviderStateMixin {
-  @visibleForTesting
-  late BlinkController caretBlinkController;
+  late BlinkController _caretBlinkController;
 
   SuperEditorAndroidControlsController? _controlsController;
 
@@ -188,7 +187,7 @@ class AndroidControlsDocumentLayerState
   @override
   void initState() {
     super.initState();
-    caretBlinkController = BlinkController(tickerProvider: this);
+    _caretBlinkController = BlinkController(tickerProvider: this);
 
     _previousSelection = widget.selection.value;
     widget.selection.addListener(_onSelectionChange);
@@ -224,7 +223,7 @@ class AndroidControlsDocumentLayerState
     widget.selection.removeListener(_onSelectionChange);
     _controlsController?.shouldCaretBlink.removeListener(_onBlinkModeChange);
 
-    caretBlinkController.dispose();
+    _caretBlinkController.dispose();
     super.dispose();
   }
 
@@ -236,6 +235,9 @@ class AndroidControlsDocumentLayerState
 
   @visibleForTesting
   bool get isCaretDisplayed => layoutData?.caret != null;
+
+  @visibleForTesting
+  bool get isCaretVisible => _caretBlinkController.opacity == 1.0;
 
   @visibleForTesting
   bool get isUpstreamHandleDisplayed => layoutData?.upstream != null;
@@ -267,14 +269,14 @@ class AndroidControlsDocumentLayerState
 
   void _onBlinkModeChange() {
     if (_controlsController!.shouldCaretBlink.value) {
-      caretBlinkController.startBlinking();
+      _caretBlinkController.startBlinking();
     } else {
-      caretBlinkController.stopBlinking();
+      _caretBlinkController.stopBlinking();
     }
   }
 
   void _caretJumpToOpaque() {
-    caretBlinkController.jumpToOpaque();
+    _caretBlinkController.jumpToOpaque();
   }
 
   @override
@@ -346,11 +348,11 @@ class AndroidControlsDocumentLayerState
       child: Leader(
         link: _controlsController!.collapsedHandleFocalPoint,
         child: ListenableBuilder(
-          listenable: caretBlinkController,
+          listenable: _caretBlinkController,
           builder: (context, child) {
             return ColoredBox(
               key: DocumentKeys.caret,
-              color: caretColor.withOpacity(caretBlinkController.opacity),
+              color: caretColor.withOpacity(_caretBlinkController.opacity),
             );
           },
         ),

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -240,6 +240,9 @@ class AndroidControlsDocumentLayerState
   bool get isCaretVisible => _caretBlinkController.opacity == 1.0;
 
   @visibleForTesting
+  Duration get caretFlashPeriod => _caretBlinkController.flashPeriod;
+
+  @visibleForTesting
   bool get isUpstreamHandleDisplayed => layoutData?.upstream != null;
 
   @visibleForTesting

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -559,12 +559,13 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   final _upstreamHandleKey = GlobalKey();
   final _downstreamHandleKey = GlobalKey();
 
-  late BlinkController _caretBlinkController;
+  @visibleForTesting
+  late BlinkController caretBlinkController;
 
   @override
   void initState() {
     super.initState();
-    _caretBlinkController = BlinkController(tickerProvider: this);
+    caretBlinkController = BlinkController(tickerProvider: this);
 
     widget.selection.addListener(_onSelectionChange);
     widget.shouldCaretBlink.addListener(_onBlinkModeChange);
@@ -599,7 +600,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
     widget.shouldCaretBlink.removeListener(_onBlinkModeChange);
     widget.floatingCursorController?.isActive.removeListener(_onFloatingCursorActivationChange);
 
-    _caretBlinkController.dispose();
+    caretBlinkController.dispose();
     super.dispose();
   }
 
@@ -626,17 +627,17 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 
   void _onBlinkModeChange() {
     if (widget.shouldCaretBlink.value) {
-      _caretBlinkController.startBlinking();
+      caretBlinkController.startBlinking();
     } else {
-      _caretBlinkController.stopBlinking();
+      caretBlinkController.stopBlinking();
     }
   }
 
   void _onFloatingCursorActivationChange() {
     if (widget.floatingCursorController?.isActive.value == true) {
-      _caretBlinkController.stopBlinking();
+      caretBlinkController.stopBlinking();
     } else {
-      _caretBlinkController.startBlinking();
+      caretBlinkController.startBlinking();
     }
   }
 
@@ -728,7 +729,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 
           return IOSCollapsedHandle(
             key: DocumentKeys.caret,
-            controller: _caretBlinkController,
+            controller: caretBlinkController,
             color: isShowingFloatingCursor ? Colors.grey : widget.handleColor,
             caretHeight: caret.height,
           );

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -559,13 +559,12 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   final _upstreamHandleKey = GlobalKey();
   final _downstreamHandleKey = GlobalKey();
 
-  @visibleForTesting
-  late BlinkController caretBlinkController;
+  late BlinkController _caretBlinkController;
 
   @override
   void initState() {
     super.initState();
-    caretBlinkController = BlinkController(tickerProvider: this);
+    _caretBlinkController = BlinkController(tickerProvider: this);
 
     widget.selection.addListener(_onSelectionChange);
     widget.shouldCaretBlink.addListener(_onBlinkModeChange);
@@ -600,7 +599,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
     widget.shouldCaretBlink.removeListener(_onBlinkModeChange);
     widget.floatingCursorController?.isActive.removeListener(_onFloatingCursorActivationChange);
 
-    caretBlinkController.dispose();
+    _caretBlinkController.dispose();
     super.dispose();
   }
 
@@ -612,6 +611,9 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 
   @visibleForTesting
   bool get isCaretDisplayed => layoutData?.caret != null;
+
+  @visibleForTesting
+  bool get isCaretVisible => _caretBlinkController.opacity == 1.0;
 
   @visibleForTesting
   bool get isUpstreamHandleDisplayed => layoutData?.upstream != null;
@@ -627,17 +629,17 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 
   void _onBlinkModeChange() {
     if (widget.shouldCaretBlink.value) {
-      caretBlinkController.startBlinking();
+      _caretBlinkController.startBlinking();
     } else {
-      caretBlinkController.stopBlinking();
+      _caretBlinkController.stopBlinking();
     }
   }
 
   void _onFloatingCursorActivationChange() {
     if (widget.floatingCursorController?.isActive.value == true) {
-      caretBlinkController.stopBlinking();
+      _caretBlinkController.stopBlinking();
     } else {
-      caretBlinkController.startBlinking();
+      _caretBlinkController.startBlinking();
     }
   }
 
@@ -729,7 +731,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
 
           return IOSCollapsedHandle(
             key: DocumentKeys.caret,
-            controller: caretBlinkController,
+            controller: _caretBlinkController,
             color: isShowingFloatingCursor ? Colors.grey : widget.handleColor,
             caretHeight: caret.height,
           );

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -616,6 +616,9 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   bool get isCaretVisible => _caretBlinkController.opacity == 1.0;
 
   @visibleForTesting
+  Duration get caretFlashPeriod => _caretBlinkController.flashPeriod;
+
+  @visibleForTesting
   bool get isUpstreamHandleDisplayed => layoutData?.upstream != null;
 
   @visibleForTesting

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -403,41 +403,35 @@ class SuperEditorInspector {
   /// {@macro supereditor_finder}
   static bool isCaretVisible([Finder? superEditorFinder]) {
     if (defaultTargetPlatform == TargetPlatform.android) {
-      final element = find
-          .descendant(
-            of: (superEditorFinder ?? find.byType(SuperEditor)),
-            matching: find.byType(AndroidHandlesDocumentLayer),
-          )
-          .evaluate()
-          .single as StatefulElement;
-
-      final androidCaretLayerState = element.state as AndroidControlsDocumentLayerState;
+      final androidCaretLayerState = _findAndroidControlsLayer(superEditorFinder);
       return androidCaretLayerState.isCaretVisible;
     }
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      final element = find
-          .descendant(
-            of: (superEditorFinder ?? find.byType(SuperEditor)),
-            matching: find.byType(IosHandlesDocumentLayer),
-          )
-          .evaluate()
-          .single as StatefulElement;
-
-      final iOSCaretLayer = element.state as IosControlsDocumentLayerState;
+      final iOSCaretLayer = _findIosControlsLayer(superEditorFinder);
       return iOSCaretLayer.isCaretVisible;
     }
 
-    final element = find
-        .descendant(
-          of: (superEditorFinder ?? find.byType(SuperEditor)),
-          matching: find.byType(CaretDocumentOverlay),
-        )
-        .evaluate()
-        .single as StatefulElement;
-
-    final desktopCaretLayer = element.state as CaretDocumentOverlayState;
+    final desktopCaretLayer = _findDesktopCaretOverlay(superEditorFinder);
     return desktopCaretLayer.isCaretVisible;
+  }
+
+  /// Returns the [Duration] to switch the caret between visible and invisible.
+  ///
+  /// {@macro supereditor_finder}
+  static Duration caretFlashPeriod([Finder? superEditorFinder]) {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      final androidCaretLayerState = _findAndroidControlsLayer(superEditorFinder);
+      return androidCaretLayerState.caretFlashPeriod;
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final iOSCaretLayer = _findIosControlsLayer(superEditorFinder);
+      return iOSCaretLayer.caretFlashPeriod;
+    }
+
+    final desktopCaretLayer = _findDesktopCaretOverlay(superEditorFinder);
+    return desktopCaretLayer.caretFlashPeriod;
   }
 
   static Finder findMobileCaretDragHandle([Finder? superEditorFinder]) {
@@ -493,6 +487,42 @@ class SuperEditorInspector {
       case TargetPlatform.fuchsia:
         return FindsNothing();
     }
+  }
+
+  static AndroidControlsDocumentLayerState _findAndroidControlsLayer([Finder? superEditorFinder]) {
+    final element = find
+        .descendant(
+          of: (superEditorFinder ?? find.byType(SuperEditor)),
+          matching: find.byType(AndroidHandlesDocumentLayer),
+        )
+        .evaluate()
+        .single as StatefulElement;
+
+    return element.state as AndroidControlsDocumentLayerState;
+  }
+
+  static IosControlsDocumentLayerState _findIosControlsLayer([Finder? superEditorFinder]) {
+    final element = find
+        .descendant(
+          of: (superEditorFinder ?? find.byType(SuperEditor)),
+          matching: find.byType(IosHandlesDocumentLayer),
+        )
+        .evaluate()
+        .single as StatefulElement;
+
+    return element.state as IosControlsDocumentLayerState;
+  }
+
+  static CaretDocumentOverlayState _findDesktopCaretOverlay([Finder? superEditorFinder]) {
+    final element = find
+        .descendant(
+          of: (superEditorFinder ?? find.byType(SuperEditor)),
+          matching: find.byType(CaretDocumentOverlay),
+        )
+        .evaluate()
+        .single as StatefulElement;
+
+    return element.state as CaretDocumentOverlayState;
   }
 
   SuperEditorInspector._();

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -397,6 +397,49 @@ class SuperEditorInspector {
     }
   }
 
+  /// Returns `true` if the caret is currently visible and 100% opaque, or `false` if it's
+  /// not.
+  ///
+  /// {@macro supereditor_finder}
+  static bool isCaretVisible([Finder? superEditorFinder]) {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      final element = find
+          .descendant(
+            of: (superEditorFinder ?? find.byType(SuperEditor)),
+            matching: find.byType(AndroidHandlesDocumentLayer),
+          )
+          .evaluate()
+          .single as StatefulElement;
+
+      final androidCaretLayerState = element.state as AndroidControlsDocumentLayerState;
+      return androidCaretLayerState.isCaretVisible;
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      final element = find
+          .descendant(
+            of: (superEditorFinder ?? find.byType(SuperEditor)),
+            matching: find.byType(IosHandlesDocumentLayer),
+          )
+          .evaluate()
+          .single as StatefulElement;
+
+      final iOSCaretLayer = element.state as IosControlsDocumentLayerState;
+      return iOSCaretLayer.isCaretVisible;
+    }
+
+    final element = find
+        .descendant(
+          of: (superEditorFinder ?? find.byType(SuperEditor)),
+          matching: find.byType(CaretDocumentOverlay),
+        )
+        .evaluate()
+        .single as StatefulElement;
+
+    final desktopCaretLayer = element.state as CaretDocumentOverlayState;
+    return desktopCaretLayer.isCaretVisible;
+  }
+
   static Finder findMobileCaretDragHandle([Finder? superEditorFinder]) {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import 'supereditor_test_tools.dart';
 
@@ -326,6 +328,81 @@ void main() {
         });
       });
     });
+
+    group('blinks caret at rest', () {
+      // Duration to switch between visible and invisible.
+      const flashPeriod = Duration(milliseconds: 500);
+
+      testWidgetsOnAllPlatforms('with autofocus', (tester) async {
+        // Configure BlinkController to animate, otherwise it won't blink.
+        BlinkController.indeterminateAnimationsEnabled = true;
+        addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .autoFocus(true)
+            .withSelection(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            )
+            .pump();
+
+        // Ensure caret is visible at start.
+        expect(_isCaretVisible(tester), true);
+
+        // Trigger a frame with an ellapsed time equal to the flashPeriod,
+        // so the caret should change from visible to invisible.
+        await tester.pump(flashPeriod);
+
+        // Ensure caret is invisible after the flash period.
+        expect(_isCaretVisible(tester), false);
+
+        // Trigger another frame to make caret visible again.
+        await tester.pump(flashPeriod);
+
+        // Ensure caret is visible.
+        expect(_isCaretVisible(tester), true);
+      });
+
+      testWidgetsOnAllPlatforms('when focused by tap', (tester) async {
+        // Configure BlinkController to animate, otherwise it won't blink.
+        BlinkController.indeterminateAnimationsEnabled = true;
+        addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .pump();
+
+        // Tap to place the caret at the beginning of the document.
+        // We don't use the robot method here because it calls pumpAndSettle,
+        // which causes a pumpAndSettle timeout, because we are constantly
+        // scheduling frames.
+        await tester.tap(find.byType(SuperEditor));
+        await tester.pump();
+
+        // Ensure caret is visible.
+        expect(_isCaretVisible(tester), true);
+
+        // Trigger a frame with an ellapsed time equal to the flashPeriod,
+        // so the caret should change from visible to invisible.
+        await tester.pump(flashPeriod);
+
+        // Ensure caret is invisible after the flash period.
+        expect(_isCaretVisible(tester), false);
+
+        // Trigger another frame to make caret visible again.
+        await tester.pump(flashPeriod);
+
+        // Ensure caret is visible.
+        expect(_isCaretVisible(tester), true);
+      });
+    });
   });
 }
 
@@ -408,4 +485,22 @@ Future<void> _resizeWindow({
     tester.view.physicalSize = currentScreenSize;
     await tester.pumpAndSettle();
   }
+}
+
+bool _isCaretVisible(WidgetTester tester) {
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    final androidCaretLayerState =
+        tester.state<AndroidControlsDocumentLayerState>(find.byType(AndroidHandlesDocumentLayer));
+
+    return androidCaretLayerState.caretBlinkController.opacity == 1.0;
+  }
+
+  if (defaultTargetPlatform == TargetPlatform.iOS) {
+    final iOSCaretLayer = tester.state<IosControlsDocumentLayerState>(find.byType(IosHandlesDocumentLayer));
+
+    return iOSCaretLayer.caretBlinkController.opacity == 1.0;
+  }
+
+  final desktopCaretLayer = tester.state<CaretDocumentOverlayState>(find.byType(CaretDocumentOverlay));
+  return desktopCaretLayer.blinkController.opacity == 1.0;
 }

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -328,13 +328,10 @@ void main() {
       });
     });
 
-    testWidgetsOnAllPlatforms('blinks caret when focused by tap', (tester) async {
+    testWidgetsOnAllPlatforms('blinks the caret when the user places the caret with a single tap', (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink.
       BlinkController.indeterminateAnimationsEnabled = true;
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
-
-      // Duration to switch between visible and invisible.
-      const flashPeriod = Duration(milliseconds: 500);
 
       await tester //
           .createDocument()
@@ -350,6 +347,9 @@ void main() {
 
       // Ensure caret is visible.
       expect(SuperEditorInspector.isCaretVisible(), true);
+
+      // Duration to switch between visible and invisible.
+      final flashPeriod = SuperEditorInspector.caretFlashPeriod();
 
       // Trigger a frame with an ellapsed time equal to the flashPeriod,
       // so the caret should change from visible to invisible.

--- a/super_editor/test/super_editor/supereditor_initialization_test.dart
+++ b/super_editor/test/super_editor/supereditor_initialization_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > initialization >', () {
+    testWidgetsOnAllPlatforms('blinks caret when autofocus is true', (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      // Duration to switch between visible and invisible.
+      const flashPeriod = Duration(milliseconds: 500);
+
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .autoFocus(true)
+          .withSelection(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          )
+          .pump();
+
+      // Ensure caret is visible at start.
+      expect(SuperEditorInspector.isCaretVisible(), true);
+
+      // Trigger a frame with an ellapsed time equal to the flashPeriod,
+      // so the caret should change from visible to invisible.
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is invisible after the flash period.
+      expect(SuperEditorInspector.isCaretVisible(), false);
+
+      // Trigger another frame to make caret visible again.
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(SuperEditorInspector.isCaretVisible(), true);
+    });
+  });
+}

--- a/super_editor/test/super_editor/supereditor_initialization_test.dart
+++ b/super_editor/test/super_editor/supereditor_initialization_test.dart
@@ -10,13 +10,10 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor > initialization >', () {
-    testWidgetsOnAllPlatforms('blinks caret when autofocus is true', (tester) async {
+    testWidgetsOnAllPlatforms('immediately shows and blinks the caret when autofocus is true', (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink.
       BlinkController.indeterminateAnimationsEnabled = true;
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
-
-      // Duration to switch between visible and invisible.
-      const flashPeriod = Duration(milliseconds: 500);
 
       await tester //
           .createDocument()
@@ -34,6 +31,9 @@ void main() {
 
       // Ensure caret is visible at start.
       expect(SuperEditorInspector.isCaretVisible(), true);
+
+      // Duration to switch between visible and invisible.
+      final flashPeriod = SuperEditorInspector.caretFlashPeriod();
 
       // Trigger a frame with an ellapsed time equal to the flashPeriod,
       // so the caret should change from visible to invisible.

--- a/super_text_layout/lib/src/infrastructure/blink_controller.dart
+++ b/super_text_layout/lib/src/infrastructure/blink_controller.dart
@@ -41,9 +41,13 @@ class BlinkController with ChangeNotifier {
 
   final Duration _flashPeriod;
 
+  /// Duration to switch between visible and invisible.
+  Duration get flashPeriod => _flashPeriod;
+
   /// Returns `true` if this controller is currently animating a blinking
   /// signal, or `false` if it's not.
-  bool get isBlinking => (_ticker != null || _timer != null) && (_ticker != null ? _ticker!.isTicking : _timer?.isActive ?? false);
+  bool get isBlinking =>
+      (_ticker != null || _timer != null) && (_ticker != null ? _ticker!.isTicking : _timer?.isActive ?? false);
 
   bool _isBlinkingEnabled = true;
   set isBlinkingEnabled(bool newValue) {


### PR DESCRIPTION
[SuperEditor][Android] Fix caret not blinking with autofocus. Resolves #1723

When the editor has autofocus, the caret is display, but it doesn't blink. We had a similar issue on iOS, which was fixed in https://github.com/superlistapp/super_editor/pull/1575

This PR applies the same solution.