### PR TITLE
[super_editor_markdown] Fix list item parsing (Resolves #1711)

### DIFF
--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -961,25 +961,20 @@ This is some code
           expect((node as ListItemNode).type, ListItemType.unordered);
         }
 
-        ListItemNode node = (document.nodes[0] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 1');
+        expect((document.nodes[0] as ListItemNode).indent, 0);
+        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
 
-        node = (document.nodes[1] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 2');
+        expect((document.nodes[1] as ListItemNode).indent, 0);
+        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
 
-        node = (document.nodes[2] as ListItemNode);
-        expect(node.indent, 1);
-        expect(node.text.text, 'list item 2.1');
+        expect((document.nodes[2] as ListItemNode).indent, 1);
+        expect((document.nodes[2] as ListItemNode).text.text, 'list item 2.1');
 
-        node = (document.nodes[3] as ListItemNode);
-        expect(node.indent, 1);
-        expect(node.text.text, 'list item 2.2');
+        expect((document.nodes[3] as ListItemNode).indent, 1);
+        expect((document.nodes[3] as ListItemNode).text.text, 'list item 2.2');
 
-        node = (document.nodes[4] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 3');
+        expect((document.nodes[4] as ListItemNode).indent, 0);
+        expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
       });
 
       test('unordered list with empty lines between items', () {
@@ -1019,25 +1014,20 @@ This is some code
           expect((node as ListItemNode).type, ListItemType.ordered);
         }
 
-        ListItemNode node = (document.nodes[0] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 1');
+        expect((document.nodes[0] as ListItemNode).indent, 0);
+        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
 
-        node = (document.nodes[1] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 2');
+        expect((document.nodes[1] as ListItemNode).indent, 0);
+        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
 
-        node = (document.nodes[2] as ListItemNode);
-        expect(node.indent, 1);
-        expect(node.text.text, 'list item 2.1');
+        expect((document.nodes[2] as ListItemNode).indent, 1);
+        expect((document.nodes[2] as ListItemNode).text.text, 'list item 2.1');
 
-        node = (document.nodes[3] as ListItemNode);
-        expect(node.indent, 1);
-        expect(node.text.text, 'list item 2.2');
+        expect((document.nodes[3] as ListItemNode).indent, 1);
+        expect((document.nodes[3] as ListItemNode).text.text, 'list item 2.2');
 
-        node = (document.nodes[4] as ListItemNode);
-        expect(node.indent, 0);
-        expect(node.text.text, 'list item 3');
+        expect((document.nodes[4] as ListItemNode).indent, 0);
+        expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
       });
 
       test('ordered list with empty lines between items', () {
@@ -1081,70 +1071,57 @@ This is some code
 
         expect(document.nodes.length, 13);
 
-        ListItemNode node = document.nodes[0] as ListItemNode;
-        expect(node.indent, 0);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Level 1');
+        expect((document.nodes[0] as ListItemNode).indent, 0);
+        expect((document.nodes[0] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[0] as ListItemNode).text.text, 'Level 1');
 
-        node = document.nodes[1] as ListItemNode;
-        expect(node.indent, 1);
-        expect(node.type, ListItemType.ordered);
-        expect(node.text.text, 'Level 2');
+        expect((document.nodes[1] as ListItemNode).indent, 1);
+        expect((document.nodes[1] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[1] as ListItemNode).text.text, 'Level 2');
 
-        node = document.nodes[2] as ListItemNode;
-        expect(node.indent, 2);
-        expect(node.type, ListItemType.ordered);
-        expect(node.text.text, 'Level 3');
+        expect((document.nodes[2] as ListItemNode).indent, 2);
+        expect((document.nodes[2] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[2] as ListItemNode).text.text, 'Level 3');
 
-        node = document.nodes[3] as ListItemNode;
-        expect(node.indent, 3);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Sublevel 1');
+        expect((document.nodes[3] as ListItemNode).indent, 3);
+        expect((document.nodes[3] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[3] as ListItemNode).text.text, 'Sublevel 1');
 
-        node = document.nodes[4] as ListItemNode;
-        expect(node.indent, 3);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Sublevel 2');
+        expect((document.nodes[4] as ListItemNode).indent, 3);
+        expect((document.nodes[4] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[4] as ListItemNode).text.text, 'Sublevel 2');
 
-        node = document.nodes[5] as ListItemNode;
-        expect(node.indent, 2);
-        expect(node.type, ListItemType.ordered);
-        expect(node.text.text, 'Level 3 again');
+        expect((document.nodes[5] as ListItemNode).indent, 2);
+        expect((document.nodes[5] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[5] as ListItemNode).text.text, 'Level 3 again');
 
-        node = document.nodes[6] as ListItemNode;
-        expect(node.indent, 1);
-        expect(node.type, ListItemType.ordered);
-        expect(node.text.text, 'Level 2 returning');
+        expect((document.nodes[6] as ListItemNode).indent, 1);
+        expect((document.nodes[6] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[6] as ListItemNode).text.text, 'Level 2 returning');
 
-        node = document.nodes[7] as ListItemNode;
-        expect(node.indent, 0);
-        expect(node.type, ListItemType.ordered);
-        expect(node.text.text, 'Level 1 once more');
+        expect((document.nodes[7] as ListItemNode).indent, 0);
+        expect((document.nodes[7] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[7] as ListItemNode).text.text, 'Level 1 once more');
 
-        node = document.nodes[8] as ListItemNode;
-        expect(node.indent, 1);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Bullet list');
+        expect((document.nodes[8] as ListItemNode).indent, 1);
+        expect((document.nodes[8] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[8] as ListItemNode).text.text, 'Bullet list');
 
-        node = document.nodes[9] as ListItemNode;
-        expect(node.indent, 2);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Another bullet');
+        expect((document.nodes[9] as ListItemNode).indent, 2);
+        expect((document.nodes[9] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[9] as ListItemNode).text.text, 'Another bullet');
 
-        node = document.nodes[10] as ListItemNode;
-        expect(node.indent, 0);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Main bullet list');
+        expect((document.nodes[10] as ListItemNode).indent, 0);
+        expect((document.nodes[10] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[10] as ListItemNode).text.text, 'Main bullet list');
 
-        node = document.nodes[11] as ListItemNode;
-        expect(node.indent, 1);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Sub bullet list');
+        expect((document.nodes[11] as ListItemNode).indent, 1);
+        expect((document.nodes[11] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[11] as ListItemNode).text.text, 'Sub bullet list');
 
-        node = document.nodes[12] as ListItemNode;
-        expect(node.indent, 2);
-        expect(node.type, ListItemType.unordered);
-        expect(node.text.text, 'Subsub bullet list');
+        expect((document.nodes[12] as ListItemNode).indent, 2);
+        expect((document.nodes[12] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[12] as ListItemNode).text.text, 'Subsub bullet list');
       });
 
       test('tasks', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -961,11 +961,46 @@ This is some code
           expect((node as ListItemNode).type, ListItemType.unordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).indent, 0);
-        expect((document.nodes[1] as ListItemNode).indent, 0);
-        expect((document.nodes[2] as ListItemNode).indent, 1);
-        expect((document.nodes[3] as ListItemNode).indent, 1);
-        expect((document.nodes[4] as ListItemNode).indent, 0);
+        ListItemNode node = (document.nodes[0] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 1');
+
+        node = (document.nodes[1] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 2');
+
+        node = (document.nodes[2] as ListItemNode);
+        expect(node.indent, 1);
+        expect(node.text.text, 'list item 2.1');
+
+        node = (document.nodes[3] as ListItemNode);
+        expect(node.indent, 1);
+        expect(node.text.text, 'list item 2.2');
+
+        node = (document.nodes[4] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 3');
+      });
+
+      test('unordered list with empty lines between items', () {
+        const markdown = '''
+ * list item 1
+ 
+ * list item 2
+
+ * list item 3''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 3);
+        for (final node in document.nodes) {
+          expect(node, isA<ListItemNode>());
+          expect((node as ListItemNode).type, ListItemType.unordered);
+        }
+
+        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
+        expect((document.nodes[2] as ListItemNode).text.text, 'list item 3');
       });
 
       test('ordered list', () {
@@ -984,11 +1019,132 @@ This is some code
           expect((node as ListItemNode).type, ListItemType.ordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).indent, 0);
-        expect((document.nodes[1] as ListItemNode).indent, 0);
-        expect((document.nodes[2] as ListItemNode).indent, 1);
-        expect((document.nodes[3] as ListItemNode).indent, 1);
-        expect((document.nodes[4] as ListItemNode).indent, 0);
+        ListItemNode node = (document.nodes[0] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 1');
+
+        node = (document.nodes[1] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 2');
+
+        node = (document.nodes[2] as ListItemNode);
+        expect(node.indent, 1);
+        expect(node.text.text, 'list item 2.1');
+
+        node = (document.nodes[3] as ListItemNode);
+        expect(node.indent, 1);
+        expect(node.text.text, 'list item 2.2');
+
+        node = (document.nodes[4] as ListItemNode);
+        expect(node.indent, 0);
+        expect(node.text.text, 'list item 3');
+      });
+
+      test('ordered list with empty lines between items', () {
+        const markdown = '''
+ 1. list item 1
+ 
+ 2. list item 2
+
+ 3. list item 3''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 3);
+        for (final node in document.nodes) {
+          expect(node, isA<ListItemNode>());
+          expect((node as ListItemNode).type, ListItemType.ordered);
+        }
+
+        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
+        expect((document.nodes[2] as ListItemNode).text.text, 'list item 3');
+      });
+
+      test('mixing multiple levels of ordered and unordered lists', () {
+        const markdown = '''
+- Level 1
+   1. Level 2
+      1. Level 3
+         - Sublevel 1         
+         - Sublevel 2
+      2. Level 3 again
+   2. Level 2 returning
+2. Level 1 once more
+   - Bullet list
+     - Another bullet
+- Main bullet list
+   - Sub bullet list
+      - Subsub bullet list
+''';
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 13);
+
+        ListItemNode node = document.nodes[0] as ListItemNode;
+        expect(node.indent, 0);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Level 1');
+
+        node = document.nodes[1] as ListItemNode;
+        expect(node.indent, 1);
+        expect(node.type, ListItemType.ordered);
+        expect(node.text.text, 'Level 2');
+
+        node = document.nodes[2] as ListItemNode;
+        expect(node.indent, 2);
+        expect(node.type, ListItemType.ordered);
+        expect(node.text.text, 'Level 3');
+
+        node = document.nodes[3] as ListItemNode;
+        expect(node.indent, 3);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Sublevel 1');
+
+        node = document.nodes[4] as ListItemNode;
+        expect(node.indent, 3);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Sublevel 2');
+
+        node = document.nodes[5] as ListItemNode;
+        expect(node.indent, 2);
+        expect(node.type, ListItemType.ordered);
+        expect(node.text.text, 'Level 3 again');
+
+        node = document.nodes[6] as ListItemNode;
+        expect(node.indent, 1);
+        expect(node.type, ListItemType.ordered);
+        expect(node.text.text, 'Level 2 returning');
+
+        node = document.nodes[7] as ListItemNode;
+        expect(node.indent, 0);
+        expect(node.type, ListItemType.ordered);
+        expect(node.text.text, 'Level 1 once more');
+
+        node = document.nodes[8] as ListItemNode;
+        expect(node.indent, 1);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Bullet list');
+
+        node = document.nodes[9] as ListItemNode;
+        expect(node.indent, 2);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Another bullet');
+
+        node = document.nodes[10] as ListItemNode;
+        expect(node.indent, 0);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Main bullet list');
+
+        node = document.nodes[11] as ListItemNode;
+        expect(node.indent, 1);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Sub bullet list');
+
+        node = document.nodes[12] as ListItemNode;
+        expect(node.indent, 2);
+        expect(node.type, ListItemType.unordered);
+        expect(node.text.text, 'Subsub bullet list');
       });
 
       test('tasks', () {


### PR DESCRIPTION
[super_editor_markdown] Fix list item parsing. Resolves #1711

Our list item parsing logic has two bugs.

The first is related to parsing lists with multiple levels. Example:

```
- Level 1
   1. Level 2
      1. Level 3
         - Sublevel 1         
         - Sublevel 2
      2. Level 3 again
   2. Level 2 returning
2. Level 1 once more
   - Bullet list
     - Another bullet
- Main bullet list
   - Sub bullet list
      - Subsub bullet list
```

Parsing this markdown results in the following document:

<img width="596" alt="image" src="https://github.com/superlistapp/super_editor/assets/8203735/b74d136f-4187-4a22-8588-7b8366e6c59e">


This issue is that we are using the `Element.textContent` as the text for the list item. When the list item contains sub-lists, `textContent` contains the text for the whole list.

This PR fixes the issue by using the `textContent` of the first child, which is the text of the list item.

The second bug is related to list items separated by empty lines. Example:

```
 * list item 1
 
 * list item 2

 * list item 3
````

Parsing this markdown generates the following document:

![Captura de Tela 2024-01-03 às 17 46 38](https://github.com/superlistapp/super_editor/assets/7597082/e4fe9381-b2d7-4279-88e8-be5ffe76e672)

The reason is that, when a list items is separated by an empty line, it has a `p` tag inside of it. This is causing us to parse the list item, and then parse its child as a paragraph.

This PR changes the parsing to avoid visiting child nodes if the list item doesn't contain a child list.



