### PR TITLE
[SuperEditor] Add image size awareness (Resolves #851)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -8,7 +8,8 @@ MutableDocument createInitialDocument() {
         id: "1",
         imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
         expectedBitmapSize: ExpectedSize(
-          height: 422,
+          width: 1911,
+          height: 630,
         ),
         metadata: const SingleColumnLayoutComponentStyles(
           width: double.infinity,

--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -7,7 +7,9 @@ MutableDocument createInitialDocument() {
       ImageNode(
         id: "1",
         imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
-        height: 422,
+        expectedBitmapSize: ExpectedSize(
+          height: 422,
+        ),
         metadata: const SingleColumnLayoutComponentStyles(
           width: double.infinity,
           padding: EdgeInsets.zero,

--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -7,6 +7,7 @@ MutableDocument createInitialDocument() {
       ImageNode(
         id: "1",
         imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
+        height: 422,
         metadata: const SingleColumnLayoutComponentStyles(
           width: double.infinity,
           padding: EdgeInsets.zero,

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -11,14 +11,12 @@ class ImageNode extends BlockNode with ChangeNotifier {
   ImageNode({
     required this.id,
     required String imageUrl,
-    double? width,
-    double? height,
+    ExpectedSize? expectedBitmapSize,
     String altText = '',
     Map<String, dynamic>? metadata,
   })  : _imageUrl = imageUrl,
-        _altText = altText,
-        _width = width,
-        _height = height {
+        _expectedBitmapSize = expectedBitmapSize,
+        _altText = altText {
     this.metadata = metadata;
 
     putMetadataValue("blockType", const NamedAttribution("image"));
@@ -36,6 +34,22 @@ class ImageNode extends BlockNode with ChangeNotifier {
     }
   }
 
+  /// The expected size of the image.
+  ///
+  /// Used to size the component while the image is still being loaded,
+  /// so the content don't shift after the image is loaded.
+  ExpectedSize? get expectedBitmapSize => _expectedBitmapSize;
+  ExpectedSize? _expectedBitmapSize;
+  set expectedBitmapSize(ExpectedSize? expectedSize) {
+    if (expectedSize == _expectedBitmapSize) {
+      return;
+    }
+
+    _expectedBitmapSize = expectedSize;
+
+    notifyListeners();
+  }
+
   String _altText;
   String get altText => _altText;
   set altText(String newAltText) {
@@ -43,28 +57,6 @@ class ImageNode extends BlockNode with ChangeNotifier {
       _altText = newAltText;
       notifyListeners();
     }
-  }
-
-  double? _width;
-  double? get width => _width;
-  set width(double? newWidth) {
-    if (newWidth == _width) {
-      return;
-    }
-
-    _width = newWidth;
-    notifyListeners();
-  }
-
-  double? _height;
-  double? get height => _height;
-  set height(double? newHeight) {
-    if (newHeight == _height) {
-      return;
-    }
-
-    _height = newHeight;
-    notifyListeners();
   }
 
   @override
@@ -80,8 +72,7 @@ class ImageNode extends BlockNode with ChangeNotifier {
   bool hasEquivalentContent(DocumentNode other) {
     return other is ImageNode &&
         imageUrl == other.imageUrl &&
-        width == other.width &&
-        height == other.height &&
+        expectedBitmapSize == other.expectedBitmapSize &&
         altText == other.altText;
   }
 
@@ -92,12 +83,11 @@ class ImageNode extends BlockNode with ChangeNotifier {
           runtimeType == other.runtimeType &&
           id == other.id &&
           _imageUrl == other._imageUrl &&
-          _width == other.width &&
-          _height == other.height &&
+          _expectedBitmapSize == other.expectedBitmapSize &&
           _altText == other._altText;
 
   @override
-  int get hashCode => id.hashCode ^ _imageUrl.hashCode ^ _altText.hashCode ^ _width.hashCode ^ _height.hashCode;
+  int get hashCode => id.hashCode ^ _imageUrl.hashCode ^ _altText.hashCode ^ _expectedBitmapSize.hashCode;
 }
 
 class ImageComponentBuilder implements ComponentBuilder {
@@ -112,8 +102,8 @@ class ImageComponentBuilder implements ComponentBuilder {
     return ImageComponentViewModel(
       nodeId: node.id,
       imageUrl: node.imageUrl,
-      width: node.width,
-      height: node.height,
+      width: node.expectedBitmapSize?.width?.toDouble(),
+      height: node.expectedBitmapSize?.height?.toDouble(),
       selectionColor: const Color(0x00000000),
     );
   }
@@ -245,4 +235,26 @@ class ImageComponent extends StatelessWidget {
       ),
     );
   }
+}
+
+/// A size with optional [width] and [height].
+class ExpectedSize {
+  ExpectedSize({
+    this.height,
+    this.width,
+  });
+
+  final int? width;
+  final int? height;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExpectedSize && //
+          runtimeType == other.runtimeType &&
+          width == other.width &&
+          height == other.height;
+
+  @override
+  int get hashCode => width.hashCode ^ height.hashCode;
 }

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -11,10 +11,14 @@ class ImageNode extends BlockNode with ChangeNotifier {
   ImageNode({
     required this.id,
     required String imageUrl,
+    double? width,
+    double? height,
     String altText = '',
     Map<String, dynamic>? metadata,
   })  : _imageUrl = imageUrl,
-        _altText = altText {
+        _altText = altText,
+        _width = width,
+        _height = height {
     this.metadata = metadata;
 
     putMetadataValue("blockType", const NamedAttribution("image"));
@@ -41,6 +45,28 @@ class ImageNode extends BlockNode with ChangeNotifier {
     }
   }
 
+  double? _width;
+  double? get width => _width;
+  set width(double? newWidth) {
+    if (newWidth == _width) {
+      return;
+    }
+
+    _width = newWidth;
+    notifyListeners();
+  }
+
+  double? _height;
+  double? get height => _height;
+  set height(double? newHeight) {
+    if (newHeight == _height) {
+      return;
+    }
+
+    _height = newHeight;
+    notifyListeners();
+  }
+
   @override
   String? copyContent(dynamic selection) {
     if (selection is! UpstreamDownstreamNodeSelection) {
@@ -52,7 +78,11 @@ class ImageNode extends BlockNode with ChangeNotifier {
 
   @override
   bool hasEquivalentContent(DocumentNode other) {
-    return other is ImageNode && imageUrl == other.imageUrl && altText == other.altText;
+    return other is ImageNode &&
+        imageUrl == other.imageUrl &&
+        width == other.width &&
+        height == other.height &&
+        altText == other.altText;
   }
 
   @override
@@ -62,10 +92,12 @@ class ImageNode extends BlockNode with ChangeNotifier {
           runtimeType == other.runtimeType &&
           id == other.id &&
           _imageUrl == other._imageUrl &&
+          _width == other.width &&
+          _height == other.height &&
           _altText == other._altText;
 
   @override
-  int get hashCode => id.hashCode ^ _imageUrl.hashCode ^ _altText.hashCode;
+  int get hashCode => id.hashCode ^ _imageUrl.hashCode ^ _altText.hashCode ^ _width.hashCode ^ _height.hashCode;
 }
 
 class ImageComponentBuilder implements ComponentBuilder {
@@ -80,6 +112,8 @@ class ImageComponentBuilder implements ComponentBuilder {
     return ImageComponentViewModel(
       nodeId: node.id,
       imageUrl: node.imageUrl,
+      width: node.width,
+      height: node.height,
       selectionColor: const Color(0x00000000),
     );
   }
@@ -94,6 +128,8 @@ class ImageComponentBuilder implements ComponentBuilder {
     return ImageComponent(
       componentKey: componentContext.componentKey,
       imageUrl: componentViewModel.imageUrl,
+      width: componentViewModel.width,
+      height: componentViewModel.height,
       selection: componentViewModel.selection,
       selectionColor: componentViewModel.selectionColor,
     );
@@ -106,11 +142,15 @@ class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel {
     double? maxWidth,
     EdgeInsetsGeometry padding = EdgeInsets.zero,
     required this.imageUrl,
+    this.width,
+    this.height,
     this.selection,
     required this.selectionColor,
   }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding);
 
   String imageUrl;
+  double? width;
+  double? height;
   UpstreamDownstreamNodeSelection? selection;
   Color selectionColor;
 
@@ -121,6 +161,8 @@ class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel {
       maxWidth: maxWidth,
       padding: padding,
       imageUrl: imageUrl,
+      width: width,
+      height: height,
       selection: selection,
       selectionColor: selectionColor,
     );
@@ -134,12 +176,20 @@ class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel {
           runtimeType == other.runtimeType &&
           nodeId == other.nodeId &&
           imageUrl == other.imageUrl &&
+          width == other.width &&
+          height == other.height &&
           selection == other.selection &&
           selectionColor == other.selectionColor;
 
   @override
   int get hashCode =>
-      super.hashCode ^ nodeId.hashCode ^ imageUrl.hashCode ^ selection.hashCode ^ selectionColor.hashCode;
+      super.hashCode ^
+      nodeId.hashCode ^
+      imageUrl.hashCode ^
+      width.hashCode ^
+      height.hashCode ^
+      selection.hashCode ^
+      selectionColor.hashCode;
 }
 
 /// Displays an image in a document.
@@ -148,6 +198,8 @@ class ImageComponent extends StatelessWidget {
     Key? key,
     required this.componentKey,
     required this.imageUrl,
+    this.width,
+    this.height,
     this.selectionColor = Colors.blue,
     this.selection,
     this.imageBuilder,
@@ -155,6 +207,8 @@ class ImageComponent extends StatelessWidget {
 
   final GlobalKey componentKey;
   final String imageUrl;
+  final double? width;
+  final double? height;
   final Color selectionColor;
   final UpstreamDownstreamNodeSelection? selection;
 
@@ -182,6 +236,8 @@ class ImageComponent extends StatelessWidget {
                   : Image.network(
                       imageUrl,
                       fit: BoxFit.contain,
+                      width: width,
+                      height: height,
                     ),
             ),
           ),

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -15,7 +15,7 @@ class ImageNode extends BlockNode with ChangeNotifier {
     String altText = '',
     Map<String, dynamic>? metadata,
   })  : _imageUrl = imageUrl,
-        _expectedSize = expectedBitmapSize,
+        _expectedBitmapSize = expectedBitmapSize,
         _altText = altText {
     this.metadata = metadata;
 
@@ -46,14 +46,14 @@ class ImageNode extends BlockNode with ChangeNotifier {
   /// in a vertical layout will likely take up more space or less space than the final
   /// image because the final image will probably be scaled. Therefore, to take
   /// advantage of [ExpectedSize], you should try to provide both dimensions.
-  ExpectedSize? get expectedSize => _expectedSize;
-  ExpectedSize? _expectedSize;
-  set expectedSize(ExpectedSize? newValue) {
-    if (newValue == _expectedSize) {
+  ExpectedSize? get expectedBitmapSize => _expectedBitmapSize;
+  ExpectedSize? _expectedBitmapSize;
+  set expectedBitmapSize(ExpectedSize? newValue) {
+    if (newValue == _expectedBitmapSize) {
       return;
     }
 
-    _expectedSize = newValue;
+    _expectedBitmapSize = newValue;
 
     notifyListeners();
   }
@@ -106,7 +106,7 @@ class ImageComponentBuilder implements ComponentBuilder {
     return ImageComponentViewModel(
       nodeId: node.id,
       imageUrl: node.imageUrl,
-      expectedSize: node.expectedSize,
+      expectedSize: node.expectedBitmapSize,
       selectionColor: const Color(0x00000000),
     );
   }
@@ -225,7 +225,7 @@ class ImageComponent extends StatelessWidget {
                           // Both width and height were provide.
                           // Preserve the aspect ratio of the original image.
                           return AspectRatio(
-                            aspectRatio: expectedSize!.width! / expectedSize!.height!,
+                            aspectRatio: expectedSize!.aspectRatio,
                             child: SizedBox(
                               width: expectedSize!.width!.toDouble(),
                               height: expectedSize!.height!.toDouble(),
@@ -250,11 +250,18 @@ class ImageComponent extends StatelessWidget {
 }
 
 /// A size with optional [width] and [height].
+///
+/// Used to size an image component based on the expected bitmap size of the image,
+/// so the content doesn't shift after the image is loaded.
 class ExpectedSize {
   const ExpectedSize(this.width, this.height);
 
   final int? width;
   final int? height;
+
+  double get aspectRatio => height != null //
+      ? (width ?? 0) / height!
+      : throw UnsupportedError("Can't compute the aspect ratio with a null height");
 
   @override
   bool operator ==(Object other) =>

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -249,10 +249,7 @@ class ImageComponent extends StatelessWidget {
   }
 }
 
-/// A size with optional [width] and [height].
-///
-/// Used to size an image component based on the expected bitmap size of the image,
-/// so the content doesn't shift after the image is loaded.
+/// The expected size of a piece of content, such as an image that's loading.
 class ExpectedSize {
   const ExpectedSize(this.width, this.height);
 

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -21,7 +21,7 @@ String serializeDocumentToMarkdown(
     // specialized cases of traditional nodes, such as serializing a
     // `ParagraphNode` with a special `"blockType"`.
     ...customNodeSerializers,
-    const ImageNodeSerializer(),
+    ImageNodeSerializer(useSizeNotation: syntax == MarkdownSyntax.superEditor),
     const HorizontalRuleNodeSerializer(),
     const ListItemNodeSerializer(),
     const TaskNodeSerializer(),
@@ -80,11 +80,34 @@ abstract class NodeTypedDocumentNodeMarkdownSerializer<NodeType> implements Docu
 /// [DocumentNodeMarkdownSerializer] for serializing [ImageNode]s as standard Markdown
 /// images.
 class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageNode> {
-  const ImageNodeSerializer();
+  const ImageNodeSerializer({
+    this.useSizeNotation = false,
+  });
+
+  final bool useSizeNotation;
 
   @override
   String doSerialization(Document document, ImageNode node) {
-    return '![${node.altText}](${node.imageUrl})';
+    if (!useSizeNotation || (node.width == null && node.height == null)) {
+      // We don't want to use size notation or the image doesn't have
+      // size information. Use the regular syntax.
+      return '![${node.altText}](${node.imageUrl})';
+    }
+
+    StringBuffer sizeNotation = StringBuffer();
+    sizeNotation.write(' =');
+
+    if (node.width != null) {
+      sizeNotation.write(node.width!.toInt());
+    }
+
+    sizeNotation.write('x');
+
+    if (node.height != null) {
+      sizeNotation.write(node.height!.toInt());
+    }
+
+    return '![${node.altText}](${node.imageUrl}${sizeNotation.toString()})';
   }
 }
 

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -88,7 +88,7 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
 
   @override
   String doSerialization(Document document, ImageNode node) {
-    if (!useSizeNotation || (node.width == null && node.height == null)) {
+    if (!useSizeNotation || (node.expectedBitmapSize?.width == null && node.expectedBitmapSize?.height == null)) {
       // We don't want to use size notation or the image doesn't have
       // size information. Use the regular syntax.
       return '![${node.altText}](${node.imageUrl})';
@@ -97,14 +97,14 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
     StringBuffer sizeNotation = StringBuffer();
     sizeNotation.write(' =');
 
-    if (node.width != null) {
-      sizeNotation.write(node.width!.toInt());
+    if (node.expectedBitmapSize?.width != null) {
+      sizeNotation.write(node.expectedBitmapSize!.width!.toInt());
     }
 
     sizeNotation.write('x');
 
-    if (node.height != null) {
-      sizeNotation.write(node.height!.toInt());
+    if (node.expectedBitmapSize?.height != null) {
+      sizeNotation.write(node.expectedBitmapSize!.height!.toInt());
     }
 
     return '![${node.altText}](${node.imageUrl}${sizeNotation.toString()})';

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -88,7 +88,7 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
 
   @override
   String doSerialization(Document document, ImageNode node) {
-    if (!useSizeNotation || (node.expectedSize?.width == null && node.expectedSize?.height == null)) {
+    if (!useSizeNotation || (node.expectedBitmapSize?.width == null && node.expectedBitmapSize?.height == null)) {
       // We don't want to use size notation or the image doesn't have
       // size information. Use the regular syntax.
       return '![${node.altText}](${node.imageUrl})';
@@ -97,14 +97,14 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
     StringBuffer sizeNotation = StringBuffer();
     sizeNotation.write(' =');
 
-    if (node.expectedSize?.width != null) {
-      sizeNotation.write(node.expectedSize!.width!.toInt());
+    if (node.expectedBitmapSize?.width != null) {
+      sizeNotation.write(node.expectedBitmapSize!.width!.toInt());
     }
 
     sizeNotation.write('x');
 
-    if (node.expectedSize?.height != null) {
-      sizeNotation.write(node.expectedSize!.height!.toInt());
+    if (node.expectedBitmapSize?.height != null) {
+      sizeNotation.write(node.expectedBitmapSize!.height!.toInt());
     }
 
     return '![${node.altText}](${node.imageUrl}${sizeNotation.toString()})';

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -88,7 +88,7 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
 
   @override
   String doSerialization(Document document, ImageNode node) {
-    if (!useSizeNotation || (node.expectedBitmapSize?.width == null && node.expectedBitmapSize?.height == null)) {
+    if (!useSizeNotation || (node.expectedSize?.width == null && node.expectedSize?.height == null)) {
       // We don't want to use size notation or the image doesn't have
       // size information. Use the regular syntax.
       return '![${node.altText}](${node.imageUrl})';
@@ -97,14 +97,14 @@ class ImageNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<ImageN
     StringBuffer sizeNotation = StringBuffer();
     sizeNotation.write(' =');
 
-    if (node.expectedBitmapSize?.width != null) {
-      sizeNotation.write(node.expectedBitmapSize!.width!.toInt());
+    if (node.expectedSize?.width != null) {
+      sizeNotation.write(node.expectedSize!.width!.toInt());
     }
 
     sizeNotation.write('x');
 
-    if (node.expectedBitmapSize?.height != null) {
-      sizeNotation.write(node.expectedBitmapSize!.height!.toInt());
+    if (node.expectedSize?.height != null) {
+      sizeNotation.write(node.expectedSize!.height!.toInt());
     }
 
     return '![${node.altText}](${node.imageUrl}${sizeNotation.toString()})';

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -1,4 +1,5 @@
 import 'package:markdown/markdown.dart' as md;
+import 'package:super_editor/super_editor.dart';
 
 /// Matches images like `![alternate text](url optional_size "optional title")` and
 /// `![alternate text][label]`.
@@ -86,7 +87,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   /// Parses a size using the notation `=widthxheight`.
   ///
   /// Returns `null` if the size notation isn't provided.
-  PreferredSize? _tryParseImageSize(md.InlineParser parser) {
+  ExpectedSize? _tryParseImageSize(md.InlineParser parser) {
     if (parser.charAt(parser.pos) != AsciiTable.equal) {
       // The image size should start with a "=" but the input doesn't. Fizzle.
       return null;
@@ -110,7 +111,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     // Parse an optional height.
     final height = _tryParseNumber(parser);
 
-    return PreferredSize(width: width?.toDouble(), height: height?.toDouble());
+    return ExpectedSize(width: width, height: height);
   }
 
   /// Tries to parse an integer number.
@@ -311,7 +312,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   MarkdownImage? _parseInlineBracketedLink(md.InlineParser parser) {
     parser.advanceBy(1);
 
-    PreferredSize? imageSize;
+    ExpectedSize? imageSize;
 
     var buffer = StringBuffer();
     while (true) {
@@ -398,7 +399,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     var parenCount = 1;
     final buffer = StringBuffer();
 
-    PreferredSize? imageSize;
+    ExpectedSize? imageSize;
 
     while (true) {
       final char = parser.charAt(parser.pos);
@@ -481,7 +482,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   md.Element createNode(
     String destination,
     String? title, {
-    PreferredSize? size,
+    ExpectedSize? size,
     required List<md.Node> Function() getChildren,
   }) {
     final element = md.Element.empty('img');
@@ -721,17 +722,6 @@ class AsciiTable {
   static const int tilde = 0x7E;
 }
 
-/// A size with optional [width] and [height].
-class PreferredSize {
-  PreferredSize({
-    required this.width,
-    required this.height,
-  });
-
-  final double? width;
-  final double? height;
-}
-
 /// A parsed image notation.
 class MarkdownImage extends md.InlineLink {
   MarkdownImage(
@@ -740,5 +730,5 @@ class MarkdownImage extends md.InlineLink {
     this.size,
   }) : super(destination, title: title);
 
-  final PreferredSize? size;
+  final ExpectedSize? size;
 }

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -1,0 +1,744 @@
+import 'package:markdown/markdown.dart' as md;
+
+/// Matches images like `![alternate text](url optional_size "optional title")` and
+/// `![alternate text][label]`.
+///
+/// To define a size, use the notation `=widthxheight`. The size notation is optional and
+/// it can be providade partially. For example:
+///
+/// - ![alternate text](url =500x200)
+/// - ![alternate text](url =500x)
+/// - ![alternate text](url =x200)
+///
+/// Extracted and adapted from the markdown package.
+class SuperEditorImageSyntax extends md.LinkSyntax {
+  static final _entirelyWhitespacePattern = RegExp(r'^\s*$.');
+
+  SuperEditorImageSyntax({md.Resolver? linkResolver})
+      : super(
+          linkResolver: linkResolver,
+          pattern: r'!\[',
+          startCharacter: AsciiTable.exclamation,
+        );
+
+  @override
+  md.Node? close(
+    md.InlineParser parser,
+    covariant md.SimpleDelimiter opener,
+    md.Delimiter? closer, {
+    String? tag,
+    required List<md.Node> Function() getChildren,
+  }) {
+    var text = parser.source!.substring(opener.endPos, parser.pos);
+    // The current character is the `]` that closed the link text. Examine the
+    // next character, to determine what type of link we might have (a '('
+    // means a possible inline link; otherwise a possible reference link).
+    if (parser.pos + 1 >= parser.source!.length) {
+      // The `]` is at the end of the document, but this may still be a valid
+      // shortcut reference link.
+      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+    }
+
+    // Peek at the next character; don't advance, so as to avoid later stepping
+    // backward.
+    var char = parser.charAt(parser.pos + 1);
+
+    if (char == AsciiTable.leftParen) {
+      // Maybe an inline link, like `[text](destination)`.
+      parser.advanceBy(1);
+      var leftParenIndex = parser.pos;
+      var inlineLink = _parseInlineLink(parser);
+      if (inlineLink != null) {
+        return _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren);
+      }
+      // At this point, we've matched `[...](`, but that `(` did not pan out to
+      // be an inline link. We must now check if `[...]` is simply a shortcut
+      // reference link.
+
+      // Reset the parser position.
+      parser.pos = leftParenIndex;
+      parser.advanceBy(-1);
+      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+    }
+
+    if (char == AsciiTable.leftBracket) {
+      parser.advanceBy(1);
+      // At this point, we've matched `[...][`. Maybe a *full* reference link,
+      // like `[foo][bar]` or a *collapsed* reference link, like `[foo][]`.
+      if (parser.pos + 1 < parser.source!.length && parser.charAt(parser.pos + 1) == AsciiTable.rightBracket) {
+        // That opening `[` is not actually part of the link. Maybe a
+        // *shortcut* reference link (followed by a `[`).
+        parser.advanceBy(1);
+        return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+      }
+      var label = _parseReferenceLinkLabel(parser);
+      if (label != null) {
+        return _tryCreateReferenceLink(parser, label, getChildren: getChildren);
+      }
+      return null;
+    }
+
+    // The link text (inside `[...]`) was not followed with a opening `(` nor
+    // an opening `[`. Perhaps just a simple shortcut reference link (`[...]`).
+    return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+  }
+
+  /// Parses a size using the notation `=widthxheight`.
+  ///
+  /// Returns `null` if the size notation isn't provided.
+  PreferredSize? _tryParseImageSize(md.InlineParser parser) {
+    if (parser.charAt(parser.pos) != AsciiTable.equal) {
+      // The image size should start with a "=" but the input doesn't. Fizzle.
+      return null;
+    }
+
+    // Consume the "=".
+    parser.advanceBy(1);
+
+    // Parse an optional width.
+    final width = _tryParseNumber(parser);
+
+    final downstreamCharacter = parser.source!.substring(parser.pos, parser.pos + 1);
+    if (downstreamCharacter.toLowerCase() != 'x') {
+      // The image size must have a "x" between the width and height, but the input doesn't.  Fizzle.
+      return null;
+    }
+
+    // Consume the "x".
+    parser.advanceBy(1);
+
+    // Parse an optional height.
+    final height = _tryParseNumber(parser);
+
+    return PreferredSize(width: width?.toDouble(), height: height?.toDouble());
+  }
+
+  /// Tries to parse an integer number.
+  ///
+  /// Returns `null` if it can't find an integer number.
+  int? _tryParseNumber(md.InlineParser parser) {
+    StringBuffer numberCharacters = StringBuffer();
+
+    while (!parser.isDone && //
+        parser.charAt(parser.pos) >= AsciiTable.numberZero &&
+        parser.charAt(parser.pos) <= AsciiTable.numberNine) {
+      // The current char is between 0-9.
+      numberCharacters.writeCharCode(parser.charAt(parser.pos));
+      parser.advanceBy(1);
+    }
+
+    if (numberCharacters.isEmpty) {
+      // We didn't find any digits. Fizzle.
+      return null;
+    }
+
+    return int.parse(numberCharacters.toString());
+  }
+
+  /// Tries to create a reference link node.
+  ///
+  /// Returns the link if it was successfully created, `null` otherwise.
+  md.Node? _tryCreateReferenceLink(md.InlineParser parser, String label,
+      {required List<md.Node> Function() getChildren}) {
+    return _resolveReferenceLink(label, parser.document.linkReferences, getChildren: getChildren);
+  }
+
+  // Tries to create an inline link node.
+  //
+  /// Returns the link if it was successfully created, `null` otherwise.
+  md.Node _tryCreateInlineLink(md.InlineParser parser, MarkdownImage link,
+      {required List<md.Node> Function() getChildren}) {
+    return createNode(link.destination, link.title, size: link.size, getChildren: getChildren);
+  }
+
+  /// Parse an inline [MarkdownImage] at the current position.
+  ///
+  /// At this point, we have parsed a link's (or image's) opening `[`, and then
+  /// a matching closing `]`, and [parser.pos] is pointing at an opening `(`.
+  /// This method will then attempt to parse a link destination wrapped in `<>`,
+  /// such as `(<http://url>)`, or a bare link destination, such as
+  /// `(http://url)`, or a link destination with a title, such as
+  /// `(http://url "title")`.
+  ///
+  /// Returns the [MarkdownImage] if one was parsed, or `null` if not.
+  MarkdownImage? _parseInlineLink(md.InlineParser parser) {
+    // Start walking to the character just after the opening `(`.
+    parser.advanceBy(1);
+
+    _moveThroughWhitespace(parser);
+    if (parser.isDone) return null; // EOF. Not a link.
+
+    if (parser.charAt(parser.pos) == AsciiTable.lessThan) {
+      // Maybe a `<...>`-enclosed link destination.
+      return _parseInlineBracketedLink(parser);
+    } else {
+      return _parseInlineBareDestinationLink(parser);
+    }
+  }
+
+  /// Parses a link title in [parser] at it's current position. The parser's
+  /// current position should be a whitespace character that followed a link
+  /// destination.
+  ///
+  /// Returns the title if it was successfully parsed, `null` otherwise.
+  String? _parseTitle(md.InlineParser parser) {
+    _moveThroughWhitespace(parser);
+    if (parser.isDone) return null;
+
+    // The whitespace should be followed by a title delimiter.
+    final delimiter = parser.charAt(parser.pos);
+    if (delimiter != AsciiTable.apostrophe && delimiter != AsciiTable.quote && delimiter != AsciiTable.leftParen) {
+      return null;
+    }
+
+    final closeDelimiter = delimiter == AsciiTable.leftParen ? AsciiTable.rightParen : delimiter;
+    parser.advanceBy(1);
+
+    // Now we look for an un-escaped closing delimiter.
+    final buffer = StringBuffer();
+    while (true) {
+      final char = parser.charAt(parser.pos);
+      if (char == AsciiTable.backslash) {
+        parser.advanceBy(1);
+        final next = parser.charAt(parser.pos);
+        if (next != AsciiTable.backslash && next != closeDelimiter) {
+          buffer.writeCharCode(char);
+        }
+        buffer.writeCharCode(next);
+      } else if (char == closeDelimiter) {
+        break;
+      } else {
+        buffer.writeCharCode(char);
+      }
+      parser.advanceBy(1);
+      if (parser.isDone) return null;
+    }
+    final title = buffer.toString();
+
+    // Advance past the closing delimiter.
+    parser.advanceBy(1);
+    if (parser.isDone) return null;
+    _moveThroughWhitespace(parser);
+    if (parser.isDone) return null;
+    if (parser.charAt(parser.pos) != AsciiTable.rightParen) return null;
+    return title;
+  }
+
+  /// Resolve a possible reference link.
+  ///
+  /// Uses [linkReferences], [linkResolver], and [createNode] to try to
+  /// resolve [label] into a [Node]. If [label] is defined in
+  /// [linkReferences] or can be resolved by [linkResolver], returns a [Node]
+  /// that links to the resolved URL.
+  ///
+  /// Otherwise, returns `null`.
+  ///
+  /// [label] does not need to be normalized.
+  md.Node? _resolveReferenceLink(
+    String label,
+    Map<String, md.LinkReference> linkReferences, {
+    required List<md.Node> Function() getChildren,
+  }) {
+    final linkReference = linkReferences[_normalizeLinkLabel(label)];
+    if (linkReference != null) {
+      return createNode(
+        linkReference.destination,
+        linkReference.title,
+        //size: linkReference.size,
+        getChildren: getChildren,
+      );
+    } else {
+      // This link has no reference definition. But we allow users of the
+      // library to specify a custom resolver function ([linkResolver]) that
+      // may choose to handle this. Otherwise, it's just treated as plain
+      // text.
+
+      // Normally, label text does not get parsed as inline Markdown. However,
+      // for the benefit of the link resolver, we need to at least escape
+      // brackets, so that, e.g. a link resolver can receive `[\[\]]` as `[]`.
+      final resolved = linkResolver(label.replaceAll(r'\\', r'\').replaceAll(r'\[', '[').replaceAll(r'\]', ']'));
+      if (resolved != null) {
+        getChildren();
+      }
+      return resolved;
+    }
+  }
+
+  /// Parse a reference link label at the current position.
+  ///
+  /// Specifically, [parser.pos] is expected to be pointing at the `[` which
+  /// opens the link label.
+  ///
+  /// Returns the label if it could be parsed, or `null` if not.
+  String? _parseReferenceLinkLabel(md.InlineParser parser) {
+    // Walk past the opening `[`.
+    parser.advanceBy(1);
+    if (parser.isDone) return null;
+
+    var buffer = StringBuffer();
+    while (true) {
+      var char = parser.charAt(parser.pos);
+      if (char == AsciiTable.backslash) {
+        parser.advanceBy(1);
+        var next = parser.charAt(parser.pos);
+        if (next != AsciiTable.backslash && next != AsciiTable.rightBracket) {
+          buffer.writeCharCode(char);
+        }
+        buffer.writeCharCode(next);
+      } else if (char == AsciiTable.rightBracket) {
+        break;
+      } else {
+        buffer.writeCharCode(char);
+      }
+      parser.advanceBy(1);
+      if (parser.isDone) return null;
+      // TODO(srawlins): only check 999 characters, for performance reasons?
+    }
+
+    var label = buffer.toString();
+
+    // A link label must contain at least one non-whitespace character.
+    if (_entirelyWhitespacePattern.hasMatch(label)) return null;
+
+    return label;
+  }
+
+  /// Parse an inline link with a bracketed destination (a destination wrapped
+  /// in `<...>`). The current position of the parser must be the first
+  /// character of the destination.
+  ///
+  /// Returns the link if it was successfully created, `null` otherwise.
+  MarkdownImage? _parseInlineBracketedLink(md.InlineParser parser) {
+    parser.advanceBy(1);
+
+    PreferredSize? imageSize;
+
+    var buffer = StringBuffer();
+    while (true) {
+      var char = parser.charAt(parser.pos);
+      if (char == AsciiTable.backslash) {
+        parser.advanceBy(1);
+        var next = parser.charAt(parser.pos);
+        // TODO: Follow the backslash spec better here.
+        // http://spec.commonmark.org/0.29/#backslash-escapes
+        if (next != AsciiTable.backslash && next != AsciiTable.greaterThan) {
+          buffer.writeCharCode(char);
+        }
+        buffer.writeCharCode(next);
+      } else if (char == AsciiTable.lineFeed || char == AsciiTable.carriageReturn || char == AsciiTable.formFeed) {
+        // Not a link (no line breaks allowed within `<...>`).
+        return null;
+      } else if (char == AsciiTable.space) {
+        buffer.write('%20');
+      } else if (char == AsciiTable.greaterThan) {
+        break;
+      } else {
+        buffer.writeCharCode(char);
+      }
+      parser.advanceBy(1);
+      if (parser.isDone) return null;
+    }
+    var destination = buffer.toString();
+
+    parser.advanceBy(1);
+    var char = parser.charAt(parser.pos);
+    if (char == AsciiTable.space ||
+        char == AsciiTable.lineFeed ||
+        char == AsciiTable.carriageReturn ||
+        char == AsciiTable.formFeed) {
+      if (char == AsciiTable.space) {
+        // We found a space, we might have a title or a size definition after it.
+        if (parser.isDone) {
+          // We are already at the end. Fizzle.
+          return null;
+        }
+
+        if (parser.charAt(parser.pos + 1) == AsciiTable.equal) {
+          // We found the start of a size definition. Try to parse it.
+          parser.advanceBy(1);
+          imageSize = _tryParseImageSize(parser);
+
+          if (imageSize != null) {
+            // We parsed the image size. Continue to parse the remainder of the input.
+          }
+        }
+      }
+
+      var title = _parseTitle(parser);
+      if (title == null && parser.charAt(parser.pos) != AsciiTable.rightParen) {
+        // This looked like an inline link, until we found this AsciiTable.$space
+        // followed by mystery characters; no longer a link.
+        return null;
+      }
+      return MarkdownImage(destination, title: title, size: imageSize);
+    } else if (char == AsciiTable.rightParen) {
+      return MarkdownImage(destination, size: imageSize);
+    } else {
+      // We parsed something like `[foo](<url>X`. Not a link.
+      return null;
+    }
+  }
+
+  /// Parse an inline link with a "bare" destination (a destination _not_
+  /// wrapped in `<...>`). The current position of the parser must be the first
+  /// character of the destination.
+  ///
+  /// Returns the link if it was successfully created, `null` otherwise.
+  MarkdownImage? _parseInlineBareDestinationLink(md.InlineParser parser) {
+    // According to
+    // [CommonMark](http://spec.commonmark.org/0.28/#link-destination):
+    //
+    // > A link destination consists of [...] a nonempty sequence of
+    // > characters [...], and includes parentheses only if (a) they are
+    // > backslash-escaped or (b) they are part of a balanced pair of
+    // > unescaped parentheses.
+    //
+    // We need to count the open parens. We start with 1 for the paren that
+    // opened the destination.
+    var parenCount = 1;
+    final buffer = StringBuffer();
+
+    PreferredSize? imageSize;
+
+    while (true) {
+      final char = parser.charAt(parser.pos);
+      switch (char) {
+        case AsciiTable.backslash:
+          parser.advanceBy(1);
+          if (parser.isDone) return null; // EOF. Not a link.
+          final next = parser.charAt(parser.pos);
+          // Parentheses may be escaped.
+          //
+          // http://spec.commonmark.org/0.28/#example-467
+          if (next != AsciiTable.backslash && next != AsciiTable.leftParen && next != AsciiTable.rightParen) {
+            buffer.writeCharCode(char);
+          }
+          buffer.writeCharCode(next);
+          break;
+
+        case AsciiTable.space:
+        case AsciiTable.lineFeed:
+        case AsciiTable.carriageReturn:
+        case AsciiTable.formFeed:
+          final destination = buffer.toString();
+
+          if (char == AsciiTable.space) {
+            // We found a space, we might have a title or a size definition after it.
+            if (parser.isDone) {
+              // We are already at the end. Fizzle.
+              return null;
+            }
+
+            if (parser.charAt(parser.pos + 1) == AsciiTable.equal) {
+              // We found the start of a size definition. Try to parse it.
+              parser.advanceBy(1);
+              imageSize = _tryParseImageSize(parser);
+
+              if (imageSize != null) {
+                // We parsed the image size. Continue to parse the remainder of the input.
+                continue;
+              }
+            }
+          }
+
+          final title = _parseTitle(parser);
+          if (title == null && (parser.isDone || parser.charAt(parser.pos) != AsciiTable.rightParen)) {
+            // This looked like an inline link, until we found this AsciiTable.$space
+            // followed by mystery characters; no longer a link.
+            return null;
+          }
+          // [_parseTitle] made sure the title was follwed by a closing `)`
+          // (but it's up to the code here to examine the balance of
+          // parentheses).
+          parenCount--;
+          if (parenCount == 0) {
+            return MarkdownImage(destination, size: imageSize, title: title);
+          }
+          break;
+
+        case AsciiTable.leftParen:
+          parenCount++;
+          buffer.writeCharCode(char);
+          break;
+
+        case AsciiTable.rightParen:
+          parenCount--;
+          if (parenCount == 0) {
+            final destination = buffer.toString();
+            return MarkdownImage(destination, size: imageSize);
+          }
+          buffer.writeCharCode(char);
+          break;
+
+        default:
+          buffer.writeCharCode(char);
+      }
+      parser.advanceBy(1);
+      if (parser.isDone) return null; // EOF. Not a link.
+    }
+  }
+
+  md.Element createNode(
+    String destination,
+    String? title, {
+    PreferredSize? size,
+    required List<md.Node> Function() getChildren,
+  }) {
+    final element = md.Element.empty('img');
+    final children = getChildren();
+    element.attributes['src'] = destination;
+    element.attributes['alt'] = children.map((node) => node.textContent).join();
+
+    if (size?.width != null) {
+      element.attributes['width'] = size!.width!.toString();
+    }
+
+    if (size?.height != null) {
+      element.attributes['height'] = size!.height!.toString();
+    }
+
+    if (title != null && title.isNotEmpty) {
+      title.replaceAll('&', '&amp;');
+      element.attributes['title'] = _escapeAttribute(title.replaceAll('&', '&amp;'));
+    }
+    return element;
+  }
+
+  // Walk the parser forward through any whitespace.
+  void _moveThroughWhitespace(md.InlineParser parser) {
+    while (!parser.isDone) {
+      final char = parser.charAt(parser.pos);
+      if (char != AsciiTable.space &&
+          char != AsciiTable.tab &&
+          char != AsciiTable.lineFeed &&
+          char != AsciiTable.vTab &&
+          char != AsciiTable.carriageReturn &&
+          char != AsciiTable.formFeed) {
+        return;
+      }
+      parser.advanceBy(1);
+    }
+  }
+}
+
+/// One or more whitespace, for compressing.
+final _oneOrMoreWhitespacePattern = RegExp('[ \n\r\t]+');
+
+/// "Normalizes" a link label, according to the [CommonMark spec].
+///
+/// Extracted from the markdown package.
+String _normalizeLinkLabel(String label) => label.trim().replaceAll(_oneOrMoreWhitespacePattern, ' ').toLowerCase();
+
+/// Escapes the contents of [value], so that it may be used as an HTML
+/// attribute.
+///
+/// Extracted from the markdown package.
+String _escapeAttribute(String value) {
+  final result = StringBuffer();
+  int ch;
+  for (var i = 0; i < value.codeUnits.length; i++) {
+    ch = value.codeUnitAt(i);
+    if (ch == AsciiTable.backslash) {
+      i++;
+      if (i == value.codeUnits.length) {
+        result.writeCharCode(ch);
+        break;
+      }
+      ch = value.codeUnitAt(i);
+      switch (ch) {
+        case AsciiTable.quote:
+          result.write('&quot;');
+          break;
+        case AsciiTable.exclamation:
+        case AsciiTable.hashSign:
+        case AsciiTable.dollar:
+        case AsciiTable.percent:
+        case AsciiTable.ampersand:
+        case AsciiTable.apostrophe:
+        case AsciiTable.leftParen:
+        case AsciiTable.rightParen:
+        case AsciiTable.asterisk:
+        case AsciiTable.plus:
+        case AsciiTable.comma:
+        case AsciiTable.dash:
+        case AsciiTable.dot:
+        case AsciiTable.slash:
+        case AsciiTable.colon:
+        case AsciiTable.semicolon:
+        case AsciiTable.lessThan:
+        case AsciiTable.equal:
+        case AsciiTable.greaterThan:
+        case AsciiTable.questionMark:
+        case AsciiTable.at:
+        case AsciiTable.leftBracket:
+        case AsciiTable.backslash:
+        case AsciiTable.rightBracket:
+        case AsciiTable.caret:
+        case AsciiTable.underscore:
+        case AsciiTable.backquote:
+        case AsciiTable.leftBrace:
+        case AsciiTable.pipe:
+        case AsciiTable.rightBrace:
+        case AsciiTable.tilde:
+          result.writeCharCode(ch);
+          break;
+        default:
+          result.write('%5C');
+          result.writeCharCode(ch);
+      }
+    } else if (ch == AsciiTable.quote) {
+      result.write('%22');
+    } else {
+      result.writeCharCode(ch);
+    }
+  }
+  return result.toString();
+}
+
+/// Codes for a set of characters in the ascii table.
+class AsciiTable {
+  /// "Horizontal Tab" character.
+  static const int tab = 0x09;
+
+  /// "Line feed" control character.
+  static const int lineFeed = 0x0A;
+
+  /// "Vertical Tab" control character.
+  static const int vTab = 0x0B;
+
+  /// "Form feed" control character.
+  static const int formFeed = 0x0C;
+
+  /// "Carriage return" control character.
+  static const int carriageReturn = 0x0D;
+
+  /// Space character.
+  static const int space = 0x20;
+
+  /// Character `!`.
+  static const int exclamation = 0x21;
+
+  /// Character `"`.
+  static const int quote = 0x22;
+
+  /// Character `"`.
+  static const int doubleQuote = 0x22; // ignore: constant_identifier_names
+
+  /// Character `#`.
+  static const int hashSign = 0x23;
+
+  /// Character `$`.
+  static const int dollar = 0x24;
+
+  /// Character `%`.
+  static const int percent = 0x25;
+
+  /// Character `&`.
+  static const int ampersand = 0x26;
+
+  /// Character `'`.
+  static const int apostrophe = 0x27;
+
+  /// Character `(`.
+  static const int leftParen = 0x28;
+
+  /// Character `)`.
+  static const int rightParen = 0x29;
+
+  /// Character `*`.
+  static const int asterisk = 0x2A;
+
+  /// Character `+`.
+  static const int plus = 0x2B;
+
+  /// Character `,`.
+  static const int comma = 0x2C;
+
+  /// Character `-`.
+  static const int dash = 0x2D;
+
+  /// Character `.`.
+  static const int dot = 0x2E;
+
+  /// Character `/`.
+  static const int slash = 0x2F;
+
+  /// Character `0`.
+  static const int numberZero = 0x30;
+
+  /// Character `9`.
+  static const int numberNine = 0x39;
+
+  /// Character `:`.
+  static const int colon = 0x3A;
+
+  /// Character `;`.
+  static const int semicolon = 0x3B;
+
+  /// Character `<`.
+  static const int lessThan = 0x3C;
+
+  /// Character `=`.
+  static const int equal = 0x3D;
+
+  /// Character `>`.
+  static const int greaterThan = 0x3E;
+
+  /// Character `?`.
+  static const int questionMark = 0x3F;
+
+  /// Character `@`.
+  static const int at = 0x40;
+
+  /// Character `[`.
+  static const int leftBracket = 0x5B;
+
+  /// Character `\`.
+  static const int backslash = 0x5C;
+
+  /// Character `]`.
+  static const int rightBracket = 0x5D;
+
+  /// Character `^`.
+  static const int caret = 0x5E;
+
+  /// Character `_`.
+  static const int underscore = 0x5F;
+
+  /// Character `` ` ``.
+  static const int backquote = 0x60;
+
+  /// Character `{`.
+  static const int leftBrace = 0x7B;
+
+  /// Character `|`.
+  static const int pipe = 0x7C;
+
+  /// Character `}`.
+  static const int rightBrace = 0x7D;
+
+  /// Character `~`.
+  static const int tilde = 0x7E;
+}
+
+/// A size with optional [width] and [height].
+class PreferredSize {
+  PreferredSize({
+    required this.width,
+    required this.height,
+  });
+
+  final double? width;
+  final double? height;
+}
+
+/// A parsed image notation.
+class MarkdownImage extends md.InlineLink {
+  MarkdownImage(
+    String destination, {
+    String? title,
+    this.size,
+  }) : super(destination, title: title);
+
+  final PreferredSize? size;
+}

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -724,12 +724,14 @@ class AsciiTable {
 }
 
 /// A parsed image notation.
-class MarkdownImage extends md.InlineLink {
-  MarkdownImage(
-    String destination, {
-    String? title,
+class MarkdownImage {
+  const MarkdownImage(
+    this.destination, {
+    this.title,
     this.size,
-  }) : super(destination, title: title);
+  });
 
+  final String destination;
+  final String? title;
   final ExpectedSize? size;
 }

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -112,7 +112,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     // Parse an optional height.
     final height = _tryParseNumber(parser);
 
-    return ExpectedSize(width: width, height: height);
+    return ExpectedSize(width, height);
   }
 
   /// Tries to parse an integer number.

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -1,8 +1,9 @@
 import 'package:markdown/markdown.dart' as md;
 import 'package:super_editor/super_editor.dart';
 
-/// Matches images like `![alternate text](url optional_size "optional title")` and
-/// `![alternate text][label]`.
+/// Matches all images.
+///
+/// For example: `![My Image](https://my-image.com)` and `![My Image](https://my-image.com =500x200)`
 ///
 /// To define a size, use the notation `=widthxheight`. The size notation is optional and
 /// it can be providade partially. For example:
@@ -11,7 +12,7 @@ import 'package:super_editor/super_editor.dart';
 /// - ![alternate text](url =500x)
 /// - ![alternate text](url =x200)
 ///
-/// Extracted and adapted from the markdown package.
+/// This class was modified from a copy of [md.LinkSyntax].
 class SuperEditorImageSyntax extends md.LinkSyntax {
   static final _entirelyWhitespacePattern = RegExp(r'^\s*$.');
 

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -302,8 +302,8 @@ class _MarkdownToDocument implements md.NodeVisitor {
         altText: altText,
         expectedBitmapSize: width != null || height != null
             ? ExpectedSize(
-                width: width != null ? int.tryParse(width) : null,
-                height: height != null ? int.tryParse(height) : null,
+                width != null ? int.tryParse(width) : null,
+                height != null ? int.tryParse(height) : null,
               )
             : null,
       ),

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -300,8 +300,12 @@ class _MarkdownToDocument implements md.NodeVisitor {
         id: Editor.createNodeId(),
         imageUrl: imageUrl,
         altText: altText,
-        width: width != null ? double.tryParse(width) : null,
-        height: height != null ? double.tryParse(height) : null,
+        expectedBitmapSize: width != null || height != null
+            ? ExpectedSize(
+                width: width != null ? int.tryParse(width) : null,
+                height: height != null ? int.tryParse(height) : null,
+              )
+            : null,
       ),
     );
   }

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -131,8 +131,12 @@ class _MarkdownToDocument implements md.NodeVisitor {
             // TODO: handle null image URL
             imageUrl: inlineVisitor.imageUrl!,
             altText: inlineVisitor.imageAltText!,
-            width: inlineVisitor.width,
-            height: inlineVisitor.height,
+            expectedBitmapSize: inlineVisitor.width != null || inlineVisitor.height != null
+                ? ExpectedSize(
+                    inlineVisitor.width != null ? int.tryParse(inlineVisitor.width!) : null,
+                    inlineVisitor.height != null ? int.tryParse(inlineVisitor.height!) : null,
+                  )
+                : null,
           );
         } else {
           _addParagraph(inlineVisitor.attributedText, element.attributes);
@@ -292,20 +296,14 @@ class _MarkdownToDocument implements md.NodeVisitor {
   void _addImage({
     required String imageUrl,
     required String altText,
-    String? width,
-    String? height,
+    ExpectedSize? expectedBitmapSize,
   }) {
     _content.add(
       ImageNode(
         id: Editor.createNodeId(),
         imageUrl: imageUrl,
         altText: altText,
-        expectedBitmapSize: width != null || height != null
-            ? ExpectedSize(
-                width != null ? int.tryParse(width) : null,
-                height != null ? int.tryParse(height) : null,
-              )
-            : null,
+        expectedBitmapSize: expectedBitmapSize,
       ),
     );
   }

--- a/super_editor_markdown/lib/src/super_editor_syntax.dart
+++ b/super_editor_markdown/lib/src/super_editor_syntax.dart
@@ -2,7 +2,7 @@ enum MarkdownSyntax {
   /// Standard markdown syntax.
   normal,
 
-  /// Extended syntax which supports serialization of text alignment, strikethrough and underline.
+  /// Extended syntax which supports serialization of text alignment, strikethrough, underline and image size.
   ///
   /// Underline text is serialized between a pair of `¬`.
   ///
@@ -16,5 +16,8 @@ enum MarkdownSyntax {
   /// `---:` represents right alignment.
   ///
   /// `-::-` represents justify alignment.
+  ///
+  /// Image size is serialized using the notation `=widthxheight` after the url,
+  /// separated by a space.
   superEditor,
 }

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -459,7 +459,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            expectedBitmapSize: ExpectedSize(width: 500, height: 400),
+            expectedBitmapSize: const ExpectedSize(500, 400),
           ),
         ]);
 
@@ -472,7 +472,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            expectedBitmapSize: ExpectedSize(width: 300),
+            expectedBitmapSize: ExpectedSize(300, null),
           ),
         ]);
 
@@ -485,7 +485,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            expectedBitmapSize: ExpectedSize(height: 200),
+            expectedBitmapSize: ExpectedSize(null, 200),
           ),
         ]);
 
@@ -848,7 +848,7 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize, isNull);
+        expect(image.expectedSize, isNull);
       });
 
       test('image with size', () {
@@ -858,8 +858,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, 500.0);
-        expect(image.expectedBitmapSize?.height, 200.0);
+        expect(image.expectedSize?.width, 500.0);
+        expect(image.expectedSize?.height, 200.0);
       });
 
       test('image with size and title', () {
@@ -869,8 +869,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, 500.0);
-        expect(image.expectedBitmapSize?.height, 200.0);
+        expect(image.expectedSize?.width, 500.0);
+        expect(image.expectedSize?.height, 200.0);
       });
 
       test('image with width', () {
@@ -880,8 +880,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, 500.0);
-        expect(image.expectedBitmapSize?.height, isNull);
+        expect(image.expectedSize?.width, 500.0);
+        expect(image.expectedSize?.height, isNull);
       });
 
       test('image with height', () {
@@ -891,8 +891,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, isNull);
-        expect(image.expectedBitmapSize?.height, 200.0);
+        expect(image.expectedSize?.width, isNull);
+        expect(image.expectedSize?.height, 200.0);
       });
 
       test('image with size notation without width and height', () {
@@ -901,8 +901,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, isNull);
-        expect(image.expectedBitmapSize?.height, isNull);
+        expect(image.expectedSize?.width, isNull);
+        expect(image.expectedSize?.height, isNull);
       });
 
       test('image with incomplete size notation', () {
@@ -911,8 +911,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedBitmapSize?.width, isNull);
-        expect(image.expectedBitmapSize?.height, isNull);
+        expect(image.expectedSize?.width, isNull);
+        expect(image.expectedSize?.height, isNull);
       });
 
       test('single unstyled paragraph', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -485,7 +485,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            expectedBitmapSize: ExpectedSize(width: 1000, height: 200),
+            expectedBitmapSize: ExpectedSize(height: 200),
           ),
         ]);
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -459,8 +459,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            width: 500.0,
-            height: 400.0,
+            expectedBitmapSize: ExpectedSize(width: 500, height: 400),
           ),
         ]);
 
@@ -473,7 +472,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            width: 300.0,
+            expectedBitmapSize: ExpectedSize(width: 300),
           ),
         ]);
 
@@ -486,7 +485,7 @@ Paragraph3""");
             id: '1',
             imageUrl: 'https://someimage.com/the/image.png',
             altText: 'some alt text',
-            height: 200.0,
+            expectedBitmapSize: ExpectedSize(width: 1000, height: 200),
           ),
         ]);
 
@@ -849,8 +848,7 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, isNull);
-        expect(image.height, isNull);
+        expect(image.expectedBitmapSize, isNull);
       });
 
       test('image with size', () {
@@ -860,8 +858,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, 500.0);
-        expect(image.height, 200.0);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with size and title', () {
@@ -871,8 +869,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, 500.0);
-        expect(image.height, 200.0);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with width', () {
@@ -882,8 +880,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, 500.0);
-        expect(image.height, isNull);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('image with height', () {
@@ -893,8 +891,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, isNull);
-        expect(image.height, 200.0);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with size notation without width and height', () {
@@ -903,8 +901,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, isNull);
-        expect(image.height, isNull);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('image with incomplete size notation', () {
@@ -913,8 +911,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.width, isNull);
-        expect(image.height, isNull);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('single unstyled paragraph', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -848,7 +848,7 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize, isNull);
+        expect(image.expectedBitmapSize, isNull);
       });
 
       test('image with size', () {
@@ -858,8 +858,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, 500.0);
-        expect(image.expectedSize?.height, 200.0);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with size and title', () {
@@ -869,8 +869,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, 500.0);
-        expect(image.expectedSize?.height, 200.0);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with width', () {
@@ -880,8 +880,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, 500.0);
-        expect(image.expectedSize?.height, isNull);
+        expect(image.expectedBitmapSize?.width, 500.0);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('image with height', () {
@@ -891,8 +891,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, isNull);
-        expect(image.expectedSize?.height, 200.0);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, 200.0);
       });
 
       test('image with size notation without width and height', () {
@@ -901,8 +901,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, isNull);
-        expect(image.expectedSize?.height, isNull);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('image with incomplete size notation', () {
@@ -911,8 +911,8 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
-        expect(image.expectedSize?.width, isNull);
-        expect(image.expectedSize?.height, isNull);
+        expect(image.expectedBitmapSize?.width, isNull);
+        expect(image.expectedBitmapSize?.height, isNull);
       });
 
       test('single unstyled paragraph', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -453,6 +453,46 @@ Paragraph3""");
         expect(serializeDocumentToMarkdown(doc), '![some alt text](https://someimage.com/the/image.png)');
       });
 
+      test('image with size', () {
+        final doc = MutableDocument(nodes: [
+          ImageNode(
+            id: '1',
+            imageUrl: 'https://someimage.com/the/image.png',
+            altText: 'some alt text',
+            width: 500.0,
+            height: 400.0,
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '![some alt text](https://someimage.com/the/image.png =500x400)');
+      });
+
+      test('image with width', () {
+        final doc = MutableDocument(nodes: [
+          ImageNode(
+            id: '1',
+            imageUrl: 'https://someimage.com/the/image.png',
+            altText: 'some alt text',
+            width: 300.0,
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '![some alt text](https://someimage.com/the/image.png =300x)');
+      });
+
+      test('image with height', () {
+        final doc = MutableDocument(nodes: [
+          ImageNode(
+            id: '1',
+            imageUrl: 'https://someimage.com/the/image.png',
+            altText: 'some alt text',
+            height: 200.0,
+          ),
+        ]);
+
+        expect(serializeDocumentToMarkdown(doc), '![some alt text](https://someimage.com/the/image.png =x200)');
+      });
+
       test('horizontal rule', () {
         final doc = MutableDocument(nodes: [
           HorizontalRuleNode(
@@ -809,6 +849,72 @@ This is some code
         final image = codeBlockDoc.nodes.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
+        expect(image.width, isNull);
+        expect(image.height, isNull);
+      });
+
+      test('image with size', () {
+        final codeBlockDoc =
+            deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =500x200)');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, 500.0);
+        expect(image.height, 200.0);
+      });
+
+      test('image with size and title', () {
+        final codeBlockDoc = deserializeMarkdownToDocument(
+            '![Image alt text](https://images.com/some/image.png =500x200 "image title")');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, 500.0);
+        expect(image.height, 200.0);
+      });
+
+      test('image with width', () {
+        final codeBlockDoc =
+            deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =500x)');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, 500.0);
+        expect(image.height, isNull);
+      });
+
+      test('image with height', () {
+        final codeBlockDoc =
+            deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =x200)');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, isNull);
+        expect(image.height, 200.0);
+      });
+
+      test('image with size notation without width and height', () {
+        final codeBlockDoc = deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =x)');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, isNull);
+        expect(image.height, isNull);
+      });
+
+      test('image with incomplete size notation', () {
+        final codeBlockDoc = deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =)');
+
+        final image = codeBlockDoc.nodes.first as ImageNode;
+        expect(image.imageUrl, 'https://images.com/some/image.png');
+        expect(image.altText, 'Image alt text');
+        expect(image.width, isNull);
+        expect(image.height, isNull);
       });
 
       test('single unstyled paragraph', () {


### PR DESCRIPTION
[SuperEditor] Add image size awareness. Resolves #851

Currently, we don't have a way to specify the image size. The images don't have an initial height and the component is resized when the image is loaded.

There isn't a standard in the markdown specification for serializing an image size. However, it seems some markdown renderers use one of the following syntaxes:

1.  `![alt text](www.foo.com/image.png =800x600)` 
2. `![alt text](www.foo.com/image.png){width=800 height=600}`

This PR implements the first syntax, but I can change to the second if needed.

The markdown package doesn't have a way to plug into the image parsing, so I had to copy the whole parsing logic and change to be able to parse the size notation.

The main changes where:

- Added the `_tryParseImageSize` method.
- Added the `_tryParseNumber` method.
- Changed `_parseInlineBracketedLink` and `_parseInlineBareDestinationLink` to handle the size notation
- Added a `AsciiTable` class to hold the character codes instead of using the top level constants prefixed with a `$`.

One thing I noticed it that it doesn't seem to stretch the same way when setting the image height. Here's a comparison of the different rendering depending on the `BoxFit`:

Original, without setting the height:

https://github.com/superlistapp/super_editor/assets/7597082/f0fc169c-e205-4a1c-9c31-b2f843a18924

Setting height to 422px, with `BoxFit.contain`:

https://github.com/superlistapp/super_editor/assets/7597082/afc5521f-a568-4128-be25-212ae2f04ae1

Setting height to 422px, with `BoxFit.cover`:

https://github.com/superlistapp/super_editor/assets/7597082/46e2f9f9-92cd-45f4-813e-0ff3e0f6271b

Setting height to 422px, with `BoxFit.fill`:

https://github.com/superlistapp/super_editor/assets/7597082/9c9cff84-02dc-4d27-8c00-c55baa16a5ac

Setting height to 422px, with `BoxFit.fitHeight`:

https://github.com/superlistapp/super_editor/assets/7597082/08d24401-e705-47ee-b632-34fb76706a0c

Setting height to 422px, with `BoxFit.fitWidth`:

https://github.com/superlistapp/super_editor/assets/7597082/8d005464-5143-4b0d-9f3e-fb29621b11ef

Setting height to 422px, with `BoxFit.none`:

https://github.com/superlistapp/super_editor/assets/7597082/99060f14-03c0-40e1-99ab-0488bf225ebe

Setting height to 422px, with `BoxFit.scaleDown`:

https://github.com/superlistapp/super_editor/assets/7597082/96992852-127a-4b46-8026-ee40f57879d5






