### PR TITLE
[SuperEditor] Fix markdown sublist deserialization (Resolves #1821) (Resolves #1822)

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -113,10 +113,7 @@ class ListItemComponentBuilder implements ComponentBuilder {
     if (node.type == ListItemType.ordered) {
       ordinalValue = 1;
       DocumentNode? nodeAbove = document.getNodeBefore(node);
-      while (nodeAbove != null &&
-          nodeAbove is ListItemNode &&
-          nodeAbove.type == ListItemType.ordered &&
-          nodeAbove.indent >= node.indent) {
+      while (nodeAbove != null && nodeAbove is ListItemNode && nodeAbove.indent >= node.indent) {
         if (nodeAbove.indent == node.indent) {
           ordinalValue = ordinalValue! + 1;
         }

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -427,6 +427,98 @@ void main() {
     });
 
     group('ordered list', () {
+      testWidgetsOnArbitraryDesktop('keeps sequence for items split by unordered list', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("""
+1. First ordered item
+   - First unordered item
+   - Second unoredered item
+
+2. Second ordered item
+   - First unordered item
+   - Second unoredered item""") //
+            .pump();
+
+        expect(context.document.nodes.length, 6);
+
+        // Ensure the nodes have the correct type.
+        expect(context.document.nodes[0], isA<ListItemNode>());
+        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[1], isA<ListItemNode>());
+        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[2], isA<ListItemNode>());
+        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[3], isA<ListItemNode>());
+        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[4], isA<ListItemNode>());
+        expect((context.document.nodes[4] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[5], isA<ListItemNode>());
+        expect((context.document.nodes[5] as ListItemNode).type, ListItemType.unordered);
+
+        // Ensure the sequence was kept.
+        final firstOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[0].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(firstOrderedItem.listIndex, 1);
+
+        final secondOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[3].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(secondOrderedItem.listIndex, 2);
+      });
+
+      testWidgetsOnArbitraryDesktop('does not keep sequence for items split by paragraphs', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("""
+1. First ordered item
+
+A paragraph
+
+2. Second ordered item""") //
+            .pump();
+
+        expect(context.document.nodes.length, 3);
+
+        // Ensure the nodes have the correct type.
+        expect(context.document.nodes[0], isA<ListItemNode>());
+        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[1], isA<ParagraphNode>());
+
+        expect(context.document.nodes[2], isA<ListItemNode>());
+        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.ordered);
+
+        // Ensure the sequence reset when reaching the second list item.
+        final firstOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[0].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(firstOrderedItem.listIndex, 1);
+
+        final secondOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[2].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(secondOrderedItem.listIndex, 1);
+      });
+
       testWidgetsOnArbitraryDesktop('updates caret position when indenting', (tester) async {
         await _pumpOrderedListWithTextField(tester);
 

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -85,6 +85,17 @@ class _MarkdownToDocument implements md.NodeVisitor {
 
   final _listItemTypeStack = <ListItemType>[];
 
+  /// The count of the list items currently being visited.
+  ///
+  /// A list item might contain children with tags like `p` and `h2`. When it does,
+  /// the list item text content is inside of its children and we only generate
+  /// document nodes when we visit the list item's children.
+  ///
+  /// We track the item count because when there are sublists, [visitElementBefore] is
+  /// called for the sublist item before [visitElementAfter] is called for the
+  /// main list item.
+  int _listItemVisitedCount = 0;
+
   /// If `true`, special HTML symbols are encoded with HTML escape codes, otherwise those
   /// symbols are left as-is.
   ///
@@ -99,6 +110,18 @@ class _MarkdownToDocument implements md.NodeVisitor {
         _content.add(node);
         return true;
       }
+    }
+
+    if (_listItemVisitedCount > 0 &&
+        !const ['li', 'ul', 'ol'].contains(element.tag) &&
+        (element.children == null || element.children!.isEmpty || element.children!.length == 1)) {
+      // We are visiting the text content of a list item. Add a list item node to the document.
+      _addListItem(
+        element,
+        listItemType: _listItemTypeStack.last,
+        indent: _listItemTypeStack.length - 1,
+      );
+      return false;
     }
 
     // TODO: re-organize parsing such that visitElementBefore collects
@@ -164,24 +187,25 @@ class _MarkdownToDocument implements md.NodeVisitor {
           throw Exception('Tried to parse a markdown list item but the list item type was null');
         }
 
+        // Mark that we are visiting a list item.
+        _listItemVisitedCount += 1;
+
+        if (element.children != null &&
+            element.children!.isNotEmpty &&
+            element.children!.first is! md.UnparsedContent) {
+          // The list item content is inside of its child's element. Wait until we visit
+          // the list item's children to generate a list node.
+          return true;
+        }
+
+        // We already have the content of the list item, generate a list node.
         _addListItem(
           element,
           listItemType: _listItemTypeStack.last,
           indent: _listItemTypeStack.length - 1,
         );
+        break;
 
-        if (element.children == null) {
-          // There isn't any children to visit.
-          return false;
-        }
-
-        // A list item might contain a "p" tag child if it's separated
-        // by a blank line. Only visit its children if it contains a child list.
-        return element.children!.any(
-          (child) =>
-              child is md.Element && //
-              const ['ol', 'ul'].contains(child.tag),
-        );
       case 'hr':
         _addHorizontalRule();
         break;
@@ -196,6 +220,9 @@ class _MarkdownToDocument implements md.NodeVisitor {
   @override
   void visitElementAfter(md.Element element) {
     switch (element.tag) {
+      case 'li':
+        _listItemVisitedCount -= 1;
+        break;
       // A list has ended. Pop the most recent list type from the stack.
       case 'ul':
       case 'ol':
@@ -590,7 +617,26 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
   bool canEndBlock(md.BlockParser parser) => false;
 
   @override
-  bool canParse(md.BlockParser parser) => !_standardNonParagraphBlockSyntaxes.any((e) => e.canParse(parser));
+  bool canParse(md.BlockParser parser) {
+    if (_standardNonParagraphBlockSyntaxes.any((e) => e.canParse(parser))) {
+      // Another parser wants to parse this input. Let the other parser run.
+      return false;
+    }
+
+    if (parser.current.isEmpty) {
+      // We consider this input to be a separator between blocks because
+      // it started with an empty line. We want to parse this input.
+      return true;
+    }
+
+    if (_isAtParagraphEnd(parser, ignoreEmptyBlocks: _endsWithHardLineBreak(parser.current))) {
+      // Ths input is at the end of a paragraph. Let other parsers run.
+      return false;
+    }
+
+    // The input is a paragraph. We want to parse it.
+    return true;
+  }
 
   @override
   md.Node? parse(md.BlockParser parser) {
@@ -666,7 +712,8 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
       return true;
     }
     for (final syntax in parser.blockSyntaxes) {
-      if (!(syntax is md.EmptyBlockSyntax && ignoreEmptyBlocks) &&
+      if (syntax != this &&
+          !(syntax is md.EmptyBlockSyntax && ignoreEmptyBlocks) &&
           syntax.canParse(parser) &&
           syntax.canEndBlock(parser)) {
         return true;

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -87,6 +87,9 @@ class _MarkdownToDocument implements md.NodeVisitor {
 
   /// The count of the list items currently being visited.
   ///
+  /// Being visited means that [visitElementBefore] was called for an element and
+  /// [visitElementAfter] wasn't called yet.
+  ///
   /// A list item might contain children with tags like `p` and `h2`. When it does,
   /// the list item text content is inside of its children and we only generate
   /// document nodes when we visit the list item's children.
@@ -619,7 +622,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
   @override
   bool canParse(md.BlockParser parser) {
     if (_standardNonParagraphBlockSyntaxes.any((e) => e.canParse(parser))) {
-      // Another parser wants to parse this input. Let the other parser run.
+      // A standard non-paragraph parser wants to parse this input. Let the other parser run.
       return false;
     }
 
@@ -630,7 +633,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
     }
 
     if (_isAtParagraphEnd(parser, ignoreEmptyBlocks: _endsWithHardLineBreak(parser.current))) {
-      // Ths input is at the end of a paragraph. Let other parsers run.
+      // Another parser wants to parse this input. Let the other parser run.
       return false;
     }
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1130,6 +1130,68 @@ This is some code
         expect((document.nodes.first as ListItemNode).text.text, isEmpty);
       });
 
+      test('unordered list followd by empty list item', () {
+        const markdown = """- list item 1
+    - """;
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 1);
+
+        expect(document.nodes[0], isA<ListItemNode>());
+        expect((document.nodes[0] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+      });
+
+      test('parses mixed unordered and ordered items', () {
+        const markdown = """
+1. Ordered 1
+   - Unordered 1
+   - Unordered 2
+
+2. Ordered 2
+   - Unordered 1
+   - Unordered 2
+
+3. Ordered 3
+   - Unordered 1
+   - Unordered 2""";
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodes.length, 9);
+        for (final node in document.nodes) {
+          expect(node, isA<ListItemNode>());
+        }
+
+        expect((document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[0] as ListItemNode).text.text, 'Ordered 1');
+
+        expect((document.nodes[1] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[1] as ListItemNode).text.text, 'Unordered 1');
+
+        expect((document.nodes[2] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[2] as ListItemNode).text.text, 'Unordered 2');
+
+        expect((document.nodes[3] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[3] as ListItemNode).text.text, 'Ordered 2');
+
+        expect((document.nodes[4] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[4] as ListItemNode).text.text, 'Unordered 1');
+
+        expect((document.nodes[5] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[5] as ListItemNode).text.text, 'Unordered 2');
+
+        expect((document.nodes[6] as ListItemNode).type, ListItemType.ordered);
+        expect((document.nodes[6] as ListItemNode).text.text, 'Ordered 3');
+
+        expect((document.nodes[7] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[7] as ListItemNode).text.text, 'Unordered 1');
+
+        expect((document.nodes[8] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[8] as ListItemNode).text.text, 'Unordered 2');
+      });
+
       test('unordered list with empty lines between items', () {
         const markdown = '''
  * list item 1


### PR DESCRIPTION
[SuperEditor] Fix markdown sublist deserialization. Resolves #1821, Resolves #1822 

We still have some issues with our list item markdown parsing:

1. The following  input causes an infinite loop:

```
- hey there friend
    - 
```

2. Parsing list with sublist still produces incorrect results. Parsing the following input produces the document of the screenshot:
 
```

final string_test = """
To create an outline using multiple levels of lists for the uploaded document, it appears we have the introductory sections of a chapter on quantum mechanics, specifically the following main points can be outlined:

1. Introduction to quantum mechanics
   - Study of physics at small length scales
   - Quantum vs. classical mechanics
   - Schrodinger equation and wave properties of particles
   - Application of quantum mechanics and philosophical questions

2. Chapter outline
   - Section 10.1: Brief history of quantum mechanics
   - Section 10.2: Schrodinger wave equation
   - Section 10.3: Examples with analogies to earlier systems
   - Section 10.4: Uncertainty principle

3. 10.1 A brief history
   - 1900: Planck's introduction of energy quantization
   - 1905: Einstein's photon hypothesis and work on photoelectric effect
   - 1913: Bohr's model of the atom with electron wave properties
   - 1924: de Broglie's wave-particle duality proposal
   - 1925: Heisenberg's matrix mechanics
   - 1926: Schrodinger's wave mechanics

Each point corresponds to a section or a significant idea presented in the text so far. Shall I continue scrolling to expand on this outline?

```

![image](https://github.com/superlistapp/super_editor/assets/8203735/13ab9abe-8bd4-4126-a2ab-a782d6a63601)


Also, when an ordered list has an unordered sublist, each item of the ordered list resets is number to 1.


- The infinite loop is caused by our `_EmptyLinePreservingParagraphSyntax`. It always returns `true` when there isn't a block parser that can parse the current input. However, there is situations were it returns `true`, but when its `parse` method is called it returns `null`. For example, when the current input is empty. This is the cause of the infinity loop, we are saying we can parse the input, but it turns out we can't. The infinite loop happens inside the markdown package code. This PR fixes that.

- The sublist issue happens because it seems we are still not handling the list item's children correctly. The list item might have child elements that we need to visit before adding the list node to the document. This PR changes the list item handling to avoid directly adding the list item to the document the moment we visit it, if it has child elements. Instead, we keep track that we are visiting a list item and add the list to the document when we visit the list item's child.

- The list numbering issue happens because we compute the list item number, we stop if we find an unordered list. This PR changes that to continue counting.