### PR TITLE
[SuperEditor][SuperTextField] Remove calls to cancel scroll momentum on tap (Resolves #824)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -758,8 +758,6 @@ Updating drag selection:
     return Listener(
       onPointerSignal: _scrollOnMouseWheel,
       onPointerHover: _onMouseMove,
-      onPointerDown: (event) => _cancelScrollMomentum(),
-      onPointerPanZoomStart: (event) => _cancelScrollMomentum(),
       child: _buildCursorStyle(
         child: _buildGestureInput(
           child: widget.child ?? const SizedBox(),

--- a/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
@@ -508,8 +508,6 @@ Updating drag selection:
     return Listener(
       onPointerHover: _onMouseMove,
       onPointerSignal: _scrollOnMouseWheel,
-      onPointerDown: (event) => _cancelScrollMomentum(),
-      onPointerPanZoomStart: (event) => _cancelScrollMomentum(),
       child: _buildCursorStyle(
         child: _buildGestureInput(
           child: _buildDocumentContainer(

--- a/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
+++ b/super_editor/lib/src/super_textfield/desktop/desktop_textfield.dart
@@ -942,8 +942,6 @@ class _SuperTextFieldGestureInteractorState extends State<SuperTextFieldGestureI
     return Listener(
       onPointerSignal: _onPointerSignal,
       onPointerHover: (event) => _cancelScrollMomentum(),
-      onPointerDown: (event) => _cancelScrollMomentum(),
-      onPointerPanZoomStart: (event) => _cancelScrollMomentum(),
       child: GestureDetector(
         onSecondaryTapUp: _onRightClick,
         child: RawGestureDetector(

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -490,8 +490,8 @@ void main() {
       }
       final scrollOffsetInMiddleOfMomentum = scrollController.offset;
 
-      // Tap to stop the momentum.
-      await tester.tap(find.byType(SuperEditor));
+      // Tap down to stop the momentum.
+      final gesture = await tester.startGesture(tester.getCenter(find.byType(SuperEditor)));
 
       // Let any remaining momentum run (there shouldn't be any).
       await tester.pumpAndSettle();
@@ -499,8 +499,46 @@ void main() {
       // Ensure that the momentum stopped exactly where we tapped.
       expect(scrollOffsetInMiddleOfMomentum, scrollController.offset);
 
+      // Release the pointer.
+      await gesture.up();
+      await tester.pump();
+
       // Ensure that tapping on the editor didn't place the caret.
       expect(SuperEditorInspector.findDocumentSelection(), isNull);
+    });
+
+    testWidgetsOnDesktop("stops momentum on tap down", (tester) async {
+      final scrollController = ScrollController();
+
+      await tester //
+          .createDocument() //
+          .withLongDoc() //
+          .withScrollController(scrollController) //
+          .pump();
+
+      // Ensure the editor initially has no selection.
+      expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+      // Fling scroll the editor.
+      await tester.fling(find.byType(SuperEditor), const Offset(0.0, -1000), 1000);
+
+      // Pump a few frames of momentum.
+      for (int i = 0; i < 25; i += 1) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      final scrollOffsetInMiddleOfMomentum = scrollController.offset;
+
+      // Tap down to stop the momentum.
+      final gesture = await tester.startGesture(tester.getCenter(find.byType(SuperEditor)));
+
+      // Let any remaining momentum run (there shouldn't be any).
+      await tester.pumpAndSettle();
+
+      // Ensure that the momentum stopped exactly where we tapped.
+      expect(scrollOffsetInMiddleOfMomentum, scrollController.offset);
+
+      // Release the pointer.
+      await gesture.up();
     });
 
     testWidgetsOnAndroid("doesn't overscroll when dragging down", (tester) async {


### PR DESCRIPTION
[SuperEditor][SuperTextField] Remove calls to cancel scroll momentum on tap. Resolves #824

Flutter 3.3.3 had some changes related to scroll momentum that required us to cancel the momentum manually.  We created a `_cancelScrollMomentum` and called it in `onPointerDown`, `onPointerPanZoomStart` and `onPointerHover`.

However, after https://github.com/flutter/flutter/pull/116689 it seems these calls are not necessary anymore because the momentum is already being cancelled.

This PR removes the calls to cancel the scroll momentum `onPointerDown` and `onPointerPanZoomStart`. We also cancel the scroll momentum in `onPointerHover`, but I'm not sure why, so I didn't remove that call for now.

I modified the existing test because it was performing a full tap (down + up) before checking if the momentum was cancelled, but the test description suggests it should cancel after a tap down.

I added a slightly different test for desktop, because it seems that even with the existing code, the selection do change after the tap up.

This PR only affects desktop because we don't use this approach on mobile.