### PR TITLE
[SuperTextField][Android][iOS] Disables text field caret blink while dragging caret (Resolves #1705)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -824,7 +824,6 @@ class AndroidEditingOverlayController with ChangeNotifier {
     super.dispose();
   }
 
-  /// Text field caret blink controller.
   final BlinkController caretBlinkController;
 
   bool _isToolbarVisible = false;

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -307,7 +307,9 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       widget.editingController.showMagnifier(_localDragOffset!);
 
       if (widget.editingController.textController.selection.isCollapsed) {
-        widget.editingController.stopCaretBlinking();
+        if (widget.editingController.caretBlinkController.isBlinking) {
+          widget.editingController.stopCaretBlinking();
+        }
       }
 
       _log.fine(' - done updating all local state for drag update');
@@ -936,17 +938,13 @@ class AndroidEditingOverlayController with ChangeNotifier {
   ///
   /// If it's already blinking, does nothing.
   void startCaretBlinking() {
-    if (!caretBlinkController.isBlinking) {
-      caretBlinkController.startBlinking();
-    }
+    caretBlinkController.startBlinking();
   }
 
   /// Stops the text field caret blinking.
   ///
   /// If it's already stopped, does nothing.
   void stopCaretBlinking() {
-    if (caretBlinkController.isBlinking) {
-      caretBlinkController.stopBlinking();
-    }
+    caretBlinkController.stopBlinking();
   }
 }

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -824,8 +824,6 @@ class AndroidEditingOverlayController with ChangeNotifier {
     super.dispose();
   }
 
-  final BlinkController caretBlinkController;
-
   bool _isToolbarVisible = false;
   bool get isToolbarVisible => _isToolbarVisible;
 
@@ -839,6 +837,8 @@ class AndroidEditingOverlayController with ChangeNotifier {
   /// selection. Those properties and behaviors are represented by
   /// this [textController].
   final AttributedTextEditingController textController;
+
+  final BlinkController caretBlinkController;
 
   void toggleToolbar() {
     if (isToolbarVisible) {

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -192,9 +192,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onCollapsedPanStart(DragStartDetails details) {
     _log.fine('_onCollapsedPanStart');
 
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
+    _onHandleDragStart();
 
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
@@ -228,16 +226,13 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onBasePanStart(DragStartDetails details) {
     _log.fine('_onBasePanStart');
 
+    _onHandleDragStart();
+
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
         _getGlobalOffsetOfMiddleOfLine(widget.editingController.textController.selection.base);
     _touchHandleOffsetFromLineOfText = globalOffsetInMiddleOfLine - details.globalPosition;
     _log.fine(' - global offset in middle of line: $globalOffsetInMiddleOfLine');
-
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
-    _log.fine(' - hid the toolbar, cancelled countdown timer');
 
     // TODO: de-dup the repeated calculations of the effective focal point: globalPosition + _touchHandleOffsetFromLineOfText
     widget.textScrollController.updateAutoScrollingForTouchOffset(
@@ -262,14 +257,12 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onExtentPanStart(DragStartDetails details) {
     _log.fine('_onExtentPanStart');
 
+    _onHandleDragStart();
+
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
         _getGlobalOffsetOfMiddleOfLine(widget.editingController.textController.selection.extent);
     _touchHandleOffsetFromLineOfText = globalOffsetInMiddleOfLine - details.globalPosition;
-
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
 
     // TODO: de-dup the repeated calculations of the effective focal point: globalPosition + _touchHandleOffsetFromLineOfText
     widget.textScrollController.updateAutoScrollingForTouchOffset(
@@ -284,6 +277,19 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingExtent = true;
       _localDragOffset = (context.findRenderObject() as RenderBox).globalToLocal(details.globalPosition);
     });
+  }
+
+  void _onHandleDragStart() {
+    _log.fine('_onHandleDragStart()');
+
+    widget.editingController
+      ..hideToolbar()
+      ..cancelCollapsedHandleAutoHideCountdown();
+    _log.fine(' - hid the toolbar, cancelled countdown timer');
+
+    if (widget.editingController.textController.selection.isCollapsed) {
+      widget.editingController.stopCaretBlinking();
+    }
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
@@ -305,12 +311,6 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-
-      if (widget.editingController.textController.selection.isCollapsed) {
-        if (widget.editingController.caretBlinkController.isBlinking) {
-          widget.editingController.stopCaretBlinking();
-        }
-      }
 
       _log.fine(' - done updating all local state for drag update');
     });

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -379,15 +379,15 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
 
-      if (widget.editingController.textController.selection.isCollapsed) {
-        widget.editingController.startCaretBlinking();
-      }
-
       if (!widget.editingController.textController.selection.isCollapsed) {
         // We hid the toolbar while dragging a handle. If the selection is
         // expanded, show it again.
         widget.editingController.showToolbar();
       } else {
+        // We stop the caret blink while dragging the collapsed handle. If the selection is
+        // collapsed, start the caret blink.
+        widget.editingController.startCaretBlinking();
+
         // The collapsed handle should disappear after some inactivity.
         widget.editingController
           ..unHideCollapsedHandle()

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -814,7 +814,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
 class AndroidEditingOverlayController with ChangeNotifier {
   AndroidEditingOverlayController({
     required this.textController,
-    required this.blinkController,
+    required this.caretBlinkController,
     required LayerLink magnifierFocalPoint,
   }) : _magnifierFocalPoint = magnifierFocalPoint;
 
@@ -823,6 +823,9 @@ class AndroidEditingOverlayController with ChangeNotifier {
     _handleAutoHideTimer?.cancel();
     super.dispose();
   }
+
+  /// Text field caret blink controller.
+  final BlinkController caretBlinkController;
 
   bool _isToolbarVisible = false;
   bool get isToolbarVisible => _isToolbarVisible;
@@ -930,15 +933,12 @@ class AndroidEditingOverlayController with ChangeNotifier {
     }
   }
 
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
-
   /// Starts the text field caret blinking.
   ///
   /// If it's already blinking, does nothing.
   void startCaretBlinking() {
-    if (!blinkController.isBlinking) {
-      blinkController.startBlinking();
+    if (!caretBlinkController.isBlinking) {
+      caretBlinkController.startBlinking();
     }
   }
 
@@ -946,8 +946,8 @@ class AndroidEditingOverlayController with ChangeNotifier {
   ///
   /// If it's already stopped, does nothing.
   void stopCaretBlinking() {
-    if (blinkController.isBlinking) {
-      blinkController.stopBlinking();
+    if (caretBlinkController.isBlinking) {
+      caretBlinkController.stopBlinking();
     }
   }
 }

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -305,7 +305,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.editingController.blinkController.stopBlinking();
+      widget.editingController.stopCaretBlinking();
       _log.fine(' - done updating all local state for drag update');
     });
   }
@@ -374,7 +374,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.editingController.blinkController.startBlinking();
+      widget.editingController.startCaretBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         // We hid the toolbar while dragging a handle. If the selection is
@@ -831,9 +831,6 @@ class AndroidEditingOverlayController with ChangeNotifier {
   /// this [textController].
   final AttributedTextEditingController textController;
 
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
-
   void toggleToolbar() {
     if (isToolbarVisible) {
       hideToolbar();
@@ -923,6 +920,27 @@ class AndroidEditingOverlayController with ChangeNotifier {
     if (!_isCollapsedHandleAutoHidden) {
       _isCollapsedHandleAutoHidden = true;
       notifyListeners();
+    }
+  }
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
+
+  /// Starts the text field caret blinking.
+  ///
+  /// If it's already blinking, does nothing.
+  void startCaretBlinking() {
+    if (!blinkController.isBlinking) {
+      blinkController.startBlinking();
+    }
+  }
+
+  /// Stops the text field caret blinking.
+  ///
+  /// If it's already stopped, does nothing.
+  void stopCaretBlinking() {
+    if (blinkController.isBlinking) {
+      blinkController.stopBlinking();
     }
   }
 }

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -32,7 +32,6 @@ class AndroidEditingOverlayControls extends StatefulWidget {
     Key? key,
     required this.editingController,
     required this.textScrollController,
-    required this.blinkController,
     required this.textFieldKey,
     required this.textContentKey,
     required this.textFieldLayerLink,
@@ -51,9 +50,6 @@ class AndroidEditingOverlayControls extends StatefulWidget {
   /// Controller that auto-scrolls text based on handle
   /// location.
   final TextScrollController textScrollController;
-
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
 
   /// [LayerLink] that is anchored to the text field's boundary.
   final LayerLink textFieldLayerLink;
@@ -309,7 +305,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.blinkController.stopBlinking();
+      widget.editingController.blinkController.stopBlinking();
       _log.fine(' - done updating all local state for drag update');
     });
   }
@@ -378,7 +374,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.blinkController.startBlinking();
+      widget.editingController.blinkController.startBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         // We hid the toolbar while dragging a handle. If the selection is
@@ -811,6 +807,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
 class AndroidEditingOverlayController with ChangeNotifier {
   AndroidEditingOverlayController({
     required this.textController,
+    required this.blinkController,
     required LayerLink magnifierFocalPoint,
   }) : _magnifierFocalPoint = magnifierFocalPoint;
 
@@ -833,6 +830,9 @@ class AndroidEditingOverlayController with ChangeNotifier {
   /// selection. Those properties and behaviors are represented by
   /// this [textController].
   final AttributedTextEditingController textController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   void toggleToolbar() {
     if (isToolbarVisible) {

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -32,6 +32,7 @@ class AndroidEditingOverlayControls extends StatefulWidget {
     Key? key,
     required this.editingController,
     required this.textScrollController,
+    required this.blinkController,
     required this.textFieldKey,
     required this.textContentKey,
     required this.textFieldLayerLink,
@@ -50,6 +51,9 @@ class AndroidEditingOverlayControls extends StatefulWidget {
   /// Controller that auto-scrolls text based on handle
   /// location.
   final TextScrollController textScrollController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   /// [LayerLink] that is anchored to the text field's boundary.
   final LayerLink textFieldLayerLink;
@@ -305,6 +309,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
+      widget.blinkController.stopBlinking();
       _log.fine(' - done updating all local state for drag update');
     });
   }
@@ -373,6 +378,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
+      widget.blinkController.startBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         // We hid the toolbar while dragging a handle. If the selection is

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -288,6 +288,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     _log.fine(' - hid the toolbar, cancelled countdown timer');
 
     if (widget.editingController.textController.selection.isCollapsed) {
+      // The user is dragging the handle. Stop the caret from blinking while dragging.
       widget.editingController.stopCaretBlinking();
     }
   }
@@ -386,8 +387,8 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
         // expanded, show it again.
         widget.editingController.showToolbar();
       } else {
-        // We stop the caret blink while dragging the collapsed handle. If the selection is
-        // collapsed, start the caret blink.
+        // The user stopped dragging a handle and the selection is collapsed.
+        // Start the caret blinking again.
         widget.editingController.startCaretBlinking();
 
         // The collapsed handle should disappear after some inactivity.
@@ -842,6 +843,16 @@ class AndroidEditingOverlayController with ChangeNotifier {
 
   final BlinkController caretBlinkController;
 
+  /// Starts the text field caret blinking.
+  void startCaretBlinking() {
+    caretBlinkController.startBlinking();
+  }
+
+  /// Stops the text field caret blinking.
+  void stopCaretBlinking() {
+    caretBlinkController.stopBlinking();
+  }
+
   void toggleToolbar() {
     if (isToolbarVisible) {
       hideToolbar();
@@ -932,19 +943,5 @@ class AndroidEditingOverlayController with ChangeNotifier {
       _isCollapsedHandleAutoHidden = true;
       notifyListeners();
     }
-  }
-
-  /// Starts the text field caret blinking.
-  ///
-  /// If it's already blinking, does nothing.
-  void startCaretBlinking() {
-    caretBlinkController.startBlinking();
-  }
-
-  /// Stops the text field caret blinking.
-  ///
-  /// If it's already stopped, does nothing.
-  void stopCaretBlinking() {
-    caretBlinkController.stopBlinking();
   }
 }

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -305,7 +305,11 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.editingController.stopCaretBlinking();
+
+      if (widget.editingController.textController.selection.isCollapsed) {
+        widget.editingController.stopCaretBlinking();
+      }
+
       _log.fine(' - done updating all local state for drag update');
     });
   }
@@ -374,7 +378,10 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.editingController.startCaretBlinking();
+
+      if (widget.editingController.textController.selection.isCollapsed) {
+        widget.editingController.startCaretBlinking();
+      }
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         // We hid the toolbar while dragging a handle. If the selection is

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -324,7 +324,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.editingOverlayController.blinkController.stopBlinking();
+      widget.editingOverlayController.stopCaretBlinking();
     });
   }
 
@@ -349,7 +349,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.editingOverlayController.blinkController.startBlinking();
+      widget.editingOverlayController.startCaretBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -303,6 +303,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       widget.editingOverlayController.cancelCollapsedHandleAutoHideCountdown();
 
       if (widget.textController.selection.isCollapsed) {
+        // The user is dragging the caret. Stop the caret from blinking while dragging.
         widget.editingOverlayController.stopCaretBlinking();
       }
     });
