### PR TITLE
[SuperEditor][Android] Fix drag handles when selection collapses due to dragging (Resolves #1736)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1425,15 +1425,15 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     _moveSelectionAndMagnifierToDragHandleOffset(dragDx: details.delta.dx);
   }
 
-  void _onHandlePanEnd(DragEndDetails details) {
-    _onHandleDragEnd();
+  void _onHandlePanEnd(DragEndDetails details, HandleType handleType) {
+    _onHandleDragEnd(handleType);
   }
 
-  void _onHandlePanCancel() {
-    _onHandleDragEnd();
+  void _onHandlePanCancel(HandleType handleType) {
+    _onHandleDragEnd(handleType);
   }
 
-  void _onHandleDragEnd() {
+  void _onHandleDragEnd(HandleType handleType) {
     _dragHandleSelectionBound = null;
     _dragHandleType = null;
     _dragHandleSelectionGlobalFocalPoint.value = null;
@@ -1443,6 +1443,16 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     _controlsController!
       ..blinkCaret()
       ..hideMagnifier();
+
+    if (widget.selection.value?.isCollapsed == true &&
+        const [HandleType.upstream, HandleType.downstream].contains(handleType)) {
+      // The user dragged an expanded handle until the selection collapsed and then released the handle.
+      // While the user was dragging, the expanded handles were displayed.
+      // Show the collapsed.
+      _controlsController!
+        ..hideExpandedHandles()
+        ..showCollapsedHandle();
+    }
 
     // Stop auto-scrolling based on the drag-handle offset.
     widget.dragHandleAutoScroller.value?.stopAutoScrollHandleMonitoring();
@@ -1580,8 +1590,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
                 },
                 onPanStart: (details) => _onHandlePanStart(details, HandleType.collapsed),
                 onPanUpdate: _onHandlePanUpdate,
-                onPanEnd: _onHandlePanEnd,
-                onPanCancel: _onHandlePanCancel,
+                onPanEnd: (details) => _onHandlePanEnd(details, HandleType.collapsed),
+                onPanCancel: () => _onHandlePanCancel(HandleType.collapsed),
                 dragStartBehavior: DragStartBehavior.down,
                 child: AndroidSelectionHandle(
                   key: DocumentKeys.androidCaretHandle,
@@ -1615,8 +1625,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
               },
               onPanStart: (details) => _onHandlePanStart(details, HandleType.upstream),
               onPanUpdate: _onHandlePanUpdate,
-              onPanEnd: _onHandlePanEnd,
-              onPanCancel: _onHandlePanCancel,
+              onPanEnd: (details) => _onHandlePanEnd(details, HandleType.upstream),
+              onPanCancel: () => _onHandlePanCancel(HandleType.upstream),
               dragStartBehavior: DragStartBehavior.down,
               child: AndroidSelectionHandle(
                 key: DocumentKeys.upstreamHandle,
@@ -1644,8 +1654,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
               },
               onPanStart: (details) => _onHandlePanStart(details, HandleType.downstream),
               onPanUpdate: _onHandlePanUpdate,
-              onPanEnd: _onHandlePanEnd,
-              onPanCancel: _onHandlePanCancel,
+              onPanEnd: (details) => _onHandlePanEnd(details, HandleType.downstream),
+              onPanCancel: () => _onHandlePanCancel(HandleType.downstream),
               dragStartBehavior: DragStartBehavior.down,
               child: AndroidSelectionHandle(
                 key: DocumentKeys.downstreamHandle,

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -200,11 +200,14 @@ class AndroidControlsDocumentLayerState
     if (_controlsController != null) {
       _controlsController!.shouldCaretBlink.removeListener(_onBlinkModeChange);
       _controlsController!.caretJumpToOpaqueSignal.removeListener(_caretJumpToOpaque);
+      _controlsController!.shouldShowCollapsedHandle.removeListener(_onShouldShowCollapsedHandleChange);
     }
 
     _controlsController = SuperEditorAndroidControlsScope.rootOf(context);
     _controlsController!.shouldCaretBlink.addListener(_onBlinkModeChange);
     _controlsController!.caretJumpToOpaqueSignal.addListener(_caretJumpToOpaque);
+
+    _controlsController!.shouldShowCollapsedHandle.addListener(_onShouldShowCollapsedHandleChange);
     _onBlinkModeChange();
   }
 
@@ -222,6 +225,7 @@ class AndroidControlsDocumentLayerState
   void dispose() {
     widget.selection.removeListener(_onSelectionChange);
     _controlsController?.shouldCaretBlink.removeListener(_onBlinkModeChange);
+    _controlsController!.shouldShowCollapsedHandle.removeListener(_onShouldShowCollapsedHandleChange);
 
     _caretBlinkController.dispose();
     super.dispose();
@@ -282,6 +286,16 @@ class AndroidControlsDocumentLayerState
     _caretBlinkController.jumpToOpaque();
   }
 
+  void _onShouldShowCollapsedHandleChange() {
+    // When the user drags an expanded handle it might collapse the selection.
+    // In this case, we have a collapsed selection, but layout data for the
+    // expanded handles. Schedule a new layout to recompute the data for
+    // the collapsed handle.
+    setState(() {
+      //
+    });
+  }
+
   @override
   DocumentSelectionLayout? computeLayoutDataWithDocumentLayout(BuildContext context, DocumentLayout documentLayout) {
     final selection = widget.selection.value;
@@ -289,7 +303,7 @@ class AndroidControlsDocumentLayerState
       return null;
     }
 
-    if (selection.isCollapsed) {
+    if (selection.isCollapsed && !_controlsController!.shouldShowExpandedHandles.value) {
       return DocumentSelectionLayout(
         caret: documentLayout.getRectForPosition(selection.extent)!,
       );

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -293,10 +293,13 @@ class AndroidControlsDocumentLayerState
   }
 
   void _onShouldShowCollapsedHandleChange() {
-    // When the user drags an expanded handle it might collapse the selection.
-    // In this case, we have a collapsed selection, but layout data for the
-    // expanded handles. Schedule a rebuild to recompute the layout data for
-    // the selection, to determine which handle we want.
+    // The controller went from wanting a collapsed handle to wanting expanded handles,
+    // or vis-a-versa. This signal is relevant to us because of an ambiguous handle situation.
+    // The user might drag an expanded handle such  that the selection is collapsed, in which
+    // case we still want to show an expanded handle. Similarly, if the user then releases that
+    // expanded handle, we should switch to a collapsed handle for the same selection. This
+    // method tells us that the desired handle type has changed. Re-run layout and build to
+    // ensure that we're showing the correct handle.
     setState(() {
       //
     });

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -207,10 +207,12 @@ class AndroidControlsDocumentLayerState
     _controlsController!.shouldCaretBlink.addListener(_onBlinkModeChange);
     _controlsController!.caretJumpToOpaqueSignal.addListener(_caretJumpToOpaque);
 
-    // The appearance of the collapsed handle is used to compute the selection layout data.
-    // We conditionally compute either the caret data or the expanded selection data. This
-    // information is then used to decide whether or not we should show the caret or the
-    // expanded handles. Therefore, we need to listen to this signal to rebuild this layer.
+    /// Listen for changes about whether we want to show the collapsed handle
+    /// or whether we want to show expanded handles for a selection. We listen to
+    /// this because there are some situations where the desired handle type is
+    /// ambiguous, such as when when the user drags an expanded handle such that
+    /// the selection collapses. In that case, the selection is collapsed but we want
+    /// to show the expanded handle. This signal clarifies which one we want.
     _controlsController!.shouldShowCollapsedHandle.addListener(_onShouldShowCollapsedHandleChange);
     _onBlinkModeChange();
   }
@@ -293,8 +295,8 @@ class AndroidControlsDocumentLayerState
   void _onShouldShowCollapsedHandleChange() {
     // When the user drags an expanded handle it might collapse the selection.
     // In this case, we have a collapsed selection, but layout data for the
-    // expanded handles. Schedule a new layout to recompute the data for
-    // the collapsed handle.
+    // expanded handles. Schedule a rebuild to recompute the layout data for
+    // the selection, to determine which handle we want.
     setState(() {
       //
     });

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -207,6 +207,10 @@ class AndroidControlsDocumentLayerState
     _controlsController!.shouldCaretBlink.addListener(_onBlinkModeChange);
     _controlsController!.caretJumpToOpaqueSignal.addListener(_caretJumpToOpaque);
 
+    // The appearance of the collapsed handle is used to compute the selection layout data.
+    // We conditionally compute either the caret data or the expanded selection data. This
+    // information is then used to decide whether or not we should show the caret or the
+    // expanded handles. Therefore, we need to listen to this signal to rebuild this layer.
     _controlsController!.shouldShowCollapsedHandle.addListener(_onShouldShowCollapsedHandleChange);
     _onBlinkModeChange();
   }

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -4,6 +4,7 @@ import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
 import '../../test_runners.dart';
+import '../../test_tools.dart';
 import '../supereditor_test_tools.dart';
 
 void main() {
@@ -112,6 +113,55 @@ void main() {
       // Resolve the gesture so that we don't have pending gesture timers.
       await gesture.up();
       await tester.pump(kTapMinTime);
+    });
+
+    testWidgetsOnAndroid("shows expanded handles when dragging to a collapsed selection", (tester) async {
+      await _pumpSingleParagraphApp(tester);
+
+      // Select the word "Lorem".
+      await tester.doubleTapInParagraph('1', 1);
+
+      // Press the upstream drag handle and drag it downstream until "Lorem|" to collapse the selection.
+      final gesture = await tester.pressDownOnUpstreamMobileHandle();
+      await gesture.moveBy(SuperEditorInspector.findDeltaBetweenCharactersInTextNode('1', 0, 5));
+      await tester.pump();
+
+      // Ensure that the selection collapsed.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
+          ),
+        ),
+      );
+
+      // Find the rectangle for the selected character.
+      final documentLayout = SuperEditorInspector.findDocumentLayout();
+      final selectedPositionRect = documentLayout.getRectForPosition(
+        const DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
+      )!;
+
+      // Ensure that the drag handles are visible and in the correct location.
+      expect(SuperEditorInspector.findAllMobileDragHandles(), findsExactly(2));
+      expect(
+        tester.getTopLeft(SuperEditorInspector.findMobileDownstreamDragHandle()),
+        offsetMoreOrLessEquals(documentLayout.getGlobalOffsetFromDocumentOffset(selectedPositionRect.bottomRight)),
+      );
+      expect(
+        tester.getTopRight(SuperEditorInspector.findMobileUpstreamDragHandle()),
+        offsetMoreOrLessEquals(documentLayout.getGlobalOffsetFromDocumentOffset(selectedPositionRect.bottomRight)),
+      );
+
+      // Release the drag handle.
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Ensure the expanded handles were hidden and the collapsed handle
+      // and the caret were displayed.
+      expect(SuperEditorInspector.findAllMobileDragHandles(), findsOneWidget);
+      expect(SuperEditorInspector.findMobileCaretDragHandle(), findsOneWidget);
+      expect(SuperEditorInspector.isCaretVisible(), isTrue);
     });
 
     group("on device and web > shows", () {


### PR DESCRIPTION
[SuperEditor][Android] Fix drag handles when selection collapses due to dragging. Resolves #1736

Dragging an expanded drag handle can cause the selection to collapse. When that happens, the expanded handles are painted in the top left corner:

https://github.com/superlistapp/super_editor/assets/31278849/69bf3eab-b2ef-41e5-8b89-ccff68a141c9

This happens because `AndroidControlsDocumentLayerState` is computing a collapsed handle layout data, while we want to display expanded handles.

This PR changes `AndroidControlsDocumentLayerState` to compute layout data for a expanded handles when the selection is collapsed but we are displaying expanded handles.

After the changes:

[expanded_handles.webm](https://github.com/superlistapp/super_editor/assets/7597082/391d9127-a98b-4382-87b9-adcc266d4f19)
