### PR TITLE
[SuperEditor][DemoApp] Fix image resizing (Resolves #1708)(Resolves #1529)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -838,7 +838,7 @@ class _ImageFormatToolbarState extends State<ImageFormatToolbar> {
                   onPressed: _makeImageConfined,
                   icon: const Icon(Icons.photo_size_select_large),
                   splashRadius: 16,
-                  tooltip: AppLocalizations.of(context)!.labelBold,
+                  tooltip: 'Limited width',
                 ),
               ),
               Center(
@@ -846,7 +846,7 @@ class _ImageFormatToolbarState extends State<ImageFormatToolbar> {
                   onPressed: _makeImageFullBleed,
                   icon: const Icon(Icons.photo_size_select_actual),
                   splashRadius: 16,
-                  tooltip: AppLocalizations.of(context)!.labelItalics,
+                  tooltip: 'Full width',
                 ),
               ),
             ],

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -838,7 +838,7 @@ class _ImageFormatToolbarState extends State<ImageFormatToolbar> {
                   onPressed: _makeImageConfined,
                   icon: const Icon(Icons.photo_size_select_large),
                   splashRadius: 16,
-                  tooltip: 'Limited width',
+                  tooltip: AppLocalizations.of(context)!.labelLimitedWidth,
                 ),
               ),
               Center(
@@ -846,7 +846,7 @@ class _ImageFormatToolbarState extends State<ImageFormatToolbar> {
                   onPressed: _makeImageFullBleed,
                   icon: const Icon(Icons.photo_size_select_actual),
                   splashRadius: 16,
-                  tooltip: 'Full width',
+                  tooltip: AppLocalizations.of(context)!.labelFullWidth,
                 ),
               ),
             ],

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -488,7 +488,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
         );
 
         _docEditor.execute([
-          ChangeComponentStylesRequest(
+          ChangeSingleColumnLayoutComponentStylesRequest(
             nodeId: nodeId,
             styles: newStyles,
           )

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -482,15 +482,14 @@ class _ExampleEditorState extends State<ExampleEditor> {
         print("Applying width $width to node $nodeId");
         final node = _doc.getNodeById(nodeId)!;
         final currentStyles = SingleColumnLayoutComponentStyles.fromMetadata(node);
-        final newStyles = SingleColumnLayoutComponentStyles(
-          width: width,
-          padding: currentStyles.padding,
-        );
 
         _docEditor.execute([
           ChangeSingleColumnLayoutComponentStylesRequest(
             nodeId: nodeId,
-            styles: newStyles,
+            styles: SingleColumnLayoutComponentStyles(
+              width: width,
+              padding: currentStyles.padding,
+            ),
           )
         ]);
       },

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -482,14 +482,17 @@ class _ExampleEditorState extends State<ExampleEditor> {
         print("Applying width $width to node $nodeId");
         final node = _doc.getNodeById(nodeId)!;
         final currentStyles = SingleColumnLayoutComponentStyles.fromMetadata(node);
-        SingleColumnLayoutComponentStyles(
+        final newStyles = SingleColumnLayoutComponentStyles(
           width: width,
           padding: currentStyles.padding,
-        ).applyTo(node);
+        );
 
-        // TODO: schedule a presentation reflow so that the image changes size immediately (https://github.com/superlistapp/super_editor/issues/1529)
-        //       Right now, nothing happens when pressing the button, unless we force a
-        //       rebuild/reflow.
+        _docEditor.execute([
+          ChangeComponentStylesRequest(
+            nodeId: nodeId,
+            styles: newStyles,
+          )
+        ]);
       },
       closeToolbar: _hideImageToolbar,
     );

--- a/super_editor/example/lib/l10n/app_en.arb
+++ b/super_editor/example/lib/l10n/app_en.arb
@@ -12,5 +12,7 @@
   "labelParagraph": "Paragraph",
   "labelBlockquote": "Blockquote",
   "labelOrderedListItem": "Ordered List Item",
-  "labelUnorderedListItem": "Unordered List Item"
+  "labelUnorderedListItem": "Unordered List Item",
+  "labelLimitedWidth": "Limited width",
+  "labelFullWidth": "Full width"
 }

--- a/super_editor/example/lib/l10n/app_es.arb
+++ b/super_editor/example/lib/l10n/app_es.arb
@@ -12,5 +12,7 @@
   "labelParagraph": "Párrafo",
   "labelBlockquote": "Cita de bloque",
   "labelOrderedListItem": "Elemento de lista cerrada",
-  "labelUnorderedListItem": "Elemento de lista no ordenada"
+  "labelUnorderedListItem": "Elemento de lista no ordenada",
+  "labelLimitedWidth": "Ancho limitado",
+  "labelFullWidth": "Ancho completo"
 }

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -194,8 +194,8 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
   (request) => request is RemoveTextAttributionsRequest
       ? RemoveTextAttributionsCommand(documentRange: request.documentRange, attributions: request.attributions)
       : null,