@@ -356,8 +357,8 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
       } else {
-        // We stop the caret blink while dragging the caret. If the selection is
-        // collapsed, start the caret blink.
+        // The user stopped dragging the caret and the selection is collapsed.
+        // Start the caret blinking again.
         widget.editingOverlayController.startCaretBlinking();
 
         // The selection is collapsed. The collapsed handle should disappear

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -46,7 +46,6 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
     required this.textController,
     required this.editingOverlayController,
     required this.textScrollController,
-    required this.blinkController,
     required this.textKey,
     required this.getGlobalCaretRect,
     required this.isMultiline,
@@ -77,9 +76,6 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
   final AndroidEditingOverlayController editingOverlayController;
 
   final TextScrollController textScrollController;
-
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
 
   /// [GlobalKey] that references the widget that contains the text within
   /// this [AndroidTextFieldTouchInteractor].
@@ -328,7 +324,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.blinkController.stopBlinking();
+      widget.editingOverlayController.blinkController.stopBlinking();
     });
   }
 
@@ -353,7 +349,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.blinkController.startBlinking();
+      widget.editingOverlayController.blinkController.startBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -324,7 +324,10 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.editingOverlayController.stopCaretBlinking();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -349,7 +352,10 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.editingOverlayController.startCaretBlinking();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.startCaretBlinking();
+      }
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -353,13 +353,13 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
 
-      if (widget.textController.selection.isCollapsed) {
-        widget.editingOverlayController.startCaretBlinking();
-      }
-
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
       } else {
+        // We stop the caret blink while dragging the caret. If the selection is
+        // collapsed, start the caret blink.
+        widget.editingOverlayController.startCaretBlinking();
+
         // The selection is collapsed. The collapsed handle should disappear
         // after some inactivity. Start the countdown (or restart an in-progress
         // countdown).

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -46,6 +46,7 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
     required this.textController,
     required this.editingOverlayController,
     required this.textScrollController,
+    required this.blinkController,
     required this.textKey,
     required this.getGlobalCaretRect,
     required this.isMultiline,
@@ -76,6 +77,9 @@ class AndroidTextFieldTouchInteractor extends StatefulWidget {
   final AndroidEditingOverlayController editingOverlayController;
 
   final TextScrollController textScrollController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   /// [GlobalKey] that references the widget that contains the text within
   /// this [AndroidTextFieldTouchInteractor].
@@ -324,6 +328,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
+      widget.blinkController.stopBlinking();
     });
   }
 
@@ -348,6 +353,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
+      widget.blinkController.startBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -301,6 +301,10 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
       // Cancel any ongoing handle auto-disappear timer.
       widget.editingOverlayController.cancelCollapsedHandleAutoHideCountdown();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -324,10 +328,6 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-
-      if (widget.textController.selection.isCollapsed) {
-        widget.editingOverlayController.stopCaretBlinking();
-      }
     });
   }
 

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -210,6 +210,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     _editingOverlayController = AndroidEditingOverlayController(
       textController: _textEditingController,
       magnifierFocalPoint: _magnifierLayerLink,
+      blinkController: _blinkController,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -557,7 +558,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             isMultiline: _isMultiline,
             handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
-            blinkController: _blinkController,
             child: TextScrollView(
               key: _scrollKey,
               textScrollController: _textScrollController,
@@ -672,7 +672,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           handleColor: widget.handlesColor,
           popoverToolbarBuilder: widget.popoverToolbarBuilder,
           showDebugPaint: widget.showDebugPaint,
-          blinkController: _blinkController,
         );
       },
     );

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -648,7 +648,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             position: _textEditingController.selection.isCollapsed //
                 ? _textEditingController.selection.extent
                 : null,
-            blinkTimingMode: widget.blinkTimingMode,
             blinkController: _blinkController,
           );
         },

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -179,12 +179,23 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   // positions the invisible touch targets for base/extent dragging.
   final _popoverController = OverlayPortalController();
 
