### PR TITLE
[SuperEditor] Implement link attribution update when text changes (Resolves #746)

### DIFF
--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -712,7 +712,8 @@ class LinkifyReaction implements EditReaction {
           .firstOrNull;
     }
 
-    if (insertionOrDeletionOffset < changedNodeText.length) {
+    if ((insertionOrDeletionEvent is TextInsertionEvent && insertionOrDeletionOffset < changedNodeText.length - 1) ||
+        (insertionOrDeletionEvent is TextDeletedEvent && insertionOrDeletionOffset < changedNodeText.length)) {
       // Check if the downstream character has a link attribution.
       final downstreamOffset = insertionOrDeletionEvent is TextInsertionEvent //
           ? insertionOrDeletionOffset + 1

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -496,7 +496,7 @@ class LinkifyReaction implements EditReaction {
     this.updatePolicy = LinkUpdatePolicy.preserve,
   });
 
-  /// Configures how a
+  /// Configures how a change in a URL should be handled.
   final LinkUpdatePolicy updatePolicy;
 
   @override
@@ -574,6 +574,7 @@ class LinkifyReaction implements EditReaction {
     }
 
     if (!didInsertSpace) {
+      // We didn't linkify any text. Check if we need to update an URL.
       _tryUpdateLinkAttribution(document, composer, edits);
     }
   }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -712,7 +712,7 @@ class LinkifyReaction implements EditReaction {
           .firstOrNull;
     }
 
-    if (insertionOrDeletionOffset < changedNodeText.length - 1) {
+    if (insertionOrDeletionOffset < changedNodeText.length) {
       // Check if the downstream character has a link attribution.
       final downstreamOffset = insertionOrDeletionEvent is TextInsertionEvent //
           ? insertionOrDeletionOffset + 1

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -1474,7 +1474,7 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-        // Ensure the characters were delete and link attribution was updated..
+        // Ensure the characters were delete and link attribution was updated.
         final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
         expect(text.text, "google.com");
         expect(
@@ -1486,6 +1486,31 @@ void main() {
           ),
           isTrue,
         );
+
+        // Delete more 9 characters, leaving only the last "m".
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure the attribution was updated.
+        final textAfter = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(textAfter.text, "m");
+        expect(
+          (textAfter.getAllAttributionsAt(0).first as LinkAttribution).url.toString(),
+          "https://m",
+        );
+
+        // Press delete to remove the last character.
+        await tester.pressDelete();
+
+        // Ensure the text was deleted.
+        expect(SuperEditorInspector.findTextInParagraph(doc.nodes.first.id).text, isEmpty);
       });
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -9,1085 +9,1077 @@ import '../supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor link editing >', () {
-    testWidgetsOnAllPlatforms('recognizes a URL when typing and converts it to a link', (tester) async {
-      await tester //
-          .createDocument()
-          .withSingleEmptyParagraph()
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      // Place the caret at the beginning of the empty document.
-      await tester.placeCaretInParagraph("1", 0);
-
-      // Type a URL. It shouldn't linkify until we add a space.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Type a space, to cause a linkify reaction.
-      await tester.typeImeText(" ");
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com ");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 2),
-        ),
-        isTrue,
-      );
-    });
-
-    testWidgetsOnAllPlatforms(
-        'recognizes a URL and converts it to a link when pressing ENTER at the end of a paragraph', (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .withSingleEmptyParagraph()
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      // Place the caret at the beginning of the empty document.
-      await tester.placeCaretInParagraph("1", 0);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new paragraph.
-      await tester.pressEnter();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty paragraph.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
-    });
-
-    testWidgetsOnAllPlatforms(
-        'recognizes a URL and converts it to a link when pressing ENTER at the middle of a paragraph', (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and split the paragraph.
-      await tester.pressEnter();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the paragraph.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
-    });
-
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a paragraph (on Android)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .withSingleEmptyParagraph()
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      // Place the caret at the beginning of the empty document.
-      await tester.placeCaretInParagraph("1", 0);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new paragraph.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty paragraph.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
-    });
-
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a paragraph (on Android)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and split the paragraph.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the paragraph.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
-    });
-
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a paragraph (on iOS)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .withSingleEmptyParagraph()
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      // Place the caret at the beginning of the empty document.
-      await tester.placeCaretInParagraph("1", 0);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new paragraph.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph("1");
-
-      expect(text.text, "https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty line.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
-    });
-
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a paragraph (on iOS)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and split the paragraph.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the paragraph.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ParagraphNode>());
-      expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
-    });
-
-    testWidgetsOnAllPlatforms(
-        'recognizes a URL and converts it to a link when pressing ENTER at the end of a list item', (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Item')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at the end of the list item.
-      await tester.placeCaretInParagraph(nodeId, 4);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText(" https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new list item.
-      await tester.pressEnter();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
-    });
-
-    testWidgetsOnAllPlatforms(
-        'recognizes a URL and converts it to a link when pressing ENTER at the middle of a list item', (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new list item.
-      await tester.pressEnter();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
-    });
-
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a list item (on Android)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Item')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at the end of the list item.
-      await tester.placeCaretInParagraph(nodeId, 4);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText(" https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new list item.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
-    });
-
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a list item (on Android)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and split the list item.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
-    });
-
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a list item (on iOS)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Item')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at the end of the list item.
-      await tester.placeCaretInParagraph(nodeId, 4);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText(" https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new list item.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Item https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(5, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we added a new empty list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
-    });
-
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a list item (on iOS)',
-        (tester) async {
-      final textContext = await tester //
-          .createDocument()
-          .fromMarkdown('* Before link after link')
-          .withInputSource(TextInputSource.ime)
-          .pump();
-
-      final nodeId = textContext.document.nodes.first.id;
-
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph(nodeId, 12);
-
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
-
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
-
-      // Press enter to linkify the URL and insert a new list item.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
-
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph(nodeId);
-
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
-
-      // Ensure we split the list item.
-      expect(textContext.document.nodes.length, 2);
-      expect(textContext.document.nodes[1], isA<ListItemNode>());
-      expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
-    });
-
-    testWidgetsOnAllPlatforms('recognizes a URL and converts it to a link when pressing ENTER at the end of a task',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+    group('recognizes a URL and converts it to a link', () {
+      testWidgetsOnAllPlatforms('when typing', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type a URL. It shouldn't linkify until we add a space.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Type a space, to cause a linkify reaction.
+        await tester.typeImeText(" ");
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com ");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 2),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when pressing ENTER at the end of a paragraph', (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new paragraph.
+        await tester.pressEnter();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty paragraph.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+      });
+
+      testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a paragraph', (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and split the paragraph.
+        await tester.pressEnter();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the paragraph.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+      });
+
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the end of a paragraph (on Android)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new paragraph.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty paragraph.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+      });
+
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the middle of a paragraph (on Android)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and split the paragraph.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the paragraph.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+      });
+
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a paragraph (on iOS)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new paragraph.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph("1");
+
+        expect(text.text, "https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty line.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+      });
+
+      testWidgetsOnIos(
+          'when pressing the newline button on the software keyboard at the middle of a paragraph (on iOS)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and split the paragraph.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the paragraph.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ParagraphNode>());
+        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+      });
+
+      testWidgetsOnAllPlatforms('when pressing ENTER at the end of a list item', (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Item')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(nodeId, 4);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText(" https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new list item.
+        await tester.pressEnter();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+      });
+
+      testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a list item', (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new list item.
+        await tester.pressEnter();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+      });
+
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the end of a list item (on Android)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Item')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(nodeId, 4);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText(" https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new list item.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+      });
+
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the middle of a list item (on Android)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and split the list item.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+      });
+
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a list item (on iOS)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Item')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(nodeId, 4);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText(" https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new list item.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Item https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(5, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we added a new empty list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+      });
+
+      testWidgetsOnIos(
+          'when pressing the newline button on the software keyboard at the middle of a list item (on iOS)',
+          (tester) async {
+        final textContext = await tester //
+            .createDocument()
+            .fromMarkdown('* Before link after link')
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final nodeId = textContext.document.nodes.first.id;
+
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph(nodeId, 12);
+
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
+
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
+
+        // Press enter to linkify the URL and insert a new list item.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
+
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInParagraph(nodeId);
+
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
+
+        // Ensure we split the list item.
+        expect(textContext.document.nodes.length, 2);
+        expect(textContext.document.nodes[1], isA<ListItemNode>());
+        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+      });
+
+      testWidgetsOnAllPlatforms('when pressing ENTER at the end of a task', (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at the end of the task.
-      await tester.placeCaretInParagraph("1", 15);
+        // Place the caret at the end of the task.
+        await tester.placeCaretInParagraph("1", 15);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and insert a new task.
-      await tester.pressEnter();
+        // Press enter to linkify the URL and insert a new task.
+        await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we added a new empty task.
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "");
-    });
+        // Ensure we added a new empty task.
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "");
+      });
 