-  (request) => request is ChangeComponentStylesRequest
-      ? ChangeComponentStylesCommand(nodeId: request.nodeId, styles: request.styles) //
+  (request) => request is ChangeSingleColumnLayoutComponentStylesRequest
+      ? ChangeSingleColumnLayoutComponentStylesCommand(nodeId: request.nodeId, styles: request.styles) //
       : null,
   (request) => request is ConvertTextNodeToParagraphRequest
       ? ConvertTextNodeToParagraphCommand(nodeId: request.nodeId, newMetadata: request.newMetadata)

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -194,6 +194,9 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
   (request) => request is RemoveTextAttributionsRequest
       ? RemoveTextAttributionsCommand(documentRange: request.documentRange, attributions: request.attributions)
       : null,
+  (request) => request is ChangeComponentStylesRequest
+      ? ChangeComponentStylesCommand(nodeId: request.nodeId, styles: request.styles) //
+      : null,
   (request) => request is ConvertTextNodeToParagraphRequest
       ? ConvertTextNodeToParagraphCommand(nodeId: request.nodeId, newMetadata: request.newMetadata)
       : null,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1364,7 +1364,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
   }
 }
 
-/// Changes layout styles, like padding and width, of a [DocumentNode].
+/// Changes layout styles, like padding and width, of a component within a [SingleColumnDocumentLayout].
 class ChangeSingleColumnLayoutComponentStylesRequest implements EditRequest {
   const ChangeSingleColumnLayoutComponentStylesRequest({
     required this.nodeId,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1364,8 +1364,9 @@ class ToggleTextAttributionsCommand implements EditCommand {
   }
 }
 
-class ChangeComponentStylesRequest implements EditRequest {
-  const ChangeComponentStylesRequest({
+/// Changes layout styles, like padding and width, of a [DocumentNode].
+class ChangeSingleColumnLayoutComponentStylesRequest implements EditRequest {
+  const ChangeSingleColumnLayoutComponentStylesRequest({
     required this.nodeId,
     required this.styles,
   });
@@ -1374,8 +1375,8 @@ class ChangeComponentStylesRequest implements EditRequest {
   final SingleColumnLayoutComponentStyles styles;
 }
 
-class ChangeComponentStylesCommand implements EditCommand {
-  ChangeComponentStylesCommand({
+class ChangeSingleColumnLayoutComponentStylesCommand implements EditCommand {
+  ChangeSingleColumnLayoutComponentStylesCommand({
     required this.nodeId,
     required this.styles,
   });

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1364,6 +1364,40 @@ class ToggleTextAttributionsCommand implements EditCommand {
   }
 }
 
+class ChangeComponentStylesRequest implements EditRequest {
+  const ChangeComponentStylesRequest({
+    required this.nodeId,
+    required this.styles,
+  });
+
+  final String nodeId;
+  final SingleColumnLayoutComponentStyles styles;
+}
+
+class ChangeComponentStylesCommand implements EditCommand {
+  ChangeComponentStylesCommand({
+    required this.nodeId,
+    required this.styles,
+  });
+
+  final String nodeId;
+  final SingleColumnLayoutComponentStyles styles;
+
+  @override
+  void execute(EditContext context, CommandExecutor executor) {
+    final document = context.find<MutableDocument>(Editor.documentKey);
+    final node = document.getNodeById(nodeId)!;
+
+    styles.applyTo(node);
+
+    executor.logChanges([
+      DocumentEdit(
+        NodeChangeEvent(node.id),
+      ),
+    ]);
+  }
+}
+
 class InsertTextRequest implements EditRequest {
   InsertTextRequest({
     required this.documentPosition,

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -108,7 +108,7 @@ class SuperEditorInspector {
   ///
   /// {@macro supereditor_finder}
   static Size findComponentSize(String nodeId, [Finder? finder]) {
-    final documentLayout = _findDocumentLayout(finder);
+    final documentLayout = findDocumentLayout(finder);
     final component = documentLayout.getComponentByNodeId(nodeId);
     assert(component != null);
     final componentBox = component!.context.findRenderObject() as RenderBox;
@@ -119,7 +119,7 @@ class SuperEditorInspector {
   ///
   /// {@macro supereditor_finder}
   static Offset calculateOffsetForCaret(DocumentPosition position, [Finder? finder]) {
-    final documentLayout = _findDocumentLayout(finder);
+    final documentLayout = findDocumentLayout(finder);
     final positionRect = documentLayout.getRectForPosition(position);
     assert(positionRect != null);
     return positionRect!.topLeft;

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -104,6 +104,27 @@ class SuperEditorInspector {
     return alignment.withinRect(rect);
   }
 
+  /// Returns the size of the component which renders the node with the given [nodeId].
+  ///
+  /// {@macro supereditor_finder}
+  static Size findComponentSize(String nodeId, [Finder? finder]) {
+    final documentLayout = _findDocumentLayout(finder);
+    final component = documentLayout.getComponentByNodeId(nodeId);
+    assert(component != null);
+    final componentBox = component!.context.findRenderObject() as RenderBox;
+    return componentBox.size;
+  }
+
+  /// Returns the (x,y) offset for a caret, if that caret appeared at the given [position].
+  ///
+  /// {@macro supereditor_finder}
+  static Offset calculateOffsetForCaret(DocumentPosition position, [Finder? finder]) {
+    final documentLayout = _findDocumentLayout(finder);
+    final positionRect = documentLayout.getRectForPosition(position);
+    assert(positionRect != null);
+    return positionRect!.topLeft;
+  }
+
   /// Returns `true` if the entire content rectangle at [position] is visible on
   /// screen, or `false` otherwise.
   ///

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -14,13 +14,25 @@ void main() {
       // the maximum width a component can be.
       final context = await tester
           .createDocument() //
-          .withSingleEmptyParagraph()
+          .withCustomContent(
+            MutableDocument(nodes: [
+              ParagraphNode(
+                id: '1',
+                text: AttributedText(),
+                metadata: const SingleColumnLayoutComponentStyles(
+                  width: 600.0,
+                ).toMetadata(),
+              ),
+            ]),
+          )
           .withEditorSize(const Size(1000.0, 5000.0))
           .useStylesheet(
             defaultStylesheet.copyWith(addRulesAfter: [
               StyleRule(
                 BlockSelector.all,
                 (doc, docNode) => {
+                  // Zeroes the padding so the component is exactly
+                  // the requested size.
                   Styles.padding: const CascadingPadding.all(0.0),
                 },
               )

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -28,24 +28,21 @@ void main() {
           )
           .pump();
 
-      // Ensure the component doesn't take all the available width.
-      expect(SuperEditorInspector.findComponentSize('1').width, lessThan(1000.0));
-
       // Change the width the of the first component in the document layout.
       context.editor.execute(
         const [
           ChangeSingleColumnLayoutComponentStylesRequest(
             nodeId: '1',
             styles: SingleColumnLayoutComponentStyles(
-              width: double.infinity,
+              width: 400.0,
             ),
           ),
         ],
       );
       await tester.pump();
 
-      // Ensure the component took all available width.
-      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0);
+      // Ensure the component width changed to the requested value.
+      expect(SuperEditorInspector.findComponentSize('1').width, 400.0);
     });
   });
 

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > single column layout >', () {
+    testWidgetsOnAllPlatforms('updates component width after changing component styles', (tester) async {
+      // Pump an editor with an arbitrary size, so we know
+      // the maximum width a component can be.
+      final context = await tester
+          .createDocument() //
+          .withSingleEmptyParagraph()
+          .withEditorSize(const Size(1000.0, 5000.0))
+          .pump();
+
+      // Ensure the component doesn't start taking all the available width.
+      expect(
+        SuperEditorInspector.findComponentSize('1').width,
+        lessThan(1000.0),
+      );
+
+      // Changes the styles.
+      context.editor.execute(
+        const [
+          ChangeSingleColumnLayoutComponentStylesRequest(
+            nodeId: '1',
+            styles: SingleColumnLayoutComponentStyles(
+              width: double.infinity,
+              padding: EdgeInsets.zero,
+            ),
+          ),
+        ],
+      );
+      await tester.pump();
+
+      // Ensure the component took all available width.
+      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0);
+    });
+  });
+}

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -8,7 +8,8 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor > single column layout >', () {
-    testWidgetsOnAllPlatforms('updates component width after changing component styles', (tester) async {
+    testWidgetsOnAllPlatforms('updates component width when component styles are changed by the editor',
+        (tester) async {
       // Pump an editor with an arbitrary size, so we know
       // the maximum width a component can be.
       final context = await tester
@@ -17,8 +18,9 @@ void main() {
           .withEditorSize(const Size(1000.0, 5000.0))
           .pump();
 
-      // Hold the padding before running the command.
-      final paddingBefore = tester
+      // Find the padding around the component to ensure the component took all
+      // the editor width, minus the padding.
+      final componentPadding = tester
           .widget<Padding>(find
               .ancestor(
                 of: find.byWidget(SuperEditorInspector.findWidgetForComponent('1')),
@@ -30,7 +32,7 @@ void main() {
       // Ensure the component doesn't start taking all the available width.
       expect(
         SuperEditorInspector.findComponentSize('1').width,
-        lessThan(1000.0 - paddingBefore.horizontal),
+        lessThan(1000.0 - componentPadding.horizontal),
       );
 
       // Changes the width.
@@ -46,21 +48,14 @@ void main() {
       );
       await tester.pump();
 
-      // Ensure the component took all available width and the padding didn't chagne.
-      final paddingAfter = tester
-          .widget<Padding>(find
-              .ancestor(
-                of: find.byWidget(SuperEditorInspector.findWidgetForComponent('1')),
-                matching: find.byType(Padding),
-              )
-              .first)
-          .padding;
-      expect(paddingAfter, paddingBefore);
-      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0 - paddingBefore.horizontal);
+      // Ensure the component took all available width.
+      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0 - componentPadding.horizontal);
     });
   });
 
-  testWidgetsOnAllPlatforms('updates component padding after changing component styles', (tester) async {
+  testWidgetsOnAllPlatforms(
+      'updates padding around each component in a document layout, when the overall document layout padding is changed by the editor',
+      (tester) async {
     final context = await tester
         .createDocument() //
         .withSingleEmptyParagraph()

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -40,6 +40,9 @@ void main() {
           )
           .pump();
 
+      // Ensure the component initially has the requested size.
+      expect(SuperEditorInspector.findComponentSize('1').width, 600.0);
+
       // Change the width the of the first component in the document layout.
       context.editor.execute(
         const [

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -23,6 +23,15 @@ void main() {
         lessThan(1000.0),
       );
 
+      // Ensure the component started with some padding.
+      final paddingBefore = tester.widget<Padding>(find
+          .ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent('1')),
+            matching: find.byType(Padding),
+          )
+          .first);
+      expect(paddingBefore.padding.horizontal, greaterThan(0.0));
+
       // Changes the styles.
       context.editor.execute(
         const [
@@ -39,6 +48,15 @@ void main() {
 
       // Ensure the component took all available width.
       expect(SuperEditorInspector.findComponentSize('1').width, 1000.0);
+
+      // Ensure the padding was removed.
+      final paddingAfter = tester.widget<Padding>(find
+          .ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent('1')),
+            matching: find.byType(Padding),
+          )
+          .first);
+      expect(paddingAfter.padding.horizontal, 0.0);
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_single_column_layout_test.dart
@@ -16,26 +16,22 @@ void main() {
           .createDocument() //
           .withSingleEmptyParagraph()
           .withEditorSize(const Size(1000.0, 5000.0))
+          .useStylesheet(
+            defaultStylesheet.copyWith(addRulesAfter: [
+              StyleRule(
+                BlockSelector.all,
+                (doc, docNode) => {
+                  Styles.padding: const CascadingPadding.all(0.0),
+                },
+              )
+            ]),
+          )
           .pump();
 
-      // Find the padding around the component to ensure the component took all
-      // the editor width, minus the padding.
-      final componentPadding = tester
-          .widget<Padding>(find
-              .ancestor(
-                of: find.byWidget(SuperEditorInspector.findWidgetForComponent('1')),
-                matching: find.byType(Padding),
-              )
-              .first)
-          .padding;
+      // Ensure the component doesn't take all the available width.
+      expect(SuperEditorInspector.findComponentSize('1').width, lessThan(1000.0));
 
-      // Ensure the component doesn't start taking all the available width.
-      expect(
-        SuperEditorInspector.findComponentSize('1').width,
-        lessThan(1000.0 - componentPadding.horizontal),
-      );
-
-      // Changes the width.
+      // Change the width the of the first component in the document layout.
       context.editor.execute(
         const [
           ChangeSingleColumnLayoutComponentStylesRequest(
@@ -49,7 +45,7 @@ void main() {
       await tester.pump();
 
       // Ensure the component took all available width.
-      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0 - componentPadding.horizontal);
+      expect(SuperEditorInspector.findComponentSize('1').width, 1000.0);
     });
   });
 


### PR DESCRIPTION
[SuperEditor][DemoApp] Fix image resizing. Resolves #1708, Resolves #1529

We have an image toolbar on the demo app the lets users switch the image from full width to limited width. However, using this toolbar isn't updating the layout immediately.

The reason is that we are directly mutating the node, instead of using the request/command pipeline.

This PR adds  `ChangeComponentStylesRequest` and `ChangeComponentStylesCommand` to handle the style changes.