+  /// Text field caret blink controller.
+  late final BlinkController _blinkController;
+
   /// Notifies the popover toolbar to rebuild itself.
   final _popoverRebuildSignal = SignalNotifier();
 
   @override
   void initState() {
     super.initState();
+
+    switch (widget.blinkTimingMode) {
+      case BlinkTimingMode.ticker:
+        _blinkController = BlinkController(tickerProvider: this);
+      case BlinkTimingMode.timer:
+        _blinkController = BlinkController.withTimer();
+    }
+
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
@@ -282,6 +293,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   @override
   void dispose() {
+    _blinkController.dispose();
+
     _removeEditingOverlayControls();
 
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -544,6 +557,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             isMultiline: _isMultiline,
             handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
+            blinkController: _blinkController,
             child: TextScrollView(
               key: _scrollKey,
               textScrollController: _textScrollController,
@@ -636,6 +650,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
                 ? _textEditingController.selection.extent
                 : null,
             blinkTimingMode: widget.blinkTimingMode,
+            blinkController: _blinkController,
           );
         },
       ),
@@ -657,6 +672,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
           handleColor: widget.handlesColor,
           popoverToolbarBuilder: widget.popoverToolbarBuilder,
           showDebugPaint: widget.showDebugPaint,
+          blinkController: _blinkController,
         );
       },
     );

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -208,8 +208,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
     _editingOverlayController = AndroidEditingOverlayController(
       textController: _textEditingController,
-      magnifierFocalPoint: _magnifierLayerLink,
       caretBlinkController: _caretBlinkController,
+      magnifierFocalPoint: _magnifierLayerLink,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -299,7 +299,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       // Dispose after the current frame so that other widgets have
       // time to remove their listeners.
       _editingOverlayController.dispose();
-      _caretBlinkController.dispose();
     });
 
     _textEditingController
@@ -321,6 +320,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     _textScrollController
       ..removeListener(_onTextScrollChange)
       ..dispose();
+
+    _caretBlinkController.dispose();
 
     _popoverRebuildSignal.dispose();
 

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -180,7 +180,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   final _popoverController = OverlayPortalController();
 
   /// Text field caret blink controller.
-  late final BlinkController _blinkController;
+  late final BlinkController _caretBlinkController;
 
   /// Notifies the popover toolbar to rebuild itself.
   final _popoverRebuildSignal = SignalNotifier();
@@ -191,9 +191,9 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
     switch (widget.blinkTimingMode) {
       case BlinkTimingMode.ticker:
-        _blinkController = BlinkController(tickerProvider: this);
+        _caretBlinkController = BlinkController(tickerProvider: this);
       case BlinkTimingMode.timer:
-        _blinkController = BlinkController.withTimer();
+        _caretBlinkController = BlinkController.withTimer();
     }
 
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
@@ -210,7 +210,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     _editingOverlayController = AndroidEditingOverlayController(
       textController: _textEditingController,
       magnifierFocalPoint: _magnifierLayerLink,
-      blinkController: _blinkController,
+      caretBlinkController: _caretBlinkController,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -300,7 +300,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
       // Dispose after the current frame so that other widgets have
       // time to remove their listeners.
       _editingOverlayController.dispose();
-      _blinkController.dispose();
+      _caretBlinkController.dispose();
     });
 
     _textEditingController
@@ -648,7 +648,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             position: _textEditingController.selection.isCollapsed //
                 ? _textEditingController.selection.extent
                 : null,
-            blinkController: _blinkController,
+            blinkController: _caretBlinkController,
           );
         },
       ),

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -294,14 +294,13 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   @override
   void dispose() {
-    _blinkController.dispose();
-
     _removeEditingOverlayControls();
 
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       // Dispose after the current frame so that other widgets have
       // time to remove their listeners.
       _editingOverlayController.dispose();
+      _blinkController.dispose();
     });
 
     _textEditingController

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -179,7 +179,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   // positions the invisible touch targets for base/extent dragging.
   final _popoverController = OverlayPortalController();
 
-  /// Text field caret blink controller.
   late final BlinkController _caretBlinkController;
 
   /// Notifies the popover toolbar to rebuild itself.

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -30,6 +30,7 @@ class IOSEditingControls extends StatefulWidget {
     Key? key,
     required this.editingController,
     required this.textScrollController,
+    required this.blinkController,
     required this.textFieldKey,
     required this.textContentKey,
     required this.textFieldLayerLink,
@@ -48,6 +49,9 @@ class IOSEditingControls extends StatefulWidget {
   /// Controller that auto-scrolls text based on handle
   /// location.
   final TextScrollController textScrollController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   /// [LayerLink] that is anchored to the text field's boundary.
   final LayerLink textFieldLayerLink;
@@ -204,6 +208,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
+      widget.blinkController.stopBlinking();
     });
   }
 
@@ -243,6 +248,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
+      widget.blinkController.startBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -558,10 +558,10 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
 class IOSEditingOverlayController with ChangeNotifier {
   IOSEditingOverlayController({
     required this.textController,
+    required this.caretBlinkController,
     required LeaderLink toolbarFocalPoint,
     required LeaderLink magnifierFocalPoint,
     required this.overlayController,
-    required this.blinkController,
   })  : _toolbarFocalPoint = toolbarFocalPoint,
         _magnifierFocalPoint = magnifierFocalPoint {
     overlayController.addListener(_overlayControllerChanged);
@@ -572,6 +572,9 @@ class IOSEditingOverlayController with ChangeNotifier {
     overlayController.removeListener(_overlayControllerChanged);
     super.dispose();
   }
+
+  /// Text field caret blink controller.
+  final BlinkController caretBlinkController;
 
   bool get isToolbarVisible => overlayController.shouldDisplayToolbar;
 
@@ -634,15 +637,12 @@ class IOSEditingOverlayController with ChangeNotifier {
     notifyListeners();
   }
 
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
-
   /// Starts the text field caret blinking.
   ///
   /// If it's already blinking, does nothing.
   void startCaretBlinking() {
-    if (!blinkController.isBlinking) {
-      blinkController.startBlinking();
+    if (!caretBlinkController.isBlinking) {
+      caretBlinkController.startBlinking();
     }
   }
 
@@ -650,8 +650,8 @@ class IOSEditingOverlayController with ChangeNotifier {
   ///
   /// If it's already stopped, does nothing.
   void stopCaretBlinking() {
-    if (blinkController.isBlinking) {
-      blinkController.stopBlinking();
+    if (caretBlinkController.isBlinking) {
+      caretBlinkController.stopBlinking();
     }
   }
 }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -191,6 +191,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     widget.textScrollController.addListener(_updateSelectionForNewDragHandleLocation);
 
     if (widget.editingController.textController.selection.isCollapsed) {
+      // The user is dragging the handle. Stop the caret from blinking while dragging.
       widget.editingController.stopCaretBlinking();
     }
   }
@@ -251,8 +252,8 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();
       } else {
-        // We stop the caret blink while dragging the collapsed handle. If the selection is
-        // collapsed, start the caret blink.
+        // The user stopped dragging a handle and the selection is collapsed.
+        // Start the caret blinking again.
         widget.editingController.startCaretBlinking();
       }
     });
@@ -588,6 +589,16 @@ class IOSEditingOverlayController with ChangeNotifier {
 
   final BlinkController caretBlinkController;
 
+  /// Starts the text field caret blinking.
+  void startCaretBlinking() {
+    caretBlinkController.startBlinking();
+  }
+
+  /// Stops the text field caret blinking.
+  void stopCaretBlinking() {
+    caretBlinkController.stopBlinking();
+  }
+
   /// Shows, hides, and positions a floating toolbar and magnifier.
   final MagnifierAndToolbarController overlayController;
 
@@ -634,19 +645,5 @@ class IOSEditingOverlayController with ChangeNotifier {
 
   void _overlayControllerChanged() {
     notifyListeners();
-  }
-
-  /// Starts the text field caret blinking.
-  ///
-  /// If it's already blinking, does nothing.
-  void startCaretBlinking() {
-    caretBlinkController.startBlinking();
-  }
-
-  /// Stops the text field caret blinking.
-  ///
-  /// If it's already stopped, does nothing.
-  void stopCaretBlinking() {
-    caretBlinkController.stopBlinking();
   }
 }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -204,7 +204,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.editingController.blinkController.stopBlinking();
+      widget.editingController.stopCaretBlinking();
     });
   }
 
@@ -244,7 +244,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.editingController.blinkController.startBlinking();
+      widget.editingController.startCaretBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();
@@ -583,9 +583,6 @@ class IOSEditingOverlayController with ChangeNotifier {
   /// Shows, hides, and positions a floating toolbar and magnifier.
   final MagnifierAndToolbarController overlayController;
 
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
-
   LeaderLink get toolbarFocalPoint => _toolbarFocalPoint;
   final LeaderLink _toolbarFocalPoint;
 
@@ -629,5 +626,26 @@ class IOSEditingOverlayController with ChangeNotifier {
 
   void _overlayControllerChanged() {
     notifyListeners();
+  }
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
+
+  /// Starts the text field caret blinking.
+  ///
+  /// If it's already blinking, does nothing.
+  void startCaretBlinking() {
+    if (!blinkController.isBlinking) {
+      blinkController.startBlinking();
+    }
+  }
+
+  /// Stops the text field caret blinking.
+  ///
+  /// If it's already stopped, does nothing.
+  void stopCaretBlinking() {
+    if (blinkController.isBlinking) {
+      blinkController.stopBlinking();
+    }
   }
 }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -248,12 +248,12 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
 
-      if (widget.editingController.textController.selection.isCollapsed) {
-        widget.editingController.startCaretBlinking();
-      }
-
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();
+      } else {
+        // We stop the caret blink while dragging the collapsed handle. If the selection is
+        // collapsed, start the caret blink.
+        widget.editingController.startCaretBlinking();
       }
     });
   }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -573,7 +573,6 @@ class IOSEditingOverlayController with ChangeNotifier {
     super.dispose();
   }
 
