### PR TITLE
[SuperEditor][iOS] Fix applying suggestions with Korean keyboard at the beginning of a paragraph (Resolves #1828)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -150,12 +150,19 @@ class TextDeltasDocumentEditor {
         offset: delta.insertionOffset,
         affinity: delta.selection.affinity,
       )),
-    )!;
-
-    insert(insertionSelection, delta.textInserted);
+    );
 
     // Update the local IME value that changes with each delta.
     _previousImeValue = delta.apply(_previousImeValue);
+
+    if (insertionSelection == null) {
+      // An insertion was reported at an invalid offset. It could be the case
+      // that the IME reported the insertion before the first visible character. Fizzle.
+      editorImeLog.warning("Couldn't map the insertion position to a document position.");
+      return;
+    }
+
+    insert(insertionSelection, delta.textInserted);
 
     // Update the IME to document serialization based on the insertion changes.
     _serializedDoc = DocumentImeSerializer(

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -144,23 +144,29 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine(
         "Inserting text: '${delta.textInserted}', at insertion offset: ${delta.insertionOffset}, with ime selection: ${delta.selection}");
 
+    final insertionPosition = TextPosition(
+      offset: delta.insertionOffset,
+      affinity: delta.selection.affinity,
+    );
+
+    if (delta.textInserted == ' ' && _serializedDoc.isPositionInsidePlaceholder(insertionPosition)) {
+      // The IME is trying to insert a space inside the invisible range. This is a situation that happens
+      // on iOS when the user is composing a character at the beginning of a node using a korean keyboard.
+      // The IME deletes the first visible character and the space from the invisible characters,
+      // them it inserts the space back. We already adjust the deletion to avoid deleting the invisible space,
+      // so we should ignore this insertion.
+      //
+      // For more information, see #1828.
+      return;
+    }
+
     editorImeLog.fine("Converting IME insertion offset into a DocumentSelection");
     final insertionSelection = _serializedDoc.imeToDocumentSelection(
-      TextSelection.fromPosition(TextPosition(
-        offset: delta.insertionOffset,
-        affinity: delta.selection.affinity,
-      )),
-    );
+      TextSelection.fromPosition(insertionPosition),
+    )!;
 
     // Update the local IME value that changes with each delta.
     _previousImeValue = delta.apply(_previousImeValue);
-
-    if (insertionSelection == null) {
-      // An insertion was reported at an invalid offset. It could be the case
-      // that the IME reported the insertion before the first visible character. Fizzle.
-      editorImeLog.warning("Couldn't map the insertion position to a document position.");
-      return;
-    }
 
     insert(insertionSelection, delta.textInserted);
 

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -226,6 +226,23 @@ class DocumentImeSerializer {
     );
   }
 
+  /// Returns `true` if the [imePosition] is inside the prepended placeholder,
+  /// or `false` otherwise.
+  ///
+  /// The placeholder is a sequence of characters that are sent to the IME, but are
+  /// invisible to the user.
+  bool isPositionInsidePlaceholder(TextPosition imePosition) {
+    if (!didPrependPlaceholder) {
+      return false;
+    }
+
+    if (imePosition.offset >= _prependedPlaceholder.length) {
+      return false;
+    }
+
+    return true;
+  }
+
   DocumentPosition _imeToDocumentPosition(TextPosition imePosition, {required bool isUpstream}) {
     for (final range in imeRangesToDocTextNodes.keys) {
       if (range.start <= imePosition.offset && imePosition.offset <= range.end) {


### PR DESCRIPTION
[SuperEditor][iOS] Fix applying suggestions with Korean keyboard at the beginning of a paragraph. Resolves #1828

Typing "ㅅㅛ" at the beginning of a paragraph is causing the following exception:

```console
======== Exception caught by services library ======================================================
The following _TypeError was thrown during method call TextInputClient.updateEditingStateWithDeltas:
Null check operator used on a null value

When the exception was thrown, this was the stack: 
#0      TextDeltasDocumentEditor._applyInsertion (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:153:6)
#1      TextDeltasDocumentEditor.applyDeltas (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:80:9)
#2      DocumentImeInputClient.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:219:30)
#3      DeltaTextInputClientDecorator.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/ime_decoration.dart:129:14)
#4      TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1870:63)
#5      TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1759:20)
#6      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:571:55)
#7      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:564:34)
call: MethodCall(TextInputClient.updateEditingStateWithDeltas, [3, {deltas: [{selectionBase: 1, oldText: . ㅅ, selectionAffinity: TextAffinity.downstream, deltaEnd: -1, deltaText: , deltaStart: -1, composingExtent: -1, selectionIsDirectional: false, selectionExtent: 3, composingBase: -1}, {selectionBase: 1, oldText: . ㅅ, selectionAffinity: TextAffinity.downstream, deltaEnd: 3, deltaText: , deltaStart: 1, composingExtent: -1, selectionIsDirectional: false, selectionExtent: 1, composingBase: -1}, {selectionBase: 2, oldText: ., selectionAffinity: TextAffinity.downstream, deltaEnd: 1, deltaText:  , deltaStart: 1, composingExtent: -1, selectionIsDirectional: false, selectionExtent: 2, composingBase: -1}, {selectionBase: 3, oldText: . , selectionAffinity: TextAffinity.downstream, deltaEnd: 2, deltaText: 쇼, deltaStart: 2, composingExtent: -1, selectionIsDirectional: false, selectionExtent: 3, composingBase: -1}]}])
====================================================================================================
```

The is caused due to how the IME is reporting the deltas:

First batch:

```dart
[
  TextEditingDeltaInsertion(
    oldText: '. ',
    textInserted: 'ㅅ',
    insertionOffset: 2,
    selection: TextSelection.collapsed(offset: 3, affinity: TextAffinity.downstream),
    composing: TextRange(start: -1, end: -1),
  ),
]
```

Second batch:

```dart
[
  TextEditingDeltaNonTextUpdate(
    oldText: '. ㅅ',
    selection: TextSelection(baseOffset: 1, extentOffset: 3, isDirectional: false),
    composing: TextRange(start: -1, end: -1),
  ),
  TextEditingDeltaDeletion(
    oldText: '. ㅅ',
    deletedRange: TextRange(start: 1, end: 3),
    selection: TextSelection.collapsed(
      offset: 1,
      affinity: TextAffinity.downstream,
    ),
    composing: TextRange(start: -1, end: -1),
  ),
  TextEditingDeltaInsertion(
    oldText: '.',
    textInserted: ' ',
    insertionOffset: 1,
    selection: TextSelection.collapsed(
      offset: 2,
      affinity: TextAffinity.downstream,
    ),
    composing: TextRange(start: -1, end: -1),
  ),
  TextEditingDeltaInsertion(
    oldText: '. ',
    textInserted: '쇼',
    insertionOffset: 2,
    selection: TextSelection.collapsed(
      offset: 3,
      affinity: TextAffinity.downstream,
   
    composing: TextRange(start: -1, end: -1),
  )
]
```

The IME is reporting a deletion of the range `TextRange(start: 1, end: 3)` and then an space insertion at offset 1. It should be reporting a deletion of the range `TextRange(start: 2, end: 3)` and no space insertion.

The reported insertion offset (`1`) sits in the invisible region (the characters we send to the IME but we don't display to the user). As a result, we can't obtain a `DocumentSelection` from this offset.

This PR changes the insertion delta handling to avoid deltas that can't be mapped to a `DocumentPosition`. This could hide other mapping bugs. Maybe we should limit to ignore only if it's a space insertion at offset zero...
