### PR TITLE
Cherry-Pick: [SuperEditor][SuperReader] Adds empty document constructor to MutableDocument (Resolves #1758) 

### DIFF
--- a/super_editor/example/lib/demos/demo_empty_document.dart
+++ b/super_editor/example/lib/demos/demo_empty_document.dart
@@ -22,7 +22,7 @@ class _EmptyDocumentDemoState extends State<EmptyDocumentDemo> {
   @override
   void initState() {
     super.initState();
-    _doc = _createDocument1();
+    _doc = MutableDocument.empty("1");
     _composer = MutableDocumentComposer();
     _docEditor = createDefaultDocumentEditor(document: _doc, composer: _composer);
   }
@@ -43,12 +43,4 @@ class _EmptyDocumentDemoState extends State<EmptyDocumentDemo> {
       ),
     );
   }
-}
-
-MutableDocument _createDocument1() {
-  return MutableDocument(
-    nodes: [
-      ParagraphNode(id: "1", text: AttributedText()),
-    ],
-  );
 }

--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -26,12 +26,7 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(""),
-      ),
-    ]);
+    _document = MutableDocument.empty();
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
@@ -23,12 +23,7 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(""),
-      ),
-    ]);
+    _document = MutableDocument.empty();
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
@@ -26,12 +26,7 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(nodes: [
-      ParagraphNode(
-        id: Editor.createNodeId(),
-        text: AttributedText(""),
-      ),
-    ]);
+    _document = MutableDocument.empty();
     _composer = MutableDocumentComposer();
     _editor = Editor(
       editables: {

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -27,14 +27,7 @@ class _MarketingVideoState extends State<MarketingVideo> {
   void initState() {
     super.initState();
 
-    _document = MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: Editor.createNodeId(),
-          text: AttributedText(),
-        ),
-      ],
-    );
+    _document = MutableDocument.empty();
     _composer = MutableDocumentComposer(
       initialSelection: DocumentSelection.collapsed(
         position: DocumentPosition(

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:attributed_text/attributed_text.dart';
 import 'package:collection/collection.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:uuid/uuid.dart';
 
@@ -494,6 +496,20 @@ class MutableDocument implements Document, Editable {
     List<DocumentNode>? nodes,
   }) : _nodes = nodes ?? [] {
     _refreshNodeIdCaches();
+  }
+
+  /// Creates an [Document] with a single [ParagraphNode].
+  ///
+  /// Optionally, takes in a [nodeId] for the [ParagraphNode].
+  factory MutableDocument.empty([String? nodeId]) {
+    return MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: nodeId ?? Editor.createNodeId(),
+          text: AttributedText(),
+        ),
+      ],
+    );
   }
 
   void dispose() {

--- a/super_editor/test/super_editor/bug_fix_test.dart
+++ b/super_editor/test/super_editor/bug_fix_test.dart
@@ -8,11 +8,7 @@ void main() {
   group("Bug fix", () {
     group("429 - delete multiple new nodes", () {
       testWidgets("bug repro", (tester) async {
-        final document = MutableDocument(
-          nodes: [
-            ParagraphNode(id: "1", text: AttributedText()),
-          ],
-        );
+        final document = MutableDocument.empty("1");
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
             position: DocumentPosition(
@@ -84,11 +80,7 @@ void main() {
       });
 
       testWidgets("related to bug", (tester) async {
-        final document = MutableDocument(
-          nodes: [
-            ParagraphNode(id: "1", text: AttributedText()),
-          ],
-        );
+        final document = MutableDocument.empty("1");
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
             position: DocumentPosition(

--- a/super_editor/test/super_editor/infrastructure/editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/editor_test.dart
@@ -13,9 +13,7 @@ void main() {
       test('throws exception when there is no command for a given request', () {
         final editor = Editor(
           editables: {
-            Editor.documentKey: MutableDocument(
-              nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText())],
-            ),
+            Editor.documentKey: MutableDocument.empty(),
           },
           requestHandlers: [],
         );
@@ -81,9 +79,7 @@ void main() {
         // and those commands expand to additional commands, the overall command
         // order is what we expect.
         List<EditEvent>? changeList;
-        final document = MutableDocument(
-          nodes: [ParagraphNode(id: Editor.createNodeId(), text: AttributedText())],
-        );
+        final document = MutableDocument.empty();
 
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
@@ -148,14 +144,7 @@ void main() {
       test('runs reactions after a command', () {
         int reactionCount = 0;
 
-        final document = MutableDocument(
-          nodes: [
-            ParagraphNode(
-              id: "1",
-              text: AttributedText(),
-            )
-          ],
-        );
+        final document = MutableDocument.empty("1");
 
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
@@ -194,9 +183,7 @@ void main() {
       });
 
       test('interrupts back-to-back commands to run a reaction', () {
-        final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText())],
-        );
+        final document = MutableDocument.empty("1");
 
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
@@ -284,9 +271,7 @@ void main() {
       });
 
       test('reactions receive a change list with events from earlier reactions', () {
-        final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText())],
-        );
+        final document = MutableDocument.empty("1");
 
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(
@@ -370,9 +355,7 @@ void main() {
       });
 
       test('reactions do not run in response to reactions', () {
-        final document = MutableDocument(
-          nodes: [ParagraphNode(id: "1", text: AttributedText())],
-        );
+        final document = MutableDocument.empty("1");
 
         final composer = MutableDocumentComposer(
           initialSelection: const DocumentSelection.collapsed(

--- a/super_editor/test/super_editor/supereditor_shortcuts_test.dart
+++ b/super_editor/test/super_editor/supereditor_shortcuts_test.dart
@@ -63,11 +63,7 @@ Future<void> _pumpShortcutsAndSuperEditor(
   List<DocumentKeyboardAction> keyboardActions,
   VoidCallback onShortcut,
 ) async {
-  final document = MutableDocument(
-    nodes: [
-      ParagraphNode(id: "1", text: AttributedText()),
-    ],
-  );
+  final document = MutableDocument.empty("1");
   final composer = MutableDocumentComposer();
   final editor = createDefaultDocumentEditor(document: document, composer: composer);
 

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -23,11 +23,7 @@ MutableDocument hrThenParagraphDoc() => MutableDocument(
       ],
     );
 
-MutableDocument singleParagraphEmptyDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(id: "1", text: AttributedText()),
-      ],
-    );
+MutableDocument singleParagraphEmptyDoc() => MutableDocument.empty("1");
 
 MutableDocument twoParagraphEmptyDoc() => MutableDocument(
       nodes: [

--- a/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
@@ -909,14 +909,7 @@ void main() {
       testWidgetsOnAllPlatforms("deletes second tag and leaves first tag alone", (tester) async {
         await _pumpTestEditor(
           tester,
-          MutableDocument(
-            nodes: [
-              ParagraphNode(
-                id: "1",
-                text: AttributedText(),
-              ),
-            ],
-          ),
+          MutableDocument.empty("1"),
         );
 
         await tester.placeCaretInParagraph("1", 0);

--- a/super_editor/test/super_reader/test_documents.dart
+++ b/super_editor/test/super_reader/test_documents.dart
@@ -22,11 +22,7 @@ MutableDocument hrThenParagraphDoc() => MutableDocument(
       ],
     );
 
-MutableDocument singleParagraphEmptyDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(id: "1", text: AttributedText()),
-      ],
-    );
+MutableDocument singleParagraphEmptyDoc() => MutableDocument.empty("1");
 
 MutableDocument twoParagraphEmptyDoc() => MutableDocument(
       nodes: [

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -13,7 +13,7 @@ import 'test_tools.dart';
 void main() {
   group("SuperEditor > pasting markdown >", () {
     testWidgetsOnArbitraryDesktop("can paste into an empty document", (tester) async {
-      final document = MutableDocument(nodes: [ParagraphNode(id: "1", text: AttributedText())]);
+      final document = MutableDocument.empty("1");
       final composer = MutableDocumentComposer();
       final editor = Editor(
         editables: {


### PR DESCRIPTION
Cherry-Pick: [SuperEditor][SuperReader] Adds empty document constructor to MutableDocument (Resolves #1758) 