### PR TITLE
[SuperEditor][SuperTexField] Clear composing region after losing focus (Resolves #1689)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_interaction_policies.dart
@@ -315,6 +315,12 @@ class _DocumentSelectionOpenAndCloseImePolicyState extends State<DocumentSelecti
         const ClearSelectionRequest(),
       ]);
     }
+
+    if (!widget.focusNode.hasFocus) {
+      widget.editor.execute([
+        const ClearComposingRegionRequest(),
+      ]);
+    }
   }
 
   void _onSelectionChange() {

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -385,6 +385,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       setState(() {
         _textEditingController.detachFromIme();
         _textEditingController.selection = const TextSelection.collapsed(offset: -1);
+        _textEditingController.composingRegion = TextRange.empty;
         _removeEditingOverlayControls();
       });
     }

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -173,7 +173,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   void initState() {
     super.initState();
 
-    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionOnFocusChange);
+    _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndComposingRegionOnFocusChange);
 
     _controller = widget.textController != null
         ? widget.textController is ImeAttributedTextEditingController
@@ -189,7 +189,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     _createTextFieldContext();
 
     // Check if we need to update the selection.
-    _updateSelectionOnFocusChange();
+    _updateSelectionAndComposingRegionOnFocusChange();
   }
 
   @override
@@ -197,14 +197,14 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     super.didUpdateWidget(oldWidget);
 
     if (widget.focusNode != oldWidget.focusNode) {
-      _focusNode.removeListener(_updateSelectionOnFocusChange);
+      _focusNode.removeListener(_updateSelectionAndComposingRegionOnFocusChange);
       if (oldWidget.focusNode == null) {
         _focusNode.dispose();
       }
-      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionOnFocusChange);
+      _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndComposingRegionOnFocusChange);
 
       // Check if we need to update the selection.
-      _updateSelectionOnFocusChange();
+      _updateSelectionAndComposingRegionOnFocusChange();
     }
 
     if (widget.textController != oldWidget.textController) {
@@ -236,7 +236,7 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
   void dispose() {
     _textFieldScroller.detach();
     _scrollController.dispose();
-    _focusNode.removeListener(_updateSelectionOnFocusChange);
+    _focusNode.removeListener(_updateSelectionAndComposingRegionOnFocusChange);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -275,13 +275,17 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     _focusNode.requestFocus();
   }
 
-  void _updateSelectionOnFocusChange() {
+  void _updateSelectionAndComposingRegionOnFocusChange() {
     // If our FocusNode just received focus, automatically set our
     // controller's text position to the end of the available content.
     //
     // This behavior matches Flutter's standard behavior.
     if (_focusNode.hasFocus && !_hasFocus && _controller.selection.extentOffset == -1) {
       _controller.selection = TextSelection.collapsed(offset: _controller.text.text.length);
+    }
+    if (!_focusNode.hasFocus) {
+      // We lost focus. Clear the composing region.
+      _controller.composingRegion = TextRange.empty;
     }
     _hasFocus = _focusNode.hasFocus;
   }

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -402,6 +402,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       setState(() {
         _textEditingController.detachFromIme();
         _textEditingController.selection = const TextSelection.collapsed(offset: -1);
+        _textEditingController.composingRegion = TextRange.empty;
         _removeEditingOverlayControls();
       });
     }


### PR DESCRIPTION
[SuperEditor][SuperTexField] Clear composing region after losing focus. Resolves #1689

When the editor/textfield has a composing region, focusing another widget doesn't cause the composing region to be cleared. This results in the composing region underline to remain visible:

https://github.com/superlistapp/super_editor/assets/31278849/ed204ea7-16fa-4f0b-bf1b-035f303a4c22

This PR changes both `SuperTextField` and `SuperEditor` to clear the composing region when losing focus. In `SuperEditor`, maybe we want that to be configurable, because clearing the selection is configurable.