### PR TITLE
[SuperEditor][SuperTextField][Android] Show toolbar upon tap on collapsed handle (Resolves #1737)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1363,6 +1363,10 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   @visibleForTesting
   bool get wantsToDisplayMagnifier => _controlsController!.shouldShowMagnifier.value;
 
+  void _toggleToolbarOnCollapsedHandleTap() {
+    _controlsController!.toggleToolbar();
+  }
+
   void _onHandlePanStart(DragStartDetails details, HandleType handleType) {
     final selection = widget.selection.value;
     if (selection == null) {
@@ -1578,6 +1582,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
                 onTapDown: (_) {
                   // Register tap down to win gesture arena ASAP.
                 },
+                onTap: _toggleToolbarOnCollapsedHandleTap,
                 onPanStart: (details) => _onHandlePanStart(details, HandleType.collapsed),
                 onPanUpdate: _onHandlePanUpdate,
                 onPanEnd: _onHandlePanEnd,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1,5 +1,5 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/foundation.dart' show ValueListenable, defaultTargetPlatform;
 import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter/services.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
@@ -8,6 +8,7 @@ import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/document_debug_paint.dart';
 import 'package:super_editor/src/core/document_interaction.dart';
 import 'package:super_editor/src/core/document_layout.dart';
+import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/core/styles.dart';
@@ -756,6 +757,7 @@ class SuperEditorState extends State<SuperEditor> {
             mobileToolbarKey,
             editContext.commonOps,
             SuperEditorAndroidControlsScope.rootOf(context),
+            editContext.composer.selectionNotifier,
           ),
           child: child,
         );
@@ -875,11 +877,13 @@ Widget defaultAndroidEditorToolbarBuilder(
   Key floatingToolbarKey,
   CommonEditorOperations editorOps,
   SuperEditorAndroidControlsController editorControlsController,
+  ValueListenable<DocumentSelection?> selectionNotifier,
 ) {
   return DefaultAndroidEditorToolbar(
     floatingToolbarKey: floatingToolbarKey,
     editorOps: editorOps,
     editorControlsController: editorControlsController,
+    selectionNotifier: selectionNotifier,
   );
 }
 
@@ -890,20 +894,22 @@ class DefaultAndroidEditorToolbar extends StatelessWidget {
     this.floatingToolbarKey,
     required this.editorOps,
     required this.editorControlsController,
+    required this.selectionNotifier,
   });
 
   final Key? floatingToolbarKey;
   final CommonEditorOperations editorOps;
   final SuperEditorAndroidControlsController editorControlsController;
+  final ValueListenable<DocumentSelection?> selectionNotifier;
 
   @override
   Widget build(BuildContext context) {
     return AndroidTextEditingFloatingToolbar(
       floatingToolbarKey: floatingToolbarKey,
-      onCopyPressed: editorOps.composer.selection == null || !editorOps.composer.selection!.isCollapsed //
+      onCopyPressed: selectionNotifier.value == null || !selectionNotifier.value!.isCollapsed //
           ? _copy
           : null,
-      onCutPressed: editorOps.composer.selection == null || !editorOps.composer.selection!.isCollapsed //
+      onCutPressed: selectionNotifier.value == null || !selectionNotifier.value!.isCollapsed //
           ? _cut
           : null,
       onPastePressed: _paste,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -900,8 +900,12 @@ class DefaultAndroidEditorToolbar extends StatelessWidget {
   Widget build(BuildContext context) {
     return AndroidTextEditingFloatingToolbar(
       floatingToolbarKey: floatingToolbarKey,
-      onCopyPressed: _copy,
-      onCutPressed: _cut,
+      onCopyPressed: editorOps.composer.selection == null || !editorOps.composer.selection!.isCollapsed //
+          ? _copy
+          : null,
+      onCutPressed: editorOps.composer.selection == null || !editorOps.composer.selection!.isCollapsed //
+          ? _cut
+          : null,
       onPastePressed: _paste,
       onSelectAllPressed: _selectAll,
     );

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -904,16 +904,21 @@ class DefaultAndroidEditorToolbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AndroidTextEditingFloatingToolbar(
-      floatingToolbarKey: floatingToolbarKey,
-      onCopyPressed: selectionNotifier.value == null || !selectionNotifier.value!.isCollapsed //
-          ? _copy
-          : null,
-      onCutPressed: selectionNotifier.value == null || !selectionNotifier.value!.isCollapsed //
-          ? _cut
-          : null,
-      onPastePressed: _paste,
-      onSelectAllPressed: _selectAll,
+    return ValueListenableBuilder(
+      valueListenable: selectionNotifier,
+      builder: (context, selection, child) {
+        return AndroidTextEditingFloatingToolbar(
+          floatingToolbarKey: floatingToolbarKey,
+          onCopyPressed: selection == null || !selection.isCollapsed //
+              ? _copy
+              : null,
+          onCutPressed: selection == null || !selection.isCollapsed //
+              ? _cut
+              : null,
+          onPastePressed: _paste,
+          onSelectAllPressed: _selectAll,
+        );
+      },
     );
   }
 

--- a/super_editor/lib/src/infrastructure/touch_controls.dart
+++ b/super_editor/lib/src/infrastructure/touch_controls.dart
@@ -16,14 +16,10 @@ enum HandleType {
 class ToolbarConfig {
   ToolbarConfig({
     required this.focalPoint,
-    this.collapsedSelection = false,
   });
 
   /// The desired point where a toolbar arrow should point to.
   ///
   /// Represented as global coordinates.
   final Offset focalPoint;
-
-  // TODO: change this.
-  final bool collapsedSelection;
 }

--- a/super_editor/lib/src/infrastructure/touch_controls.dart
+++ b/super_editor/lib/src/infrastructure/touch_controls.dart
@@ -16,10 +16,14 @@ enum HandleType {
 class ToolbarConfig {
   ToolbarConfig({
     required this.focalPoint,
+    this.collapsedSelection = false,
   });
 
   /// The desired point where a toolbar arrow should point to.
   ///
   /// Represented as global coordinates.
   final Offset focalPoint;
+
+  // TODO: change this.
+  final bool collapsedSelection;
 }

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -588,10 +588,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
               child: widget.popoverToolbarBuilder(
                 context,
                 widget.editingController,
-                ToolbarConfig(
-                  focalPoint: textFieldGlobalOffset + toolbarTopAnchor,
-                  collapsedSelection: widget.editingController.textController.selection.isCollapsed,
-                ),
+                ToolbarConfig(focalPoint: textFieldGlobalOffset + toolbarTopAnchor),
               ),
             );
           }),

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/multi_listenable_builder.dart';
@@ -216,6 +217,12 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       // this drag event started in a handle, not within this overall widget.
       _localDragOffset = (context.findRenderObject() as RenderBox).globalToLocal(details.globalPosition);
     });
+  }
+
+  void _onHandleTap(HandleType handleType) {
+    if (handleType == HandleType.collapsed) {
+      widget.editingController.toggleToolbar();
+    }
   }
 
   void _onBasePanStart(DragStartDetails details) {
@@ -581,7 +588,10 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
               child: widget.popoverToolbarBuilder(
                 context,
                 widget.editingController,
-                ToolbarConfig(focalPoint: textFieldGlobalOffset + toolbarTopAnchor),
+                ToolbarConfig(
+                  focalPoint: textFieldGlobalOffset + toolbarTopAnchor,
+                  collapsedSelection: widget.editingController.textController.selection.isCollapsed,
+                ),
               ),
             );
           }),
