### PR TITLE
Fix: Single-line desktop text field shouldn't be scrollable when it's content doesn't exceed viewport (Resolves #1749)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -330,6 +330,9 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     });
   }
 
+  @visibleForTesting
+  TextScrollController get scrollController => _textScrollController;
+
   @override
   ProseTextLayout get textLayout => _textContentKey.currentState!.textLayout;
 

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -260,6 +260,9 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
     );
   }
 
+  @visibleForTesting
+  ScrollController get scrollController => _scrollController;
+
   @override
   ProseTextLayout get textLayout => _textKey.currentState!.textLayout;
 
@@ -475,50 +478,57 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
 
   Widget _buildSelectableText() {
     return FillWidthIfConstrained(
-      child: SuperText(
-        key: _textKey,
-        richText: _controller.text.computeTextSpan(widget.textStyleBuilder),
-        textAlign: widget.textAlign,
-        textScaler: _textScaler,
-        layerBeneathBuilder: (context, textLayout) {
-          return Stack(
-            children: [
-              if (widget.textController?.selection.isValid == true)
-                // Selection highlight beneath the text.
-                TextLayoutSelectionHighlight(
-                  textLayout: textLayout,
-                  style: widget.selectionHighlightStyle,
-                  selection: widget.textController?.selection,
-                ),
-              // Underline beneath the composing region.
-              if (widget.textController?.composingRegion.isValid == true && _shouldShowComposingUnderline)
-                TextUnderlineLayer(
-                  textLayout: textLayout,
-                  underlines: [
-                    TextLayoutUnderline(
-                      style: UnderlineStyle(
-                        color: widget.textStyleBuilder({}).color ?? //
-                            (Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white),
+      child: Padding(
+        // WARNING: Padding within the text scroll view must be placed here, under
+        // FillWidthIfConstrained, rather than around it, because FillWidthIfConstrained makes
+        // decisions about sizing that expects its child to fill all available space in the
+        // ancestor Scrollable.
+        padding: widget.padding,
+        child: SuperText(
+          key: _textKey,
+          richText: _controller.text.computeTextSpan(widget.textStyleBuilder),
+          textAlign: widget.textAlign,
+          textScaler: _textScaler,
+          layerBeneathBuilder: (context, textLayout) {
+            return Stack(
+              children: [
+                if (widget.textController?.selection.isValid == true)
+                  // Selection highlight beneath the text.
+                  TextLayoutSelectionHighlight(
+                    textLayout: textLayout,
+                    style: widget.selectionHighlightStyle,
+                    selection: widget.textController?.selection,
+                  ),
+                // Underline beneath the composing region.
+                if (widget.textController?.composingRegion.isValid == true && _shouldShowComposingUnderline)
+                  TextUnderlineLayer(
+                    textLayout: textLayout,
+                    underlines: [
+                      TextLayoutUnderline(
+                        style: UnderlineStyle(
+                          color: widget.textStyleBuilder({}).color ?? //
+                              (Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white),
+                        ),
+                        range: widget.textController!.composingRegion,
                       ),
-                      range: widget.textController!.composingRegion,
-                    ),
-                  ],
-                ),
-            ],
-          );
-        },
-        layerAboveBuilder: (context, textLayout) {
-          if (!_focusNode.hasFocus) {
-            return const SizedBox();
-          }
+                    ],
+                  ),
+              ],
+            );
+          },
+          layerAboveBuilder: (context, textLayout) {
+            if (!_focusNode.hasFocus) {
+              return const SizedBox();
+            }
 
-          return TextLayoutCaret(
-            textLayout: textLayout,
-            style: widget.caretStyle,
-            position: _controller.selection.extent,
-            blinkTimingMode: widget.blinkTimingMode,
-          );
-        },
+            return TextLayoutCaret(
+              textLayout: textLayout,
+              style: widget.caretStyle,
+              position: _controller.selection.extent,
+              blinkTimingMode: widget.blinkTimingMode,
+            );
+          },
+        ),
       ),
     );
   }
@@ -1463,7 +1473,7 @@ class SuperTextFieldScrollview extends StatefulWidget {
     required this.textKey,
     required this.textController,
     required this.scrollController,
-    required this.padding,
+    this.padding = EdgeInsets.zero,
     required this.viewportHeight,
     required this.estimatedLineHeight,
     required this.isMultiline,

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -422,7 +422,6 @@ class SuperDesktopTextFieldState extends State<SuperDesktopTextField> implements
                     scrollController: _scrollController,
                     viewportHeight: _viewportHeight,
                     estimatedLineHeight: _getEstimatedLineHeight(),
-                    padding: widget.padding,
                     isMultiline: isMultiline,
                     child: Stack(
                       children: [

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -351,6 +351,9 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     });
   }
 
+  @visibleForTesting
+  TextScrollController get scrollController => _textScrollController;
+
   @override
   ProseTextLayout get textLayout => _textContentKey.currentState!.textLayout;
 

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -113,6 +113,22 @@ class SuperTextFieldInspector {
     return !isSingleLine(superTextFieldFinder);
   }
 
+  /// Returns `true` if the given [SuperTextField] is scrollable, i.e., the content
+  /// exceeds the viewport size.
+  static bool hasScrollableExtent([Finder? superTextFieldFinder]) {
+    final desktopScrollController = findDesktopScrollController(superTextFieldFinder);
+    if (desktopScrollController != null) {
+      return desktopScrollController.position.maxScrollExtent > 0;
+    }
+
+    final mobileScrollController = findMobileScrollController(superTextFieldFinder);
+    if (mobileScrollController != null) {
+      return mobileScrollController.endScrollOffset > 0;
+    }
+
+    throw Exception("Couldn't find a SuperTextField to check the scrollable extent. Finder: $superTextFieldFinder");
+  }
+
   /// Returns `true` if the given [SuperTextField] has a scroll offset of zero, i.e.,
   /// is scrolled to the beginning of the viewport.
   ///

--- a/super_editor/test/super_textfield/super_textfield_scrolling_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_scrolling_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/super_textfield/super_textfield.dart';
+
+import 'super_textfield_inspector.dart';
+
+void main() {
+  group("SuperTextField > scrolling >", () {
+    group("single line >", () {
+      testWidgetsOnAllPlatforms("scroll bar doesn't appear when empty", (tester) async {
+        await _pumpSingleLineTextField(tester);
+
+        // The bug that originally caused an issue with empty scrolling (#1749) didn't have
+        // a scrollable distance until the 2nd frame. Therefore, we pump one extra frame.
+        await tester.pump();
+        await tester.pump();
+
+        // Ensure that the text field isn't scrollable (the content shouldn't exceed the viewport).
+        expect(SuperTextFieldInspector.hasScrollableExtent(), isFalse);
+      });
+    });
+  });
+}
+
+Future<void> _pumpSingleLineTextField(
+  WidgetTester tester, {
+  AttributedTextEditingController? controller,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SuperTextField(
+                  textController: controller,
+                  hintBuilder: _createHintBuilder("Hint text..."),
+                  padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+                  minLines: 1,
+                  maxLines: 1,
+                  inputSource: TextInputSource.ime,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+WidgetBuilder _createHintBuilder(String hintText) {
+  return (BuildContext context) {
+    return Text(
+      hintText,
+      style: const TextStyle(color: Colors.grey),
+    );
+  };
+}


### PR DESCRIPTION
Fix: Single-line desktop text field shouldn't be scrollable when it's content doesn't exceed viewport (Resolves #1749)

The problem was a nuanced interaction between the padding inside the desktop text field and the `FillWidthIfConstrained` widget, which expects its child to fill all of the ancestor `Scrollable`. That's a very fragile assumption, but I didn't have a better option to replace it, at the moment.

To fix the issue, I moved the padding from outside the `FillWidthIfConstrained` to inside of it.