### PR TITLE
[SuperEditor][Android] Fix magnifier position inside an ancestor scrollable (Resolves #1810)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1397,9 +1397,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       documentLayout.getRectForPosition(selectionBoundPosition)!.center,
     );
     _dragHandleSelectionGlobalFocalPoint.value = centerOfContentAtOffset;
-
-    final myBox = context.findRenderObject() as RenderBox;
-    _magnifierFocalPoint.value = myBox.globalToLocal(centerOfContentAtOffset);
+    _magnifierFocalPoint.value = centerOfContentAtOffset;
 
     // Update the controls for handle dragging.
     _controlsController!
@@ -1493,15 +1491,12 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
 
     // Move the magnifier focal point to match the drag x-offset, but always remain focused on the vertical
     // center of the line.
-    final myBox = context.findRenderObject() as RenderBox;
     final centerOfContentAtNearestPosition = documentLayout.getAncestorOffsetFromDocumentOffset(
       documentLayout.getRectForPosition(nearestPosition)!.center,
     );
-    _magnifierFocalPoint.value = myBox.globalToLocal(
-      Offset(
-        _magnifierFocalPoint.value!.dx + dragDx,
-        centerOfContentAtNearestPosition.dy,
-      ),
+    _magnifierFocalPoint.value = Offset(
+      _magnifierFocalPoint.value!.dx + dragDx,
+      centerOfContentAtNearestPosition.dy,
     );
 
     switch (_dragHandleType!) {

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -576,6 +576,21 @@ class SuperEditorInspector {
     }
   }
 
+  /// Finds the magnifier for a mobile `SuperEditor`.
+  static Finder findMobileMagnifier([Finder? superEditorFinder]) {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        return find.byKey(DocumentKeys.magnifier);
+
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.linux:
+      case TargetPlatform.fuchsia:
+        return FindsNothing();
+    }
+  }
+
   static AndroidControlsDocumentLayerState _findAndroidControlsLayer([Finder? superEditorFinder]) {
     final element = find
         .descendant(

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -263,9 +263,9 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible, it's placed above the caret and not
-        // too far to the top.If the wrong coordinate space is used, the content
-        // above the editor will push the magnifier down.
+        // Ensure that the magnifier appears above the caret. To check this, we make
+        // sure the bottom of the magnifier is above the top of the caret, and we make
+        // sure that the bottom of the magnifier is not unreasonable far above the caret.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
@@ -273,7 +273,7 @@ void main() {
         );
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
-              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+              tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(70.0),
         );
 
@@ -310,8 +310,9 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible, it's placed above the caret and not
-        // too far to the top.
+        // Ensure that the magnifier appears above the caret. To check this, we make
+        // sure the bottom of the magnifier is above the top of the caret, and we make
+        // sure that the bottom of the magnifier is not unreasonable far above the caret.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
@@ -319,7 +320,7 @@ void main() {
         );
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
-              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+              tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(70.0),
         );
 
@@ -374,9 +375,9 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible, it's placed above the caret and not
-        // too far to the top.If the wrong coordinate space is used, the content
-        // above the editor will push the magnifier down.
+        // Ensure that the magnifier appears above the caret. To check this, we make
+        // sure the bottom of the magnifier is above the top of the caret, and we make
+        // sure that the bottom of the magnifier is not unreasonable far above the caret.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
@@ -384,7 +385,7 @@ void main() {
         );
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
-              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+              tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(70.0),
         );
 

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -264,6 +264,8 @@ void main() {
         }
 
         // Ensure magnifier is visible and it's placed above the caret.
+        // If the wrong coordinate space is used, the content above the editor
+        // will push the magnifier down.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
@@ -362,6 +364,8 @@ void main() {
         }
 
         // Ensure magnifier is visible and it's placed above the caret.
+        // If the wrong coordinate space is used, the content above the editor
+        // will push the magnifier down.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -263,13 +263,18 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible and it's placed above the caret.
-        // If the wrong coordinate space is used, the content above the editor
-        // will push the magnifier down.
+        // Ensure magnifier is visible, it's placed above the caret and not
+        // too far to the top.If the wrong coordinate space is used, the content
+        // above the editor will push the magnifier down.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy),
+        );
+        expect(
+          tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
+              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+          lessThan(70.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.
@@ -305,11 +310,17 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible and it's placed above the caret.
+        // Ensure magnifier is visible, it's placed above the caret and not
+        // too far to the top.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy),
+        );
+        expect(
+          tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
+              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+          lessThan(70.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.
@@ -363,13 +374,18 @@ void main() {
           await tester.pump();
         }
 
-        // Ensure magnifier is visible and it's placed above the caret.
-        // If the wrong coordinate space is used, the content above the editor
-        // will push the magnifier down.
+        // Ensure magnifier is visible, it's placed above the caret and not
+        // too far to the top.If the wrong coordinate space is used, the content
+        // above the editor will push the magnifier down.
         expect(SuperEditorInspector.isMobileMagnifierVisible(), isTrue);
         expect(
           tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
           lessThan(tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy),
+        );
+        expect(
+          tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
+              tester.getTopLeft(SuperEditorInspector.findMobileMagnifier()).dy,
+          lessThan(70.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -274,7 +274,7 @@ void main() {
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
               tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
-          lessThan(70.0),
+          lessThan(20.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.
@@ -321,7 +321,7 @@ void main() {
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
               tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
-          lessThan(70.0),
+          lessThan(20.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.
@@ -386,7 +386,7 @@ void main() {
         expect(
           tester.getTopLeft(SuperEditorInspector.findMobileCaret()).dy -
               tester.getBottomLeft(SuperEditorInspector.findMobileMagnifier()).dy,
-          lessThan(70.0),
+          lessThan(20.0),
         );
 
         // Resolve the gesture so that we don't have pending gesture timers.


### PR DESCRIPTION
[SuperEditor][Android] Fix magnifier position inside an ancestor scrollable. Resolves #1810

If the editor is inside a `CustomScrollView` with other widgets above the editor, the magnifier isn't positioned correctly when dragging the drag handle:

https://github.com/superlistapp/super_editor/assets/31278849/bba51f3a-6ca4-4f2a-b29c-91c31e6f00e1

I noticed we are positioning the drag handle leader using the mobile interactor coordinate space, and it seems the we need to position it using the global coordinate space.

Modifying the android interactor to position the leader using the global coordinates seems to solve the issue:

Inside a `CustomScrollView`: 

[android_with_scrollable.webm](https://github.com/superlistapp/super_editor/assets/7597082/dfd7587c-2c55-498c-af0d-634efcdc5fe4)

Without an ancestor `Scrollable`:

[android_without_scrollable.webm](https://github.com/superlistapp/super_editor/assets/7597082/18611cfe-09d0-4178-aaf4-4d74a9697ac0)