@@ -716,7 +726,9 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       child: FractionalTranslation(
         translation: fractionalTranslation,
         child: GestureDetector(
+          dragStartBehavior: DragStartBehavior.down,
           behavior: HitTestBehavior.translucent,
+          onTap: () => _onHandleTap(handleType),
           onPanStart: onPanStart,
           onPanUpdate: _onPanUpdate,
           onPanEnd: _onPanEnd,

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -176,6 +176,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
+    final previousSelection = widget.textController.selection;
+
     _selectAtOffset(details.localPosition);
 
     if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
@@ -194,7 +196,6 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       return;
     }
 
-    final previousSelection = widget.textController.selection;
     final didTapOnExistingSelection = previousSelection.isCollapsed
         ? tapTextPosition == previousSelection.extent
         : tapTextPosition.offset >= previousSelection.start && tapTextPosition.offset <= previousSelection.end;

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -160,18 +160,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     }
   }
 
-  void _onTapDown(TapDownDetails details) {
-    _log.fine("User tapped down");
-    if (!widget.focusNode.hasFocus) {
-      _log.finer("Field isn't focused. Ignoring press.");
-      return;
-    }
-
-    // When the user drags, the toolbar should not be visible.
-    // A drag can begin with a tap down, so we hide the toolbar
-    // preemptively.
-    widget.editingOverlayController.hideToolbar();
-  }
+  void _onTapDown(TapDownDetails details) {}
 
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -160,8 +160,6 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     }
   }
 
