### PR TITLE
Cherry-Pick: [SuperTextField][Android][iOS] Disables text field caret blink while dragging caret (Resolves #1705) (#1778)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -192,9 +192,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onCollapsedPanStart(DragStartDetails details) {
     _log.fine('_onCollapsedPanStart');
 
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
+    _onHandleDragStart();
 
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
@@ -228,16 +226,13 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onBasePanStart(DragStartDetails details) {
     _log.fine('_onBasePanStart');
 
+    _onHandleDragStart();
+
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
         _getGlobalOffsetOfMiddleOfLine(widget.editingController.textController.selection.base);
     _touchHandleOffsetFromLineOfText = globalOffsetInMiddleOfLine - details.globalPosition;
     _log.fine(' - global offset in middle of line: $globalOffsetInMiddleOfLine');
-
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
-    _log.fine(' - hid the toolbar, cancelled countdown timer');
 
     // TODO: de-dup the repeated calculations of the effective focal point: globalPosition + _touchHandleOffsetFromLineOfText
     widget.textScrollController.updateAutoScrollingForTouchOffset(
@@ -262,14 +257,12 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _onExtentPanStart(DragStartDetails details) {
     _log.fine('_onExtentPanStart');
 
+    _onHandleDragStart();
+
     // TODO: de-dup the calculation of the mid-line focal point
     final globalOffsetInMiddleOfLine =
         _getGlobalOffsetOfMiddleOfLine(widget.editingController.textController.selection.extent);
     _touchHandleOffsetFromLineOfText = globalOffsetInMiddleOfLine - details.globalPosition;
-
-    widget.editingController
-      ..hideToolbar()
-      ..cancelCollapsedHandleAutoHideCountdown();
 
     // TODO: de-dup the repeated calculations of the effective focal point: globalPosition + _touchHandleOffsetFromLineOfText
     widget.textScrollController.updateAutoScrollingForTouchOffset(
@@ -284,6 +277,20 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
       _isDraggingExtent = true;
       _localDragOffset = (context.findRenderObject() as RenderBox).globalToLocal(details.globalPosition);
     });
+  }
+
+  void _onHandleDragStart() {
+    _log.fine('_onHandleDragStart()');
+
+    widget.editingController
+      ..hideToolbar()
+      ..cancelCollapsedHandleAutoHideCountdown();
+    _log.fine(' - hid the toolbar, cancelled countdown timer');
+
+    if (widget.editingController.textController.selection.isCollapsed) {
+      // The user is dragging the handle. Stop the caret from blinking while dragging.
+      widget.editingController.stopCaretBlinking();
+    }
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
@@ -305,6 +312,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
     setState(() {
       _localDragOffset = _localDragOffset! + details.delta;
       widget.editingController.showMagnifier(_localDragOffset!);
+
       _log.fine(' - done updating all local state for drag update');
     });
   }
@@ -379,6 +387,10 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
         // expanded, show it again.
         widget.editingController.showToolbar();
       } else {
+        // The user stopped dragging a handle and the selection is collapsed.
+        // Start the caret blinking again.
+        widget.editingController.startCaretBlinking();
+
         // The collapsed handle should disappear after some inactivity.
         widget.editingController
           ..unHideCollapsedHandle()
@@ -805,6 +817,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
 class AndroidEditingOverlayController with ChangeNotifier {
   AndroidEditingOverlayController({
     required this.textController,
+    required this.caretBlinkController,
     required LayerLink magnifierFocalPoint,
   }) : _magnifierFocalPoint = magnifierFocalPoint;
 
@@ -827,6 +840,18 @@ class AndroidEditingOverlayController with ChangeNotifier {
   /// selection. Those properties and behaviors are represented by
   /// this [textController].
   final AttributedTextEditingController textController;
+
+  final BlinkController caretBlinkController;
+
+  /// Starts the text field caret blinking.
+  void startCaretBlinking() {
+    caretBlinkController.startBlinking();
+  }
+
+  /// Stops the text field caret blinking.
+  void stopCaretBlinking() {
+    caretBlinkController.stopBlinking();
+  }
 
   void toggleToolbar() {
     if (isToolbarVisible) {

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -301,6 +301,11 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
 
       // Cancel any ongoing handle auto-disappear timer.
       widget.editingOverlayController.cancelCollapsedHandleAutoHideCountdown();
+
+      if (widget.textController.selection.isCollapsed) {
+        // The user is dragging the caret. Stop the caret from blinking while dragging.
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -352,6 +357,10 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
       } else {
+        // The user stopped dragging the caret and the selection is collapsed.
+        // Start the caret blinking again.
+        widget.editingOverlayController.startCaretBlinking();
+
         // The selection is collapsed. The collapsed handle should disappear
         // after some inactivity. Start the countdown (or restart an in-progress
         // countdown).

--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -179,12 +179,22 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
   // positions the invisible touch targets for base/extent dragging.
   final _popoverController = OverlayPortalController();
 
+  late final BlinkController _caretBlinkController;
+
   /// Notifies the popover toolbar to rebuild itself.
   final _popoverRebuildSignal = SignalNotifier();
 
   @override
   void initState() {
     super.initState();
+
+    switch (widget.blinkTimingMode) {
+      case BlinkTimingMode.ticker:
+        _caretBlinkController = BlinkController(tickerProvider: this);
+      case BlinkTimingMode.timer:
+        _caretBlinkController = BlinkController.withTimer();
+    }
+
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_updateSelectionAndImeConnectionOnFocusChange);
 
     _textEditingController = (widget.textController ?? ImeAttributedTextEditingController())
@@ -198,6 +208,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
     _editingOverlayController = AndroidEditingOverlayController(
       textController: _textEditingController,
+      caretBlinkController: _caretBlinkController,
       magnifierFocalPoint: _magnifierLayerLink,
     );
 
@@ -309,6 +320,8 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
     _textScrollController
       ..removeListener(_onTextScrollChange)
       ..dispose();
+
+    _caretBlinkController.dispose();
 
     _popoverRebuildSignal.dispose();
 
@@ -635,7 +648,7 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             position: _textEditingController.selection.isCollapsed //
                 ? _textEditingController.selection.extent
                 : null,
-            blinkTimingMode: widget.blinkTimingMode,
+            blinkController: _caretBlinkController,
           );
         },
       ),

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -294,6 +294,11 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
 
       // When the user drags, the toolbar should not be visible.
       widget.editingOverlayController.hideToolbar();
+
+      if (widget.textController.selection.isCollapsed) {
+        // The user is dragging the caret. Stop the caret from blinking while dragging.
+        widget.editingOverlayController.stopCaretBlinking();
+      }
     });
   }
 
@@ -343,6 +348,10 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
 
       if (!widget.textController.selection.isCollapsed) {
         widget.editingOverlayController.showToolbar();
+      } else {
+        // The user stopped dragging the caret and the selection is collapsed.
+        // Start the caret blinking again.
+        widget.editingOverlayController.startCaretBlinking();
       }
     });
   }

