### PR TITLE
Fix demo app compilation error due to ExpectedSize

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_example_document.dart
+++ b/super_editor/example/lib/demos/example_editor/_example_document.dart
@@ -7,10 +7,7 @@ MutableDocument createInitialDocument() {
       ImageNode(
         id: "1",
         imageUrl: 'https://i.ibb.co/5nvRdx1/flutter-horizon.png',
-        expectedBitmapSize: ExpectedSize(
-          width: 1911,
-          height: 630,
-        ),
+        expectedBitmapSize: ExpectedSize(1911, 630),
         metadata: const SingleColumnLayoutComponentStyles(
           width: double.infinity,
           padding: EdgeInsets.zero,


### PR DESCRIPTION
Fix demo app compilation error due to ExpectedSize

There is a file that wasn't pushed after the last changes in https://github.com/superlistapp/super_editor/pull/1738

The `ExpectedSize` was changed to have positional parameters instead of named parameters, but the `_example_document.dart` wasn't push with the proper change.

This PR fixes this compilation error.