-    testWidgetsOnAllPlatforms('recognizes a URL and converts it to a link when pressing ENTER at the middle of a task',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+      testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a task', (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph("1", 12);
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph("1", 12);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and split the task.
-      await tester.pressEnter();
+        // Press enter to linkify the URL and split the task.
+        await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we split the task
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "after link");
-    });
+        // Ensure we split the task
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "after link");
+      });
 
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a task (on Android)',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the end of a task (on Android)',
+          (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at the end of the task.
-      await tester.placeCaretInParagraph("1", 15);
+        // Place the caret at the end of the task.
+        await tester.placeCaretInParagraph("1", 15);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and insert a new task.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
+        // Press enter to linkify the URL and insert a new task.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we added a new empty task.
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "");
-    });
+        // Ensure we added a new empty task.
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "");
+      });
 
-    testWidgetsOnAndroid(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a task (on Android)',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+      testWidgetsOnAndroid(
+          'when pressing the newline button on the software keyboard at the middle of a task (on Android)',
+          (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph("1", 12);
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph("1", 12);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and insert a new task.
-      // On Android, pressing ENTER generates a "\n" insertion.
-      await tester.typeImeText('\n');
+        // Press enter to linkify the URL and insert a new task.
+        // On Android, pressing ENTER generates a "\n" insertion.
+        await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we split the task.
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "after link");
-    });
+        // Ensure we split the task.
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "after link");
+      });
 
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the end of a task (on iOS)',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a task (on iOS)',
+          (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("This is a task "), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at the end of the task.
-      await tester.placeCaretInParagraph("1", 15);
+        // Place the caret at the end of the task.
+        await tester.placeCaretInParagraph("1", 15);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and insert a new task.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
+        // Press enter to linkify the URL and insert a new task.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "This is a task https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(15, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "This is a task https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(15, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we added a new empty task.
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "");
-    });
+        // Ensure we added a new empty task.
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "");
+      });
 
