### PR TITLE
[SuperEditor][SuperReader] Adds tests editor's scrolling when present within parent scrollable

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -4,14 +4,14 @@ import 'package:super_editor/super_editor.dart';
 MutableDocument createInitialDocument() {
   return MutableDocument(
     nodes: [
-      ImageNode(
-        id: "1",
-        imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
-        metadata: const SingleColumnLayoutComponentStyles(
-          width: double.infinity,
-          padding: EdgeInsets.zero,
-        ).toMetadata(),
-      ),
+      // ImageNode(
+      //   id: "1",
+      //   imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
+      //   metadata: const SingleColumnLayoutComponentStyles(
+      //     width: double.infinity,
+      //     padding: EdgeInsets.zero,
+      //   ).toMetadata(),
+      // ),
       ParagraphNode(
         id: Editor.createNodeId(),
         text: AttributedText('Welcome to Super Editor 💙 🚀'),

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -259,6 +259,43 @@ class _ExampleEditorState extends State<ExampleEditor> {
 
   @override
   Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          return ListView(
+            children: [
+              SizedBox(
+                height: MediaQuery.of(context).size.height * 0.5,
+                width: double.infinity,
+                child: const Placeholder(
+                  child: Center(
+                    child: Text("Content"),
+                  ),
+                ),
+              ),
+              SizedBox(
+                height: 350,
+                width: double.infinity,
+                child: ListView(
+                  children: [
+                    _buildEditor(context),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: MediaQuery.of(context).size.height,
+                width: double.infinity,
+                child: const Placeholder(
+                  child: Center(
+                    child: Text("Content"),
+                  ),
+                ),
+              ),
+            ],
+          );
+        }),
+      ),
+    );
     return ValueListenableBuilder(
       valueListenable: _brightness,
       builder: (context, brightness, child) {
@@ -374,26 +411,24 @@ class _ExampleEditorState extends State<ExampleEditor> {
           key: _viewportKey,
           child: SuperEditorIosControlsScope(
             controller: _iosControlsController,
-            child: SuperEditor(
-              editor: _docEditor,
+            child: SuperReader(
               document: _doc,
-              composer: _composer,
               focusNode: _editorFocusNode,
               scrollController: _scrollController,
               documentLayoutKey: _docLayoutKey,
-              documentOverlayBuilders: [
-                DefaultCaretOverlayBuilder(
-                  caretStyle: const CaretStyle().copyWith(color: isLight ? Colors.black : Colors.redAccent),
-                ),
-                if (defaultTargetPlatform == TargetPlatform.iOS) ...[
-                  SuperEditorIosHandlesDocumentLayerBuilder(),
-                  SuperEditorIosToolbarFocalPointDocumentLayerBuilder(),
-                ],
-                if (defaultTargetPlatform == TargetPlatform.android) ...[
-                  SuperEditorAndroidToolbarFocalPointDocumentLayerBuilder(),
-                  SuperEditorAndroidHandlesDocumentLayerBuilder(),
-                ],
-              ],
+              // documentOverlayBuilders: [
+              //   DefaultCaretOverlayBuilder(
+              //     caretStyle: const CaretStyle().copyWith(color: isLight ? Colors.black : Colors.redAccent),
+              //   ),
+              //   if (defaultTargetPlatform == TargetPlatform.iOS) ...[
+              //     SuperEditorIosHandlesDocumentLayerBuilder(),
+              //     SuperEditorIosToolbarFocalPointDocumentLayerBuilder(),
+              //   ],
+              //   if (defaultTargetPlatform == TargetPlatform.android) ...[
+              //     SuperEditorAndroidToolbarFocalPointDocumentLayerBuilder(),
+              //     SuperEditorAndroidHandlesDocumentLayerBuilder(),
+              //   ],
+              // ],
               selectionLayerLinks: _selectionLayerLinks,
               selectionStyle: isLight
                   ? defaultSelectionStyle
@@ -411,8 +446,8 @@ class _ExampleEditorState extends State<ExampleEditor> {
                 ...defaultComponentBuilders,
               ],
               gestureMode: _gestureMode,
-              inputSource: _inputSource,
-              keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
+              // inputSource: _inputSource,
+              // keyboardActions: _inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions,
               androidToolbarBuilder: (_) => _buildAndroidFloatingToolbar(),
               overlayController: _overlayController,
             ),

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -1191,7 +1191,8 @@ void main() {
 
           final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
 
-          // Scroll an arbitrary amount in the page before we attempt to scroll the editor.
+          // Scroll an arbitrary amount in the page. This is to test scrolling up
+          // in page at the end.
           pageScrollable.position.jumpTo(100);
 
           // Hover to the editor's center.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -1130,7 +1130,7 @@ void main() {
       });
 
       group("when hovering over editor", () {
-        testWidgets("scroll down doesn't scroll the page untill editor's scrollable content is consumed",
+        testWidgets("scroll down scrolls ancestor scrollable after editor's scrollable content is consumed",
             (tester) async {
           await _pumpSuperEditorWithinScrollable(tester);
 
@@ -1172,10 +1172,11 @@ void main() {
           );
 
           // Ensure page is scrolled.
-          expect(pageScrollable.position.pixels, greaterThan(0));
+          expect(pageScrollable.position.pixels, 200);
         });
 
-        testWidgets("scroll up doesn't scroll the page untill editor's scrollable content is consumed", (tester) async {
+        testWidgets("scroll up scrolls ancestor scrollable after editor's scrollable content is consumed",
+            (tester) async {
           await _pumpSuperEditorWithinScrollable(tester);
 
           final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -1148,20 +1148,21 @@ void main() {
             find.ancestor(of: find.byType(SuperEditor), matching: find.byType(Scrollable)).first,
           ));
 
+          // Scroll to the editor's bottom.
           await tester.sendEventToBinding(
             testPointer.scroll(
               Offset(0, superEditorScrollable.position.maxScrollExtent),
             ),
           );
 
-          // Ensure parent scrollable isn't scrolled.
-          expect(pageScrollable.position.pixels, 0);
-
           // Ensure editor's is scrolled.
           expect(
             superEditorScrollable.position.pixels,
             greaterThan(0),
           );
+
+          // Ensure parent scrollable isn't scrolled.
+          expect(pageScrollable.position.pixels, 0);
 
           // Scroll down within the page.
           await tester.sendEventToBinding(
@@ -1189,17 +1190,8 @@ void main() {
 
           final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
 
-          testPointer.hover(
-            Offset.zero,
-          );
-
-          // Scroll down a little to introduce scrollable content we can scroll back to within
-          // the page.
-          await tester.sendEventToBinding(
-            testPointer.scroll(
-              const Offset(0, 100),
-            ),
-          );
+          // Scroll an arbitrary amount in the page before we attempt to scroll the editor.
+          pageScrollable.position.jumpTo(100);
 
           // Hover to the editor's center.
           testPointer.hover(

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -143,7 +143,7 @@ void main() {
       final firstParagraph = document.nodes.first as ParagraphNode;
       final lastParagraph = document.nodes.last as ParagraphNode;
 
-      // Place the caret at the end of the document, which causes the editor to
+      // Place the caret at the end of the document, which causes the reader to
       // scroll to the bottom.
       testDocContext.documentContext.selection.value = DocumentSelection.collapsed(
         position: DocumentPosition(
@@ -198,7 +198,7 @@ void main() {
       final lastParagraph = document.nodes.last as ParagraphNode;
 
       // Place the caret at the end of the document, which should cause the
-      // editor to scroll to the bottom.
+      // reader to scroll to the bottom.
       docContext.documentContext.selection.value = DocumentSelection.collapsed(
         position: DocumentPosition(
           nodeId: lastParagraph.id,
@@ -659,7 +659,7 @@ void main() {
           final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
           // Find reader's direct ancestor scrollable
-          final superEditorScrollable = tester.state<ScrollableState>(
+          final superReaderScrollable = tester.state<ScrollableState>(
             find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
           );
 
@@ -674,14 +674,14 @@ void main() {
 
           await tester.sendEventToBinding(
             testPointer.scroll(
-              Offset(0, superEditorScrollable.position.maxScrollExtent),
+              Offset(0, superReaderScrollable.position.maxScrollExtent),
             ),
           );
 
           // Ensure reader's is scrolled to the bottom.
           expect(
-            superEditorScrollable.position.pixels,
-            superEditorScrollable.position.maxScrollExtent,
+            superReaderScrollable.position.pixels,
+            superReaderScrollable.position.maxScrollExtent,
           );
 
           // Ensure page isn't scrolled.
@@ -706,16 +706,17 @@ void main() {
             final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
             // Find reader's direct ancestor scrollable.
-            final superEditorScrollable = tester.state<ScrollableState>(
+            final superReaderScrollable = tester.state<ScrollableState>(
               find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
             );
 
-            // Scroll the editor all the way to the bottom.
-            superEditorScrollable.position.jumpTo(superEditorScrollable.position.maxScrollExtent);
+            // Scroll the reader all the way to the bottom.
+            superReaderScrollable.position.jumpTo(superReaderScrollable.position.maxScrollExtent);
 
             final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
 
-            // Scroll an arbitrary amount in the page before we attempt to scroll the editor.
+            // Scroll an arbitrary amount in the page. This is to test scrolling up
+            // in page at the end.
             pageScrollable.position.jumpTo(100);
 
             // Hover to the reader's center.
@@ -725,16 +726,16 @@ void main() {
               ),
             );
 
-            // Scroll the editor all the way to the top.
+            // Scroll the reader all the way to the top.
             await tester.sendEventToBinding(
               testPointer.scroll(
-                Offset(0, -superEditorScrollable.position.maxScrollExtent),
+                Offset(0, -superReaderScrollable.position.maxScrollExtent),
               ),
             );
 
             // Ensure reader's is scrolled all the way to the top.
             expect(
-              superEditorScrollable.position.pixels,
+              superReaderScrollable.position.pixels,
               0,
             );
 

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -805,50 +805,6 @@ class _FixedHeightEditorWithinAncestorScrollable extends StatelessWidget {
   }
 }
 
-/// Creates a [SuperEditor] experience within an ancestor scrollable
-/// with scrollable editor content.
-Future<void> _pumpSuperEditorWithinScrollable(WidgetTester tester) async {
-  return;
-  await tester.createDocument().withLongTextContent().withCustomWidgetTreeBuilder((superReader) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Builder(builder: (context) {
-          return ListView(
-            children: [
-              SizedBox(
-                height: MediaQuery.of(context).size.height * 0.5,
-                width: double.infinity,
-                child: const Placeholder(
-                  child: Center(
-                    child: Text("Content"),
-                  ),
-                ),
-              ),
-              SizedBox(
-                height: 350,
-                child: ListView(
-                  children: [
-                    superReader,
-                  ],
-                ),
-              ),
-              SizedBox(
-                height: MediaQuery.of(context).size.height,
-                width: double.infinity,
-                child: const Placeholder(
-                  child: Center(
-                    child: Text("Content"),
-                  ),
-                ),
-              ),
-            ],
-          );
-        }),
-      ),
-    );
-  }).pump();
-}
-
 final _scrollDirectionVariant = ValueVariant<_ScrollDirection>({
   _ScrollDirection.up,
   _ScrollDirection.down,

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -654,7 +654,7 @@ void main() {
       group("when hovering over reader", () {
         testWidgets("scroll down scrolls ancestor scrollable after reader's scrollable content is consumed",
             (tester) async {
-          await tester.pumpWidget(const ScrollingWithinAncestorScrollable());
+          await tester.pumpWidget(const _FixedHeightEditorWithinAncestorScrollable());
 
           final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
@@ -701,7 +701,7 @@ void main() {
         testWidgets(
           "scroll up scrolls ancestor scrollable after reader's scrollable content is consumed",
           (tester) async {
-            await tester.pumpWidget(const ScrollingWithinAncestorScrollable());
+            await tester.pumpWidget(const _FixedHeightEditorWithinAncestorScrollable());
 
             final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
@@ -757,10 +757,10 @@ void main() {
   });
 }
 
-/// Creates a [SuperReader] experience within an ancestor scrollable
-/// with scrollable editor content.
-class ScrollingWithinAncestorScrollable extends StatelessWidget {
-  const ScrollingWithinAncestorScrollable({super.key});
+/// Creates a [SuperReader] experience with reader having a fixed height with
+/// scrollable content and is present within an ancestor scrollable.
+class _FixedHeightEditorWithinAncestorScrollable extends StatelessWidget {
+  const _FixedHeightEditorWithinAncestorScrollable({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -651,21 +651,21 @@ void main() {
         expect(scrollController.offset, scrollController.position.maxScrollExtent);
       });
 
-      group("when hovering over editor", () {
-        testWidgets("scroll down doesn't scroll the page untill editor's scrollable content is consumed",
+      group("when hovering over reader", () {
+        testWidgets("scroll down scrolls ancestor scrollable after reader's scrollable content is consumed",
             (tester) async {
           await tester.pumpWidget(const ScrollingWithinAncestorScrollable());
 
           final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
-          // Find editor's direct ancestor scrollable
+          // Find reader's direct ancestor scrollable
           final superEditorScrollable = tester.state<ScrollableState>(
             find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
           );
 
           final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
 
-          // Hover to the editor's center.
+          // Hover to the reader's center.
           testPointer.hover(
             tester.getCenter(
               find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
@@ -678,7 +678,7 @@ void main() {
             ),
           );
 
-          // Ensure editor's is scrolled to the bottom.
+          // Ensure reader's is scrolled to the bottom.
           expect(
             superEditorScrollable.position.pixels,
             superEditorScrollable.position.maxScrollExtent,
@@ -695,17 +695,17 @@ void main() {
           );
 
           // Ensure page is scrolled.
-          expect(pageScrollable.position.pixels, greaterThan(0));
+          expect(pageScrollable.position.pixels, 200);
         });
 
         testWidgets(
-          "scroll up doesn't scroll the page untill editor's scrollable content is consumed",
+          "scroll up scrolls ancestor scrollable after reader's scrollable content is consumed",
           (tester) async {
             await tester.pumpWidget(const ScrollingWithinAncestorScrollable());
 
             final pageScrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
 
-            // Find editor's direct ancestor scrollable.
+            // Find reader's direct ancestor scrollable.
             final superEditorScrollable = tester.state<ScrollableState>(
               find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
             );
@@ -718,7 +718,7 @@ void main() {
             // Scroll an arbitrary amount in the page before we attempt to scroll the editor.
             pageScrollable.position.jumpTo(100);
 
-            // Hover to the editor's center.
+            // Hover to the reader's center.
             testPointer.hover(
               tester.getCenter(
                 find.ancestor(of: find.byType(SuperReader), matching: find.byType(Scrollable)).first,
@@ -732,7 +732,7 @@ void main() {
               ),
             );
 
-            // Ensure editor's is scrolled all the way to the top.
+            // Ensure reader's is scrolled all the way to the top.
             expect(
               superEditorScrollable.position.pixels,
               0,
@@ -808,6 +808,7 @@ class ScrollingWithinAncestorScrollable extends StatelessWidget {
 /// Creates a [SuperEditor] experience within an ancestor scrollable
 /// with scrollable editor content.
 Future<void> _pumpSuperEditorWithinScrollable(WidgetTester tester) async {
+  return;
   await tester.createDocument().withLongTextContent().withCustomWidgetTreeBuilder((superReader) {
     return MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
[SuperEditor][SuperReader] Adds tests editor's scrolling when present within parent scrollable (Related #120)

This PR adds tests for locking down the behaviour for `SuperEditor` and `SuperReader` for the following scenario: 

When scrolling within a parent scrollable, makes sure parent scrollable is scrolled after all of the scrollable content is consumed within editor when the user's hovering over editor.