### PR TITLE
Fixing iOS blinking cursor while typing.

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -625,9 +625,30 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   bool get isDownstreamHandleDisplayed => layoutData?.downstream != null;
 
   void _onSelectionChange() {
+    _updateCaretFlash();
     setState(() {
       // Schedule a new layout computation because the caret and/or handles need to move.
     });
+  }
+
+  void _updateCaretFlash() {
+    _caretBlinkController.jumpToOpaque();
+    _startOrStopBlinking();
+  }
+
+  void _startOrStopBlinking() {
+    // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
+    final wantsToBlink = widget.selection.value != null;
+    if (wantsToBlink && _caretBlinkController.isBlinking) {
+      return;
+    }
+    if (!wantsToBlink && !_caretBlinkController.isBlinking) {
+      return;
+    }
+
+    wantsToBlink //
+        ? _caretBlinkController.startBlinking()
+        : _caretBlinkController.stopBlinking();
   }
 
   void _onBlinkModeChange() {


### PR DESCRIPTION
This PR aims to fix the cursor that continues to blink when typing on iOS

It seems that some logic has been added to `CaretDocumentOverlay` to manage this use case on Desktop, but this logic hasn't been replicated in `IosHandlesDocumentLayer`. The `AndroidControlsDocumentLayerState` has fixed the issue as well. 

When adding the same following logic to `IosHandlesDocumentLayer` it fixes the issue (*replicated from `CaretDocumentOverlay`*)  :

```dart
  void _onSelectionChange() {
    _updateCaretFlash();
    setState(() {
      // Schedule a new layout computation because the caret and/or handles need to move.
    });
  }

  void _updateCaretFlash() {
    _caretBlinkController.jumpToOpaque();
    _startOrStopBlinking();
  }

  void _startOrStopBlinking() {
    // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
    final wantsToBlink = widget.selection.value != null;
    if (wantsToBlink && _caretBlinkController.isBlinking) {
      return;
    }
    if (!wantsToBlink && !_caretBlinkController.isBlinking) {
      return;
    }

    wantsToBlink //
        ? _caretBlinkController.startBlinking()
        : _caretBlinkController.stopBlinking();
  }
```
### Before 

[ios_blinking_cursor.webm](https://github.com/superlistapp/super_editor/assets/7687231/5e087ca9-7970-4ce9-8e5e-66cf9c6a05cb)

### After

[ios_blinking_cursor_fixed.webm](https://github.com/superlistapp/super_editor/assets/7687231/f2d08bd1-84b5-42e0-a5cb-7809fe97f4f4)


The associated issue : #1876 