-  /// Text field caret blink controller.
   final BlinkController caretBlinkController;
 
   bool get isToolbarVisible => overlayController.shouldDisplayToolbar;

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -206,7 +206,9 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       widget.editingController.showMagnifier(_localDragOffset!);
 
       if (widget.editingController.textController.selection.isCollapsed) {
-        widget.editingController.stopCaretBlinking();
+        if (widget.editingController.caretBlinkController.isBlinking) {
+          widget.editingController.stopCaretBlinking();
+        }
       }
     });
   }
@@ -640,17 +642,13 @@ class IOSEditingOverlayController with ChangeNotifier {
   ///
   /// If it's already blinking, does nothing.
   void startCaretBlinking() {
-    if (!caretBlinkController.isBlinking) {
-      caretBlinkController.startBlinking();
-    }
+    caretBlinkController.startBlinking();
   }
 
   /// Stops the text field caret blinking.
   ///
   /// If it's already stopped, does nothing.
   void stopCaretBlinking() {
-    if (caretBlinkController.isBlinking) {
-      caretBlinkController.stopBlinking();
-    }
+    caretBlinkController.stopBlinking();
   }
 }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -204,7 +204,10 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.editingController.stopCaretBlinking();
+
+      if (widget.editingController.textController.selection.isCollapsed) {
+        widget.editingController.stopCaretBlinking();
+      }
     });
   }
 
@@ -244,7 +247,10 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.editingController.startCaretBlinking();
+
+      if (widget.editingController.textController.selection.isCollapsed) {
+        widget.editingController.startCaretBlinking();
+      }
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -30,7 +30,6 @@ class IOSEditingControls extends StatefulWidget {
     Key? key,
     required this.editingController,
     required this.textScrollController,
-    required this.blinkController,
     required this.textFieldKey,
     required this.textContentKey,
     required this.textFieldLayerLink,
@@ -49,9 +48,6 @@ class IOSEditingControls extends StatefulWidget {
   /// Controller that auto-scrolls text based on handle
   /// location.
   final TextScrollController textScrollController;
-
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
 
   /// [LayerLink] that is anchored to the text field's boundary.
   final LayerLink textFieldLayerLink;
@@ -208,7 +204,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-      widget.blinkController.stopBlinking();
+      widget.editingController.blinkController.stopBlinking();
     });
   }
 
@@ -248,7 +244,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
       _isDraggingBase = false;
       _isDraggingExtent = false;
       widget.editingController.hideMagnifier();
-      widget.blinkController.startBlinking();
+      widget.editingController.blinkController.startBlinking();
 
       if (!widget.editingController.textController.selection.isCollapsed) {
         widget.editingController.showToolbar();
@@ -559,6 +555,7 @@ class IOSEditingOverlayController with ChangeNotifier {
     required LeaderLink toolbarFocalPoint,
     required LeaderLink magnifierFocalPoint,
     required this.overlayController,
+    required this.blinkController,
   })  : _toolbarFocalPoint = toolbarFocalPoint,
         _magnifierFocalPoint = magnifierFocalPoint {
     overlayController.addListener(_overlayControllerChanged);
@@ -585,6 +582,9 @@ class IOSEditingOverlayController with ChangeNotifier {
 
   /// Shows, hides, and positions a floating toolbar and magnifier.
   final MagnifierAndToolbarController overlayController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   LeaderLink get toolbarFocalPoint => _toolbarFocalPoint;
   final LeaderLink _toolbarFocalPoint;

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -573,8 +573,6 @@ class IOSEditingOverlayController with ChangeNotifier {
     super.dispose();
   }
 
-  final BlinkController caretBlinkController;
-
   bool get isToolbarVisible => overlayController.shouldDisplayToolbar;
 
   /// The [AttributedTextEditingController] controlling the text
@@ -587,6 +585,8 @@ class IOSEditingOverlayController with ChangeNotifier {
   /// selection. Those properties and behaviors are represented by
   /// this [textController].
   final AttributedTextEditingController textController;
+
+  final BlinkController caretBlinkController;
 
   /// Shows, hides, and positions a floating toolbar and magnifier.
   final MagnifierAndToolbarController overlayController;

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -155,13 +155,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
   void _onBasePanStart(DragStartDetails details) {
     _log.fine('_onBasePanStart');
 
-    widget.editingController.hideToolbar();
-
-    widget.textScrollController.updateAutoScrollingForTouchOffset(
-      userInteractionOffsetInViewport:
-          (widget.textFieldKey.currentContext!.findRenderObject() as RenderBox).globalToLocal(details.globalPosition),
-    );
-    widget.textScrollController.addListener(_updateSelectionForNewDragHandleLocation);
+    _onHandleDragStart(details);
 
     setState(() {
       _isDraggingBase = true;
@@ -176,6 +170,18 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
   void _onExtentPanStart(DragStartDetails details) {
     _log.fine('_onExtentPanStart');
 
+    _onHandleDragStart(details);
+
+    setState(() {
+      _isDraggingBase = false;
+      _isDraggingExtent = true;
+      _localDragOffset = (context.findRenderObject() as RenderBox).globalToLocal(details.globalPosition);
+    });
+  }
+
+  void _onHandleDragStart(DragStartDetails details) {
+    _log.fine('_onHandleDragStart()');
+
     widget.editingController.hideToolbar();
 
     widget.textScrollController.updateAutoScrollingForTouchOffset(
@@ -184,11 +190,9 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     );
     widget.textScrollController.addListener(_updateSelectionForNewDragHandleLocation);
 
-    setState(() {
-      _isDraggingBase = false;
-      _isDraggingExtent = true;
-      _localDragOffset = (context.findRenderObject() as RenderBox).globalToLocal(details.globalPosition);
-    });
+    if (widget.editingController.textController.selection.isCollapsed) {
+      widget.editingController.stopCaretBlinking();
+    }
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
@@ -204,12 +208,6 @@ class _IOSEditingControlsState extends State<IOSEditingControls> with WidgetsBin
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
-
-      if (widget.editingController.textController.selection.isCollapsed) {
-        if (widget.editingController.caretBlinkController.isBlinking) {
-          widget.editingController.stopCaretBlinking();
-        }
-      }
     });
   }
 

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -42,6 +42,7 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
     required this.textController,
     required this.editingOverlayController,
     required this.textScrollController,
+    required this.blinkController,
     required this.selectableTextKey,
     required this.getGlobalCaretRect,
     required this.isMultiline,
@@ -72,6 +73,9 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
   final IOSEditingOverlayController editingOverlayController;
 
   final TextScrollController textScrollController;
+
+  /// Text field caret blink controller.
+  final BlinkController blinkController;
 
   /// [GlobalKey] that references the widget that contains the field's
   /// text.
@@ -316,6 +320,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
+      widget.blinkController.stopBlinking();
     });
   }
 
@@ -340,6 +345,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
+      widget.blinkController.startBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -42,7 +42,6 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
     required this.textController,
     required this.editingOverlayController,
     required this.textScrollController,
-    required this.blinkController,
     required this.selectableTextKey,
     required this.getGlobalCaretRect,
     required this.isMultiline,
@@ -73,9 +72,6 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
   final IOSEditingOverlayController editingOverlayController;
 
   final TextScrollController textScrollController;
-
-  /// Text field caret blink controller.
-  final BlinkController blinkController;
 
   /// [GlobalKey] that references the widget that contains the field's
   /// text.
@@ -320,7 +316,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.blinkController.stopBlinking();
+      widget.editingOverlayController.blinkController.stopBlinking();
     });
   }
 
@@ -345,7 +341,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.blinkController.startBlinking();
+      widget.editingOverlayController.blinkController.startBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -316,7 +316,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.editingOverlayController.blinkController.stopBlinking();
+      widget.editingOverlayController.stopCaretBlinking();
     });
   }
 
@@ -341,7 +341,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.editingOverlayController.blinkController.startBlinking();
+      widget.editingOverlayController.startCaretBlinking();
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -296,6 +296,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       widget.editingOverlayController.hideToolbar();
 
       if (widget.textController.selection.isCollapsed) {
+        // The user is dragging the caret. Stop the caret from blinking while dragging.
         widget.editingOverlayController.stopCaretBlinking();
       }
     });