--- a/super_editor/test/super_textfield/super_textfield_caret_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_caret_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
+import 'super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField caret", () {
@@ -165,6 +166,199 @@ void main() {
       expect(caret.style.color, caretStyle.color);
       expect(caret.style.width, caretStyle.width);
       expect(caret.style.borderRadius, caretStyle.borderRadius);
+    });
+
+    testWidgetsOnMobile("does not blink while dragging the caret", (tester) async {
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
+
+      await tester.placeCaretInSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      // Drag caret by a small distance so that we trigger a user drag event.
+      // This drag event is continued down below so that we can check for caret blinking
+      // during a user drag.
+      final TestGesture gesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => gesture.removePointer());
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+    });
+
+    testWidgetsOnMobile("does not blink while dragging expanded handles", (tester) async {
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
+
+      await tester.doubleTapAtSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      // Drag the upstream selection handle by a small distance so that we trigger a
+      // user drag event. This drag event is continued down below so that we can check
+      // for caret blinking during a user drag.
+      final TestGesture upstreamHandleGesture =
+          await tester.dragUpstreamMobileHandleByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => upstreamHandleGesture.removePointer());
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      // End the current drag gesture before we start the downstream handle drag.
+      // We don't want multiple gesture pointers active at the same time.
+      await upstreamHandleGesture.up();
+      await tester.pump();
+
+      // Drag the downstream selection handle by a small distance so that we trigger a
+      // user drag event. This drag event is continued down below so that we can check
+      // for caret blinking during a user drag.
+      final TestGesture downstreamHandleGesture =
+          await tester.dragDownstreamMobileHandleByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => downstreamHandleGesture.removePointer());
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+    });
+
+    testWidgetsOnAndroid("does not blink while dragging collapsed handle", (tester) async {
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      final controller = AttributedTextEditingController(
+        text: AttributedText(
+          'SuperTextField with a content that spans multiple lines of text to test scrolling with  a scrollbar.',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildScaffold(
+          child: SuperTextField(
+            textController: controller,
+          ),
+        ),
+      );
+
+      await tester.placeCaretInSuperTextField(0);
+
+      // Configure BlinkController to animate, otherwise it won't blink.
+      BlinkController.indeterminateAnimationsEnabled = true;
+
+      // Drag the collapsed handle by a small distance so that we trigger a
+      // user drag event. This drag event is continued down below so that we
+      // can check for caret blinking during a user drag.
+      final TestGesture gesture =
+          await tester.dragAndroidCollapsedHandleByDistanceInSuperTextField(const Offset(100, 100));
+      addTearDown(() => gesture.removePointer());
+
+      // Check for the caret visibility across 3-4 frames and ensure it doesn't blink.
+      // Test in half-flash period intervals as we don't know how much time has passed and
+      // we might get unlucky and check the visibility when the caret is momentarily
+      // invisible.
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
+
+      await tester.pump(flashPeriod ~/ 2);
+
+      // Ensure caret is visible.
+      expect(_isCaretVisible(tester), true);
     });
   });
 }

