### PR TITLE
[SuperEditor] Fix selection shifting when moving between nodes (Resolves #1761)

### DIFF
--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -347,7 +347,13 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
 
   @override
   Offset getOffsetForPosition(NodePosition nodePosition) {
-    return _getOffsetFromChild(_childDocumentComponent.getOffsetForPosition(nodePosition));
+    // Get the offset from the child to return the offset in
+    // component space instead of text space. Without this,
+    // the offset for components that shift the text, like a task,
+    // won't be aligned with a text component.
+    return _getOffsetFromChild(
+      _childDocumentComponent.getOffsetForPosition(nodePosition),
+    );
   }
 
   @override

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -347,10 +347,11 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
 
   @override
   Offset getOffsetForPosition(NodePosition nodePosition) {
-    // Get the offset from the child to return the offset in
-    // component space instead of text space. Without this,
-    // the offset for components that shift the text, like a task,
-    // won't be aligned with a text component.
+    // In addition to the standard `getOffsetForPosition` of the child component, the proxy
+    // also calls `_getOffsetFromChild`, which returns the offset from the top-left of this
+    // proxy box, to the top-left of the child. Some proxy components, such as a task,
+    // add content that shifts the child component, like adding a checkbox. Any such
+    // shift of the child component must be accounted for when reporting a content offset.
     return _getOffsetFromChild(
       _childDocumentComponent.getOffsetForPosition(nodePosition),
     );

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -451,35 +451,6 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
   }
 }
 
-class ProxyTextComponent extends StatefulWidget {
-  const ProxyTextComponent({
-    super.key,
-    required this.childDocumentComponentKey,
-    required this.child,
-  });
-
-  final GlobalKey<State<StatefulWidget>> childDocumentComponentKey;
-
-  final Widget child;
-
-  @override
-  State<ProxyTextComponent> createState() => _ProxyTextComponentState();
-}
-
-class _ProxyTextComponentState extends State<ProxyTextComponent>
-    with ProxyDocumentComponent<ProxyTextComponent>, ProxyTextComposable {
-  @override
-  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => widget.childDocumentComponentKey;
-
-  @override
-  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
-
-  @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
-}
-
 /// Preferences for how the document selection should change, e.g.,
 /// move word-by-word instead of character-by-character.
 ///

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -347,7 +347,7 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
 
   @override
   Offset getOffsetForPosition(NodePosition nodePosition) {
-    return _childDocumentComponent.getOffsetForPosition(nodePosition);
+    return _getOffsetFromChild(_childDocumentComponent.getOffsetForPosition(nodePosition));
   }
 
   @override

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/infrastructure/composable_text.dart';
 
 import 'document_selection.dart';
 import 'document.dart';
