### PR TITLE
Adds tools to easily paste Markdown from the clipboard (Resolves #1590)

### DIFF
--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -59,6 +59,12 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
           attributions: request.attributions,
         )
       : null,
+  (request) => request is PasteStructuredContentEditorRequest
+      ? PasteStructuredContentEditorCommand(
+          content: request.content,
+          pastePosition: request.pastePosition,
+        )
+      : null,
   (request) => request is InsertNodeAtIndexRequest
       ? InsertNodeAtIndexCommand(nodeIndex: request.nodeIndex, newNode: request.newNode)
       : null,

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -14,6 +14,241 @@ import 'paragraph.dart';
 
 final _log = Logger(scope: 'multi_node_editing.dart');
 
+/// Request to paste the given structured [content] in the document at the
+/// given [pastePosition].
+class PasteStructuredContentEditorRequest implements EditRequest {
+  PasteStructuredContentEditorRequest({
+    required this.content,
+    required this.pastePosition,
+  });
+
+  final List<DocumentNode> content;
+  final DocumentPosition pastePosition;
+}
+
+/// Inserts the given structured [_content] in the document at the given [_pastePosition].
+class PasteStructuredContentEditorCommand implements EditCommand {
+  PasteStructuredContentEditorCommand({
+    required List<DocumentNode> content,
+    required DocumentPosition pastePosition,
+  })  : _content = content,
+        _pastePosition = pastePosition;
+
+  final List<DocumentNode> _content;
+  final DocumentPosition _pastePosition;
+
+  @override
+  void execute(EditContext context, CommandExecutor executor) {
+    if (_content.isEmpty) {
+      // Nothing to paste. Return.
+      return;
+    }
+
+    final document = context.find<MutableDocument>(Editor.documentKey);
+    final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
+    final currentNodeWithSelection = document.getNodeById(_pastePosition.nodeId);
+    if (currentNodeWithSelection is! TextNode) {
+      throw Exception('Can\'t handle pasting text within node of type: $currentNodeWithSelection');
+    }
+
+    editorOpsLog.info("Pasting clipboard content as Markdown in document.");
+
+    if (_content.length == 1) {
+      _pasteSingleNode(executor, document, _content.first, _pastePosition, currentNodeWithSelection);
+    } else {
+      _pasteMultipleNodes(executor, document, _content, currentNodeWithSelection);
+    }
+
+    editorOpsLog.fine('New selection after paste operation: ${composer.selection}');
+    editorOpsLog.fine('Done with paste command.');
+  }
+
+  void _pasteSingleNode(CommandExecutor executor, MutableDocument document, DocumentNode pastedNode,
+      DocumentPosition pastePosition, TextNode currentNodeWithSelection) {
+    if (_canMergeNodes(currentNodeWithSelection, pastedNode)) {
+      executor.executeCommand(
+        InsertAttributedTextCommand(
+          documentPosition: pastePosition,
+          // Only text nodes are merge-able, therefore we know that the first pasted node
+          // is a TextNode.
+          textToInsert: (pastedNode as TextNode).text,
+        ),
+      );
+
+      return;
+    }
+
+    final (upstreamNodeId, _) = _splitPasteParagraph(
+        executor, currentNodeWithSelection.id, (pastePosition.nodePosition as TextNodePosition).offset);
+
+    // Insert the pasted node after the split upstream node.
+    document.insertNodeAfter(
+      existingNode: document.getNodeById(upstreamNodeId)!,
+      newNode: pastedNode,
+    );
+    executor.logChanges([
+      DocumentEdit(
+        NodeInsertedEvent(pastedNode.id, document.getNodeIndexById(pastedNode.id)),
+      )
+    ]);
+
+    // Place the caret at the end of the pasted content.
+    executor.executeCommand(
+      ChangeSelectionCommand(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: pastedNode.id,
+            nodePosition: pastedNode.endPosition,
+          ),
+        ),
+        SelectionChangeType.insertContent,
+        SelectionReason.userInteraction,
+      ),
+    );
+  }
+
+  void _pasteMultipleNodes(
+    CommandExecutor executor,
+    MutableDocument document,
+    List<DocumentNode> pastedNodes,
+    TextNode currentNodeWithSelection,
+  ) {
+    final textNode = document.getNode(_pastePosition) as TextNode;
+    final pasteTextOffset = (_pastePosition.nodePosition as TextPosition).offset;
+    final nodesToInsert = List.from(_content);
+
+    // Split the original node in two, around the caret.
+    TextNode? downstreamSplitNode;
+    if (pasteTextOffset < textNode.endPosition.offset) {
+      // The caret sits somewhere in the middle of an existing text node. Split the
+      // node at the caret so we can paste structured content in between.
+      final (_, downstreamSplitNodeId) = _splitPasteParagraph(executor, currentNodeWithSelection.id, pasteTextOffset);
+      downstreamSplitNode = document.getNodeById(downstreamSplitNodeId) as TextNode;
+    }
+
+    // (Possibly) merge or delete the upstream split node.
+    bool deleteInitiallySelectedNode = false;
+    final firstPastedNode = nodesToInsert.first;
+    if (_canMergeNodes(currentNodeWithSelection, firstPastedNode)) {
+      // The text in the first pasted node is stylistically compatible with the
+      // existing text in the node where the paste was triggered. Therefore, instead
+      // inserting the first pasted node, merge its content with the existing node.
+      executor.executeCommand(
+        InsertAttributedTextCommand(
+          documentPosition: _pastePosition,
+          // Only text nodes are merge-able, therefore we know that the first pasted node
+          // is a TextNode.
+          textToInsert: (firstPastedNode as TextNode).text,
+        ),
+      );
+
+      // We've pasted the first new node. Remove it from the nodes to insert.
+      nodesToInsert.removeAt(0);
+    }
+    if (currentNodeWithSelection.text.length == 0) {
+      // The node with the selection is an empty text node. After we use that node's
+      // position to insert other nodes, we want to delete that first node, as if the
+      // pasted content replaced it.
+      deleteInitiallySelectedNode = true;
+    }
+
+    // (Possibly) merge or the downstream split node.
+    final lastPastedNode = nodesToInsert.last;
+    if (downstreamSplitNode != null && _canMergeNodes(lastPastedNode, downstreamSplitNode)) {
+      // The text in the last pasted node is stylistically compatible with the
+      // existing text in the node that was split after the caret. Therefore, instead
+      // of inserting the last pasted node, merge its content with the existing split
+      // node.
+      executor.executeCommand(
+        InsertAttributedTextCommand(
+          documentPosition: DocumentPosition(
+            nodeId: downstreamSplitNode.id,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+          // Only text nodes are merge-able, therefore we know that the first pasted node
+          // is a TextNode.
+          textToInsert: (lastPastedNode as TextNode).text,
+        ),
+      );
+
+      // We've pasted the first new node. Remove it from the nodes to insert.
+      nodesToInsert.removeLast();
+    }
+
+    // Now that the first and last pasted nodes have been merged with existing content
+    // (or not), insert all remaining pasted nodes into the document.
+    DocumentNode previousNode = currentNodeWithSelection;
+    for (final pastedNode in nodesToInsert) {
+      document.insertNodeAfter(
+        existingNode: previousNode,
+        newNode: pastedNode,
+      );
+      previousNode = pastedNode;
+
+      executor.logChanges([
+        DocumentEdit(
+          NodeInsertedEvent(pastedNode.id, document.getNodeIndexById(pastedNode.id)),
+        )
+      ]);
+    }
+
+    if (deleteInitiallySelectedNode) {
+      document.deleteNode(currentNodeWithSelection);
+      executor.logChanges([
+        DocumentEdit(
+          NodeRemovedEvent(currentNodeWithSelection.id, currentNodeWithSelection),
+        )
+      ]);
+    }
+
+    // Place the caret at the end of the pasted content.
+    executor.executeCommand(
+      ChangeSelectionCommand(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: previousNode.id,
+            nodePosition: previousNode.endPosition,
+          ),
+        ),
+        SelectionChangeType.insertContent,
+        SelectionReason.userInteraction,
+      ),
+    );
+  }
+
+  (String upstreamNode, String downstreamNode) _splitPasteParagraph(
+    CommandExecutor executor,
+    String currentNodeWithSelectionId,
+    int pasteTextOffset,
+  ) {
+    final newNodeId = Editor.createNodeId();
+    executor.executeCommand(
+      SplitParagraphCommand(
+        nodeId: currentNodeWithSelectionId,
+        splitPosition: TextPosition(offset: pasteTextOffset),
+        newNodeId: newNodeId,
+        replicateExistingMetadata: true,
+      ),
+    );
+
+    return (currentNodeWithSelectionId, newNodeId);
+  }
+
+  bool _canMergeNodes(DocumentNode existingNode, DocumentNode newNode) {
+    if (existingNode is! TextNode || newNode is! TextNode) {
+      // We can only merge text nodes.
+      return false;
+    }
+
+    if (existingNode.metadata['blockType'] != newNode.metadata['blockType']) {
+      // Text nodes with different block types cannot be merged, e.g., "Header 1" with a "Blockquote".
+      return false;
+    }
+
+    return true;
+  }
+}
+
 class InsertNodeAtIndexRequest implements EditRequest {
   InsertNodeAtIndexRequest({
     required this.nodeIndex,

--- a/super_editor_markdown/analysis_options.yaml
+++ b/super_editor_markdown/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+    exclude: [build/**]
+
+linter:
+    rules:
+        omit_local_variable_types: false
+        use_key_in_widget_constructors: false
+        avoid_renaming_method_parameters: false

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -350,7 +350,7 @@ class AttributedTextMarkdownSerializer extends AttributionVisitor {
   /// Checks for the presence of a link in the attributions and returns the characters necessary to represent it
   /// at the open or closing boundary of the attribution, depending on the event.
   static String _encodeLinkMarker(Set<Attribution> attributions, AttributionVisitEvent event) {
-    final linkAttributions = attributions.where((element) => element is LinkAttribution?);
+    final linkAttributions = attributions.whereType<LinkAttribution?>();
     if (linkAttributions.isNotEmpty) {
       final linkAttribution = linkAttributions.first as LinkAttribution;
 

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -28,10 +28,10 @@ MutableDocument deserializeMarkdownToDocument(
       ...customBlockSyntax,
       if (syntax == MarkdownSyntax.superEditor) ...[
         _HeaderWithAlignmentSyntax(),
-        _ParagraphWithAlignmentSyntax(),
+        const _ParagraphWithAlignmentSyntax(),
       ],
-      _EmptyLinePreservingParagraphSyntax(),
-      _TaskSyntax(),
+      const _EmptyLinePreservingParagraphSyntax(),
+      const _TaskSyntax(),
     ],
   );
   final blockParser = md.BlockParser(markdownLines, markdownDoc);
@@ -239,7 +239,7 @@ class _MarkdownToDocument implements md.NodeVisitor {
         id: Editor.createNodeId(),
         text: attributedText,
         metadata: {
-          'textAlign': textAlign != null ? textAlign : null,
+          'textAlign': textAlign,
         },
       ),
     );

--- a/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
+++ b/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/services.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/src/markdown_to_document_parsing.dart';
+
+/// A [SuperEditor] keyboard action that pastes clipboard content into the document,
+/// interpreting the clipboard content as Markdown.
+ExecutionInstruction pasteMarkdownOnCmdAndCtrlV({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyV) {
+    return ExecutionInstruction.continueExecution;
+  }
+  if (editContext.composer.selection == null) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  pasteMarkdown(
+    editor: editContext.editor,
+    document: editContext.document,
+    composer: editContext.composer,
+  );
+
+  return ExecutionInstruction.haltExecution;
+}
+
+/// Deletes all selected content, and then pastes the current clipboard
+/// content at the given location, interpreting the clipboard content
+/// as Markdown.
+///
+/// The clipboard operation is asynchronous. As a result, if the user quickly
+/// moves the caret, it's possible that the clipboard content will be pasted
+/// at the wrong spot.
+Future<void> pasteMarkdown({
+  required Editor editor,
+  required Document document,
+  required DocumentComposer composer,
+}) async {
+  DocumentPosition pastePosition = composer.selection!.extent;
+
+  // Delete all currently selected content.
+  if (!composer.selection!.isCollapsed) {
+    pastePosition = CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
+      document: document,
+      selection: composer.selection!,
+    );
+
+    // Delete the selected content.
+    editor.execute([
+      DeleteContentRequest(documentRange: composer.selection!),
+      ChangeSelectionRequest(
+        DocumentSelection.collapsed(position: pastePosition),
+        SelectionChangeType.deleteContent,
+        SelectionReason.userInteraction,
+      ),
+    ]);
+  }
+
+  final markdownToPaste = (await Clipboard.getData('text/plain'))?.text ?? '';
+  final deserializedMarkdown = deserializeMarkdownToDocument(markdownToPaste);
+
+  // Paste the structured content into the document.
+  editor.execute([
+    PasteStructuredContentEditorRequest(
+      content: deserializedMarkdown.nodes,
+      pastePosition: pastePosition,
+    ),
+  ]);
+}

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.5
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -29,6 +29,8 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
+  flutter_test_robots: ^0.0.22
+  flutter_test_runners: ^0.0.4
   golden_toolkit: ^0.15.0
 
 flutter:

--- a/super_editor_markdown/test/attributed_text_markdown_test.dart
+++ b/super_editor_markdown/test/attributed_text_markdown_test.dart
@@ -58,10 +58,10 @@ void main() {
           "This is overlapping styles.",
           AttributedSpans(
             attributions: [
-              SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: boldAttribution, offset: 13, markerType: SpanMarkerType.end),
-              SpanMarker(attribution: italicsAttribution, offset: 11, markerType: SpanMarkerType.start),
-              SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 13, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: italicsAttribution, offset: 11, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: italicsAttribution, offset: 18, markerType: SpanMarkerType.end),
             ],
           ),
         ).toMarkdown(),

--- a/super_editor_markdown/test/custom_block_parser_test.dart
+++ b/super_editor_markdown/test/custom_block_parser_test.dart
@@ -15,7 +15,7 @@ This is a normal paragraph.
 @@@ upsell
   
 This is another normal paragraph.''',
-        customBlockSyntax: [UpsellBlockSyntax()],
+        customBlockSyntax: [const UpsellBlockSyntax()],
         customElementToNodeConverters: [UpsellElementToNodeConverter()],
       );
 
@@ -48,7 +48,7 @@ This is a **callout**!
 @@@
   
 This is another normal paragraph.''',
-        customBlockSyntax: [CalloutBlockSyntax()],
+        customBlockSyntax: [const CalloutBlockSyntax()],
         customElementToNodeConverters: [CalloutElementToNodeConverter()],
       );
 

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -359,22 +359,7 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.''',
 Future<(Editor, MutableDocument, MutableDocumentComposer)> _pumpSuperEditor(
     WidgetTester tester, MutableDocument document) async {
   final composer = MutableDocumentComposer();
-  final editor = Editor(
-    editables: {
-      Editor.documentKey: document,
-      Editor.composerKey: composer,
-    },
-    requestHandlers: [
-      (request) => request is PasteStructuredContentEditorRequest
-          ? PasteStructuredContentEditorCommand(
-              content: request.content,
-              pastePosition: request.pastePosition,
-            )
-          : null,
-      ...defaultRequestHandlers,
-    ],
-    reactionPipeline: List.from(defaultEditorReactions),
-  );
+  final editor = createDefaultDocumentEditor(document: document, composer: composer);
 
   await tester.pumpWidget(
     MaterialApp(

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -90,7 +90,7 @@ This is the document that exists before Markdown is pasted.
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent(_markdownHeaderSnippet);
@@ -134,7 +134,7 @@ This is the document that exists before Markdown is pasted.
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent(_markdownPlainTextSnippet);
@@ -174,7 +174,7 @@ This is the document that exists before Markdown is pasted.''',
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent(_markdownPlainTextSnippet);
@@ -202,14 +202,14 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continu
         deserializeMarkdownToDocument('''This is a paragraph that will add text >< here and continue.'''),
       );
 
-      // Place the caret between chevrons ">|<"
+      // Place the caret between chevrons ">|<".
       final lastParagraph = document.nodes.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, 40);
 
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent("this is a snippet of plain text");
@@ -235,14 +235,14 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continu
         ),
       );
 
-      // Place the caret between chevrons ">|<"
+      // Place the caret between chevrons ">|<".
       final lastParagraph = document.nodes.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, 42);
 
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent("![A Fake Test Image](https://flutter.dev/logo.png)");
@@ -280,7 +280,7 @@ This is the document that exists before Markdown is pasted.
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent(_markdownHeaderSnippet);
@@ -325,7 +325,7 @@ This is the document that exists before Markdown is pasted.
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
 
-      // Simulate the user copying a markdown snippet
+      // Simulate the user copying a markdown snippet.
       tester
         ..simulateClipboard()
         ..setSimulatedClipboardContent(_markdownPlainTextSnippet);

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -250,8 +250,8 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continu
       // Paste the markdown content into the empty document.
       await tester.pressCmdV();
 
-      // Ensure that the pasted text split the existing paragraph and then merged
-      // the starting and ending text of the pasted Markdown.
+      // Ensure that the pasted text split the existing paragraph and then inserted
+      // an image in between.
       final documentMarkdown = serializeDocumentToMarkdown(document);
 
       expect(

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -1,0 +1,439 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+import 'package:super_editor_markdown/src/document_to_markdown_serializer.dart';
+import 'package:super_editor_markdown/src/markdown_to_document_parsing.dart';
+import 'package:super_editor_markdown/src/super_editor_paste_markdown.dart';
+
+import 'test_tools.dart';
+
+void main() {
+  group("SuperEditor > pasting markdown >", () {
+    testWidgetsOnArbitraryDesktop("can paste into an empty document", (tester) async {
+      final document = MutableDocument(nodes: [ParagraphNode(id: "1", text: AttributedText())]);
+      final composer = MutableDocumentComposer();
+      final editor = Editor(
+        editables: {
+          Editor.documentKey: document,
+          Editor.composerKey: composer,
+        },
+        requestHandlers: [
+          (request) => request is PasteStructuredContentEditorRequest
+              ? PasteStructuredContentEditorCommand(
+                  content: request.content,
+                  pastePosition: request.pastePosition,
+                )
+              : null,
+          ...defaultRequestHandlers,
+        ],
+        reactionPipeline: List.from(defaultEditorReactions),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+              keyboardActions: [
+                pasteMarkdownOnCmdAndCtrlV,
+                ...defaultKeyboardActions,
+              ],
+              componentBuilders: [
+                TaskComponentBuilder(editor),
+                ...defaultComponentBuilders,
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret in the empty document.
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a full markdown document
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_fullDocumentMarkdown);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // The editor should now contain a full document that was deserialized
+      // from pasted markdown. To verify this, re-serialize the document's
+      // content and compare it to the Markdown that we pasted.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(documentMarkdown, _fullDocumentMarkdown);
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste at the beginning of a document (without merging text)", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''
+# Primary document
+
+This is the document that exists before Markdown is pasted.
+      '''),
+      );
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_markdownHeaderSnippet);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // The editor should now contain the markdown snippet, followed by the
+      // primary document content.
+      //
+      // To verify this, re-serialize the document's content and compare it
+      // to a Markdown representation of the expected document content.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''# A Markdown snippet
+
+---
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.
+
+# Primary document
+
+This is the document that exists before Markdown is pasted.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste at the beginning of a document (with merging text)", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''
+Primary document
+
+This is the document that exists before Markdown is pasted.
+      '''),
+      );
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_markdownPlainTextSnippet);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // The editor should now contain the markdown snippet, followed by the
+      // primary document content.
+      //
+      // To verify this, re-serialize the document's content and compare it
+      // to a Markdown representation of the expected document content.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Phasellus sed sagittis urna.
+
+Aenean mattis ante justo, quis sollicitudin metus interdum id.Primary document
+
+This is the document that exists before Markdown is pasted.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste in the middle of a document and merge both sides of text", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''This is a paragraph that will split >< here and continue.'''),
+      );
+
+      // Place the caret between chevrons ">|<"
+      final lastParagraph = document.nodes.last as TextNode;
+      await tester.placeCaretInParagraph(lastParagraph.id, 37);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_markdownPlainTextSnippet);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // Ensure that the pasted text split the existing paragraph and then merged
+      // the starting and ending text of the pasted Markdown.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''This is a paragraph that will split >Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Phasellus sed sagittis urna.
+
+Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continue.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste a text snippet within a single paragraph", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''This is a paragraph that will add text >< here and continue.'''),
+      );
+
+      // Place the caret between chevrons ">|<"
+      final lastParagraph = document.nodes.last as TextNode;
+      await tester.placeCaretInParagraph(lastParagraph.id, 40);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent("this is a snippet of plain text");
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // Ensure that the pasted text split the existing paragraph and then merged
+      // the starting and ending text of the pasted Markdown.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''This is a paragraph that will add text >this is a snippet of plain text< here and continue.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste an image in the middle of a paragraph", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument(
+          '''This is a paragraph that will split here >< and show an image between paragraphs.''',
+        ),
+      );
+
+      // Place the caret between chevrons ">|<"
+      final lastParagraph = document.nodes.last as TextNode;
+      await tester.placeCaretInParagraph(lastParagraph.id, 42);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent("![A Fake Test Image](https://flutter.dev/logo.png)");
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // Ensure that the pasted text split the existing paragraph and then merged
+      // the starting and ending text of the pasted Markdown.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''This is a paragraph that will split here >
+
+![A Fake Test Image](https://flutter.dev/logo.png)
+< and show an image between paragraphs.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste at the end of a document (without merging text)", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''
+# Primary document
+
+This is the document that exists before Markdown is pasted.
+      '''),
+      );
+
+      // Place the caret at the end of the existing document.
+      final lastParagraph = document.nodes.last as TextNode;
+      await tester.placeCaretInParagraph(lastParagraph.id, lastParagraph.endPosition.offset);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_markdownHeaderSnippet);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // The editor should now contain the primary document content, followed by
+      // the Markdown snippet.
+      //
+      // To verify this, re-serialize the document's content and compare it
+      // to a Markdown representation of the expected document content.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''# Primary document
+
+This is the document that exists before Markdown is pasted.
+
+# A Markdown snippet
+
+---
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.''',
+      );
+    });
+
+    testWidgetsOnArbitraryDesktop("can paste at the end of a document (with merging text)", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument('''
+# Primary document
+
+This is the document that exists before Markdown is pasted.
+      '''),
+      );
+
+      // Place the caret at the end of the existing document.
+      final lastParagraph = document.nodes.last as TextNode;
+      await tester.placeCaretInParagraph(lastParagraph.id, lastParagraph.endPosition.offset);
+
+      // Ensure that the document has the caret.
+      expect(composer.selection, isNotNull);
+
+      // Simulate the user copying a markdown snippet
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent(_markdownPlainTextSnippet);
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // The editor should now contain the primary document content, followed by
+      // the Markdown snippet.
+      //
+      // To verify this, re-serialize the document's content and compare it
+      // to a Markdown representation of the expected document content.
+      final documentMarkdown = serializeDocumentToMarkdown(document);
+
+      expect(
+        documentMarkdown,
+        '''# Primary document
+
+This is the document that exists before Markdown is pasted.Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Phasellus sed sagittis urna.
+
+Aenean mattis ante justo, quis sollicitudin metus interdum id.''',
+      );
+    });
+  });
+}
+
+/// Pumps a [SuperEditor], which displays the given [document], including typical Markdown
+/// extensions, and extensions to paste Markdown.
+Future<(Editor, MutableDocument, MutableDocumentComposer)> _pumpSuperEditor(
+    WidgetTester tester, MutableDocument document) async {
+  final composer = MutableDocumentComposer();
+  final editor = Editor(
+    editables: {
+      Editor.documentKey: document,
+      Editor.composerKey: composer,
+    },
+    requestHandlers: [
+      (request) => request is PasteStructuredContentEditorRequest
+          ? PasteStructuredContentEditorCommand(
+              content: request.content,
+              pastePosition: request.pastePosition,
+            )
+          : null,
+      ...defaultRequestHandlers,
+    ],
+    reactionPipeline: List.from(defaultEditorReactions),
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperEditor(
+          editor: editor,
+          document: document,
+          composer: composer,
+          keyboardActions: [
+            pasteMarkdownOnCmdAndCtrlV,
+            ...defaultKeyboardActions,
+          ],
+          componentBuilders: [
+            TaskComponentBuilder(editor),
+            const FakeImageComponentBuilder(size: Size(800, 400)), // Size doesn't matter.
+            ...defaultComponentBuilders,
+          ],
+        ),
+      ),
+    ),
+  );
+
+  return (editor, document, composer);
+}
+
+const _markdownHeaderSnippet = '''
+# A Markdown snippet
+
+---
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.
+''';
+
+const _markdownPlainTextSnippet = '''
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Phasellus sed sagittis urna.
+
+Aenean mattis ante justo, quis sollicitudin metus interdum id.
+''';
+
+const _fullDocumentMarkdown = '''
+# Example Document
+
+---
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed sagittis urna. Aenean mattis ante justo, quis sollicitudin metus interdum id. Aenean ornare urna ac enim consequat mollis. In aliquet convallis efficitur. Phasellus convallis purus in fringilla scelerisque. Ut ac orci a turpis egestas lobortis. Morbi aliquam dapibus sem, vitae sodales arcu ultrices eu. Duis vulputate mauris quam, eleifend pulvinar quam blandit eget.
+
+  * This is an unordered list item
+  * This is another list item
+  * This is a 3rd list item, with [a link](https://flutter.dev)
+
+Cras vitae sodales nisi. Vivamus dignissim vel purus vel aliquet. Sed viverra diam vel nisi rhoncus pharetra. Donec gravida ut ligula euismod pharetra. Etiam sed urna scelerisque, efficitur mauris vel, semper arcu. Nullam sed vehicula sapien. Donec id tellus volutpat, eleifend nulla eget, rutrum mauris.
+
+  1. First thing to do
+  1. Second thing to do
+  1. Third thing to do
+
+Nam hendrerit vitae elit ut placerat. Maecenas nec congue neque. Fusce eget tortor pulvinar, cursus neque vitae, sagittis lectus. Duis mollis libero eu scelerisque ullamcorper. Pellentesque eleifend arcu nec augue molestie, at iaculis dui rutrum. Etiam lobortis magna at magna pellentesque ornare. Sed accumsan, libero vel porta molestie, tortor lorem eleifend ante, at egestas leo felis sed nunc. Quisque mi neque, molestie vel dolor a, eleifend tempor odio.
+
+Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.
+
+- [ ] This is an incomplete task
+- [x] This is a completed task''';

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1293,7 +1293,7 @@ with multiple lines
       });
 
       test('multiple paragraphs', () {
-        final input = """Paragraph1
+        const input = """Paragraph1
 
 Paragraph2""";
         final doc = deserializeMarkdownToDocument(input);
@@ -1304,7 +1304,7 @@ Paragraph2""";
       });
 
       test('empty paragraph between paragraphs', () {
-        final input = """Paragraph1
+        const input = """Paragraph1
 
 
 
@@ -1318,7 +1318,7 @@ Paragraph3""";
       });
 
       test('multiple empty paragraph between paragraphs', () {
-        final input = """Paragraph1
+        const input = """Paragraph1
 
 
 

--- a/super_editor_markdown/test/test_tools.dart
+++ b/super_editor_markdown/test/test_tools.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// A [ComponentBuilder] which builds an [ImageComponent] that always renders
+/// images as a [SizedBox] with the given [size].
+class FakeImageComponentBuilder implements ComponentBuilder {
+  const FakeImageComponentBuilder({
+    required this.size,
+  });
+
+  final Size size;
+
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    return null;
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! ImageComponentViewModel) {
+      return null;
+    }
+
+    return ImageComponent(
+      componentKey: componentContext.componentKey,
+      imageUrl: componentViewModel.imageUrl,
+      selection: componentViewModel.selection,
+      selectionColor: componentViewModel.selectionColor,
+      imageBuilder: (context, imageUrl) => SizedBox(
+        height: size.height,
+        width: size.width,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Adds tools to easily paste Markdown from the clipboard (Resolves #1590)

To add Markdown pasting capability to a `SuperEditor` in an app, do the following:

```dart
SuperEditor(
  //...
  keyboardActions: [
    pasteMarkdownOnCmdAndCtrlV,
    ...defaultKeyboardActions,
  ],
 //...
);
```

This PR also...

  * Migrates `super_editor_markdown` to Dart 3.x.
  * Updates and fixes analysis warnings. 
  * Adds a new request/command pair to the default list, which can insert/paste structured content.