-  void _onTapDown(TapDownDetails details) {}
-
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
@@ -461,7 +459,6 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
             () => TapSequenceGestureRecognizer(),
             (TapSequenceGestureRecognizer recognizer) {
               recognizer
-                ..onTapDown = _onTapDown
                 ..onTapUp = _onTapUp
                 ..onDoubleTapDown = _onDoubleTapDown
                 ..onTripleTapDown = _onTripleTapDown

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -186,9 +186,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
         ? tapTextPosition == previousSelection.extent
         : tapTextPosition.offset >= previousSelection.start && tapTextPosition.offset <= previousSelection.end;
 
-    if (didTapOnExistingSelection) {
-      // Toggle the toolbar display when the user taps on the collapsed caret,
-      // or on top of an existing selection.
+    if (didTapOnExistingSelection && previousSelection.isCollapsed) {
+      // Toggle the toolbar display when the user taps on the collapsed caret.
       widget.editingOverlayController.toggleToolbar();
     } else {
       // The user tapped somewhere in the text outside any existing selection.

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -165,10 +165,6 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
   void _onTapUp(TapUpDetails details) {
     _log.fine('User released a tap');
 
-    final previousSelection = widget.textController.selection;
-
-    _selectAtOffset(details.localPosition);
-
     if (widget.focusNode.hasFocus && widget.textController.isAttachedToIme) {
       widget.textController.showKeyboard();
     } else {
@@ -185,6 +181,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       return;
     }
 
+    final previousSelection = widget.textController.selection;
     final didTapOnExistingSelection = previousSelection.isCollapsed
         ? tapTextPosition == previousSelection.extent
         : tapTextPosition.offset >= previousSelection.start && tapTextPosition.offset <= previousSelection.end;

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -657,48 +657,58 @@ Widget _defaultAndroidToolbarBuilder(
   AndroidEditingOverlayController controller,
   ToolbarConfig config,
 ) {
+  final hasCollapsedSelection = controller.textController.selection != TextRange.empty;
+
   return AndroidTextEditingFloatingToolbar(
-    onCutPressed: config.collapsedSelection
+    onCutPressed: hasCollapsedSelection //
         ? null
-        : () {
-            final textController = controller.textController;
-
-            final selection = textController.selection;
-            if (selection.isCollapsed) {
-              return;
-            }
-
-            final selectedText = selection.textInside(textController.text.text);
-
-            textController.deleteSelectedText();
-
-            Clipboard.setData(ClipboardData(text: selectedText));
-          },
-    onCopyPressed: config.collapsedSelection
+        : () => _onToolbarCutPressed(controller),
+    onCopyPressed: hasCollapsedSelection //
         ? null
-        : () {
-            final textController = controller.textController;
-            final selection = textController.selection;
-            final selectedText = selection.textInside(textController.text.text);
-
-            Clipboard.setData(ClipboardData(text: selectedText));
-          },
-    onPastePressed: () async {
-      final clipboardContent = await Clipboard.getData('text/plain');
-      if (clipboardContent == null || clipboardContent.text == null) {
-        return;
-      }
-
-      final textController = controller.textController;
-      final selection = textController.selection;
-      if (selection.isCollapsed) {
-        textController.insertAtCaret(text: clipboardContent.text!);
-      } else {
-        textController.replaceSelectionWithUnstyledText(replacementText: clipboardContent.text!);
-      }
-    },
-    onSelectAllPressed: () {
-      controller.textController.selectAll();
-    },
+        : () => _onToolbarCopyPressed(controller),
+    onPastePressed: () => _onToolbarPastePressed(controller),
+    onSelectAllPressed: () => _onToolbarSelectAllPressed(controller),
   );
+}
+
+void _onToolbarCutPressed(AndroidEditingOverlayController controller) {
+  final textController = controller.textController;
+
+  final selection = textController.selection;
+  if (selection.isCollapsed) {
+    return;
+  }
+
+  final selectedText = selection.textInside(textController.text.text);
+
+  textController.deleteSelectedText();
+
+  Clipboard.setData(ClipboardData(text: selectedText));
+}
+
+void _onToolbarCopyPressed(AndroidEditingOverlayController controller) {
+  final textController = controller.textController;
+  final selection = textController.selection;
+  final selectedText = selection.textInside(textController.text.text);
+
+  Clipboard.setData(ClipboardData(text: selectedText));
+}
+
+Future<void> _onToolbarPastePressed(AndroidEditingOverlayController controller) async {
+  final clipboardContent = await Clipboard.getData('text/plain');
+  if (clipboardContent == null || clipboardContent.text == null) {
+    return;
+  }
+
+  final textController = controller.textController;
+  final selection = textController.selection;
+  if (selection.isCollapsed) {
+    textController.insertAtCaret(text: clipboardContent.text!);
+  } else {
+    textController.replaceSelectionWithUnstyledText(replacementText: clipboardContent.text!);
+  }
+}
+
+void _onToolbarSelectAllPressed(AndroidEditingOverlayController controller) {
+  controller.textController.selectAll();
 }

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -657,15 +657,15 @@ Widget _defaultAndroidToolbarBuilder(
   AndroidEditingOverlayController controller,
   ToolbarConfig config,
 ) {
-  final hasCollapsedSelection = controller.textController.selection != TextRange.empty;
+  final isSelectionExpanded = !controller.textController.selection.isCollapsed;
 
   return AndroidTextEditingFloatingToolbar(
-    onCutPressed: hasCollapsedSelection //
-        ? null
-        : () => _onToolbarCutPressed(controller),
-    onCopyPressed: hasCollapsedSelection //
-        ? null
-        : () => _onToolbarCopyPressed(controller),
+    onCutPressed: isSelectionExpanded //
+        ? () => _onToolbarCutPressed(controller)
+        : null,
+    onCopyPressed: isSelectionExpanded //
+        ? () => _onToolbarCopyPressed(controller)
+        : null,
     onPastePressed: () => _onToolbarPastePressed(controller),
     onSelectAllPressed: () => _onToolbarSelectAllPressed(controller),
   );

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -658,27 +658,31 @@ Widget _defaultAndroidToolbarBuilder(
   ToolbarConfig config,
 ) {
   return AndroidTextEditingFloatingToolbar(
-    onCutPressed: () {
-      final textController = controller.textController;
+    onCutPressed: config.collapsedSelection
+        ? null
+        : () {
+            final textController = controller.textController;
 
-      final selection = textController.selection;
-      if (selection.isCollapsed) {
-        return;
-      }
+            final selection = textController.selection;
+            if (selection.isCollapsed) {
+              return;
+            }
 
-      final selectedText = selection.textInside(textController.text.text);
+            final selectedText = selection.textInside(textController.text.text);
 
-      textController.deleteSelectedText();
+            textController.deleteSelectedText();
 
-      Clipboard.setData(ClipboardData(text: selectedText));
-    },
-    onCopyPressed: () {
-      final textController = controller.textController;
-      final selection = textController.selection;
-      final selectedText = selection.textInside(textController.text.text);
+            Clipboard.setData(ClipboardData(text: selectedText));
+          },
+    onCopyPressed: config.collapsedSelection
+        ? null
+        : () {
+            final textController = controller.textController;
+            final selection = textController.selection;
+            final selectedText = selection.textInside(textController.text.text);
 
-      Clipboard.setData(ClipboardData(text: selectedText));
-    },
+            Clipboard.setData(ClipboardData(text: selectedText));
+          },
     onPastePressed: () async {
       final clipboardContent = await Clipboard.getData('text/plain');
       if (clipboardContent == null || clipboardContent.text == null) {

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -87,7 +87,7 @@ void main() {
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
     });
 
-    testWidgetsOnAndroid("hides toolbar when placing the caret", (tester) async {
+    testWidgetsOnAndroid("hides toolbar when the user taps to move the caret", (tester) async {
       await _pumpSingleParagraphApp(tester);
 
       // Place the caret at the beginning of the document.

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -87,6 +87,29 @@ void main() {
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
     });
 
+    testWidgetsOnAndroid("hides toolbar when placing the caret", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the drag handle to show the toolbar.
+      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Place the caret at "Lorem |ipsum".
+      await tester.placeCaretInParagraph("1", 6);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
     testWidgetsOnAndroid("shows toolbar when selection is expanded", (tester) async {
       await _pumpSingleParagraphApp(tester);
 

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -63,6 +63,30 @@ void main() {
       await tester.pump(kTapMinTime);
     });
 
+    testWidgetsOnAndroid("shows and hides toolbar upon tap on collapsed handle", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Tap the drag handle to show the toolbar.
+      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.pump();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Tap the drag handle to hide the toolbar.
+      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.pump();
+
+      // Ensure the toolbar isn't visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
     testWidgetsOnAndroid("shows toolbar when selection is expanded", (tester) async {
       await _pumpSingleParagraphApp(tester);
 

--- a/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
@@ -79,7 +79,33 @@ void main() {
       await tester.tapOnAndroidCollapsedHandle();
       await tester.pump();
 
-      // Ensure no toolbar disappeared.
+      // Ensure the toolbar disappeared.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+    });
+
+    testWidgetsOnAndroid("hides toolbar when the user taps to move the caret", (tester) async {
+      await _pumpTestApp(tester);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Place caret at the beginning of the textfield.
+      await tester.placeCaretInSuperTextField(0);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Tap on the drag handle to show the toolbar.
+      await tester.tapOnAndroidCollapsedHandle();
+      await tester.pump();
+
+      // Ensure that the text field toolbar is visible.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsOneWidget);
+
+      // Place caret at the end of the textfield.
+      await tester.placeCaretInSuperTextField(3);
+
+      // Ensure the toolbar disappeared.
       expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
     });
   });

--- a/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
@@ -83,6 +83,39 @@ void main() {
       expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
     });
 
+    testWidgetsOnAndroid("tapping at existing selection shows/hides the toolbar", (tester) async {
+      await _pumpTestApp(tester);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Place caret at "ab|c".
+      await tester.placeCaretInSuperTextField(2);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Tap again on the same position to show the toolbar.
+      await tester.placeCaretInSuperTextField(2);
+
+      // Ensure that the toolbar is visible and the selection didn't change.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsOneWidget);
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 2),
+      );
+
+      // Tap again on the same position to hide the toolbar.
+      await tester.placeCaretInSuperTextField(2);
+
+      // Ensure the toolbar disappeared and the selection didn't change.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 2),
+      );
+    });
+
     testWidgetsOnAndroid("hides toolbar when the user taps to move the caret", (tester) async {
       await _pumpTestApp(tester);
 

--- a/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/super_text_field.dart';
 
@@ -83,7 +84,7 @@ void main() {
       expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
     });
 
-    testWidgetsOnAndroid("tapping at existing selection shows/hides the toolbar", (tester) async {
+    testWidgetsOnAndroid("tapping at existing collapsed selection shows/hides the toolbar", (tester) async {
       await _pumpTestApp(tester);
 
       // Ensure no toolbar is displayed.
@@ -109,6 +110,30 @@ void main() {
       await tester.placeCaretInSuperTextField(2);
 
       // Ensure the toolbar disappeared and the selection didn't change.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 2),
+      );
+    });
+
+    testWidgetsOnAndroid("tapping at existing expanded selection places the caret", (tester) async {
+      await _pumpTestApp(tester);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Double tap to select "abc".
+      await tester.doubleTapAtSuperTextField(2);
+
+      // Ensure the toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsOneWidget);
+
+      // Tap at "ab|c" to place the caret. Pump to avoid a pan gesture.
+      await tester.pump(kTapTimeout);
+      await tester.placeCaretInSuperTextField(2);
+
+      // Ensure that the toolbar disappeared and the selection changed.
       expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
       expect(
         SuperTextFieldInspector.findSelection(),

--- a/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
+++ b/super_editor/test/super_textfield/android/super_textfield_android_selection_test.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/super_text_field.dart';
 
 import '../super_textfield_inspector.dart';
+import '../super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField Android selection >", () {
@@ -52,6 +53,33 @@ void main() {
       await tester.pumpAndSettle(kDoubleTapTimeout);
 
       // Ensure that no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+    });
+
+    testWidgetsOnAndroid("tapping at collapsed handle shows/hides the toolbar", (tester) async {
+      await _pumpTestApp(tester);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Place caret at the end of the textfield.
+      await tester.placeCaretInSuperTextField(3);
+
+      // Ensure no toolbar is displayed.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
+
+      // Tap on the drag handle to show the toolbar.
+      await tester.tapOnAndroidCollapsedHandle();
+      await tester.pump();
+
+      // Ensure that the text field toolbar is visible.
+      expect(find.byType(AndroidTextEditingFloatingToolbar), findsOneWidget);
+
+      // Tap on the drag handle to hide the toolbar.
+      await tester.tapOnAndroidCollapsedHandle();
+      await tester.pump();
+
+      // Ensure no toolbar disappeared.
       expect(find.byType(AndroidTextEditingFloatingToolbar), findsNothing);
     });
   });

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
@@ -119,6 +120,19 @@ extension SuperTextFieldRobot on WidgetTester {
     }
 
     return gesture;
+  }
+
+  /// Tap on an Android collapsed drag handle.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<void> tapOnAndroidCollapsedHandle([Finder? superTextFieldFinder]) async {
+    await tap(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is AndroidSelectionHandle && //
+            widget.handleType == HandleType.collapsed,
+      ),
+    );
   }
 
   /// Double taps in a [SuperTextField] at the given [offset]


### PR DESCRIPTION
[SuperEditor][SuperTextField][Android] Show toolbar upon tap on collapsed handle. Resolves #1737

On Android, tapping on the collapsed drag handle doesn't show the popover toolbar.

This PR changes the editor/textfield to show a toolbar containing only the options "Select All" and "Paste" after tapping on the collapsed handle:

[toolbar.webm](https://github.com/superlistapp/super_editor/assets/7597082/b9b66419-3575-41e9-b3eb-5882e620ca73)

Currently, the toolbar builders don't receive the document selection, so I'm using a workaround right now. We need to decide how we want to provide this information to the toolbar builders (for both the editor and the textfield) before merging this PR.