### PR TITLE
[SuperEditor] Remove the editor scrollbar when configured in the ScrollBehavior  (Resolves #1786)

### DIFF
--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
@@ -198,6 +198,41 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
     required Widget child,
   }) {
     final scrollBehavior = ScrollConfiguration.of(context);
+    return _buildScrollbar(
+      behavior: scrollBehavior,
+      child: ScrollConfiguration(
+        behavior: scrollBehavior.copyWith(scrollbars: false),
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          physics: const NeverScrollableScrollPhysics(),
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScrollbar({
+    required ScrollBehavior behavior,
+    required Widget child,
+  }) {
+    // We allow apps to prevent the custom scrollbar from being added by
+    // wrapping the editor with a `ScrollConfiguration` configured to not
+    // display scrollbars. However, at this moment we can't query this
+    // information from the BuildContext. As a workaround, we check whether
+    // or not the buildScrollbar method returns a ScrollBar. If it doesn't,
+    // this means the app doesn't want us to add our own ScrollBar.
+    //
+    // Change this after https://github.com/flutter/flutter/issues/141508 is solved.
+    final maybeScrollBar = behavior.buildScrollbar(
+      context,
+      child,
+      ScrollableDetails.vertical(controller: _scrollController),
+    );
+    if (maybeScrollBar is! Scrollbar) {
+      // The scroll behavior is configured to NOT show scrollbars.
+      return child;
+    }
+
     // As we handle the scrolling gestures ourselves,
     // we use NeverScrollableScrollPhysics to prevent SingleChildScrollView
     // from scrolling. This also prevents the user from interacting
@@ -208,15 +243,8 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
     // See https://github.com/superlistapp/super_editor/issues/1628 for more details.
     return ScrollbarWithCustomPhysics(
       controller: _scrollController,
-      physics: scrollBehavior.getScrollPhysics(context),
-      child: ScrollConfiguration(
-        behavior: scrollBehavior.copyWith(scrollbars: false),
-        child: SingleChildScrollView(
-          controller: _scrollController,
-          physics: const NeverScrollableScrollPhysics(),
-          child: child,
-        ),
-      ),
+      physics: behavior.getScrollPhysics(context),
+      child: child,
     );
   }
 

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/src/infrastructure/blinking_caret.dart';
+import 'package:super_editor/src/infrastructure/flutter/material_scrollbar.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -1179,6 +1180,60 @@ void main() {
           variant: _scrollDirectionVariant,
         );
       });
+    });
+
+    testWidgetsOnDesktop('shows scrollbar by default', (tester) async {
+      final scrollController = ScrollController();
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withEditorSize(const Size(300, 300))
+          .withScrollController(scrollController)
+          .pump();
+
+      // Ensure the editor is scrollable.
+      expect(scrollController.position.maxScrollExtent, greaterThan(0.0));
+
+      // Ensure the scrollbar is displayed.
+      expect(
+        find.descendant(
+          of: find.byType(SuperEditor),
+          matching: find.byType(ScrollbarWithCustomPhysics),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgetsOnDesktop('does not show scrollbar when configured to', (tester) async {
+      final scrollController = ScrollController();
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withEditorSize(const Size(300, 300))
+          .withScrollController(scrollController)
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: Scaffold(
+                body: ScrollConfiguration(
+                  behavior: const ScrollBehavior().copyWith(scrollbars: false),
+                  child: superEditor,
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      // Ensure the editor is scrollable.
+      expect(scrollController.position.maxScrollExtent, greaterThan(0.0));
+
+      // Ensure no scrollbar is displayed.
+      expect(
+        find.descendant(
+          of: find.byType(SuperEditor),
+          matching: find.byType(ScrollbarWithCustomPhysics),
+        ),
+        findsNothing,
+      );
     });
   });
 }


### PR DESCRIPTION
[SuperEditor] Remove the editor scrollbar when configured in the ScrollBehavior.  Resolves #1786

When the editor isn't inside an ancestor scrollable we install our own scrollbar in the widget tree. However, some developers want to prevent this toolbar from being displayed.

This PR changes the editor to avoid installing the toolbar if the scroll behavior is configure to NOT display scrollbars. Developers will be able to hide the scrollbar with the following code:

```dart
ScrollConfiguration(
 behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
 child: SuperEditor(...),
)
```

Flutter doesn't provide a way to query the `scrollbars` property, so I'm using a hack to determine if the app wants the scrollbar. I left a comment to change that as soon as we can.