-    testWidgetsOnIos(
-        'recognizes a URL and converts it to a link when pressing the newline button on the software keyboard at the middle of a task (on iOS)',
-        (tester) async {
-      final document = MutableDocument(
-        nodes: [
-          TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
-        ],
-      );
-      final composer = MutableDocumentComposer();
-      final editor = createDefaultDocumentEditor(document: document, composer: composer);
-      final task = document.getNodeAt(0) as TaskNode;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SuperEditor(
-              editor: editor,
-              document: document,
-              composer: composer,
-              componentBuilders: [
-                TaskComponentBuilder(editor),
-                ...defaultComponentBuilders,
-              ],
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a task (on iOS)',
+          (tester) async {
+        final document = MutableDocument(
+          nodes: [
+            TaskNode(id: "1", text: AttributedText("Before link after link"), isComplete: false),
+          ],
+        );
+        final composer = MutableDocumentComposer();
+        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final task = document.getNodeAt(0) as TaskNode;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SuperEditor(
+                editor: editor,
+                document: document,
+                composer: composer,
+                componentBuilders: [
+                  TaskComponentBuilder(editor),
+                  ...defaultComponentBuilders,
+                ],
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      // Place the caret at "Before link |after link".
-      await tester.placeCaretInParagraph("1", 12);
+        // Place the caret at "Before link |after link".
+        await tester.placeCaretInParagraph("1", 12);
 
-      // Type a URL. It shouldn't linkify until the user presses ENTER.
-      await tester.typeImeText("https://www.google.com");
+        // Type a URL. It shouldn't linkify until the user presses ENTER.
+        await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = task.text;
+        // Ensure it's not linkified yet.
+        var text = task.text;
 
-      expect(text.text, "Before link https://www.google.comafter link");
-      expect(
-        text.getAttributionSpansInRange(
-          attributionFilter: (attribution) => true,
-          range: const SpanRange(12, 34),
-        ),
-        isEmpty,
-      );
+        expect(text.text, "Before link https://www.google.comafter link");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => true,
+            range: const SpanRange(12, 34),
+          ),
+          isEmpty,
+        );
 
-      // Press enter to linkify the URL and split the task.
-      // On iOS, pressing ENTER generates a newline action.
-      await tester.testTextInput.receiveAction(TextInputAction.newline);
-      await tester.pump();
+        // Press enter to linkify the URL and split the task.
+        // On iOS, pressing ENTER generates a newline action.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
 
-      // Ensure it's linkified.
-      text = task.text;
+        // Ensure it's linkified.
+        text = task.text;
 
-      expect(text.text, "Before link https://www.google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
-          },
-          range: SpanRange(12, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "Before link https://www.google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.com")),
+            },
+            range: SpanRange(12, text.text.length - 1),
+          ),
+          isTrue,
+        );
 