@@ -348,8 +349,8 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
       } else {
-        // We stop the caret blink while dragging the collapsed caret. If the selection is
-        // collapsed, start the caret blink.
+        // The user stopped dragging the caret and the selection is collapsed.
+        // Start the caret blinking again.
         widget.editingOverlayController.startCaretBlinking();
       }
     });

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -316,7 +316,10 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-      widget.editingOverlayController.stopCaretBlinking();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -341,7 +344,10 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     setState(() {
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
-      widget.editingOverlayController.startCaretBlinking();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.startCaretBlinking();
+      }
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -345,12 +345,12 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       _isDraggingCaret = false;
       widget.editingOverlayController.hideMagnifier();
 
-      if (widget.textController.selection.isCollapsed) {
-        widget.editingOverlayController.startCaretBlinking();
-      }
-
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
+      } else {
+        // We stop the caret blink while dragging the collapsed caret. If the selection is
+        // collapsed, start the caret blink.
+        widget.editingOverlayController.startCaretBlinking();
       }
     });
   }

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -294,6 +294,10 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
 
       // When the user drags, the toolbar should not be visible.
       widget.editingOverlayController.hideToolbar();
+
+      if (widget.textController.selection.isCollapsed) {
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -316,10 +320,6 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       );
 
       widget.editingOverlayController.showMagnifier(_globalDragOffset!);
-
-      if (widget.textController.selection.isCollapsed) {
-        widget.editingOverlayController.stopCaretBlinking();
-      }
     });
   }
 

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -654,7 +654,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
               position: _textEditingController.selection.isCollapsed //
                   ? _textEditingController.selection.extent
                   : null,
-              blinkController: _blinkController,
+              blinkController: _caretBlinkController,
             ),
             IOSFloatingCursor(
               controller: _floatingCursorController,

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -224,10 +224,10 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
     _editingOverlayController = IOSEditingOverlayController(
       textController: _textEditingController,
+      caretBlinkController: _caretBlinkController,
       toolbarFocalPoint: _toolbarLeaderLink,
       magnifierFocalPoint: _magnifierLeaderLink,
       overlayController: _overlayController,
-      caretBlinkController: _caretBlinkController,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -319,7 +319,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       // time to remove their listeners.
       _editingOverlayController.dispose();
       _overlayController.dispose();
-      _caretBlinkController.dispose();
     });
 
     _textEditingController
@@ -342,6 +341,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
     _textScrollController
       ..removeListener(_onTextScrollChange)
       ..dispose();
+
+    _caretBlinkController.dispose();
 
     WidgetsBinding.instance.removeObserver(this);
 

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -188,7 +188,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   // positions the invisible touch targets for base/extent dragging.
   final _popoverController = OverlayPortalController();
 
-  /// Text field caret blink controller.
   late final BlinkController _caretBlinkController;
 
   /// Notifies the popover toolbar to rebuild itself.

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -189,7 +189,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   final _popoverController = OverlayPortalController();
 
   /// Text field caret blink controller.
-  late final BlinkController _blinkController;
+  late final BlinkController _caretBlinkController;
 
   /// Notifies the popover toolbar to rebuild itself.
   final _overlayControlsRebuildSignal = SignalNotifier();
@@ -200,9 +200,9 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
     switch (widget.blinkTimingMode) {
       case BlinkTimingMode.ticker:
-        _blinkController = BlinkController(tickerProvider: this);
+        _caretBlinkController = BlinkController(tickerProvider: this);
       case BlinkTimingMode.timer:
-        _blinkController = BlinkController.withTimer();
+        _caretBlinkController = BlinkController.withTimer();
     }
 
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
@@ -228,7 +228,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       toolbarFocalPoint: _toolbarLeaderLink,
       magnifierFocalPoint: _magnifierLeaderLink,
       overlayController: _overlayController,
-      blinkController: _blinkController,
+      caretBlinkController: _caretBlinkController,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -320,7 +320,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       // time to remove their listeners.
       _editingOverlayController.dispose();
       _overlayController.dispose();
-      _blinkController.dispose();
+      _caretBlinkController.dispose();
     });
 
     _textEditingController

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -313,8 +313,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
   @override
   void dispose() {
-    _blinkController.dispose();
-
     _removeEditingOverlayControls();
 
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -322,6 +320,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       // time to remove their listeners.
       _editingOverlayController.dispose();
       _overlayController.dispose();
+      _blinkController.dispose();
     });
 
     _textEditingController

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -188,12 +188,23 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
   // positions the invisible touch targets for base/extent dragging.
   final _popoverController = OverlayPortalController();
 
+  /// Text field caret blink controller.
+  late final BlinkController _blinkController;
+
   /// Notifies the popover toolbar to rebuild itself.
   final _overlayControlsRebuildSignal = SignalNotifier();
 
   @override
   void initState() {
     super.initState();
+
+    switch (widget.blinkTimingMode) {
+      case BlinkTimingMode.ticker:
+        _blinkController = BlinkController(tickerProvider: this);
+      case BlinkTimingMode.timer:
+        _blinkController = BlinkController.withTimer();
+    }
+
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
@@ -301,6 +312,8 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
   @override
   void dispose() {
+    _blinkController.dispose();
+
     _removeEditingOverlayControls();
 
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -538,6 +551,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             textController: _textEditingController,
             editingOverlayController: _editingOverlayController,
             textScrollController: _textScrollController,
+            blinkController: _blinkController,
             isMultiline: _isMultiline,
             handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
@@ -642,7 +656,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
               position: _textEditingController.selection.isCollapsed //
                   ? _textEditingController.selection.extent
                   : null,
-              blinkTimingMode: widget.blinkTimingMode,
+              blinkController: _blinkController,
             ),
             IOSFloatingCursor(
               controller: _floatingCursorController,
@@ -660,6 +674,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         return IOSEditingControls(
           editingController: _editingOverlayController,
           textScrollController: _textScrollController,
+          blinkController: _blinkController,
           textFieldLayerLink: _textFieldLayerLink,
           textFieldKey: _textFieldKey,
           textContentLayerLink: _textContentLayerLink,

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -228,6 +228,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
       toolbarFocalPoint: _toolbarLeaderLink,
       magnifierFocalPoint: _magnifierLeaderLink,
       overlayController: _overlayController,
+      blinkController: _blinkController,
     );
 
     WidgetsBinding.instance.addObserver(this);
@@ -551,7 +552,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             textController: _textEditingController,
             editingOverlayController: _editingOverlayController,
             textScrollController: _textScrollController,
-            blinkController: _blinkController,
             isMultiline: _isMultiline,
             handleColor: widget.handlesColor,
             showDebugPaint: widget.showDebugPaint,
@@ -674,7 +674,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         return IOSEditingControls(
           editingController: _editingOverlayController,
           textScrollController: _textScrollController,
-          blinkController: _blinkController,
           textFieldLayerLink: _textFieldLayerLink,
           textFieldKey: _textFieldKey,
           textContentLayerLink: _textContentLayerLink,

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -173,7 +173,7 @@ void main() {
 
       final controller = AttributedTextEditingController(
         text: AttributedText(
-          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
         ),
       );
 
@@ -225,7 +225,7 @@ void main() {
 
       final controller = AttributedTextEditingController(
         text: AttributedText(
-          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
         ),
       );
 
@@ -315,7 +315,7 @@ void main() {
 
       final controller = AttributedTextEditingController(
         text: AttributedText(
-          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
         ),
       );
 

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -169,14 +169,27 @@ void main() {
     });
 
     testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
+      // Disable indeterminate animations.
+      BlinkController.indeterminateAnimationsEnabled = false;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
       final controller = AttributedTextEditingController(
         text: AttributedText(
             '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
       );
 
-      await _pumpTestApp(tester, controller: controller);
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
 
       await tester.placeCaretInSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
 
       // Drag caret by an arbitrary distance.
       await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
@@ -196,14 +209,27 @@ void main() {
     });
 
     testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
+      // Disable indeterminate animations.
+      BlinkController.indeterminateAnimationsEnabled = false;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
       final controller = AttributedTextEditingController(
         text: AttributedText(
             '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
       );
 
-      await _pumpTestApp(tester, controller: controller);
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
 
       await tester.placeCaretInSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
 
       // Drag handle by an arbitrary distance.
       await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -218,6 +218,82 @@ void main() {
       expect(_isCaretVisible(tester), true);
     });
 
+    testWidgetsOnMobile("does not blink while dragging expanded handles", (tester) async {
+      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
+
+      await tester.doubleTapAtSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      // Drag the upstream handle by an arbitrary distance.
+      await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      // Drag the downstream handle by an arbitrary distance.
+      await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+    });
+
     testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
       // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -243,9 +243,8 @@ void main() {
       BlinkController.indeterminateAnimationsEnabled = true;
 
       // Drag the upstream selection handle by a small distance so that we trigger a
-      // user drag event.
-      // This drag event is continued down below so that we can check for caret blinking
-      // during a user drag.
+      // user drag event. This drag event is continued down below so that we can check
+      // for caret blinking during a user drag.
       final TestGesture gesture =
           await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
       addTearDown(() => gesture.removePointer());
@@ -279,9 +278,8 @@ void main() {
       await tester.pump();
 
       // Drag the downstream selection handle by a small distance so that we trigger a
-      // user drag event.
-      // This drag event is continued down below so that we can check for caret blinking
-      // during a user drag.
+      // user drag event. This drag event is continued down below so that we can check
+      // for caret blinking during a user drag.
       final TestGesture gesture2 =
           await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
       addTearDown(() => gesture2.removePointer());
@@ -333,9 +331,8 @@ void main() {
       BlinkController.indeterminateAnimationsEnabled = true;
 
       // Drag the collapsed handle by a small distance so that we trigger a
-      // user drag event.
-      // This drag event is continued down below so that we can check for caret blinking
-      // during a user drag.
+      // user drag event. This drag event is continued down below so that we
+      // can check for caret blinking during a user drag.
       final TestGesture gesture =
           await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
       addTearDown(() => gesture.removePointer());

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
+import 'super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField caret", () {
@@ -166,6 +167,60 @@ void main() {
       expect(caret.style.width, caretStyle.width);
       expect(caret.style.borderRadius, caretStyle.borderRadius);
     });
+
+    testWidgetsOnMobile("does not blink while dragging", (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+            '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
+      );
+
+      await _pumpTestApp(tester, controller: controller);
+
+      await tester.placeCaretInSuperTextField(0);
+
+      // Drag caret by an arbitrary distance.
+      await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+    });
+
+    testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+            '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
+      );
+
+      await _pumpTestApp(tester, controller: controller);
+
+      await tester.placeCaretInSuperTextField(0);
+
+      // Drag handle by an arbitrary distance.
+      await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+    });
   });
 }
 
