### PR TITLE
[SuperEditor][Web] Fix cmd + left to move selection (Resolves #1852)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -247,14 +247,13 @@ class DocumentImeSerializer {
   ///
   /// If a placeholder is prepended, returns the first position after the placeholder,
   /// otherwise, returns the first position.
-  TextPosition firstVisiblePosition() {
+  TextPosition get firstVisiblePosition {
     return didPrependPlaceholder //
         ? TextPosition(offset: _prependedPlaceholder.length)
         : const TextPosition(offset: 0);
   }
 
   DocumentPosition _imeToDocumentPosition(TextPosition imePosition, {required bool isUpstream}) {
-    final affinity = isUpstream ? TextAffinity.upstream : TextAffinity.downstream;
     for (final range in imeRangesToDocTextNodes.keys) {
       if (range.start <= imePosition.offset && imePosition.offset <= range.end) {
         final node = _doc.getNodeById(imeRangesToDocTextNodes[range]!)!;
@@ -262,7 +261,7 @@ class DocumentImeSerializer {
         if (node is TextNode) {
           return DocumentPosition(
             nodeId: imeRangesToDocTextNodes[range]!,
-            nodePosition: TextNodePosition(offset: imePosition.offset - range.start, affinity: affinity),
+            nodePosition: TextNodePosition(offset: imePosition.offset - range.start),
           );
         } else {
           if (imePosition.offset <= range.start) {

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -243,7 +243,18 @@ class DocumentImeSerializer {
     return true;
   }
 
+  /// Returns the first visible position in the IME content.
+  ///
+  /// If a placeholder is prepended, returns the first position after the placeholder,
+  /// otherwise, returns the first position.
+  TextPosition firstVisiblePosition() {
+    return didPrependPlaceholder //
+        ? TextPosition(offset: _prependedPlaceholder.length)
+        : const TextPosition(offset: 0);
+  }
+
   DocumentPosition _imeToDocumentPosition(TextPosition imePosition, {required bool isUpstream}) {
+    final affinity = isUpstream ? TextAffinity.upstream : TextAffinity.downstream;
     for (final range in imeRangesToDocTextNodes.keys) {
       if (range.start <= imePosition.offset && imePosition.offset <= range.end) {
         final node = _doc.getNodeById(imeRangesToDocTextNodes[range]!)!;
@@ -251,7 +262,7 @@ class DocumentImeSerializer {
         if (node is TextNode) {
           return DocumentPosition(
             nodeId: imeRangesToDocTextNodes[range]!,
-            nodePosition: TextNodePosition(offset: imePosition.offset - range.start),
+            nodePosition: TextNodePosition(offset: imePosition.offset - range.start, affinity: affinity),
           );
         } else {
           if (imePosition.offset <= range.start) {

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -80,6 +80,17 @@ class SuperEditorInspector {
     return superEditor.editContext.composer.selection;
   }
 
+  /// Returns the current composing region for the [SuperEditor] matched by
+  /// [finder], or the singular [SuperEditor] in the widget tree, if [finder]
+  /// is `null`.
+  ///
+  /// {@macro supereditor_finder}
+  static DocumentRange? findComposingRegion([Finder? finder]) {
+    final element = (finder ?? find.byType(SuperEditor)).evaluate().single as StatefulElement;
+    final superEditor = element.state as SuperEditorState;
+    return superEditor.editContext.composer.composingRegion.value;
+  }
+
   /// Returns the (x,y) offset for the caret that's currently visible in the document.
   static Offset findCaretOffsetInDocument([Finder? finder]) {
     final caret = find.byKey(DocumentKeys.caret).evaluate().singleOrNull?.renderObject as RenderBox?;

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -284,6 +284,42 @@ void main() {
       });
     });
 
+    group('on web', () {
+      group('moves caret', () {
+        testWidgetsOnMacWeb("to beginning of line when CMD + LEFT_ARROW is pressed", (tester) async {
+          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: TextInputSource.ime);
+
+          // Simulate the user pressing CMD + LEFT ARROW, which generates a delta moving
+          // the selection to the beginning of the line.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. This is some testing text.',
+              selection: TextSelection.collapsed(offset: 12),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. This is some testing text.',
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.collapsed(0),
+            ),
+          ], getter: imeClientGetter);
+
+          // Ensure the selection and composing region were updated.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(_caretInParagraph(nodeId, 0)),
+          );
+          expect(
+            SuperEditorInspector.findComposingRegion(),
+            DocumentRange(
+              start: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
+              end: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
+            ),
+          );
+        });
+      });
+    });
+
     testAllInputsOnAllPlatforms('does nothing without primary focus', (
       tester, {
       required TextInputSource inputSource,

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -284,40 +284,36 @@ void main() {
       });
     });
 
-    group('on web', () {
-      group('moves caret', () {
-        testWidgetsOnMacWeb("to beginning of line when CMD + LEFT_ARROW is pressed", (tester) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: TextInputSource.ime);
+    testWidgetsOnMacWeb("on web moves caret to beginning of line when CMD + LEFT_ARROW is pressed", (tester) async {
+      final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: TextInputSource.ime);
 
-          // Simulate the user pressing CMD + LEFT ARROW, which generates a delta moving
-          // the selection to the beginning of the line.
-          await tester.ime.sendDeltas([
-            const TextEditingDeltaNonTextUpdate(
-              oldText: '. This is some testing text.',
-              selection: TextSelection.collapsed(offset: 12),
-              composing: TextRange.empty,
-            ),
-            const TextEditingDeltaNonTextUpdate(
-              oldText: '. This is some testing text.',
-              selection: TextSelection.collapsed(offset: 0),
-              composing: TextRange.collapsed(0),
-            ),
-          ], getter: imeClientGetter);
+      // Simulate the user pressing CMD + LEFT ARROW, which generates a delta moving
+      // the selection to the beginning of the line.
+      await tester.ime.sendDeltas([
+        const TextEditingDeltaNonTextUpdate(
+          oldText: '. This is some testing text.',
+          selection: TextSelection.collapsed(offset: 12),
+          composing: TextRange.empty,
+        ),
+        const TextEditingDeltaNonTextUpdate(
+          oldText: '. This is some testing text.',
+          selection: TextSelection.collapsed(offset: 0),
+          composing: TextRange.collapsed(0),
+        ),
+      ], getter: imeClientGetter);
 
-          // Ensure the selection and composing region were updated.
-          expect(
-            SuperEditorInspector.findDocumentSelection(),
-            selectionEquivalentTo(_caretInParagraph(nodeId, 0)),
-          );
-          expect(
-            SuperEditorInspector.findComposingRegion(),
-            DocumentRange(
-              start: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
-              end: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
-            ),
-          );
-        });
-      });
+      // Ensure the selection and composing region were updated.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(_caretInParagraph(nodeId, 0)),
+      );
+      expect(
+        SuperEditorInspector.findComposingRegion(),
+        DocumentRange(
+          start: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
+          end: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
+        ),
+      );
     });
 
     testAllInputsOnAllPlatforms('does nothing without primary focus', (


### PR DESCRIPTION
[SuperEditor][Web] Fix cmd + left to move selection (Resolves #1852)

On web, pressing CMD + LEFT ARROW isn't changing the selection. The selection movement on web is done using the non-text deltas that the IME generates instead of handling key presses. This causes an issue when the user tries to move the selection to the first character, because the first character the IME sees sits in the invisible region. For example, for the paragraph with the content "This is the first line", the IME content looks like this:

```
. This is the first line
```

So, when the IME moves the selection to the beginning of the line, the selection sits before the `.`. Because of that, we can't map the IME position to a document position and the selection remains unchanged.

This PR changes how we handle non-text deltas on web when the a collapsed selection or composing region sits in the invisible area. Now, in those cases we move the selection/composing region to the first visible character.