-      // Ensure we split the task.
-      expect(document.nodes.length, 2);
-      expect(document.nodes[1], isA<TaskNode>());
-      expect((document.nodes[1] as TaskNode).text.text, "after link");
+        // Ensure we split the task.
+        expect(document.nodes.length, 2);
+        expect(document.nodes[1], isA<TaskNode>());
+        expect((document.nodes[1] as TaskNode).text.text, "after link");
+      });
     });
 
     testWidgetsOnAllPlatforms('recognizes a second URL when typing and converts it to a link', (tester) async {
@@ -1203,182 +1195,590 @@ void main() {
       );
     });
 
-    testWidgetsOnAllPlatforms('does not expand the link when inserting before the link', (tester) async {
-      // Configure and render a document.
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .pump();
+    group('does not expand the link when inserting before the link', () {
+      testWidgetsOnAllPlatforms('when configured to preserve links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret in the first paragraph at the start of the link.
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
 
-      // Type some text by simulating hardware keyboard key presses.
-      await tester.typeKeyboardText('Go to ');
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText('Go to ');
 
-      // Ensure that the link is unchanged
-      expect(
-        SuperEditorInspector.findDocument(),
-        equalsMarkdown("Go to [www.google.com](www.google.com)"),
-      );
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("Go to [www.google.com](www.google.com)"),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when configured to update links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText('Go to ');
+
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("Go to [www.google.com](www.google.com)"),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('when configured to remove links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText('Go to ');
+
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("Go to [www.google.com](www.google.com)"),
+        );
+      });
     });
 
-    testWidgets('does not expand the link when inserting after the link', (tester) async {
-      // Configure and render a document.
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .pump();
+    group('does not expand the link when inserting after the link', () {
+      testWidgets('when configured to preserve links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret in the first paragraph at the start of the link.
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
 
-      // Type some text by simulating hardware keyboard key presses.
-      await tester.typeKeyboardText(' to learn anything');
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText(' to learn anything');
 
-      // Ensure that the link is unchanged
-      expect(
-        SuperEditorInspector.findDocument(),
-        equalsMarkdown("[www.google.com](www.google.com) to learn anything"),
-      );
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("[www.google.com](www.google.com) to learn anything"),
+        );
+      });
+
+      testWidgets('when configured to update links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText(' to learn anything');
+
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("[www.google.com](www.google.com) to learn anything"),
+        );
+      });
+
+      testWidgets('when configured to remove links on change', (tester) async {
+        // Configure and render a document.
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret in the first paragraph at the start of the link.
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+        // Type some text by simulating hardware keyboard key presses.
+        await tester.typeKeyboardText(' to learn anything');
+
+        // Ensure that the link is unchanged
+        expect(
+          SuperEditorInspector.findDocument(),
+          equalsMarkdown("[www.google.com](www.google.com) to learn anything"),
+        );
+      });
     });
 