@@ -195,4 +250,30 @@ bool _isCaretVisible(WidgetTester tester) {
   final customPaint = find.byWidgetPredicate((widget) => widget is CustomPaint && widget.painter is CaretPainter);
   final caretPainter = tester.widget<CustomPaint>(customPaint.last).painter as CaretPainter;
   return caretPainter.blinkController!.opacity == 1.0;
+}
+
+/// Pumps a [SuperTextField] experience.
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  AttributedTextEditingController? controller,
+  EdgeInsets? padding,
+  TextAlign? textAlign,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 300,
+          child: SuperTextField(
+            padding: padding,
+            textAlign: textAlign ?? TextAlign.left,
+            textController: controller ??
+                AttributedTextEditingController(
+                  text: AttributedText('abc'),
+                ),
+          ),
+        ),
+      ),
+    ),
+  );
 }

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -190,7 +190,9 @@ void main() {
       // Configure BlinkController to animate, otherwise it won't blink.
       BlinkController.indeterminateAnimationsEnabled = true;
 
-      // Drag caret by an arbitrary distance.
+      // Drag caret by a small distance so that we trigger a user drag event.
+      // This drag event is continued down below so that we can check for caret blinking
+      // during a user drag.
       await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
@@ -239,7 +241,10 @@ void main() {
       // Configure BlinkController to animate, otherwise it won't blink.
       BlinkController.indeterminateAnimationsEnabled = true;
 
-      // Drag the upstream handle by an arbitrary distance.
+      // Drag the upstream selection handle by a small distance so that we trigger a
+      // user drag event.
+      // This drag event is continued down below so that we can check for caret blinking
+      // during a user drag.
       await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
@@ -265,7 +270,10 @@ void main() {
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
-      // Drag the downstream handle by an arbitrary distance.
+      // Drag the downstream selection handle by a small distance so that we trigger a
+      // user drag event.
+      // This drag event is continued down below so that we can check for caret blinking
+      // during a user drag.
       await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
@@ -314,7 +322,10 @@ void main() {
       // Configure BlinkController to animate, otherwise it won't blink.
       BlinkController.indeterminateAnimationsEnabled = true;
 
-      // Drag handle by an arbitrary distance.
+      // Drag the collapsed handle by a small distance so that we trigger a
+      // user drag event.
+      // This drag event is continued down below so that we can check for caret blinking
+      // during a user drag.
       await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -170,7 +170,6 @@ void main() {
 
     testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
       // Disable indeterminate animations.
-      BlinkController.indeterminateAnimationsEnabled = false;
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(
@@ -215,7 +214,6 @@ void main() {
 
     testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
       // Disable indeterminate animations.
-      BlinkController.indeterminateAnimationsEnabled = false;
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -169,7 +169,6 @@ void main() {
     });
 
     testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
-      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(
@@ -219,7 +218,6 @@ void main() {
     });
 
     testWidgetsOnMobile("does not blink while dragging expanded handles", (tester) async {
-      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(
@@ -295,7 +293,6 @@ void main() {
     });
 
     testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
-      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -168,7 +168,7 @@ void main() {
       expect(caret.style.borderRadius, caretStyle.borderRadius);
     });
 
-    testWidgetsOnMobile("does not blink while dragging", (tester) async {
+    testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
       final controller = AttributedTextEditingController(
         text: AttributedText(
             '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -169,7 +169,7 @@ void main() {
     });
 
     testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
-      // Disable indeterminate animations.
+      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(
@@ -194,6 +194,11 @@ void main() {
       // Drag caret by an arbitrary distance.
       await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
 
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
@@ -214,7 +219,7 @@ void main() {
     });
 
     testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
-      // Disable indeterminate animations.
+      // Disable indeterminate animations so that pumpAndSettle() doesn't time out.
       addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
 
       final controller = AttributedTextEditingController(
@@ -238,6 +243,11 @@ void main() {
 
       // Drag handle by an arbitrary distance.
       await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
 
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -245,9 +245,9 @@ void main() {
       // Drag the upstream selection handle by a small distance so that we trigger a
       // user drag event. This drag event is continued down below so that we can check
       // for caret blinking during a user drag.
-      final TestGesture gesture =
+      final TestGesture upstreamHandleGesture =
           await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
-      addTearDown(() => gesture.removePointer());
+      addTearDown(() => upstreamHandleGesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and
@@ -274,15 +274,15 @@ void main() {
 
       // End the current drag gesture before we start the downstream handle drag.
       // We don't want multiple gesture pointers active at the same time.
-      await gesture.up();
+      await upstreamHandleGesture.up();
       await tester.pump();
 
       // Drag the downstream selection handle by a small distance so that we trigger a
       // user drag event. This drag event is continued down below so that we can check
       // for caret blinking during a user drag.
-      final TestGesture gesture2 =
+      final TestGesture downstreamHandleGesture =
           await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
-      addTearDown(() => gesture2.removePointer());
+      addTearDown(() => downstreamHandleGesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -174,7 +174,8 @@ void main() {
 
       final controller = AttributedTextEditingController(
         text: AttributedText(
-            '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
+          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+        ),
       );
 
       await tester.pumpWidget(
@@ -218,7 +219,8 @@ void main() {
 
       final controller = AttributedTextEditingController(
         text: AttributedText(
-            '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.'''),
+          '''SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.''',
+        ),
       );
 
       await tester.pumpWidget(

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -193,7 +193,8 @@ void main() {
       // Drag caret by a small distance so that we trigger a user drag event.
       // This drag event is continued down below so that we can check for caret blinking
       // during a user drag.
-      await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
+      final TestGesture gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => gesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and
@@ -245,7 +246,9 @@ void main() {
       // user drag event.
       // This drag event is continued down below so that we can check for caret blinking
       // during a user drag.
-      await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
+      final TestGesture gesture =
+          await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
+      addTearDown(() => gesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and
@@ -270,11 +273,18 @@ void main() {
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
+      // End the current drag gesture before we start the downstream handle drag.
+      // We don't want multiple gesture pointers active at the same time.
+      await gesture.up();
+      await tester.pump();
+
       // Drag the downstream selection handle by a small distance so that we trigger a
       // user drag event.
       // This drag event is continued down below so that we can check for caret blinking
       // during a user drag.
-      await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
+      final TestGesture gesture2 =
+          await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
+      addTearDown(() => gesture2.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and
@@ -326,7 +336,9 @@ void main() {
       // user drag event.
       // This drag event is continued down below so that we can check for caret blinking
       // during a user drag.
-      await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
+      final TestGesture gesture =
+          await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => gesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
       // Test in half-flash period intervals as we don't know how much time has passed and

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -277,29 +277,3 @@ bool _isCaretVisible(WidgetTester tester) {
   final caretPainter = tester.widget<CustomPaint>(customPaint.last).painter as CaretPainter;
   return caretPainter.blinkController!.opacity == 1.0;
 }
-
-/// Pumps a [SuperTextField] experience.
-Future<void> _pumpTestApp(
-  WidgetTester tester, {
-  AttributedTextEditingController? controller,
-  EdgeInsets? padding,
-  TextAlign? textAlign,
-}) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Scaffold(
-        body: SizedBox(
-          width: 300,
-          child: SuperTextField(
-            padding: padding,
-            textAlign: textAlign ?? TextAlign.left,
-            textController: controller ??
-                AttributedTextEditingController(
-                  text: AttributedText('abc'),
-                ),
-          ),
-        ),
-      ),
-    ),
-  );
-}

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -197,12 +197,17 @@ void main() {
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
-      await tester.pump(flashPeriod);
+      await tester.pump(flashPeriod ~/ 2);
 
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
-      await tester.pump(flashPeriod);
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
 
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
@@ -237,12 +242,17 @@ void main() {
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
-      await tester.pump(flashPeriod);
+      await tester.pump(flashPeriod ~/ 2);
 
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);
 
-      await tester.pump(flashPeriod);
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
 
       // Ensure caret is visible.
       expect(_isCaretVisible(tester), true);

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -246,7 +246,7 @@ void main() {
       // user drag event. This drag event is continued down below so that we can check
       // for caret blinking during a user drag.
       final TestGesture upstreamHandleGesture =
-          await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.upstream, const Offset(100, 100));
+          await tester.dragUpstreamMobileHandleByDistanceInSuperTextField(const Offset(100, 100));
       addTearDown(() => upstreamHandleGesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
@@ -281,7 +281,7 @@ void main() {
       // user drag event. This drag event is continued down below so that we can check
       // for caret blinking during a user drag.
       final TestGesture downstreamHandleGesture =
-          await tester.dragHandleByDistanceInSuperTextFieldOnMobile(HandleType.downstream, const Offset(100, 100));
+          await tester.dragDownstreamMobileHandleByDistanceInSuperTextField(const Offset(100, 100));
       addTearDown(() => downstreamHandleGesture.removePointer());
 
       // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -123,11 +123,10 @@ extension SuperTextFieldRobot on WidgetTester {
     return gesture;
   }
 
-  /// Drags the [SuperTextField] handle by the given delta.
+  /// Drags the [SuperTextField] upstream handle by the given delta.
   ///
   /// {@macro supertextfield_finder}
-  Future<TestGesture> dragHandleByDistanceInSuperTextFieldOnMobile(
-    HandleType handleType,
+  Future<TestGesture> dragUpstreamMobileHandleByDistanceInSuperTextField(
     Offset delta, [
     Finder? superTextFieldFinder,
   ]) async {
@@ -136,21 +135,42 @@ extension SuperTextFieldRobot on WidgetTester {
     final match = fieldFinder.evaluate().single.widget;
 
     if (match is SuperAndroidTextField) {
-      return _dragAndroidHandleByDistanceInSuperTextField(handleType, delta, fieldFinder);
+      return _dragAndroidUpstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
     }
 
     if (match is SuperIOSTextField) {
-      return _dragIOSHandleByDistanceInSuperTextField(handleType, delta, fieldFinder);
+      return _dragIOSUpstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
     }
 
     throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
   }
 
-  /// Drags the [SuperAndroidTextField] handle by the given delta.
+  /// Drags the [SuperTextField] downstream handle by the given delta.
   ///
   /// {@macro supertextfield_finder}
-  Future<TestGesture> _dragAndroidHandleByDistanceInSuperTextField(
-    HandleType handleType,
+  Future<TestGesture> dragDownstreamMobileHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    final fieldFinder =
+        SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
+    final match = fieldFinder.evaluate().single.widget;
+
+    if (match is SuperAndroidTextField) {
+      return _dragAndroidDownstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    if (match is SuperIOSTextField) {
+      return _dragIOSDownstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
+  }
+
+  /// Drags the [SuperAndroidTextField] upstream handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragAndroidUpstreamHandleByDistanceInSuperTextField(
     Offset delta, [
     Finder? superTextFieldFinder,
   ]) async {
@@ -161,30 +181,46 @@ extension SuperTextFieldRobot on WidgetTester {
       matching: find.byWidgetPredicate(
         (widget) =>
             widget is AndroidSelectionHandle && //
-            widget.handleType == handleType,
+            widget.handleType == HandleType.upstream,
       ),
     );
 
     expect(handleFinder, findsOne);
 
-    final handleCenter = getCenter(handleFinder);
-
-    final gesture = await startGesture(handleCenter);
-    await pump(kTapMinTime);
-
-    for (int i = 0; i < 50; i += 1) {
-      await gesture.moveBy(delta / 50);
-      await pump(const Duration(milliseconds: 50));
-    }
+    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
 
     return gesture;
   }
 
-  /// Drags the [SuperIOSTextField] handle by the given delta.
+  /// Drags the [SuperAndroidTextField] downstream handle by the given delta.
   ///
   /// {@macro supertextfield_finder}
-  Future<TestGesture> _dragIOSHandleByDistanceInSuperTextField(
-    HandleType handleType,
+  Future<TestGesture> _dragAndroidDownstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperAndroidTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is AndroidSelectionHandle && //
+            widget.handleType == HandleType.downstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+
+    return gesture;
+  }
+
+  /// Drags the [SuperIOSTextField] upstream handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragIOSUpstreamHandleByDistanceInSuperTextField(
     Offset delta, [
     Finder? superTextFieldFinder,
   ]) async {
@@ -195,13 +231,48 @@ extension SuperTextFieldRobot on WidgetTester {
       matching: find.byWidgetPredicate(
         (widget) =>
             widget is IOSSelectionHandle && //
-            widget.handleType == handleType,
+            widget.handleType == HandleType.upstream,
       ),
     );
 
     expect(handleFinder, findsOne);
 
-    final handleCenter = getCenter(handleFinder);
+    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+
+    return gesture;
+  }
+
+  /// Drags the [SuperIOSTextField] downstream handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragIOSDownstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperIOSTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is IOSSelectionHandle && //
+            widget.handleType == HandleType.downstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+
+    return gesture;
+  }
+
+  /// Drags the [SuperTextField] handle by the given delta.
+  Future<TestGesture> _dragHandleByDistanceInSuperTextField(
+    Finder superTextFieldHandleFinder,
+    Offset delta,
+  ) async {
+    final handleCenter = getCenter(superTextFieldHandleFinder);
 
     final gesture = await startGesture(handleCenter);
     await pump(kTapMinTime);

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -193,9 +193,7 @@ extension SuperTextFieldRobot on WidgetTester {
 
     expect(handleFinder, findsOne);
 
-    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
-
-    return gesture;
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
   /// Drags the [SuperAndroidTextField] downstream handle by the given delta.
@@ -220,9 +218,7 @@ extension SuperTextFieldRobot on WidgetTester {
 
     expect(handleFinder, findsOne);
 
-    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
-
-    return gesture;
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
   /// Drags the [SuperIOSTextField] upstream handle by the given delta.
@@ -247,9 +243,7 @@ extension SuperTextFieldRobot on WidgetTester {
 
     expect(handleFinder, findsOne);
 
-    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
-
-    return gesture;
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
   /// Drags the [SuperIOSTextField] downstream handle by the given delta.
@@ -274,9 +268,7 @@ extension SuperTextFieldRobot on WidgetTester {
 
     expect(handleFinder, findsOne);
 
-    final gesture = await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
-
-    return gesture;
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
   /// Drags the [SuperTextField] handle found by [superTextFieldHandleFinder] by

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -123,9 +123,8 @@ extension SuperTextFieldRobot on WidgetTester {
     return gesture;
   }
 
-  /// Drags the [SuperTextField] upstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> dragUpstreamMobileHandleByDistanceInSuperTextField(
@@ -147,9 +146,8 @@ extension SuperTextFieldRobot on WidgetTester {
     throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
   }
 
-  /// Drags the [SuperTextField] downstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> dragDownstreamMobileHandleByDistanceInSuperTextField(
@@ -171,9 +169,8 @@ extension SuperTextFieldRobot on WidgetTester {
     throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
   }
 
-  /// Drags the [SuperAndroidTextField] upstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperAndroidTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragAndroidUpstreamHandleByDistanceInSuperTextField(
@@ -196,9 +193,8 @@ extension SuperTextFieldRobot on WidgetTester {
     return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
-  /// Drags the [SuperAndroidTextField] downstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperAndroidTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragAndroidDownstreamHandleByDistanceInSuperTextField(
@@ -221,9 +217,8 @@ extension SuperTextFieldRobot on WidgetTester {
     return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
-  /// Drags the [SuperIOSTextField] upstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperIOSTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragIOSUpstreamHandleByDistanceInSuperTextField(
@@ -246,9 +241,8 @@ extension SuperTextFieldRobot on WidgetTester {
     return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
   }
 
-  /// Drags the [SuperIOSTextField] downstream handle by the given delta.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
+  /// Drags the [SuperIOSTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragIOSDownstreamHandleByDistanceInSuperTextField(
@@ -272,11 +266,9 @@ extension SuperTextFieldRobot on WidgetTester {
   }
 
   /// Drags the [SuperTextField] handle found by [superTextFieldHandleFinder] by
-  /// the given delta.
+  /// the given delta and returns the [TestGesture] used to perform the drag.
   ///
   /// Can be used to drag [SuperTextField] collapsed or expanded selection handles.
-  ///
-  /// Returns the [TestGesture] used to perform the drag.
   Future<TestGesture> _dragHandleByDistanceInSuperTextField(
     Finder superTextFieldHandleFinder,
     Offset delta,

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
+import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
@@ -110,6 +111,97 @@ extension SuperTextFieldRobot on WidgetTester {
     final caretLayerState = caretLayerElement.state as TextLayoutCaretState;
     final caretBottom = caretLayerState.globalCaretGeometry!.bottomCenter;
     final handleCenter = caretBottom + const Offset(0, 12);
+
+    final gesture = await startGesture(handleCenter);
+    await pump(kTapMinTime);
+
+    for (int i = 0; i < 50; i += 1) {
+      await gesture.moveBy(delta / 50);
+      await pump(const Duration(milliseconds: 50));
+    }
+
+    return gesture;
+  }
+
+  /// Drags the [SuperTextField] handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> dragHandleByDistanceInSuperTextFieldOnMobile(
+    HandleType handleType,
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    final fieldFinder =
+        SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
+    final match = fieldFinder.evaluate().single.widget;
+
+    if (match is SuperAndroidTextField) {
+      return _dragAndroidHandleByDistanceInSuperTextField(handleType, delta, fieldFinder);
+    }
+
+    if (match is SuperIOSTextField) {
+      return _dragIOSHandleByDistanceInSuperTextField(handleType, delta, fieldFinder);
+    }
+
+    throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
+  }
+
+  /// Drags the [SuperAndroidTextField] handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragAndroidHandleByDistanceInSuperTextField(
+    HandleType handleType,
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperAndroidTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is AndroidSelectionHandle && //
+            widget.handleType == handleType,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    final handleCenter = getCenter(handleFinder);
+
+    final gesture = await startGesture(handleCenter);
+    await pump(kTapMinTime);
+
+    for (int i = 0; i < 50; i += 1) {
+      await gesture.moveBy(delta / 50);
+      await pump(const Duration(milliseconds: 50));
+    }
+
+    return gesture;
+  }
+
+  /// Drags the [SuperIOSTextField] handle by the given delta.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragIOSHandleByDistanceInSuperTextField(
+    HandleType handleType,
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperIOSTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is IOSSelectionHandle && //
+            widget.handleType == handleType,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    final handleCenter = getCenter(handleFinder);
 
     final gesture = await startGesture(handleCenter);
     await pump(kTapMinTime);

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -125,6 +125,8 @@ extension SuperTextFieldRobot on WidgetTester {
 
   /// Drags the [SuperTextField] upstream handle by the given delta.
   ///
+  /// Returns the [TestGesture] used to perform the drag.
+  ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> dragUpstreamMobileHandleByDistanceInSuperTextField(
     Offset delta, [
@@ -147,6 +149,8 @@ extension SuperTextFieldRobot on WidgetTester {
 
   /// Drags the [SuperTextField] downstream handle by the given delta.
   ///
+  /// Returns the [TestGesture] used to perform the drag.
+  ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> dragDownstreamMobileHandleByDistanceInSuperTextField(
     Offset delta, [
@@ -168,6 +172,8 @@ extension SuperTextFieldRobot on WidgetTester {
   }
 
   /// Drags the [SuperAndroidTextField] upstream handle by the given delta.
+  ///
+  /// Returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragAndroidUpstreamHandleByDistanceInSuperTextField(
@@ -194,6 +200,8 @@ extension SuperTextFieldRobot on WidgetTester {
 
   /// Drags the [SuperAndroidTextField] downstream handle by the given delta.
   ///
+  /// Returns the [TestGesture] used to perform the drag.
+  ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragAndroidDownstreamHandleByDistanceInSuperTextField(
     Offset delta, [
@@ -218,6 +226,8 @@ extension SuperTextFieldRobot on WidgetTester {
   }
 
   /// Drags the [SuperIOSTextField] upstream handle by the given delta.
+  ///
+  /// Returns the [TestGesture] used to perform the drag.
   ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragIOSUpstreamHandleByDistanceInSuperTextField(
@@ -244,6 +254,8 @@ extension SuperTextFieldRobot on WidgetTester {
 
   /// Drags the [SuperIOSTextField] downstream handle by the given delta.
   ///
+  /// Returns the [TestGesture] used to perform the drag.
+  ///
   /// {@macro supertextfield_finder}
   Future<TestGesture> _dragIOSDownstreamHandleByDistanceInSuperTextField(
     Offset delta, [
@@ -267,7 +279,12 @@ extension SuperTextFieldRobot on WidgetTester {
     return gesture;
   }
 
-  /// Drags the [SuperTextField] handle by the given delta.
+  /// Drags the [SuperTextField] handle found by [superTextFieldHandleFinder] by
+  /// the given delta.
+  ///
+  /// Can be used to drag [SuperTextField] collapsed or expanded selection handles.
+  ///
+  /// Returns the [TestGesture] used to perform the drag.
   Future<TestGesture> _dragHandleByDistanceInSuperTextField(
     Finder superTextFieldHandleFinder,
     Offset delta,

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -34,7 +34,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
   @override
   void initState() {
     super.initState();
-    _blinkController = _createBlinkController();
+    _blinkController = _obtainBlinkController();
     if (widget.blinkCaret) {
       _blinkController.startBlinking();
     }
@@ -56,7 +56,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
           oldBlinkController.dispose();
         });
       }
-      _blinkController = _createBlinkController();
+      _blinkController = _obtainBlinkController();
     }
 
     if (widget.position != oldWidget.position && widget.blinkCaret) {
@@ -75,7 +75,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
     super.dispose();
   }
 
-  BlinkController _createBlinkController() {
+  BlinkController _obtainBlinkController() {
     if (widget.blinkController != null) {
       return widget.blinkController!;
     }

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -77,7 +77,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
 
   BlinkController _createBlinkController() {
     if (widget.blinkController != null) {
-      return _blinkController;
+      return widget.blinkController!;
     }
 
     switch (widget.blinkTimingMode) {
@@ -97,7 +97,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
   @visibleForTesting
   double? get caretHeight => isCaretPresent
       ? widget.textLayout.getHeightForCaret(widget.position!) ??
-      widget.textLayout.getLineHeightAtPosition(widget.position!)
+          widget.textLayout.getLineHeightAtPosition(widget.position!)
       : null;
 
   @visibleForTesting


### PR DESCRIPTION
[SuperTextField][Android][ios] Disables text field caret blink while dragging caret (Resolves #1705)

### **Issue:** 

Text field's caret keeps blinking while caret's being dragged within the text field. On both Android and iOS, in the native apps, the caret stops blinking as long as the user's dragging the caret. Same is expected from super text field on android and ios.

`SuperTextField` behaviour on Android and iOS:

https://github.com/superlistapp/super_editor/assets/65209850/6465ba53-134a-4d05-aeec-3107463c7bee


### Solution: 

This PR updates both `SuperAndroidTextField` and `SuperIOSTextField` and their necessary internal components to match the native behaviour for caret blinking when user's dragging the caret within text field.  As long as the drag's is happening, caret blinking is disabled, and once the drag ends, caret blinking is enabled for the text field.

With fix, `SuperTextField` behaviour on Android and iOS:

https://github.com/superlistapp/super_editor/assets/65209850/3b08287a-e71f-4791-b64d-03ca513ebcee


### Remarks: 

* `SuperAndroidTextField` and `SuperAndroidTextField` are updated to create an internal `BlinkController` that can be passed down to their respective `TextLayoutCaret` that displays and controlls the text field caret. 
* Fixes a bug in the `TextLayoutCaret`'s by updating the `createBlinkController` method to return the passed `BlinkController` if present instead of returning it's own internal `blinkController` variable.
* `AndroidTextFieldTouchInteractor` and `IOSEditingControls` are updated to receive the internal `BlinkController` from text field which is used to control blinking of caret on drag start/end within their drag interaction handlers.
* `AndroidTextFieldTouchInteractor` and `IOSTextFieldTouchInteractor` are updated to receive the internal `BlinkController` from text field which is used to control blinking of caret on drag start/end within their drag interaction handlers.