--- a/super_editor/test/super_textfield/super_textfield_robot.dart
+++ b/super_editor/test/super_textfield/super_textfield_robot.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
+import 'package:super_editor/src/infrastructure/platforms/ios/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
@@ -110,6 +111,169 @@ extension SuperTextFieldRobot on WidgetTester {
     final caretLayerState = caretLayerElement.state as TextLayoutCaretState;
     final caretBottom = caretLayerState.globalCaretGeometry!.bottomCenter;
     final handleCenter = caretBottom + const Offset(0, 12);
+
+    final gesture = await startGesture(handleCenter);
+    await pump(kTapMinTime);
+
+    for (int i = 0; i < 50; i += 1) {
+      await gesture.moveBy(delta / 50);
+      await pump(const Duration(milliseconds: 50));
+    }
+
+    return gesture;
+  }
+
+  /// Drags the [SuperTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> dragUpstreamMobileHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    final fieldFinder =
+        SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
+    final match = fieldFinder.evaluate().single.widget;
+
+    if (match is SuperAndroidTextField) {
+      return _dragAndroidUpstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    if (match is SuperIOSTextField) {
+      return _dragIOSUpstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
+  }
+
+  /// Drags the [SuperTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> dragDownstreamMobileHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    final fieldFinder =
+        SuperTextFieldInspector.findInnerPlatformTextField(superTextFieldFinder ?? find.byType(SuperTextField));
+    final match = fieldFinder.evaluate().single.widget;
+
+    if (match is SuperAndroidTextField) {
+      return _dragAndroidDownstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    if (match is SuperIOSTextField) {
+      return _dragIOSDownstreamHandleByDistanceInSuperTextField(delta, fieldFinder);
+    }
+
+    throw Exception("Couldn't find a SuperTextField with the given Finder: $fieldFinder");
+  }
+
+  /// Drags the [SuperAndroidTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragAndroidUpstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperAndroidTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is AndroidSelectionHandle && //
+            widget.handleType == HandleType.upstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+  }
+
+  /// Drags the [SuperAndroidTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragAndroidDownstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperAndroidTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is AndroidSelectionHandle && //
+            widget.handleType == HandleType.downstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+  }
+
+  /// Drags the [SuperIOSTextField] upstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragIOSUpstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperIOSTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is IOSSelectionHandle && //
+            widget.handleType == HandleType.upstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+  }
+
+  /// Drags the [SuperIOSTextField] downstream handle by the given delta and
+  /// returns the [TestGesture] used to perform the drag.
+  ///
+  /// {@macro supertextfield_finder}
+  Future<TestGesture> _dragIOSDownstreamHandleByDistanceInSuperTextField(
+    Offset delta, [
+    Finder? superTextFieldFinder,
+  ]) async {
+    // TODO: lookup the actual handle size and offset when follow_the_leader correctly reports global bounds for followers
+    // Use our knowledge that the handle sits directly beneath the caret to drag it.
+    final handleFinder = find.descendant(
+      of: superTextFieldFinder ?? find.byType(SuperIOSTextField),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is IOSSelectionHandle && //
+            widget.handleType == HandleType.downstream,
+      ),
+    );
+
+    expect(handleFinder, findsOne);
+
+    return await _dragHandleByDistanceInSuperTextField(handleFinder, delta);
+  }
+
+  /// Drags the [SuperTextField] handle found by [superTextFieldHandleFinder] by
+  /// the given delta and returns the [TestGesture] used to perform the drag.
+  ///
+  /// Can be used to drag [SuperTextField] collapsed or expanded selection handles.
+  Future<TestGesture> _dragHandleByDistanceInSuperTextField(
+    Finder superTextFieldHandleFinder,
+    Offset delta,
+  ) async {
+    final handleCenter = getCenter(superTextFieldHandleFinder);
 
     final gesture = await startGesture(handleCenter);
     await pump(kTapMinTime);

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -34,7 +34,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
   @override
   void initState() {
     super.initState();
-    _blinkController = _createBlinkController();
+    _blinkController = _obtainBlinkController();
     if (widget.blinkCaret) {
       _blinkController.startBlinking();
     }
@@ -56,7 +56,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
           oldBlinkController.dispose();
         });
       }
-      _blinkController = _createBlinkController();
+      _blinkController = _obtainBlinkController();
     }
 
     if (widget.position != oldWidget.position && widget.blinkCaret) {
@@ -75,9 +75,9 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
     super.dispose();
   }
 
-  BlinkController _createBlinkController() {
+  BlinkController _obtainBlinkController() {
     if (widget.blinkController != null) {
-      return _blinkController;
+      return widget.blinkController!;
     }
 
     switch (widget.blinkTimingMode) {
@@ -97,7 +97,7 @@ class TextLayoutCaretState extends State<TextLayoutCaret> with TickerProviderSta
   @visibleForTesting
   double? get caretHeight => isCaretPresent
       ? widget.textLayout.getHeightForCaret(widget.position!) ??
-      widget.textLayout.getLineHeightAtPosition(widget.position!)
+          widget.textLayout.getLineHeightAtPosition(widget.position!)
       : null;
 
   @visibleForTesting


### PR DESCRIPTION
[SuperTextField][Android][iOS] Disables text field caret blink while dragging caret (Resolves #1705)