### PR TITLE
Fix getAllAttributionsThroughout

### DIFF
--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -112,7 +112,7 @@ class AttributedText {
     while (index <= range.end && attributionsThroughout.isNotEmpty) {
       final missingAttributions = <Attribution>{};
       for (final attribution in attributionsThroughout) {
-        if (!hasAttributionAt(index)) {
+        if (!hasAttributionAt(index, attribution: attribution)) {
           missingAttributions.add(attribution);
         }
       }

--- a/attributed_text/lib/src/test_tools.dart
+++ b/attributed_text/lib/src/test_tools.dart
@@ -6,6 +6,7 @@ import 'attribution.dart';
 class ExpectedSpans {
   static const bold = NamedAttribution('bold');
   static const italics = NamedAttribution('italics');
+  static const underline = NamedAttribution('underline');
   static const strikethrough = NamedAttribution('strikethrough');
   static const hashTag = NamedAttribution('hashTag');
 

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -428,6 +428,42 @@ void main() {
             .getAttributedRange({ExpectedSpans.bold, ExpectedSpans.italics, ExpectedSpans.strikethrough}, 2);
         expect(range, const SpanRange(1, 3));
       });
+
+      group('getAllAttributionsThroughout', () {
+        test('returns empty list if the range does not have any attributions', () {
+          final attributedText = AttributedText('Text without attributions');
+          expect(attributedText.getAllAttributionsThroughout(const SpanRange(5, 12)), isEmpty);
+        });
+
+        test('returns attributions that apply to the entirety of the range', () {
+          // Create a text with the following attributions:
+          // - bold: applied throught the entire text.
+          // - underline: applied to the word "with",
+          // - italics: applied from the begining of the text until "wi|th".
+          // - strikethrough: applied from "wi|th" until the end of the text.
+
+          final attributedText = AttributedText(
+            'Text with attributions',
+            AttributedSpans(
+              attributions: const [
+                SpanMarker(attribution: ExpectedSpans.bold, offset: 0, markerType: SpanMarkerType.start),
+                SpanMarker(attribution: ExpectedSpans.italics, offset: 0, markerType: SpanMarkerType.start),
+                SpanMarker(attribution: ExpectedSpans.underline, offset: 5, markerType: SpanMarkerType.start),
+                SpanMarker(attribution: ExpectedSpans.italics, offset: 6, markerType: SpanMarkerType.end),
+                SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 6, markerType: SpanMarkerType.start),
+                SpanMarker(attribution: ExpectedSpans.underline, offset: 8, markerType: SpanMarkerType.end),
+                SpanMarker(attribution: ExpectedSpans.strikethrough, offset: 21, markerType: SpanMarkerType.end),
+                SpanMarker(attribution: ExpectedSpans.bold, offset: 21, markerType: SpanMarkerType.end),
+              ],
+            ),
+          );
+
+          expect(
+            attributedText.getAllAttributionsThroughout(const SpanRange(5, 8)),
+            {ExpectedSpans.bold, ExpectedSpans.underline},
+          );
+        });
+      });
     });
 
     group("attribution visitation", () {


### PR DESCRIPTION
Fix getAllAttributionsThroughout

In https://github.com/superlistapp/super_editor/pull/1819 I found a bug on the getAllAttributionsThroughout method:

When we check each index for the attributions, we are not passing the current attribution as argument, so it was looking for any attributions.

This PR fixes the issue.