### PR TITLE
[SuperEditor] Clear composing region after splitting list items (Resolves #1039)

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -1,6 +1,7 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:super_editor/src/core/document_composer.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
@@ -732,6 +733,8 @@ class SplitListItemCommand implements EditCommand {
   @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
+    final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
+
     final node = document.getNodeById(nodeId);
     final listItemNode = node as ListItemNode;
     final text = listItemNode.text;
@@ -767,6 +770,10 @@ class SplitListItemCommand implements EditCommand {
       existingNode: node,
       newNode: newNode,
     );
+
+    // Clear the composing region to avoid keeping a region pointing to the
+    // node that was split.
+    composer.setComposingRegion(null);
 
     _log.log('SplitListItemCommand', ' - inserted new node: ${newNode.id} after old one: ${node.id}');
 

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -222,7 +222,18 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.nodes.last.id, 6);
+
+        // Type at the end of the list item to generate a composing region,
+        // simulating the Samsung keyboard.
+        await tester.typeImeText('2');
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Item 12',
+            selection: TextSelection.collapsed(offset: 9),
+            composing: TextRange.collapsed(9),
+          ),
+        ], getter: imeClientGetter);
 
         // Press enter to create a new list item.
         await tester.pressEnter();
@@ -232,7 +243,7 @@ void main() {
 
         // Ensure the existing item remains the same.
         expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
         expect(document.nodes.last, isA<ListItemNode>());
@@ -261,6 +272,17 @@ void main() {
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
 
+        // Type at the end of the list item to generate a composing region,
+        // simulating the Samsung keyboard.
+        await tester.typeImeText('2');
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Item 12',
+            selection: TextSelection.collapsed(offset: 9),
+            composing: TextRange.collapsed(9),
+          ),
+        ], getter: imeClientGetter);
+
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
 
@@ -269,7 +291,7 @@ void main() {
 
         // Ensure the existing item remains the same.
         expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
         expect(document.nodes.last, isA<ListItemNode>());
@@ -298,6 +320,17 @@ void main() {
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(document.nodes.first.id, 6);
 
+        // Type at the end of the list item to generate a composing region,
+        // simulating the Samsung keyboard.
+        await tester.typeImeText('2');
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Item 12',
+            selection: TextSelection.collapsed(offset: 9),
+            composing: TextRange.collapsed(9),
+          ),
+        ], getter: imeClientGetter);
+
         // On iOS, pressing ENTER generates a newline action.
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
@@ -306,7 +339,7 @@ void main() {
 
         // Ensure the existing item remains the same.
         expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
         expect(document.nodes.last, isA<ListItemNode>());


### PR DESCRIPTION
[SuperEditor] Clear composing region after splitting list items (Resolves #1039)

On a Samsung device using the Samsung default keyboard, typing at the end of a list item and pressing the new line button causes the editor to stop responding.

The issue is that we are not clearing the composing region when we split a list item. The Samsung keyboard generates a composing region when we start typing at the end of the list item, so after we split the item and send the new editing value to the IME, we were trying to map a composing region pointing to the node that was split. This causes a mapping error and crashes the editor.

This PR changes the `SplitListItemCommand` to clear the composing region after splitting the node.