@@ -447,6 +448,35 @@ mixin ProxyDocumentComponent<T extends StatefulWidget> implements DocumentCompon
   @override
   MouseCursor? getDesiredCursorAtOffset(Offset localOffset) {
     return _childDocumentComponent.getDesiredCursorAtOffset(_getChildOffset(localOffset));
+  }
+}
+
+class ProxyTextComponent extends StatefulWidget {
+  const ProxyTextComponent({
+    super.key,
+    required this.childDocumentComponentKey,
+    required this.child,
+  });
+
+  final GlobalKey<State<StatefulWidget>> childDocumentComponentKey;
+
+  final Widget child;
+
+  @override
+  State<ProxyTextComponent> createState() => _ProxyTextComponentState();
+}
+
+class _ProxyTextComponentState extends State<ProxyTextComponent>
+    with ProxyDocumentComponent<ProxyTextComponent>, ProxyTextComposable {
+  @override
+  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => widget.childDocumentComponentKey;
+
+  @override
+  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
   }
 }
 

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -316,7 +316,7 @@ class UnorderedListItemComponent extends StatelessWidget {
     final lineHeight = textScaler.scale(textStyle.fontSize! * (textStyle.height ?? 1.25));
     const manualVerticalAdjustment = 3.0;
 
-    return ProxyTextComponent(
+    return ProxyTextDocumentComponent(
       key: componentKey,
       childDocumentComponentKey: _textKey,
       child: Row(
@@ -418,7 +418,7 @@ class OrderedListItemComponent extends StatelessWidget {
     final textScaler = MediaQuery.textScalerOf(context);
     final lineHeight = textScaler.scale(textStyle.fontSize! * (textStyle.height ?? 1.0));
 
-    return ProxyTextComponent(
+    return ProxyTextDocumentComponent(
       key: componentKey,
       childDocumentComponentKey: _textKey,
       child: Row(

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -1,7 +1,6 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
@@ -306,7 +305,17 @@ class UnorderedListItemComponent extends StatelessWidget {
   final bool showComposingUnderline;
   final bool showDebugPaint;
 
-  final GlobalKey _textKey = GlobalKey();
+  /// A [GlobalKey] that connects a [ProxyTextDocumentComponent] to its
+  /// descendant [TextComponent].
+  ///
+  /// The [ProxyTextDocumentComponent] doesn't know where the [TextComponent] sits
+  /// in its subtree, but the proxy needs access to the [TextComponent] to provide
+  /// access to text layout details.
+  ///
+  /// This key doesn't need to be public because the given [componentKey]
+  /// provides clients with direct access to text layout queries, as well as
+  /// standard [DocumentComponent] queries.
+  final GlobalKey _innerTextComponentKey = GlobalKey();
 
   @override
   Widget build(BuildContext context) {
@@ -318,7 +327,7 @@ class UnorderedListItemComponent extends StatelessWidget {
 
     return ProxyTextDocumentComponent(
       key: componentKey,
-      childDocumentComponentKey: _textKey,
+      textComponentKey: _innerTextComponentKey,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -335,7 +344,7 @@ class UnorderedListItemComponent extends StatelessWidget {
           ),
           Expanded(
             child: TextComponent(
-              key: _textKey,
+              key: _innerTextComponentKey,
               text: text,
               textStyleBuilder: styleBuilder,
               textSelection: textSelection,
@@ -409,7 +418,17 @@ class OrderedListItemComponent extends StatelessWidget {
   final bool showComposingUnderline;
   final bool showDebugPaint;
 
-  final GlobalKey _textKey = GlobalKey();
+  /// A [GlobalKey] that connects a [ProxyTextDocumentComponent] to its
+  /// descendant [TextComponent].
+  ///
+  /// The [ProxyTextDocumentComponent] doesn't know where the [TextComponent] sits
+  /// in its subtree, but the proxy needs access to the [TextComponent] to provide
+  /// access to text layout details.
+  ///
+  /// This key doesn't need to be public because the given [componentKey]
+  /// provides clients with direct access to text layout queries, as well as
+  /// standard [DocumentComponent] queries.
+  final GlobalKey _innerTextComponentKey = GlobalKey();
 
   @override
   Widget build(BuildContext context) {
@@ -420,7 +439,7 @@ class OrderedListItemComponent extends StatelessWidget {
 
     return ProxyTextDocumentComponent(
       key: componentKey,
-      childDocumentComponentKey: _textKey,
+      textComponentKey: _innerTextComponentKey,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -437,7 +456,7 @@ class OrderedListItemComponent extends StatelessWidget {
           ),
           Expanded(
             child: TextComponent(
-              key: _textKey,
+              key: _innerTextComponentKey,
               text: text,
               textStyleBuilder: styleBuilder,
               textSelection: textSelection,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1011,6 +1011,35 @@ class TextComponentState extends State<TextComponent> with DocumentComponent imp
   }
 }
 
+class ProxyTextDocumentComponent extends StatefulWidget {
+  const ProxyTextDocumentComponent({
+    super.key,
+    required this.childDocumentComponentKey,
+    required this.child,
+  });
+
+  final GlobalKey<State<StatefulWidget>> childDocumentComponentKey;
+
+  final Widget child;
+
+  @override
+  State<ProxyTextDocumentComponent> createState() => _ProxyTextDocumentComponentState();
+}
+
+class _ProxyTextDocumentComponentState extends State<ProxyTextDocumentComponent>
+    with ProxyDocumentComponent<ProxyTextDocumentComponent>, ProxyTextComposable {
+  @override
+  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => widget.childDocumentComponentKey;
+
+  @override
+  TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
 class AddTextAttributionsRequest implements EditRequest {
   AddTextAttributionsRequest({
     required this.documentRange,

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1011,15 +1011,27 @@ class TextComponentState extends State<TextComponent> with DocumentComponent imp
   }
 }
 
+/// A [ProxyDocumentComponent] that adds [TextComposable] capabilities so
+/// that simple text-based proxy components can meet their expected contract
+/// without going through the work of defining a stateful widget that mixes in
+/// the [ProxyDocumentComponent] methods.
+///
+/// Using a [ProxyTextDocumentComponent] is never technically necessary.
+/// Custom [DocumentComponent]s can achieve a similar result by mixing in
+/// [ProxyDocumentComponent] within a `State` object. This widget is provided
+/// as a convenience so that some components can be defined as stateless
+/// widgets while still providing access to component behaviors and text layout queries.
 class ProxyTextDocumentComponent extends StatefulWidget {
   const ProxyTextDocumentComponent({
     super.key,
-    required this.childDocumentComponentKey,
+    required this.textComponentKey,
     required this.child,
   });
 
-  final GlobalKey<State<StatefulWidget>> childDocumentComponentKey;
+  final GlobalKey textComponentKey;
 
+  /// The widget subtree, which must include a widget that implements `TextComposable`,
+  /// and that `TextComposable` must be bound to the given [textComponentKey].
   final Widget child;
 
   @override
@@ -1029,7 +1041,7 @@ class ProxyTextDocumentComponent extends StatefulWidget {
 class _ProxyTextDocumentComponentState extends State<ProxyTextDocumentComponent>
     with ProxyDocumentComponent<ProxyTextDocumentComponent>, ProxyTextComposable {
   @override
-  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => widget.childDocumentComponentKey;
+  GlobalKey<State<StatefulWidget>> get childDocumentComponentKey => widget.textComponentKey;
 
   @override
   TextComposable get childTextComposable => childDocumentComponentKey.currentState as TextComposable;

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -167,7 +167,17 @@ class SuperEditorInspector {
   /// {@macro supereditor_finder}
   static AttributedText findTextInParagraph(String nodeId, [Finder? superEditorFinder]) {
     final documentLayout = findDocumentLayout(superEditorFinder);
-    return (documentLayout.getComponentByNodeId(nodeId) as TextComponentState).widget.text;
+    final component = documentLayout.getComponentByNodeId(nodeId);
+
+    if (component is TextComponentState) {
+      return component.widget.text;
+    }
+
+    if (component is ProxyDocumentComponent) {
+      return (component.childDocumentComponentKey.currentState as TextComponentState).widget.text;
+    }
+
+    throw Exception('The component for node id $nodeId is not a TextComponent.');
   }
 
   /// Finds the paragraph with the given [nodeId] and returns the paragraph's content as a [TextSpan].
@@ -179,7 +189,7 @@ class SuperEditorInspector {
   static TextSpan findRichTextInParagraph(String nodeId, [Finder? superEditorFinder]) {
     final documentLayout = findDocumentLayout(superEditorFinder);
 
-    final textComponentState = documentLayout.getComponentByNodeId(nodeId) as TextComponentState;
+    final textComponentState = documentLayout.getComponentByNodeId(nodeId) as DocumentComponent;
     final superText = find
         .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperText))
         .evaluate()

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -189,9 +189,9 @@ class SuperEditorInspector {
   static TextSpan findRichTextInParagraph(String nodeId, [Finder? superEditorFinder]) {
     final documentLayout = findDocumentLayout(superEditorFinder);
 
-    final textComponentState = documentLayout.getComponentByNodeId(nodeId) as DocumentComponent;
+    final component = documentLayout.getComponentByNodeId(nodeId) as DocumentComponent;
     final superText = find
-        .descendant(of: find.byWidget(textComponentState.widget), matching: find.byType(SuperText))
+        .descendant(of: find.byWidget(component.widget), matching: find.byType(SuperText))
         .evaluate()
         .single
         .widget as SuperText;

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -165,7 +165,7 @@ class SuperEditorInspector {
   /// [SuperEditor].
   ///
   /// {@macro supereditor_finder}
-  static AttributedText findTextInParagraph(String nodeId, [Finder? superEditorFinder]) {
+  static AttributedText findTextInComponent(String nodeId, [Finder? superEditorFinder]) {
     final documentLayout = findDocumentLayout(superEditorFinder);
     final component = documentLayout.getComponentByNodeId(nodeId);
 

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -31,7 +31,7 @@ void main() {
 
       // Ensure that the text was pasted into the paragraph.
       final nodeId = doc.nodes.first.id;
-      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
+      expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Pasted text: This was pasted here");
     });
 
     testWidgetsOnApple('pastes within a list item', (tester) async {
@@ -55,7 +55,7 @@ void main() {
 
       // Ensure that the text was pasted into the paragraph.
       final nodeId = doc.nodes.first.id;
-      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Pasted text: This was pasted here");
+      expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Pasted text: This was pasted here");
     });
 
     testAllInputsOnDesktop('pastes multiple paragraphs', (

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -279,7 +279,7 @@ void main() {
 
       // Ensure the text was inserted.
       expect(
-        SuperEditorInspector.findTextInParagraph('1').text,
+        SuperEditorInspector.findTextInComponent('1').text,
         'Going.',
       );
     });
@@ -621,7 +621,7 @@ Paragraph two
         ], getter: imeClientGetter);
 
         expect(
-          SuperEditorInspector.findTextInParagraph('1').text,
+          SuperEditorInspector.findTextInComponent('1').text,
           'Anonymous ',
         );
       });
@@ -666,7 +666,7 @@ Paragraph two
         ], getter: imeClientGetter);
 
         expect(
-          SuperEditorInspector.findTextInParagraph('1').text,
+          SuperEditorInspector.findTextInComponent('1').text,
           'Anonymous ',
         );
       });
@@ -907,7 +907,7 @@ Paragraph two
       );
 
       // Ensure the last character was deleted.
-      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'This is a paragrap');
+      expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'This is a paragrap');
     });
 
     group('text serialization and selected content', () {

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -1957,7 +1957,7 @@ This is a paragraph
         await tester.pressBackspace();
 
         // Ensure the selected content was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "Text with [] selection");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "Text with [] selection");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -2005,7 +2005,7 @@ This is a paragraph
         await tester.pressDelete();
 
         // Ensure the selected content was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "Text with [] selection");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "Text with [] selection");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -2054,7 +2054,7 @@ This is a paragraph
         await tester.typeKeyboardText("a");
 
         // Ensure the selected content was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "Text with [a] selection");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "Text with [a] selection");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -2102,7 +2102,7 @@ This is a paragraph
         await tester.pressEscape();
 
         // Ensure the selected content was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "Text with [SELECTME] selection");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "Text with [SELECTME] selection");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -2136,7 +2136,7 @@ This is a paragraph
       await tester.pressEscape();
 
       // Ensure that nothing changed.
-      expect(SuperEditorInspector.findTextInParagraph("1").text, "This is some text");
+      expect(SuperEditorInspector.findTextInComponent("1").text, "This is some text");
       expect(
         SuperEditorInspector.findDocumentSelection(),
         const DocumentSelection.collapsed(

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -825,7 +825,7 @@ void main() {
         variant: inputSourceVariant,
       );
 
-      group("jumps to downstream node preserving approximate x position with DOWN ARROW", () {
+      group("jumps to downstream node preserving approximate x-position with DOWN ARROW", () {
         testWidgetsOnDesktop('from paragraph to paragraph', (tester) async {
           final context = await tester //
               .createDocument()
@@ -1162,7 +1162,7 @@ This is a paragraph''') //
         });
       });
 
-      group("jumps to upstream node preserving approximate x position with UP ARROW", () {
+      group("jumps to upstream node preserving approximate x-position with UP ARROW", () {
         testWidgetsOnDesktop('from paragraph to paragraph', (tester) async {
           final context = await tester //
               .createDocument()

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -2544,6 +2544,7 @@ Future<TestDocumentContext> _pumpPageScrollSliverTestSetup(
   }).pump();
 }
 
+/// Pumps a [SuperEditor] configured with the [TaskComponentBuilder].
 Future<void> _pumpEditorWithTaskComponent(
   WidgetTester tester, {
   required MutableDocument document,

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -361,7 +361,7 @@ void main() {
 
       // Ensure the document doesn't change.
       expect(
-        SuperEditorInspector.findTextInParagraph('1').text,
+        SuperEditorInspector.findTextInComponent('1').text,
         (singleParagraphDoc().nodes.first as TextNode).text.text,
       );
       expect(

--- a/super_editor/test/super_editor/supereditor_multi_editor_test.dart
+++ b/super_editor/test/super_editor/supereditor_multi_editor_test.dart
@@ -172,7 +172,7 @@ void main() {
 
       // Ensure that the text was edited upon pressing backspace.
       expect(
-        SuperEditorInspector.findTextInParagraph("Editor2_Header").text,
+        SuperEditorInspector.findTextInComponent("Editor2_Header").text,
         "Document #",
       );
 
@@ -180,7 +180,7 @@ void main() {
 
       // Ensure that the text was inserted into the paragraph.
       expect(
-        SuperEditorInspector.findTextInParagraph("Editor2_Header").text,
+        SuperEditorInspector.findTextInComponent("Editor2_Header").text,
         "Document #Edit",
       );
     });

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -178,7 +178,7 @@ void main() {
       await tester.typeKeyboardText("Hello, world!");
 
       // Verify that SuperEditor displays the text we typed.
-      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!");
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hello, world!");
     });
 
     testWidgetsOnDesktop("enters text with hardware keyboard with multiple taps", (tester) async {
@@ -201,7 +201,7 @@ void main() {
       await tester.typeKeyboardText("ABC");
 
       // Ensure that the text is inserted.
-      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hello, world!ABC");
     });
 
     testWidgetsOnDesktop("enters text with IME keyboard", (tester) async {
@@ -221,7 +221,7 @@ void main() {
       await tester.typeImeText("Hello, world!");
 
       // Verify that SuperEditor displays the text we typed.
-      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!");
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hello, world!");
     });
 
     testWidgetsOnDesktop("enters text with IME keyboard with multiple taps", (tester) async {
@@ -244,7 +244,7 @@ void main() {
       await tester.typeImeText("ABC");
 
       // Ensure that the text is inserted.
-      expect(SuperEditorInspector.findTextInParagraph("1").text, "Hello, world!ABC");
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hello, world!ABC");
     });
 
     testWidgetsOnAllPlatforms("performs back to back taps with hardware keyboard", (tester) async {
@@ -266,7 +266,7 @@ void main() {
       await tester.typeKeyboardText("new ");
 
       // Ensure that the text is inserted.
-      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Hello, new world!");
+      expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Hello, new world!");
     });
 
     testWidgetsOnAllPlatforms("performs back to back taps with software keyboard", (tester) async {
@@ -288,7 +288,7 @@ void main() {
       await tester.typeImeText("new ");
 
       // Ensure that the text is inserted.
-      expect(SuperEditorInspector.findTextInParagraph(nodeId).text, "Hello, new world!");
+      expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Hello, new world!");
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -1077,7 +1077,7 @@ Second Paragraph
       // Place the caret at the middle of the first word.
       await tester.placeCaretInParagraph('1', 2);
 
-      final text = SuperEditorInspector.findTextInParagraph('1').text;
+      final text = SuperEditorInspector.findTextInComponent('1').text;
 
       await tester.ime.sendDeltas(
         [

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -34,20 +34,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph('1').text, '-');
+        expect(SuperEditorInspector.findTextInComponent('1').text, '-');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph('1').text, SpecialCharacters.emDash);
+        expect(SuperEditorInspector.findTextInComponent('1').text, SpecialCharacters.emDash);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' is an em-dash');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph('1').text, '— is an em-dash');
+        expect(SuperEditorInspector.findTextInComponent('1').text, '— is an em-dash');
       });
 
       testAllInputsOnAllPlatforms('at the beginning of a non-empty paragraph', (
@@ -69,20 +69,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '-was inserted');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—was inserted');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive('(em-dash) ');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—(em-dash) was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—(em-dash) was inserted');
       });
 
       testAllInputsOnAllPlatforms('at the middle of a paragraph', (
@@ -104,14 +104,14 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -with a reaction');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting -with a reaction');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —with a reaction');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —with a reaction');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' typing two dashes ');
@@ -120,13 +120,13 @@ void main() {
         // and the second should be inserted as is.
         await tester.typeTextAdaptive('---');
         expect(
-            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
+            SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
 
         // Type another dash. The previously inserted dash and the current one
         // should be converted to an em-dash.
         await tester.typeTextAdaptive('-');
         expect(
-            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
+            SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
       });
 
       testAllInputsOnAllPlatforms('at the end of a paragraph', (
@@ -151,20 +151,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting -');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' by typing two dashes');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — by typing two dashes');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — by typing two dashes');
       });
 
       testAllInputsOnAllPlatforms('at the beginning of an empty list item', (
@@ -186,20 +186,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '-');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' is an em-dash');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '— is an em-dash');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '— is an em-dash');
       });
 
       testAllInputsOnAllPlatforms('at the beginning of a non-empty list item', (
@@ -221,27 +221,27 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '-was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '-was inserted');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—was inserted');
 
         // Type a third dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure a dash was inserted and no other nodes were added.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—-was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—-was inserted');
         expect(context.document.nodes.length, 1);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive('(em-dash) ');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, '—-(em-dash) was inserted');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—-(em-dash) was inserted');
       });
 
       testAllInputsOnAllPlatforms('at the middle of a list item', (
@@ -263,14 +263,14 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -with a reaction');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting -with a reaction');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —with a reaction');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —with a reaction');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' typing two dashes ');
@@ -279,13 +279,13 @@ void main() {
         // and the second should be inserted as is.
         await tester.typeTextAdaptive('---');
         expect(
-            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
+            SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — typing two dashes —-with a reaction');
 
         // Type another dash. The previously inserted dash and the current one
         // should be converted to an em-dash.
         await tester.typeTextAdaptive('-');
         expect(
-            SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
+            SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — typing two dashes ——with a reaction');
       });
 
       testAllInputsOnAllPlatforms('at the end of a list item', (
@@ -310,20 +310,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting -');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting -');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
         expect(context.document.nodes.length, 1);
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting —');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' by typing two dashes');
 
         // Ensure the text was inserted.
-        expect(SuperEditorInspector.findTextInParagraph(nodeId).text, 'Inserting — by typing two dashes');
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting — by typing two dashes');
       });
 
       testAllInputsOnAllPlatforms('at the beginning of an empty task', (

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -23,8 +23,8 @@ void main() {
         // Type a URL. It shouldn't linkify until we add a space.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -38,8 +38,8 @@ void main() {
         // Type a space, to cause a linkify reaction.
         await tester.typeImeText(" ");
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com ");
         expect(
@@ -66,8 +66,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -81,8 +81,8 @@ void main() {
         // Press enter to linkify the URL and insert a new paragraph.
         await tester.pressEnter();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -116,8 +116,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -131,8 +131,8 @@ void main() {
         // Press enter to linkify the URL and split the paragraph.
         await tester.pressEnter();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -166,8 +166,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -182,8 +182,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -219,8 +219,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -235,8 +235,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -269,8 +269,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -286,8 +286,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph("1");
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -323,8 +323,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -340,8 +340,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -375,8 +375,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -390,8 +390,8 @@ void main() {
         // Press enter to linkify the URL and insert a new list item.
         await tester.pressEnter();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -425,8 +425,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -440,8 +440,8 @@ void main() {
         // Press enter to linkify the URL and insert a new list item.
         await tester.pressEnter();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -477,8 +477,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -493,8 +493,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -530,8 +530,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -546,8 +546,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -582,8 +582,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -599,8 +599,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -636,8 +636,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's not linkified yet.
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -653,8 +653,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-        // Ensure it's linkified.
-        text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure it's linkified.
+      text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -1096,7 +1096,7 @@ void main() {
       await tester.typeImeText("https://www.google.com and https://flutter.dev ");
 
       // Ensure both URLs are linkified with the correct URLs.
-      final text = SuperEditorInspector.findTextInParagraph("1");
+      final text = SuperEditorInspector.findTextInComponent("1");
 
       expect(text.text, "https://www.google.com and https://flutter.dev ");
       expect(
@@ -1134,7 +1134,7 @@ void main() {
       await tester.typeImeText("google.com");
 
       // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInParagraph("1");
+      var text = SuperEditorInspector.findTextInComponent("1");
 
       expect(text.text, "google.com");
       expect(
@@ -1149,7 +1149,7 @@ void main() {
       await tester.typeImeText(" ");
 
       // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInParagraph("1");
+      text = SuperEditorInspector.findTextInComponent("1");
 
       expect(text.text, "google.com ");
       expect(
@@ -1180,8 +1180,8 @@ void main() {
       await tester.typeImeText(" ");
 
       // Ensure it's linkified with a URL schema.
-      var text = SuperEditorInspector.findTextInParagraph("1");
-      text = SuperEditorInspector.findTextInParagraph("1");
+      var text = SuperEditorInspector.findTextInComponent("1");
+      text = SuperEditorInspector.findTextInComponent("1");
 
       expect(text.text, "www.google.com ");
       expect(
@@ -1351,9 +1351,9 @@ void main() {
         // Add characters.
         await tester.typeImeText("oooo");
 
-        // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure the characters were inserted, the whole link is still attributed.
+      final nodeId = doc.nodes.first.id;
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.googoooole.com");
         expect(
@@ -1439,9 +1439,9 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-        // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure the characters were inserted, the whole link is still attributed.
+      final nodeId = doc.nodes.first.id;
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "google.com");
         expect(
@@ -1559,19 +1559,9 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-        // Ensure the characters were deleted and the whole link is still attributed.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
-        expect(text.text, "www.g.com");
-        expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
-        );
-      });
+      // Ensure the characters were inserted, the whole link is still attributed.
+      final nodeId = doc.nodes.first.id;
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
         await tester //
@@ -1653,9 +1643,9 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-        // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
-        var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      // Ensure the characters were inserted, the whole link is still attributed.
+      final nodeId = doc.nodes.first.id;
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.google");
         expect(
@@ -1826,7 +1816,7 @@ void main() {
 
       // Ensure the text were inserted, and only the URL is linkified.
       final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInParagraph(nodeId);
+      var text = SuperEditorInspector.findTextInComponent(nodeId);
 
       expect(text.text, "www.google.co hello");
       expect(
@@ -1869,14 +1859,14 @@ void main() {
       // ensure that no link markers were added to the empty paragraph.
       expect(doc.nodes.length, 2);
       final newParagraphId = doc.nodes[1].id;
-      AttributedText newParagraphText = SuperEditorInspector.findTextInParagraph(newParagraphId);
+      AttributedText newParagraphText = SuperEditorInspector.findTextInComponent(newParagraphId);
       expect(newParagraphText.spans.markers, isEmpty);
 
       // Type some text.
       await tester.typeImeText("New paragraph");
 
       // Ensure the text we typed didn't re-introduce a link attribution.
-      newParagraphText = SuperEditorInspector.findTextInParagraph(newParagraphId);
+      newParagraphText = SuperEditorInspector.findTextInComponent(newParagraphId);
       expect(newParagraphText.text, "New paragraph");
       expect(
         newParagraphText.getAttributionSpansInRange(
@@ -1911,14 +1901,14 @@ void main() {
       expect(doc.nodes.length, 2);
       expect(doc.nodes[1], isA<ListItemNode>());
       final newListItemId = doc.nodes[1].id;
-      AttributedText newListItemText = SuperEditorInspector.findTextInParagraph(newListItemId);
+      AttributedText newListItemText = SuperEditorInspector.findTextInComponent(newListItemId);
       expect(newListItemText.spans.markers, isEmpty);
 
       // Type some text.
       await tester.typeImeText("New list item");
 
       // Ensure the text we typed didn't re-introduce a link attribution.
-      newListItemText = SuperEditorInspector.findTextInParagraph(newListItemId);
+      newListItemText = SuperEditorInspector.findTextInComponent(newListItemId);
       expect(newListItemText.text, "New list item");
       expect(
         newListItemText.getAttributionSpansInRange(

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -23,8 +23,8 @@ void main() {
         // Type a URL. It shouldn't linkify until we add a space.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -38,8 +38,8 @@ void main() {
         // Type a space, to cause a linkify reaction.
         await tester.typeImeText(" ");
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com ");
         expect(
@@ -66,8 +66,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -81,8 +81,8 @@ void main() {
         // Press enter to linkify the URL and insert a new paragraph.
         await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -116,8 +116,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -131,8 +131,8 @@ void main() {
         // Press enter to linkify the URL and split the paragraph.
         await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -166,8 +166,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -182,8 +182,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -219,8 +219,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -235,8 +235,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -269,8 +269,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -286,8 +286,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent("1");
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.text, "https://www.google.com");
         expect(
@@ -323,8 +323,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -340,8 +340,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -375,8 +375,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -390,8 +390,8 @@ void main() {
         // Press enter to linkify the URL and insert a new list item.
         await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -425,8 +425,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -440,8 +440,8 @@ void main() {
         // Press enter to linkify the URL and insert a new list item.
         await tester.pressEnter();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -477,8 +477,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -493,8 +493,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -530,8 +530,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -546,8 +546,8 @@ void main() {
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText('\n');
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -582,8 +582,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText(" https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -599,8 +599,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Item https://www.google.com");
         expect(
@@ -636,8 +636,8 @@ void main() {
         // Type a URL. It shouldn't linkify until the user presses ENTER.
         await tester.typeImeText("https://www.google.com");
 
-      // Ensure it's not linkified yet.
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's not linkified yet.
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.comafter link");
         expect(
@@ -653,8 +653,8 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
         await tester.pump();
 
-      // Ensure it's linkified.
-      text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure it's linkified.
+        text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "Before link https://www.google.com");
         expect(
@@ -1351,9 +1351,9 @@ void main() {
         // Add characters.
         await tester.typeImeText("oooo");
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.googoooole.com");
         expect(
@@ -1384,7 +1384,7 @@ void main() {
         await tester.typeImeText("oooo");
 
         // Ensure the characters were inserted and the link was updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.googoooole.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1414,7 +1414,7 @@ void main() {
         await tester.typeImeText("oooo");
 
         // Ensure the characters were inserted and the attribution was removed.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.googoooole.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1439,9 +1439,9 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "google.com");
         expect(
@@ -1475,7 +1475,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the characters were delete and link attribution was updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "google.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1499,7 +1499,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the attribution was updated.
-        final textAfter = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final textAfter = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(textAfter.text, "m");
         expect(
           (textAfter.getAllAttributionsAt(0).first as LinkAttribution).url.toString(),
@@ -1510,7 +1510,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the text was deleted.
-        expect(SuperEditorInspector.findTextInParagraph(doc.nodes.first.id).text, isEmpty);
+        expect(SuperEditorInspector.findTextInComponent(doc.nodes.first.id).text, isEmpty);
       });
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
@@ -1533,7 +1533,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the characters were delete and link attribution was removed.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "google.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1559,9 +1559,19 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure the characters were deleted and the whole link is still attributed.
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        expect(text.text, "www.g.com");
+        expect(
+          text.hasAttributionsThroughout(
+            attributions: {
+              LinkAttribution(url: Uri.parse("www.google.com")),
+            },
+            range: SpanRange(0, text.length - 1),
+          ),
+          isTrue,
+        );
+      });
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
         await tester //
@@ -1588,7 +1598,7 @@ void main() {
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        var text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        var text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1618,7 +1628,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the text was updated and the attribution was removed.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.googl.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1643,9 +1653,9 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-      // Ensure the characters were inserted, the whole link is still attributed.
-      final nodeId = doc.nodes.first.id;
-      var text = SuperEditorInspector.findTextInComponent(nodeId);
+        // Ensure the characters were inserted, the whole link is still attributed.
+        final nodeId = doc.nodes.first.id;
+        var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.google");
         expect(
@@ -1677,7 +1687,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the characters were deleted and the link was updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.google.c");
         expect(
           text.hasAttributionsThroughout(
@@ -1707,7 +1717,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the character was deleted and the link was removed.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.google.co");
         expect(text.spans.markers, isEmpty);
       });
@@ -1730,7 +1740,7 @@ void main() {
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1760,7 +1770,7 @@ void main() {
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1790,7 +1800,7 @@ void main() {
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInParagraph(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(text.spans.markers, isEmpty);
       });

--- a/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
+++ b/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
@@ -286,7 +286,7 @@ void main() {
 
         // Ensure that the header became a paragraph.
         expect(headerNode.metadata["blockType"], paragraphAttribution);
-        expect(SuperEditorInspector.findTextInParagraph(headerNode.id).text, "My Header");
+        expect(SuperEditorInspector.findTextInComponent(headerNode.id).text, "My Header");
       });
 
       testWidgetsOnAllPlatforms("blockquotes", (tester) async {
@@ -322,7 +322,7 @@ void main() {
 
         // Ensure that the blockquote became a paragraph.
         expect(blockquoteNode.metadata["blockType"], paragraphAttribution);
-        expect(SuperEditorInspector.findTextInParagraph(blockquoteNode.id).text, "My Blockquote");
+        expect(SuperEditorInspector.findTextInComponent(blockquoteNode.id).text, "My Blockquote");
       });
 
       testWidgetsOnAllPlatforms("ordered list items", (tester) async {
@@ -360,7 +360,7 @@ void main() {
         final newNode = context.findEditContext().document.nodes.first;
         expect(newNode, isA<ParagraphNode>());
         expect(newNode.metadata["blockType"], paragraphAttribution);
-        expect(SuperEditorInspector.findTextInParagraph(listItemNode.id).text, "My list item");
+        expect(SuperEditorInspector.findTextInComponent(listItemNode.id).text, "My list item");
       });
     });
   });

--- a/super_editor/test/super_editor/text_entry/super_editor_common_text_entry_test.dart
+++ b/super_editor/test/super_editor/text_entry/super_editor_common_text_entry_test.dart
@@ -13,7 +13,7 @@ void main() {
     testWidgetsOnDesktop("control keys don't impact content", (tester) async {
       await _pumpApp(tester, _desktopInputSourceAndControlKeyVariant.currentValue!.inputSource);
 
-      final initialParagraphText = SuperEditorInspector.findTextInParagraph("1");
+      final initialParagraphText = SuperEditorInspector.findTextInComponent("1");
 
       // Select some content -> "Lorem |ipsum| dolor sit..."
       await tester.doubleTapInParagraph("1", 8);
@@ -30,14 +30,14 @@ void main() {
       );
 
       // Make sure the content and selection remains the same.
-      expect(SuperEditorInspector.findTextInParagraph("1"), initialParagraphText);
+      expect(SuperEditorInspector.findTextInComponent("1"), initialParagraphText);
       expect(SuperEditorInspector.findDocumentSelection(), expectedSelection);
     }, variant: _desktopInputSourceAndControlKeyVariant);
 
     testWidgetsOnMobile("control keys don't impact content", (tester) async {
       await _pumpApp(tester, _mobileInputSourceAndControlKeyVariant.currentValue!.inputSource);
 
-      final initialParagraphText = SuperEditorInspector.findTextInParagraph("1");
+      final initialParagraphText = SuperEditorInspector.findTextInComponent("1");
 
       // Select some content -> "Lorem |ipsum| dolor sit..."
       await tester.doubleTapInParagraph("1", 8);
@@ -54,7 +54,7 @@ void main() {
       );
 
       // Make sure the content and selection remains the same.
-      expect(SuperEditorInspector.findTextInParagraph("1"), initialParagraphText);
+      expect(SuperEditorInspector.findTextInComponent("1"), initialParagraphText);
       expect(SuperEditorInspector.findDocumentSelection(), expectedSelection);
     }, variant: _mobileInputSourceAndControlKeyVariant);
   });

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -22,7 +22,7 @@ void main() {
         await tester.typeImeText("/header");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "/header");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 0),
@@ -50,7 +50,7 @@ void main() {
         await tester.typeImeText("/header");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
@@ -79,7 +79,7 @@ void main() {
 
         // Ensure that there's no more composing attribution because the tag
         // should have been submitted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header after");
         expect(
           text.getAttributionSpansInRange(
@@ -115,7 +115,7 @@ void main() {
         await tester.typeImeText("/header");
 
         // Ensure that we started a composing tag before adding a space.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
@@ -125,7 +125,7 @@ void main() {
         await tester.typeImeText(" after");
 
         // Ensure that the composing attribution continues after the space.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
@@ -154,7 +154,7 @@ void main() {
         await tester.typeImeText("@john");
 
         // Ensure that we're composing an action tag.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
@@ -202,7 +202,7 @@ void main() {
         );
 
         // Ensure we're still composing
-        AttributedText text = SuperEditorInspector.findTextInParagraph("1");
+        AttributedText text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
           const SpanRange(7, 13),
@@ -217,7 +217,7 @@ void main() {
         await tester.pressShiftLeftArrow();
 
         // Ensure we're still composing
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
           const SpanRange(7, 13),
@@ -228,7 +228,7 @@ void main() {
         await tester.pressShiftLeftArrow();
 
         // Ensure we're still composing
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
           const SpanRange(7, 13),
@@ -290,7 +290,7 @@ void main() {
         );
 
         // Ensure we're still composing
-        AttributedText text = SuperEditorInspector.findTextInParagraph("1");
+        AttributedText text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
           const SpanRange(7, 13),
@@ -331,7 +331,7 @@ void main() {
         );
 
         // Ensure that the tag was submitted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
@@ -377,7 +377,7 @@ void main() {
         await tester.pressLeftArrow();
 
         // Ensure that the action tag was cancelled.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
@@ -430,7 +430,7 @@ void main() {
         await tester.pressRightArrow();
 
         // Ensure that the action tag was cancelled.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /header after");
         expect(
           text.getAttributedRange({actionTagCancelledAttribution}, 7),
@@ -458,7 +458,7 @@ void main() {
         await tester.typeImeText("/");
 
         // Ensure that we're composing.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({actionTagComposingAttribution}, 7),
           const SpanRange(7, 7),
@@ -468,7 +468,7 @@ void main() {
         await tester.pressEscape();
 
         // Ensure that the composing was cancelled.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
@@ -485,7 +485,7 @@ void main() {
         await tester.typeImeText("h");
 
         // Ensure that we didn't start composing again.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /h");
         expect(
           text.getAttributionSpansInRange(
@@ -503,7 +503,7 @@ void main() {
         await tester.typeImeText(" ");
 
         // Ensure that the cancelled tag wasn't submitted, and didn't start composing again.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before /h ");
         expect(
           text.getAttributionSpansInRange(
@@ -578,7 +578,7 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that the action tag was removed after submission.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "");
       });
 
@@ -605,7 +605,7 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that the action tag was removed.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before ");
         expect(
           text.getAttributionSpansInRange(
@@ -639,7 +639,7 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that the action tag was removed.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before  after");
         expect(
           text.getAttributionSpansInRange(

--- a/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
@@ -21,7 +21,7 @@ void main() {
         await tester.typeImeText("#");
 
         // Ensure that no hash tag was created.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "#");
         expect(
           text.hasAttributionAt(0, attribution: const PatternTagAttribution()),
@@ -40,7 +40,7 @@ void main() {
         await tester.typeImeText("#flutter");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "#flutter");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 0),
@@ -68,7 +68,7 @@ void main() {
         await tester.typeImeText("#flutter");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before #flutter after");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 7),
@@ -96,7 +96,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure that the tag doesn't have a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "#");
         expect(
           text.hasAttributionAt(0, attribution: const PatternTagAttribution()),
@@ -125,7 +125,7 @@ void main() {
 
         // Ensure that there's no more composing attribution because the tag
         // should have been committed.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before #flutter after");
         expect(
           text.getAttributionSpansInRange(
@@ -162,7 +162,7 @@ void main() {
         await tester.typeImeText("#flutter. after");
 
         // Ensure that the hash tag doesn't include the period.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before #flutter. after");
         expect(
           text.getAttributionSpansInRange(
@@ -203,7 +203,7 @@ void main() {
         await tester.typeImeText(".");
 
         // Ensure that the hash tag shrunk to where the period was inserted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before #flutter.dart");
         expect(
           text.getAttributionSpansInRange(
@@ -230,7 +230,7 @@ void main() {
         // Compose a hash tag.
         await tester.typeImeText("hello #flutter#d");
 
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "hello #flutter#d");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
@@ -245,7 +245,7 @@ void main() {
         await tester.typeImeText("art");
 
         // Ensure that the tag has a composing attribution.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "hello #flutter#dart");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
@@ -268,7 +268,7 @@ void main() {
         await tester.typeImeText("hello #flutter #dart");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "hello #flutter #dart");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 6),
@@ -475,7 +475,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure that the tag is still marked as a hash tag.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "#bcdfghi ");
         expect(
           text.getAttributedRange({const PatternTagAttribution()}, 0),

--- a/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
@@ -21,7 +21,7 @@ void main() {
         await tester.typeImeText("@john");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "@john");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 0),
@@ -49,7 +49,7 @@ void main() {
         await tester.typeImeText("@john");
 
         // Ensure that the tag has a composing attribution.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
@@ -78,7 +78,7 @@ void main() {
 
         // Ensure that there's no more composing attribution because the tag
         // should have been committed.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john after");
         expect(
           text.getAttributionSpansInRange(
@@ -110,7 +110,7 @@ void main() {
         await tester.typeImeText("@john");
 
         // Ensure that we started composing a tag before adding a space.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
@@ -120,7 +120,7 @@ void main() {
         await tester.typeImeText(" after");
 
         // Ensure that the composing attribution continues after the space.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
@@ -168,7 +168,7 @@ void main() {
         );
 
         // Ensure we're still composing
-        AttributedText text = SuperEditorInspector.findTextInParagraph("1");
+        AttributedText text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
           const SpanRange(7, 11),
@@ -181,7 +181,7 @@ void main() {
         await tester.pressShiftLeftArrow();
 
         // Ensure we're still composing
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
           const SpanRange(7, 11),
@@ -192,7 +192,7 @@ void main() {
         await tester.pressShiftLeftArrow();
 
         // Ensure we're still composing
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
           const SpanRange(7, 11),
@@ -250,7 +250,7 @@ void main() {
         );
 
         // Ensure we're still composing
-        AttributedText text = SuperEditorInspector.findTextInParagraph("1");
+        AttributedText text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
           const SpanRange(7, 11),
@@ -277,7 +277,7 @@ void main() {
         await tester.typeImeText("@");
 
         // Ensure that we're composing.
-        var text = SuperEditorInspector.findTextInParagraph("1");
+        var text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributedRange({stableTagComposingAttribution}, 7),
           const SpanRange(7, 7),
@@ -287,7 +287,7 @@ void main() {
         await tester.pressEscape();
 
         // Ensure that the composing was cancelled.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == stableTagComposingAttribution,
@@ -304,7 +304,7 @@ void main() {
         await tester.typeImeText("j");
 
         // Ensure that we didn't start composing again.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @j");
         expect(
           text.getAttributionSpansInRange(
@@ -322,7 +322,7 @@ void main() {
         await tester.typeImeText(" ");
 
         // Ensure that the cancelled tag wasn't committed, and didn't start composing again.
-        text = SuperEditorInspector.findTextInParagraph("1");
+        text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @j ");
         expect(
           text.getAttributionSpansInRange(
@@ -407,7 +407,7 @@ void main() {
         await tester.typeImeText("@john after");
 
         // Ensure that only the stable tag is attributed as a stable tag.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "@john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 0),
@@ -435,7 +435,7 @@ void main() {
         await tester.typeImeText("@john after");
 
         // Ensure that only the stable tag is attributed as a stable tag.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
@@ -477,7 +477,7 @@ void main() {
         );
 
         // Ensure that the tag was submitted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
@@ -521,7 +521,7 @@ void main() {
         await tester.pressLeftArrow();
 
         // Ensure that the stable tag was submitted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
@@ -570,7 +570,7 @@ void main() {
         await tester.pressRightArrow();
 
         // Ensure that the stable tag was submitted.
-        final text = SuperEditorInspector.findTextInParagraph("1");
+        final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before @john after");
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
@@ -856,7 +856,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure that the entire user tag was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "before  after");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "before  after");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -894,7 +894,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure that the entire user tag was deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "before  after");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "before  after");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -924,7 +924,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the 2nd tag was deleted, and the 1st tag remains.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "one @john two  three");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "one @john two  three");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -974,7 +974,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure that both user tags were completely deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "one  three");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "one  three");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
@@ -1030,7 +1030,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure that both user tags were completely deleted.
-        expect(SuperEditorInspector.findTextInParagraph("1").text, "one  four");
+        expect(SuperEditorInspector.findTextInComponent("1").text, "one  four");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(


### PR DESCRIPTION
[SuperEditor] Fix selection shifting when moving between nodes. Resolves #1761

In the "Animated task height" demo, moving the caret between nodes using UP or DOWN arrow is shifting the selection horizontally:

https://github.com/superlistapp/super_editor/assets/31278849/0b810924-ba05-4a8f-91c1-9fca023baad6

This would happen to any component that mixes in `ProxyDocumentComponent`. 

To move the selection vertically between nodes we first get the current offset for the selected position and then compute 
 which position in the upstream/downstream node is closer to this offset.

The issue is that for `ProxyDocumentComponent`, `getOffsetForPosition` only considers the text inside the component, not the whole component. In the example of the task component, it ignores the checkbox that appears before the text.

For example, consider this layout:

```
[ ]  This is the task 1
[ ]  This is the task 2
```

If the caret sits in `This is the task 1|`, pressing DOWN should move the caret to `This is the task 2|`.

However, we are computing the original offset as if the layout was like the following:

```
This is the task 1
[ ]  This is the task 2
```

So the offset at `This is the task 1|` would move down to `This is the t|ask 2`.

This PR changes `ProxyDocumentComponent` to consider the offset inside the whole component layout.