### PR TITLE
[SuperEditor][SuperTextField] Fixed missed tap warnings on tests (Resolves #1811)

### DIFF
--- a/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_robot.dart
@@ -324,6 +324,15 @@ extension SuperEditorRobot on WidgetTester {
     return gesture;
   }
 
+  Future<void> tapOnCollapsedMobileHandle() async {
+    final handleElement = find.byKey(DocumentKeys.androidCaretHandle).evaluate().firstOrNull;
+    assert(handleElement != null, "Tried to press down on Android collapsed handle but no handle was found.");
+    final renderHandle = handleElement!.renderObject as RenderBox;
+    final handleCenter = renderHandle.localToGlobal(renderHandle.size.center(Offset.zero));
+
+    await tapAt(handleCenter);
+  }
+
   Future<TestGesture> pressDownOnUpstreamMobileHandle() async {
     final handleElement = find.byKey(DocumentKeys.upstreamHandle).evaluate().firstOrNull;
     assert(handleElement != null, "Tried to press down on upstream handle but no handle was found.");

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -74,14 +74,14 @@ void main() {
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
 
       // Tap the drag handle to show the toolbar.
-      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.tapOnCollapsedMobileHandle();
       await tester.pump();
 
       // Ensure the toolbar is visible.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
 
       // Tap the drag handle to hide the toolbar.
-      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.tapOnCollapsedMobileHandle();
       await tester.pump();
 
       // Ensure the toolbar isn't visible.
@@ -98,7 +98,7 @@ void main() {
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
 
       // Tap the drag handle to show the toolbar.
-      await tester.tap(SuperEditorInspector.findMobileCaretDragHandle());
+      await tester.tapOnCollapsedMobileHandle();
       await tester.pump();
 
       // Ensure the toolbar is visible.

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -126,13 +126,19 @@ extension SuperTextFieldRobot on WidgetTester {
   ///
   /// {@macro supertextfield_finder}
   Future<void> tapOnAndroidCollapsedHandle([Finder? superTextFieldFinder]) async {
-    await tap(
-      find.byWidgetPredicate(
-        (widget) =>
-            widget is AndroidSelectionHandle && //
-            widget.handleType == HandleType.collapsed,
-      ),
-    );
+    final handleElement = find
+        .byWidgetPredicate(
+          (widget) =>
+              widget is AndroidSelectionHandle && //
+              widget.handleType == HandleType.collapsed,
+        )
+        .evaluate()
+        .firstOrNull;
+    assert(handleElement != null, "Tried to press down on Android collapsed handle but no handle was found.");
+    final renderHandle = handleElement!.renderObject as RenderBox;
+    final handleCenter = renderHandle.localToGlobal(renderHandle.size.center(Offset.zero));
+
+    await tapAt(handleCenter);
   }
 
   /// Double taps in a [SuperTextField] at the given [offset]


### PR DESCRIPTION
[SuperEditor][SuperTextField] Fixed missed tap warnings on tests. Resolves #1811

Some of our tests are passing, but generate warnings about missed taps. The issue is how we are tapping on the collapsed drag handle. 

We are trying to tap directly at the `AndroidSelectionHandle`. The problem seems to be that `AndroidSelectionHandle` has a `Transform` inside of it.  To confirm, I tested some expectations. This is how the handle subtree looks like:

```dart
Transform.rotate(
  angle: -pi / 4,
  child: Container(
    width: radius * 2,
    height: radius * 2,
    decoration: BoxDecoration(
      color: color,
      borderRadius: BorderRadius.only(
        topLeft: Radius.circular(radius),
        bottomLeft: Radius.circular(radius),
        bottomRight: Radius.circular(radius),
      ),
    ),
  ),
)
```

This tap triggers the warning:

```dart
await tester.tap(
  find.descendant(
    of: SuperEditorInspector.findMobileCaretDragHandle(),
    matching: find.byType(Transform),
  ),
);
```

And this don't:

```dart
  await tester.tap(
    find.descendant(
      of: SuperEditorInspector.findMobileCaretDragHandle(),
      matching: find.byType(Container),
    ),
  );
```

This PR changes the way we are tapping on the handles.