-    testWidgetsOnAllPlatforms('can insert characters in the middle of a link', (tester) async {
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .withInputSource(TextInputSource.ime)
-          .pump();
+    group('can insert characters in the middle of a link', () {
+      testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret at "www.goog|le.com"
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+        // Place the caret at "www.goog|le.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
 
-      // Add characters.
-      await tester.typeImeText("oooo");
+        // Add characters.
+        await tester.typeImeText("oooo");
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
 
-      expect(text.text, "www.googoooole.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "www.googoooole.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.goog|le.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+
+        // Add characters.
+        await tester.typeImeText("oooo");
+
+        // Ensure the characters were inserted and the link was updated.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.googoooole.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.googoooole.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.goog|le.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+
+        // Add characters.
+        await tester.typeImeText("oooo");
+
+        // Ensure the characters were inserted and the attribution was removed.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.googoooole.com");
+        expect(text.spans.markers, isEmpty);
+      });
     });
 
-    testWidgetsOnAllPlatforms('user can delete characters at the beginning of a link', (tester) async {
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .withInputSource(TextInputSource.ime)
-          .pump();
+    group('can delete characters at the beginning of a link', () {
+      testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret at "|www.google.com"
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        // Place the caret at "|www.google.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
 
-      // Delete downstream characters.
-      await tester.pressDelete();
-      await tester.pressDelete();
-      await tester.pressDelete();
-      await tester.pressDelete();
+        // Delete downstream characters.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
 
-      expect(text.text, "google.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "|www.google.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Delete downstream characters.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure the characters were delete and link attribution was updated..
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "google.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "|www.google.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+
+        // Delete downstream characters.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure the characters were delete and link attribution was removed.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "google.com");
+        expect(text.spans.markers, isEmpty);
+      });
     });
 
-    testWidgetsOnAllPlatforms('user can delete characters in the middle of a link', (tester) async {
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .withInputSource(TextInputSource.ime)
-          .pump();
+    group('can delete characters in the middle of a link', () {
+      testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret at "www.google.com|"
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+        // Place the caret at "www.google.com|"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
 
-      // Delete upstream characters.
-      await tester.pressBackspace();
-      await tester.pressBackspace();
-      await tester.pressBackspace();
-      await tester.pressBackspace();
-      await tester.pressBackspace();
+        // Delete upstream characters.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
+        // Ensure the characters were deleted and the whole link is still attributed.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.g.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
 
-      expect(text.text, "www.g.com");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
+      testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.google|.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+
+        // Remove characters.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+
+        // Type another text.
+        await tester.typeImeText('duckduckgo');
+
+        // Ensure the text and the link were updated.
+        var text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.duckduckgo.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.duckduckgo.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.google|.com"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+
+        // Remove a single character.
+        await tester.pressBackspace();
+
+        // Ensure the text was updated and the attribution was removed.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.googl.com");
+        expect(text.spans.markers, isEmpty);
+      });
     });
 
-    testWidgetsOnAllPlatforms('user can delete characters at the end of a link', (tester) async {
-      await tester //
-          .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
-          .withInputSource(TextInputSource.ime)
-          .pump();
+    group('can delete characters at the end of a link', () {
+      testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .pump();
 
-      final doc = SuperEditorInspector.findDocument()!;
+        final doc = SuperEditorInspector.findDocument()!;
 
-      // Place the caret at "www.google.com|"
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        // Place the caret at "www.google.com|"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
 
-      // Delete upstream characters.
-      await tester.pressBackspace();
-      await tester.pressBackspace();
-      await tester.pressBackspace();
-      await tester.pressBackspace();
+        // Delete upstream characters.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInParagraph(nodeId);
 
-      expect(text.text, "www.google");
-      expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
-          },
-          range: SpanRange(0, text.text.length - 1),
-        ),
-        isTrue,
-      );
+        expect(text.text, "www.google");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.google.com|"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+        // Delete upstream characters.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+
+        // Ensure the characters were deleted and the link was updated.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.google.c");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.google.c")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Place the caret at "www.google.com|"
+        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+
+        // Delete an upstream characters.
+        await tester.pressBackspace();
+
+        // Ensure the character was deleted and the link was removed.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.google.co");
+        expect(text.spans.markers, isEmpty);
+      });
+    });
+
+    group('can replace characters in the middle of a link', () {
+      testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Double tap to select "google".
+        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+
+        // Replace "google" with "duckduckgo".
+        await tester.typeImeText('duckduckgo');
+
+        // Ensure the text and the link were updated.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.duckduckgo.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Double tap to select "google".
+        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+
+        // Replace "google" with "duckduckgo".
+        await tester.typeImeText('duckduckgo');
+
+        // Ensure the text and the link were updated.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.duckduckgo.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("https://www.duckduckgo.com")),
+            },
+            range: SpanRange(0, text.text.length - 1),
+          ),
+          isTrue,
+        );
+      });
+
+      testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
+        await tester //
+            .createDocument()
+            .fromMarkdown("[www.google.com](www.google.com)")
+            .withInputSource(TextInputSource.ime)
+            .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.remove)]) //
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Double tap to select "google".
+        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+
+        // Replace "google" with "duckduckgo".
+        await tester.typeImeText('duckduckgo');
+
+        // Ensure the text and the link were updated.
+        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        expect(text.text, "www.duckduckgo.com");
+        expect(text.spans.markers, isEmpty);
+      });
     });
 
     testWidgetsOnAllPlatforms('user can delete characters at the end of a link and then keep typing', (tester) async {


### PR DESCRIPTION
[SuperEditor] Implement link attribution update when text changes. Resolves #746

Currently, we allow users to add or removes characters inside a link, but we don't update the link attribution to reflect the changes. For example, the user might type "www.google.com" and then change it to be "www.duckduckgo.com", but the link still points to "www.google.com".

I looked into some other editors. Some of them update the link, some keep the link unchanged and some remove the link entirely.

This PR adds a configuration to `LinkifyReaction` so apps can define how they want to handle changes in URL's. We could also introduce a separate reaction to this.

This PR also re-groups some existing link tests that are similar, to make the test file easier to navigate on.
 