### PR TITLE
[SuperEditor][SuperReader] Fix setting attributions across multiple nodes (Resolves #1865)

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1444,9 +1444,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
     // ignore: prefer_collection_literals
     final nodesAndSelections = LinkedHashMap<TextNode, SpanRange>();
 
-    /// Number of nodes having all of the given attributions applied to any of
-    /// their characters.
-    int nodesWithExistingAttributions = 0;
+    bool alreadyHasAttributions = true;
 
     for (final textNode in nodes) {
       if (textNode is! TextNode) {
@@ -1487,16 +1485,11 @@ class ToggleTextAttributionsCommand implements EditCommand {
 
       final selectionRange = SpanRange(startOffset, endOffset);
 
-      final bool alreadyHasAttributions = textNode.text.hasAttributionsWithin(
-        attributions: attributions,
-        range: selectionRange,
-      );
-
-      if (alreadyHasAttributions) {
-        // Each of the given attributions exists for atleast a single character within
-        // the current text node.
-        nodesWithExistingAttributions++;
-      }
+      alreadyHasAttributions = alreadyHasAttributions &&
+          textNode.text.hasAttributionsWithin(
+            attributions: attributions,
+            range: selectionRange,
+          );
 
       nodesAndSelections.putIfAbsent(textNode, () => selectionRange);
     }
@@ -1507,8 +1500,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
         final node = entry.key;
         final range = entry.value;
 
-        if (node.text.hasAttributionsThroughout(attributions: {attribution}, range: range) &&
-            nodesWithExistingAttributions != nodesAndSelections.entries.length) {
+        if (!alreadyHasAttributions && node.text.hasAttributionsThroughout(attributions: {attribution}, range: range)) {
           // Attribution is applied throughout this entire node and there is alteast one node
           // that doesn't have this attribution. In that case, avoid toggling current node attribution
           // as this indicates the current attribution should be applied across all the nodes.

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1509,13 +1509,12 @@ class ToggleTextAttributionsCommand implements EditCommand {
           // Create a new AttributedText with updated attribution spans, so that the presentation system can
           // see that we made a change, and re-renders the text in the document.
           node.text = AttributedText(
-              node.text.text,
-              node.text.spans.copy()
-                ..removeAttribution(
-                  attributionToRemove: attribution,
-                  start: range.start,
-                  end: range.end,
-                ));
+            node.text.text,
+            node.text.spans.copy(),
+          )..removeAttribution(
+              attribution,
+              range,
+            );
         } else {
           // Attribution isn't present throughout the user selection. Apply attribution.
 
@@ -1525,13 +1524,11 @@ class ToggleTextAttributionsCommand implements EditCommand {
           // see that we made a change, and re-renders the text in the document.
           node.text = AttributedText(
             node.text.text,
-            node.text.spans.copy()
-              ..addAttribution(
-                newAttribution: attribution,
-                start: range.start,
-                end: range.end,
-              ),
-          );
+            node.text.spans.copy(),
+          )..addAttribution(
+              attribution,
+              range,
+            );
         }
 
         executor.logChanges([

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -305,8 +305,8 @@ class SuperEditorInspector {
   ///
   /// {@macro supereditor_finder}
   static void toggleAttributionsForDocumentSelection({
-    required DocumentNode selectionBaseNode,
-    required DocumentNode selectionExtentNode,
+    required DocumentPosition base,
+    required DocumentPosition extent,
     required Set<Attribution> attributions,
   }) {
     final editor = findEditor();
@@ -314,14 +314,8 @@ class SuperEditorInspector {
     return editor.execute([
       ToggleTextAttributionsRequest(
         documentRange: DocumentSelection(
-          base: DocumentPosition(
-            nodeId: selectionBaseNode.id,
-            nodePosition: selectionBaseNode.beginningPosition,
-          ),
-          extent: DocumentPosition(
-            nodeId: selectionExtentNode.id,
-            nodePosition: selectionExtentNode.endPosition,
-          ),
+          base: base,
+          extent: extent,
         ),
         attributions: attributions,
       )

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -301,6 +301,33 @@ class SuperEditorInspector {
     return documentLayoutElement.state as DocumentLayout;
   }
 
+  /// Toggles given attributions for the given document selection.
+  ///
+  /// {@macro supereditor_finder}
+  static void toggleAttributionsForDocumentSelection({
+    required DocumentNode selectionBaseNode,
+    required DocumentNode selectionExtentNode,
+    required Set<Attribution> attributions,
+  }) {
+    final editor = findEditor();
+
+    return editor.execute([
+      ToggleTextAttributionsRequest(
+        documentRange: DocumentSelection(
+          base: DocumentPosition(
+            nodeId: selectionBaseNode.id,
+            nodePosition: selectionBaseNode.beginningPosition,
+          ),
+          extent: DocumentPosition(
+            nodeId: selectionExtentNode.id,
+            nodePosition: selectionExtentNode.endPosition,
+          ),
+        ),
+        attributions: attributions,
+      )
+    ]);
+  }
+
   /// Returns `true` if [SuperEditor]'s policy believes that a mobile toolbar should
   /// be visible right now, or `false` otherwise.
   ///

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -49,6 +49,16 @@ class SuperEditorInspector {
     return imeInteractor.isAttachedToIme;
   }
 
+  /// Returns the [Editor] within the [SuperEditor] matched by [finder],
+  /// or the singular [SuperEditor] in the widget tree, if [finder] is `null`.
+  ///
+  /// {@macro supereditor_finder}
+  static Editor findEditor([Finder? finder]) {
+    final element = (finder ?? find.byType(SuperEditor)).evaluate().single as StatefulElement;
+    final superEditor = element.state as SuperEditorState;
+    return superEditor.editContext.editor;
+  }
+
   /// Returns the [Document] within the [SuperEditor] matched by [finder],
   /// or the singular [SuperEditor] in the widget tree, if [finder] is `null`.
   ///

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -301,22 +301,19 @@ class SuperEditorInspector {
     return documentLayoutElement.state as DocumentLayout;
   }
 
-  /// Toggles given attributions for the given document selection.
+  /// Toggles given [attributions] for the [documentSelection].
   ///
   /// {@macro supereditor_finder}
-  static void toggleAttributionsForDocumentSelection({
-    required DocumentPosition base,
-    required DocumentPosition extent,
-    required Set<Attribution> attributions,
-  }) {
-    final editor = findEditor();
+  static void toggleAttributionsForDocumentSelection(
+    DocumentSelection documentSelection,
+    Set<Attribution> attributions, [
+    Finder? superEditorFinder,
+  ]) {
+    final editor = findEditor(superEditorFinder);
 
     return editor.execute([
       ToggleTextAttributionsRequest(
-        documentRange: DocumentSelection(
-          base: base,
-          extent: extent,
-        ),
+        documentRange: documentSelection,
         attributions: attributions,
       )
     ]);

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -49,16 +49,6 @@ class SuperEditorInspector {
     return imeInteractor.isAttachedToIme;
   }
 
-  /// Returns the [Editor] within the [SuperEditor] matched by [finder],
-  /// or the singular [SuperEditor] in the widget tree, if [finder] is `null`.
-  ///
-  /// {@macro supereditor_finder}
-  static Editor findEditor([Finder? finder]) {
-    final element = (finder ?? find.byType(SuperEditor)).evaluate().single as StatefulElement;
-    final superEditor = element.state as SuperEditorState;
-    return superEditor.editContext.editor;
-  }
-
   /// Returns the [Document] within the [SuperEditor] matched by [finder],
   /// or the singular [SuperEditor] in the widget tree, if [finder] is `null`.
   ///

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -301,24 +301,6 @@ class SuperEditorInspector {
     return documentLayoutElement.state as DocumentLayout;
   }
 
-  /// Toggles given [attributions] for the [documentSelection].
-  ///
-  /// {@macro supereditor_finder}
-  static void toggleAttributionsForDocumentSelection(
-    DocumentSelection documentSelection,
-    Set<Attribution> attributions, [
-    Finder? superEditorFinder,
-  ]) {
-    final editor = findEditor(superEditorFinder);
-
-    return editor.execute([
-      ToggleTextAttributionsRequest(
-        documentRange: documentSelection,
-        attributions: attributions,
-      )
-    ]);
-  }
-
   /// Returns `true` if [SuperEditor]'s policy believes that a mobile toolbar should
   /// be visible right now, or `false` otherwise.
   ///

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -202,7 +202,7 @@ void main() {
             isEmpty,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
@@ -215,7 +215,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
@@ -245,7 +245,7 @@ void main() {
             isEmpty,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -258,7 +258,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -291,7 +291,7 @@ void main() {
 
           final firstNode = doc.getNodeById("1")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -304,7 +304,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -339,7 +339,7 @@ void main() {
 
           final firstNode = doc.getNodeById("1")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
@@ -352,7 +352,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
@@ -384,7 +384,7 @@ void main() {
             isEmpty,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {italicsAttribution, boldAttribution},
           );
@@ -397,7 +397,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution, italicsAttribution},
           );
@@ -430,7 +430,7 @@ void main() {
             true,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -446,7 +446,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -483,7 +483,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -503,7 +503,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -541,7 +541,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -561,7 +561,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -600,7 +600,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -620,7 +620,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -658,7 +658,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -678,7 +678,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -716,7 +716,7 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
           final secondNode = doc.getNodeById("2")!;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -732,7 +732,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -772,7 +772,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.positionAt(18),
@@ -789,7 +789,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.positionAt(18),
@@ -826,7 +826,7 @@ void main() {
             true,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -846,7 +846,7 @@ void main() {
           );
 
           // Toggle bold attribution for both nodes.
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -882,7 +882,7 @@ void main() {
             true,
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: secondNode.positionAt(18),
@@ -898,7 +898,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: secondNode.positionAt(18),
@@ -936,7 +936,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: thirdNode.positionAt(18),
@@ -952,7 +952,7 @@ void main() {
             ),
           );
 
-          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          _toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: thirdNode.positionAt(18),
@@ -1320,4 +1320,20 @@ AttributedSpans _createAttributedSpansForAttribution({
       ),
     ],
   );
+}
+
+/// Toggles given [attributions] for the [documentSelection].
+void _toggleAttributionsForDocumentSelection(
+  DocumentSelection documentSelection,
+  Set<Attribution> attributions, [
+  Finder? superEditorFinder,
+]) {
+  final editor = SuperEditorInspector.findEditor(superEditorFinder);
+
+  return editor.execute([
+    ToggleTextAttributionsRequest(
+      documentRange: documentSelection,
+      attributions: attributions,
+    )
+  ]);
 }

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -185,13 +185,14 @@ void main() {
 
       group("when a single node is selected", () {
         testWidgetsOnAllPlatforms("toggles attribution throughout a node", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 singleParagraphDocShortText(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -202,7 +203,7 @@ void main() {
             isEmpty,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
@@ -215,7 +216,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
@@ -228,13 +229,14 @@ void main() {
         });
 
         testWidgetsOnAllPlatforms("toggles attribution on a partial node selection", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 singleParagraphDocShortText(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -245,7 +247,7 @@ void main() {
             isEmpty,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -258,7 +260,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -272,13 +274,14 @@ void main() {
 
         testWidgetsOnAllPlatforms("toggles an attribution within a sub-range of an existing same attribution",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 singleParagraphDocAllBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is present.
@@ -291,7 +294,7 @@ void main() {
 
           final firstNode = doc.getNodeById("1")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -304,7 +307,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
@@ -320,13 +323,14 @@ void main() {
 
         testWidgetsOnAllPlatforms("toggles a different attribution within a sub-range of another existing attribution",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 singleParagraphDocAllBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is present.
@@ -339,7 +343,7 @@ void main() {
 
           final firstNode = doc.getNodeById("1")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
@@ -352,7 +356,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
@@ -367,13 +371,14 @@ void main() {
         });
 
         testWidgetsOnAllPlatforms("toggles multiple attributions throughout a node", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 singleParagraphDocShortText(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -384,7 +389,7 @@ void main() {
             isEmpty,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {italicsAttribution, boldAttribution},
           );
@@ -397,7 +402,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution, italicsAttribution},
           );
@@ -412,13 +417,14 @@ void main() {
 
       group("when multiple nodes are selected", () {
         testWidgetsOnAllPlatforms("toggles attribution throughout multiple nodes", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 twoParagraphDoc(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -430,7 +436,7 @@ void main() {
             true,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -446,7 +452,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -463,12 +469,14 @@ void main() {
 
         testWidgetsOnAllPlatforms(
             "toggles an attribution across nodes with the attribution applied throughout first node", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphFullBoldThenParagraph(),
               )
               .pump();
+
+          final Editor editor = context.editor;
 
           final doc = SuperEditorInspector.findDocument()!;
 
@@ -483,13 +491,15 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: secondNode.endDocumentPosition,
-            ),
-            {boldAttribution},
-          );
+          editor.execute([
+            ToggleTextAttributionsRequest(
+              documentRange: DocumentSelection(
+                base: firstNode.beginningDocumentPosition,
+                extent: secondNode.endDocumentPosition,
+              ),
+              attributions: {boldAttribution},
+            )
+          ]);
 
           // Ensure bold attribution is applied throughout both nodes.
           //
@@ -503,7 +513,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -521,13 +531,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles an attribution across nodes with the attribution applied partially within first node",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphPartiallyBoldThenParagraph(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied partially to the first node.
@@ -541,7 +552,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -561,7 +572,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -579,13 +590,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles an attribution across nodes with the attribution applied throughout and partially within first and second node respectively",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphFullyBoldThenParagraphPartiallyBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied partially to first node and
@@ -600,7 +612,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -620,7 +632,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -638,13 +650,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles an attribution across nodes with the attribution applied partially within all nodes",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphPartiallyBoldThenParagraphPartiallyBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied partially across both nodes.
@@ -658,7 +671,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -678,7 +691,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -696,13 +709,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles a different attribution across nodes with an existing attribution applied throughout them",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 twoParagraphDocAllBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied throughout both nodes.
@@ -716,7 +730,7 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
           final secondNode = doc.getNodeById("2")!;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -732,7 +746,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -752,13 +766,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles a different attribution partially across nodes with an existing attribution applied throughout them",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 twoParagraphDocAllBold(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied throughout the selection.
@@ -772,7 +787,7 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
           final secondNode = doc.getNodeById("2")! as TextNode;
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.positionAt(18),
@@ -789,7 +804,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.positionAt(18),
@@ -808,13 +823,14 @@ void main() {
         });
 
         testWidgetsOnAllPlatforms("toggles multiple attributions throughout multiple nodes", (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 twoParagraphDoc(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -826,7 +842,7 @@ void main() {
             true,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -846,7 +862,7 @@ void main() {
           );
 
           // Toggle bold attribution for both nodes.
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
               extent: secondNode.endDocumentPosition,
@@ -864,13 +880,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles attribution for a selection going halfway from first node and halfway within second node",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 twoParagraphDoc(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -882,7 +899,7 @@ void main() {
             true,
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: secondNode.positionAt(18),
@@ -898,7 +915,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: secondNode.positionAt(18),
@@ -916,13 +933,14 @@ void main() {
         testWidgetsOnAllPlatforms(
             "toggles attribution for a selection going halfway in first node till the halfway into the third node",
             (tester) async {
-          await tester //
+          final TestDocumentContext context = await tester //
               .createDocument()
               .withCustomContent(
                 threeParagraphDoc(),
               )
               .pump();
 
+          final Editor editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           final firstNode = doc.getNodeById("1")! as TextNode;
@@ -936,7 +954,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: thirdNode.positionAt(18),
@@ -952,7 +970,7 @@ void main() {
             ),
           );
 
-          _toggleAttributionsForDocumentSelection(
+          editor.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.positionAt(18),
               extent: thirdNode.positionAt(18),
@@ -1299,6 +1317,21 @@ extension _GetDocumentPosition on DocumentNode {
   }
 }
 
+extension _ToggleAttributions on Editor {
+  /// Toggles given [attributions] for the [documentSelection].
+  void toggleAttributionsForDocumentSelection(
+    DocumentSelection documentSelection,
+    Set<Attribution> attributions,
+  ) {
+    return execute([
+      ToggleTextAttributionsRequest(
+        documentRange: documentSelection,
+        attributions: attributions,
+      )
+    ]);
+  }
+}
+
 /// Creates an [AttributedSpans] for the [attribution] starting at [startOffset]
 /// and ending at [endOffset].
 AttributedSpans _createAttributedSpansForAttribution({
@@ -1320,20 +1353,4 @@ AttributedSpans _createAttributedSpansForAttribution({
       ),
     ],
   );
-}
-
-/// Toggles given [attributions] for the [documentSelection].
-void _toggleAttributionsForDocumentSelection(
-  DocumentSelection documentSelection,
-  Set<Attribution> attributions, [
-  Finder? superEditorFinder,
-]) {
-  final editor = SuperEditorInspector.findEditor(superEditorFinder);
-
-  return editor.execute([
-    ToggleTextAttributionsRequest(
-      documentRange: documentSelection,
-      attributions: attributions,
-    )
-  ]);
 }

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -188,7 +188,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphDoc(),
+                paragraphDoc(),
               )
               .pump();
 
@@ -203,10 +203,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.endDocumentPosition,
-            ),
+            firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
 
@@ -219,10 +216,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.endDocumentPosition,
-            ),
+            firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution},
           );
 
@@ -237,7 +231,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphDoc(),
+                paragraphDoc(),
               )
               .pump();
 
@@ -252,10 +246,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
 
@@ -268,10 +259,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
 
@@ -287,7 +275,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _fullyBoldParagraphDoc(),
+                fullyBoldParagraphDoc(),
               )
               .pump();
 
@@ -301,13 +289,10 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
 
@@ -320,10 +305,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {boldAttribution},
           );
 
@@ -341,7 +323,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _fullyBoldParagraphDoc(),
+                fullyBoldParagraphDoc(),
               )
               .pump();
 
@@ -355,13 +337,10 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
 
@@ -374,10 +353,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.atOffset(17),
-            ),
+            firstNode.selectionBetween(0, 17),
             {italicsAttribution},
           );
 
@@ -394,7 +370,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphDoc(),
+                paragraphDoc(),
               )
               .pump();
 
@@ -409,10 +385,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.endDocumentPosition,
-            ),
+            firstNode.selectionBetween(0, firstNode.text.length),
             {italicsAttribution, boldAttribution},
           );
 
@@ -425,10 +398,7 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            DocumentSelection(
-              base: firstNode.beginningDocumentPosition,
-              extent: firstNode.endDocumentPosition,
-            ),
+            firstNode.selectionBetween(0, firstNode.text.length),
             {boldAttribution, italicsAttribution},
           );
 
@@ -445,7 +415,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphThenParagraphDoc(),
+                paragraphThenParagraphDoc(),
               )
               .pump();
 
@@ -729,7 +699,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphFullBoldThenParagraphFullyBold(),
+                paragraphFullBoldThenParagraphFullyBold(),
               )
               .pump();
 
@@ -785,7 +755,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphFullBoldThenParagraphFullyBold(),
+                paragraphFullBoldThenParagraphFullyBold(),
               )
               .pump();
 
@@ -799,13 +769,13 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
-              extent: secondNode.atOffset(18),
+              extent: secondNode.positionAt(18),
             ),
             {italicsAttribution},
           );
@@ -822,7 +792,7 @@ void main() {
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
               base: firstNode.beginningDocumentPosition,
-              extent: secondNode.atOffset(18),
+              extent: secondNode.positionAt(18),
             ),
             {italicsAttribution},
           );
@@ -841,7 +811,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphThenParagraphDoc(),
+                paragraphThenParagraphDoc(),
               )
               .pump();
 
@@ -897,7 +867,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphThenParagraphDoc(),
+                paragraphThenParagraphDoc(),
               )
               .pump();
 
@@ -914,8 +884,8 @@ void main() {
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
-              base: firstNode.atOffset(18),
-              extent: secondNode.atOffset(18),
+              base: firstNode.positionAt(18),
+              extent: secondNode.positionAt(18),
             ),
             {boldAttribution},
           );
@@ -930,8 +900,8 @@ void main() {
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
-              base: firstNode.atOffset(18),
-              extent: secondNode.atOffset(18),
+              base: firstNode.positionAt(18),
+              extent: secondNode.positionAt(18),
             ),
             {boldAttribution},
           );
@@ -949,7 +919,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                _paragraphThenParagraphThenParagraphDoc(),
+                paragraphThenParagraphThenParagraphDoc(),
               )
               .pump();
 
@@ -968,8 +938,8 @@ void main() {
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
-              base: firstNode.atOffset(18),
-              extent: thirdNode.atOffset(18),
+              base: firstNode.positionAt(18),
+              extent: thirdNode.positionAt(18),
             ),
             {boldAttribution},
           );
@@ -984,8 +954,8 @@ void main() {
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
-              base: firstNode.atOffset(18),
-              extent: thirdNode.atOffset(18),
+              base: firstNode.positionAt(18),
+              extent: thirdNode.positionAt(18),
             ),
             {boldAttribution},
           );
@@ -1215,73 +1185,6 @@ void main() {
   });
 }
 
-MutableDocument _paragraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument _fullyBoldParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-            _createAttributedSpansForAttribution(
-              attribution: boldAttribution,
-              startOffset: 0,
-              endOffset: 36,
-            ),
-          ),
-        ),
-      ],
-    );
-
-MutableDocument _paragraphThenParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument _paragraphThenParagraphThenParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "3",
-          text: AttributedText(
-            "This is the third node in a document.",
-          ),
-        ),
-      ],
-    );
-
 MutableDocument _paragraphFullBoldThenParagraph() => MutableDocument(
       nodes: [
         ParagraphNode(
@@ -1380,33 +1283,6 @@ MutableDocument _paragraphPartiallyBoldThenParagraphPartiallyBold() => MutableDo
       ],
     );
 
-MutableDocument _paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-            _createAttributedSpansForAttribution(
-              attribution: boldAttribution,
-              startOffset: 0,
-              endOffset: 36,
-            ),
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-            _createAttributedSpansForAttribution(
-              attribution: boldAttribution,
-              startOffset: 0,
-              endOffset: 37,
-            ),
-          ),
-        ),
-      ],
-    );
-
 extension _GetDocumentPosition on DocumentNode {
   DocumentPosition get beginningDocumentPosition {
     return DocumentPosition(
@@ -1419,15 +1295,6 @@ extension _GetDocumentPosition on DocumentNode {
     return DocumentPosition(
       nodeId: id,
       nodePosition: endPosition,
-    );
-  }
-
-  DocumentPosition atOffset(int offset) {
-    return DocumentPosition(
-      nodeId: id,
-      nodePosition: TextNodePosition(
-        offset: offset,
-      ),
     );
   }
 }

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -194,15 +194,13 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are present.
-          expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
-          );
-
           final firstNode = doc.getNodeById("1")! as TextNode;
+
+          // Ensure markers are empty.
+          expect(
+            firstNode.text.spans.markers,
+            isEmpty,
+          );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -228,12 +226,10 @@ void main() {
             {boldAttribution},
           );
 
-          // Ensure attribution was removed from the selection.
+          // Ensure bold attribution was removed from the selection.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
+            firstNode.text.spans.markers,
+            isEmpty,
           );
         });
 
@@ -247,15 +243,13 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are present.
-          expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
-          );
+          final firstNode = doc.getNodeById("1")! as TextNode;
 
-          final firstNode = doc.getNodeById("1")!;
+          // Ensure markers are empty.
+          expect(
+            firstNode.text.spans.markers,
+            isEmpty,
+          );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -281,12 +275,10 @@ void main() {
             {boldAttribution},
           );
 
-          // Ensure attribution was removed from the selection.
+          // Ensure bold attribution was removed from the selection.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
+            firstNode.text.spans.markers,
+            isEmpty,
           );
         });
 
@@ -405,15 +397,13 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are present.
-          expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
-          );
+          final firstNode = doc.getNodeById("1")! as TextNode;
 
-          final firstNode = doc.getNodeById("1")!;
+          // Ensure markers are empty.
+          expect(
+            firstNode.text.spans.markers,
+            isEmpty,
+          );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -439,12 +429,10 @@ void main() {
             {boldAttribution, italicsAttribution},
           );
 
-          // Ensure all attributions are removed from the node.
+          // Ensure both bold and italic attributions are removed from the node.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.",
-            ),
+            firstNode.text.spans.markers,
+            isEmpty,
           );
         });
       });
@@ -460,16 +448,14 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are present.
-          expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
-          );
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          // Ensure markers are empty for both nodes.
+          expect(
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
+          );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -497,10 +483,8 @@ void main() {
 
           // Ensure bold attribution was removed from both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
 
@@ -523,8 +507,8 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -552,10 +536,8 @@ void main() {
 
           // Ensure bold attribution was removed from both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
 
@@ -578,8 +560,8 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -607,10 +589,8 @@ void main() {
 
           // Ensure bold attribution was removed from both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
 
@@ -634,8 +614,8 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -663,10 +643,8 @@ void main() {
 
           // Ensure bold attribution was removed from both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
 
@@ -688,8 +666,8 @@ void main() {
             ),
           );
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -717,10 +695,8 @@ void main() {
 
           // Ensure bold attribution was removed from both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
 
@@ -769,7 +745,7 @@ void main() {
             {italicsAttribution},
           );
 
-          // Ensure bold attribution was removed from both nodes.
+          // Ensure italic attribution was removed from both nodes.
           expect(
             doc,
             equalsMarkdown(
@@ -845,16 +821,14 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are present.
-          expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
-          );
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
 
-          final firstNode = doc.getNodeById("1")!;
-          final secondNode = doc.getNodeById("2")!;
+          // Ensure markers are empty for both nodes.
+          expect(
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
+          );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             DocumentSelection(
@@ -884,12 +858,10 @@ void main() {
             {boldAttribution, italicsAttribution},
           );
 
-          // Ensure both bold and italic attributions were removed from the selection.
+          // Ensure markers are empty for both nodes.
           expect(
-            doc,
-            equalsMarkdown(
-              "This is the first node in a document.\n\nThis is the second node in a document.",
-            ),
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
           );
         });
       });

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -386,6 +386,57 @@ void main() {
             ),
           );
         });
+
+        testWidgetsOnAllPlatforms("toggles multiple attributions throughout a node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure no attributions are applied.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+
+          // Toggle attributions for the node.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.endDocumentPosition,
+            attributions: {italicsAttribution, boldAttribution},
+          );
+
+          // Ensure the attributions were applied.
+          expect(
+            doc,
+            equalsMarkdown(
+              "***This is the first node in a document.***",
+            ),
+          );
+
+          // Toggle attributions for the node.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.endDocumentPosition,
+            attributions: {boldAttribution, italicsAttribution},
+          );
+
+          // Ensure all attributions are removed from the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+        });
       });
 
       group("when multiple nodes are selected", () {
@@ -759,7 +810,60 @@ void main() {
         );
       });
 
-      // applies multiple attributions to multiple nodes
+      testWidgetsOnAllPlatforms("toggles multiple attributions throughout multiple nodes", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              _paragraphThenParagraphDoc(),
+            )
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure no attributions are applied.
+        expect(
+          doc,
+          equalsMarkdown(
+            "This is the first node in a document.\n\nThis is the second node in a document.",
+          ),
+        );
+
+        final firstNode = doc.getNodeById("1")!;
+        final secondNode = doc.getNodeById("2")!;
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {
+            italicsAttribution,
+            boldAttribution,
+          },
+        );
+
+        // Ensure the selection has both bold and italic attributions applied.
+        expect(
+          doc,
+          equalsMarkdown(
+            "***This is the first node in a document.***\n\n***This is the second node in a document.***",
+          ),
+        );
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {boldAttribution, italicsAttribution},
+        );
+
+        // Ensure all attributions are removed from both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "This is the first node in a document.\n\nThis is the second node in a document.",
+          ),
+        );
+      });
     });
 
     group("applies color attributions", () {

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/test/ime.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_inspector.dart';
 import 'package:super_editor/src/test/super_editor_test/supereditor_robot.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
 
 import 'supereditor_test_tools.dart';
 import 'test_documents.dart';
@@ -184,14 +185,13 @@ void main() {
 
       group("when multiple nodes are selected", () {
         testWidgetsOnAllPlatforms("toggles bold attribution across fully bold node and a plain node", (tester) async {
-          final context = await tester //
+          await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphFullBoldThenParagraph(),
               )
               .pump();
 
-          final editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied partially to the first node.
@@ -206,21 +206,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           // Toggle bold attribution for both nodes.
-          editor.execute([
-            ToggleTextAttributionsRequest(
-              documentRange: DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: "1",
-                  nodePosition: firstNode.beginningPosition,
-                ),
-                extent: DocumentPosition(
-                  nodeId: "2",
-                  nodePosition: secondNode.endPosition,
-                ),
-              ),
-              attributions: {boldAttribution},
-            ),
-          ]);
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            selectionBaseNode: firstNode,
+            selectionExtentNode: secondNode,
+            attributions: {boldAttribution},
+          );
 
           // Ensure bold attribution is applied to both nodes.
           expect(
@@ -231,21 +221,11 @@ void main() {
           );
 
           // Toggle bold attribution for both nodes.
-          editor.execute([
-            ToggleTextAttributionsRequest(
-              documentRange: DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: "1",
-                  nodePosition: firstNode.beginningPosition,
-                ),
-                extent: DocumentPosition(
-                  nodeId: "2",
-                  nodePosition: secondNode.endPosition,
-                ),
-              ),
-              attributions: {boldAttribution},
-            ),
-          ]);
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            selectionBaseNode: firstNode,
+            selectionExtentNode: secondNode,
+            attributions: {boldAttribution},
+          );
 
           // Ensure bold attribution was removed from both nodes.
           expect(
@@ -258,14 +238,13 @@ void main() {
 
         testWidgetsOnAllPlatforms("toggles bold attribution across partially bold node and a plain node",
             (tester) async {
-          final TestDocumentContext context = await tester //
+          await tester //
               .createDocument()
               .withCustomContent(
                 _paragraphPartiallyBoldThenParagraph(),
               )
               .pump();
 
-          final editor = context.editor;
           final doc = SuperEditorInspector.findDocument()!;
 
           // Ensure bold attribution is applied to the first node.
@@ -280,21 +259,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           // Toggle bold attribution for both nodes.
-          editor.execute([
-            ToggleTextAttributionsRequest(
-              documentRange: DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: "1",
-                  nodePosition: firstNode.beginningPosition,
-                ),
-                extent: DocumentPosition(
-                  nodeId: "2",
-                  nodePosition: secondNode.endPosition,
-                ),
-              ),
-              attributions: {boldAttribution},
-            ),
-          ]);
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            selectionBaseNode: firstNode,
+            selectionExtentNode: secondNode,
+            attributions: {boldAttribution},
+          );
 
           // Ensure bold attribution is applied to both nodes.
           expect(
@@ -305,21 +274,11 @@ void main() {
           );
 
           // Toggle bold attribution for both nodes.
-          editor.execute([
-            ToggleTextAttributionsRequest(
-              documentRange: DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: "1",
-                  nodePosition: firstNode.beginningPosition,
-                ),
-                extent: DocumentPosition(
-                  nodeId: "2",
-                  nodePosition: secondNode.endPosition,
-                ),
-              ),
-              attributions: {boldAttribution},
-            ),
-          ]);
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            selectionBaseNode: firstNode,
+            selectionExtentNode: secondNode,
+            attributions: {boldAttribution},
+          );
 
           // Ensure bold attribution was removed from both nodes.
           expect(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -188,7 +188,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphDoc(),
+                singleParagraphDocShortText(),
               )
               .pump();
 
@@ -231,7 +231,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphDoc(),
+                singleParagraphDocShortText(),
               )
               .pump();
 
@@ -275,7 +275,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                fullyBoldParagraphDoc(),
+                singleParagraphDocAllBold(),
               )
               .pump();
 
@@ -323,7 +323,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                fullyBoldParagraphDoc(),
+                singleParagraphDocAllBold(),
               )
               .pump();
 
@@ -370,7 +370,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphDoc(),
+                singleParagraphDocShortText(),
               )
               .pump();
 
@@ -415,7 +415,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphThenParagraphDoc(),
+                twoParagraphDoc(),
               )
               .pump();
 
@@ -699,7 +699,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphFullBoldThenParagraphFullyBold(),
+                twoParagraphDocAllBold(),
               )
               .pump();
 
@@ -755,7 +755,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphFullBoldThenParagraphFullyBold(),
+                twoParagraphDocAllBold(),
               )
               .pump();
 
@@ -811,7 +811,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphThenParagraphDoc(),
+                twoParagraphDoc(),
               )
               .pump();
 
@@ -867,7 +867,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphThenParagraphDoc(),
+                twoParagraphDoc(),
               )
               .pump();
 
@@ -919,7 +919,7 @@ void main() {
           await tester //
               .createDocument()
               .withCustomContent(
-                paragraphThenParagraphThenParagraphDoc(),
+                threeParagraphDoc(),
               )
               .pump();
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -181,6 +181,155 @@ void main() {
           expect(doc, equalsMarkdown("[This is a linnk](https://google.com) pointing to google"));
         });
       });
+
+      group("when multiple nodes are selected", () {
+        testWidgetsOnAllPlatforms("toggles bold attribution across fully bold node and a plain node", (tester) async {
+          final context = await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphFullBoldThenParagraph(),
+              )
+              .pump();
+
+          final editor = context.editor;
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied partially to the first node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\nThis is the second node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          // Toggle bold attribution for both nodes.
+          editor.execute([
+            ToggleTextAttributionsRequest(
+              documentRange: DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: firstNode.beginningPosition,
+                ),
+                extent: DocumentPosition(
+                  nodeId: "2",
+                  nodePosition: secondNode.endPosition,
+                ),
+              ),
+              attributions: {boldAttribution},
+            ),
+          ]);
+
+          // Ensure bold attribution is applied to both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for both nodes.
+          editor.execute([
+            ToggleTextAttributionsRequest(
+              documentRange: DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: firstNode.beginningPosition,
+                ),
+                extent: DocumentPosition(
+                  nodeId: "2",
+                  nodePosition: secondNode.endPosition,
+                ),
+              ),
+              attributions: {boldAttribution},
+            ),
+          ]);
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles bold attribution across partially bold node and a plain node",
+            (tester) async {
+          final TestDocumentContext context = await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphPartiallyBoldThenParagraph(),
+              )
+              .pump();
+
+          final editor = context.editor;
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied to the first node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first** node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          // Toggle bold attribution for both nodes.
+          editor.execute([
+            ToggleTextAttributionsRequest(
+              documentRange: DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: firstNode.beginningPosition,
+                ),
+                extent: DocumentPosition(
+                  nodeId: "2",
+                  nodePosition: secondNode.endPosition,
+                ),
+              ),
+              attributions: {boldAttribution},
+            ),
+          ]);
+
+          // Ensure bold attribution is applied to both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for both nodes.
+          editor.execute([
+            ToggleTextAttributionsRequest(
+              documentRange: DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: firstNode.beginningPosition,
+                ),
+                extent: DocumentPosition(
+                  nodeId: "2",
+                  nodePosition: secondNode.endPosition,
+                ),
+              ),
+              attributions: {boldAttribution},
+            ),
+          ]);
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+      });
     });
 
     group("applies color attributions", () {
@@ -396,3 +545,65 @@ void main() {
     });
   });
 }
+
+MutableDocument _paragraphFullBoldThenParagraph() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 36,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphPartiallyBoldThenParagraph() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 16,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -183,6 +183,211 @@ void main() {
         });
       });
 
+      group("when a single node is selected", () {
+        testWidgetsOnAllPlatforms("toggles attribution throughout a node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure no attributions are applied to the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")! as TextNode;
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied to the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed from the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles attribution for partial node selection", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure no attributions are applied to the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied to the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first** node in a document.",
+            ),
+          );
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed from the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.",
+            ),
+          );
+        });
+
+        // toggles attribution for a partial text section within a fully attributed node
+        testWidgetsOnAllPlatforms("toggles attribution for a partially selected fully attributed node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _fullyBoldParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied to the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is removed for the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first** node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied throughout the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first**** node in a document.**",
+            ),
+          );
+        });
+        testWidgetsOnAllPlatforms("toggles a different attribution for fully attributed node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _fullyBoldParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+
+          // Toggle italic attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure italic attribution is applied to the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "***This is the first* node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for the selection.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: firstNode.atOffset(17),
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure bold attribution is applied throughout the node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**",
+            ),
+          );
+        });
+      });
+
       group("when multiple nodes are selected", () {
         testWidgetsOnAllPlatforms("toggles attribution across multiple nodes", (tester) async {
           await tester //
@@ -300,7 +505,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure bold attribution is applied to the first node.
+          // Ensure bold attribution is applied partially to the first node.
           expect(
             doc,
             equalsMarkdown(
@@ -342,6 +547,219 @@ void main() {
           );
         });
       });
+
+      testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed and partially attributed node",
+          (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              _paragraphFullyBoldThenParagraphPartiallyBold(),
+            )
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure bold attribution is applied partially to first node and
+        // fully to second node.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first** node in a document.\n\n**This is the second node in a document.**",
+          ),
+        );
+
+        final firstNode = doc.getNodeById("1")!;
+        final secondNode = doc.getNodeById("2")!;
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {boldAttribution},
+        );
+
+        // Ensure bold attribution is applied to both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {boldAttribution},
+        );
+
+        // Ensure bold attribution was removed from both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "This is the first node in a document.\n\nThis is the second node in a document.",
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms("toggles an attribution across multiple partially attributed node", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              _paragraphPartiallyBoldThenParagraphPartiallyBold(),
+            )
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure bold attribution is applied to the first node.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first** node in a document.\n\n**This is the second** node in a document.",
+          ),
+        );
+
+        final firstNode = doc.getNodeById("1")!;
+        final secondNode = doc.getNodeById("2")!;
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {boldAttribution},
+        );
+
+        // Ensure bold attribution is applied to both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {boldAttribution},
+        );
+
+        // Ensure bold attribution was removed from both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "This is the first node in a document.\n\nThis is the second node in a document.",
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms("toggles an attribution across multiple fully attributed node", (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              _paragraphFullBoldThenParagraphFullyBold(),
+            )
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure bold attribution is applied to both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+
+        final firstNode = doc.getNodeById("1")!;
+        final secondNode = doc.getNodeById("2")!;
+
+        // Toggle italic attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {italicsAttribution},
+        );
+
+        // Ensure the selection has both bold and italic attributions applied.
+        expect(
+          doc,
+          equalsMarkdown(
+            "***This is the first node in a document.***\n\n***This is the second node in a document.***",
+          ),
+        );
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.endDocumentPosition,
+          attributions: {italicsAttribution},
+        );
+
+        // Ensure bold attribution was removed from both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms("toggles an attribution for a partial selection across multiple fully attributed node",
+          (tester) async {
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              _paragraphFullBoldThenParagraphFullyBold(),
+            )
+            .pump();
+
+        final doc = SuperEditorInspector.findDocument()!;
+
+        // Ensure bold attribution is applied to the selection.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+
+        final firstNode = doc.getNodeById("1")!;
+        final secondNode = doc.getNodeById("2")!;
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.atOffset(18),
+          attributions: {italicsAttribution},
+        );
+
+        // Ensure the selection has both bold and italic attributions applied.
+        expect(
+          doc,
+          equalsMarkdown(
+            "***This is the first node in a document.***\n\n***This is the second* node in a document.**",
+          ),
+        );
+
+        // Toggle bold attribution for both nodes.
+        SuperEditorInspector.toggleAttributionsForDocumentSelection(
+          base: firstNode.beginningDocumentPosition,
+          extent: secondNode.atOffset(18),
+          attributions: {italicsAttribution},
+        );
+
+        // Ensure bold attribution was applied to both nodes.
+        expect(
+          doc,
+          equalsMarkdown(
+            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+          ),
+        );
+      });
+
+      // applies multiple attributions to multiple nodes
     });
 
     group("applies color attributions", () {
@@ -569,6 +987,30 @@ MutableDocument _paragraphDoc() => MutableDocument(
       ],
     );
 
+MutableDocument _fullyBoldParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+              "This is the first node in a document.",
+              AttributedSpans(
+                attributions: [
+                  const SpanMarker(
+                    attribution: boldAttribution,
+                    offset: 0,
+                    markerType: SpanMarkerType.start,
+                  ),
+                  const SpanMarker(
+                    attribution: boldAttribution,
+                    offset: 36,
+                    markerType: SpanMarkerType.end,
+                  ),
+                ],
+              )),
+        ),
+      ],
+    );
+
 MutableDocument _paragraphThenParagraphDoc() => MutableDocument(
       nodes: [
         ParagraphNode(
@@ -643,6 +1085,141 @@ MutableDocument _paragraphPartiallyBoldThenParagraph() => MutableDocument(
           id: "2",
           text: AttributedText(
             "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphFullyBoldThenParagraphPartiallyBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 16,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 37,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphPartiallyBoldThenParagraphPartiallyBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 16,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 17,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 36,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: boldAttribution,
+                  offset: 37,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -520,6 +520,10 @@ void main() {
           );
 
           // Ensure bold attribution is applied throughout both nodes.
+          //
+          // The toggled attribution already existed across the selection. In
+          // such cases, the attribution is applied throughout the selection without removing it from
+          // any of the node selections that already have it.
           expect(
             doc,
             equalsMarkdown(
@@ -573,6 +577,10 @@ void main() {
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
+          //
+          // The toggled attribution already existed across the selection.In
+          // such cases, the attribution is applied throughout the selection without removing it from
+          // any of the node selections that already have it.
           expect(
             doc,
             equalsMarkdown(
@@ -627,6 +635,10 @@ void main() {
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
+          //
+          // The toggled attribution already existed across the selection. In
+          // such cases, the attribution is applied throughout the selection without removing it from
+          // any of the node selections that already have it.
           expect(
             doc,
             equalsMarkdown(
@@ -679,6 +691,10 @@ void main() {
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
+          //
+          // The toggled attribution already existed across the selection. In
+          // such cases, the attribution is applied throughout the selection without removing it from
+          // any of the node selections that already have it.
           expect(
             doc,
             equalsMarkdown(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -224,7 +224,7 @@ void main() {
             attributions: {boldAttribution},
           );
 
-          // Ensure attribution was removed from the.
+          // Ensure attribution was removed from the selection.
           expect(
             doc,
             equalsMarkdown(
@@ -259,7 +259,7 @@ void main() {
             attributions: {boldAttribution},
           );
 
-          // Ensure attribution was applied.
+          // Ensure attribution was applied to the selection.
           expect(
             doc,
             equalsMarkdown(
@@ -273,7 +273,7 @@ void main() {
             attributions: {boldAttribution},
           );
 
-          // Ensure attribution was removed.
+          // Ensure attribution was removed from the selection.
           expect(
             doc,
             equalsMarkdown(
@@ -308,7 +308,7 @@ void main() {
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is removed.
+          // Ensure bold attribution is removed from the selection.
           expect(
             doc,
             equalsMarkdown(
@@ -340,6 +340,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
+          // Ensure bold attribution is present.
           expect(
             doc,
             equalsMarkdown(
@@ -349,7 +350,6 @@ void main() {
 
           final firstNode = doc.getNodeById("1")!;
 
-          // Toggle italic attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
@@ -364,7 +364,6 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
@@ -400,14 +399,13 @@ void main() {
 
           final firstNode = doc.getNodeById("1")!;
 
-          // Toggle attributions for the node.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.endDocumentPosition,
             attributions: {italicsAttribution, boldAttribution},
           );
 
-          // Ensure the attributions were applied.
+          // Ensure both bold and italic attributions were applied throughout the node.
           expect(
             doc,
             equalsMarkdown(
@@ -415,7 +413,6 @@ void main() {
             ),
           );
 
-          // Toggle attributions for the node.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.endDocumentPosition,
@@ -454,14 +451,13 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
           final secondNode = doc.getNodeById("2")!;
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is applied to both nodes.
+          // Ensure bold attribution is applied throughout both nodes.
           expect(
             doc,
             equalsMarkdown(
@@ -469,7 +465,6 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
@@ -496,7 +491,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure bold attribution is applied partially to the first node.
+          // Ensure bold attribution is applied throughout the first node.
           expect(
             doc,
             equalsMarkdown(
@@ -507,14 +502,13 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
           final secondNode = doc.getNodeById("2")!;
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is applied to both nodes.
+          // Ensure bold attribution is applied throughout both nodes.
           expect(
             doc,
             equalsMarkdown(
@@ -522,7 +516,6 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
@@ -560,14 +553,13 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
           final secondNode = doc.getNodeById("2")!;
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is applied to both nodes.
+          // Ensure bold attribution is applied throughout the both nodes.
           expect(
             doc,
             equalsMarkdown(
@@ -575,7 +567,6 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: secondNode.endDocumentPosition,
@@ -604,7 +595,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure bold attribution is applied partially to first node and
-        // fully to second node.
+        // throughout the second node.
         expect(
           doc,
           equalsMarkdown(
@@ -615,14 +606,13 @@ void main() {
         final firstNode = doc.getNodeById("1")!;
         final secondNode = doc.getNodeById("2")!;
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
           attributions: {boldAttribution},
         );
 
-        // Ensure bold attribution is applied to both nodes.
+        // Ensure bold attribution is applied throughout the both nodes.
         expect(
           doc,
           equalsMarkdown(
@@ -630,7 +620,6 @@ void main() {
           ),
         );
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
@@ -656,7 +645,7 @@ void main() {
 
         final doc = SuperEditorInspector.findDocument()!;
 
-        // Ensure bold attribution is applied to the first node.
+        // Ensure bold attribution is applied partially across both nodes.
         expect(
           doc,
           equalsMarkdown(
@@ -667,14 +656,13 @@ void main() {
         final firstNode = doc.getNodeById("1")!;
         final secondNode = doc.getNodeById("2")!;
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
           attributions: {boldAttribution},
         );
 
-        // Ensure bold attribution is applied to both nodes.
+        // Ensure bold attribution is applied throughout the both nodes.
         expect(
           doc,
           equalsMarkdown(
@@ -682,7 +670,6 @@ void main() {
           ),
         );
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
@@ -708,7 +695,7 @@ void main() {
 
         final doc = SuperEditorInspector.findDocument()!;
 
-        // Ensure bold attribution is applied to both nodes.
+        // Ensure bold attribution is applied throughout both nodes.
         expect(
           doc,
           equalsMarkdown(
@@ -719,14 +706,13 @@ void main() {
         final firstNode = doc.getNodeById("1")!;
         final secondNode = doc.getNodeById("2")!;
 
-        // Toggle italic attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
           attributions: {italicsAttribution},
         );
 
-        // Ensure the selection has both bold and italic attributions applied.
+        // Ensure both bold and italic attributions were applied throughout the selection.
         expect(
           doc,
           equalsMarkdown(
@@ -734,7 +720,6 @@ void main() {
           ),
         );
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
@@ -761,7 +746,7 @@ void main() {
 
         final doc = SuperEditorInspector.findDocument()!;
 
-        // Ensure bold attribution is applied to the selection.
+        // Ensure bold attribution is applied throughout the selection.
         expect(
           doc,
           equalsMarkdown(
@@ -772,14 +757,14 @@ void main() {
         final firstNode = doc.getNodeById("1")!;
         final secondNode = doc.getNodeById("2")!;
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.atOffset(18),
           attributions: {italicsAttribution},
         );
 
-        // Ensure the selection has both bold and italic attributions applied.
+        // Ensure both bold and italic attributions were applied throughout
+        // the selection.
         expect(
           doc,
           equalsMarkdown(
@@ -787,14 +772,14 @@ void main() {
           ),
         );
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.atOffset(18),
           attributions: {italicsAttribution},
         );
 
-        // Ensure bold attribution was applied to both nodes.
+        // Ensure italic attribution was removed from the selection while keeping the bold
+        // attribution.
         expect(
           doc,
           equalsMarkdown(
@@ -813,7 +798,7 @@ void main() {
 
         final doc = SuperEditorInspector.findDocument()!;
 
-        // Ensure no attributions are applied.
+        // Ensure no attributions are present.
         expect(
           doc,
           equalsMarkdown(
@@ -824,7 +809,6 @@ void main() {
         final firstNode = doc.getNodeById("1")!;
         final secondNode = doc.getNodeById("2")!;
 
-        // Toggle bold attribution for both nodes.
         SuperEditorInspector.toggleAttributionsForDocumentSelection(
           base: firstNode.beginningDocumentPosition,
           extent: secondNode.endDocumentPosition,
@@ -834,7 +818,7 @@ void main() {
           },
         );
 
-        // Ensure the selection has both bold and italic attributions applied.
+        // Ensure both bold and italic attributions were applied throughout the selection.
         expect(
           doc,
           equalsMarkdown(
@@ -849,7 +833,7 @@ void main() {
           attributions: {boldAttribution, italicsAttribution},
         );
 
-        // Ensure all attributions are removed from both nodes.
+        // Ensure both bold and italic attributions were removed from the selection.
         expect(
           doc,
           equalsMarkdown(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -334,6 +334,7 @@ void main() {
             ),
           );
         });
+
         testWidgetsOnAllPlatforms("toggles a different attribution for fully attributed node", (tester) async {
           await tester //
               .createDocument()

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -581,372 +581,372 @@ void main() {
             ),
           );
         });
-      });
 
-      testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed and partially attributed node",
-          (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              _paragraphFullyBoldThenParagraphPartiallyBold(),
-            )
-            .pump();
+        testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed and partially attributed node",
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphFullyBoldThenParagraphPartiallyBold(),
+              )
+              .pump();
 
-        final doc = SuperEditorInspector.findDocument()!;
+          final doc = SuperEditorInspector.findDocument()!;
 
-        // Ensure bold attribution is applied partially to first node and
-        // throughout the second node.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first** node in a document.\n\n**This is the second node in a document.**",
-          ),
-        );
-
-        final firstNode = doc.getNodeById("1")!;
-        final secondNode = doc.getNodeById("2")!;
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {boldAttribution},
-        );
-
-        // Ensure bold attribution is applied throughout the both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {boldAttribution},
-        );
-
-        // Ensure bold attribution was removed from both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "This is the first node in a document.\n\nThis is the second node in a document.",
-          ),
-        );
-      });
-
-      testWidgetsOnAllPlatforms("toggles an attribution across multiple partially attributed node", (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              _paragraphPartiallyBoldThenParagraphPartiallyBold(),
-            )
-            .pump();
-
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Ensure bold attribution is applied partially across both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first** node in a document.\n\n**This is the second** node in a document.",
-          ),
-        );
-
-        final firstNode = doc.getNodeById("1")!;
-        final secondNode = doc.getNodeById("2")!;
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {boldAttribution},
-        );
-
-        // Ensure bold attribution is applied throughout the both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {boldAttribution},
-        );
-
-        // Ensure bold attribution was removed from both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "This is the first node in a document.\n\nThis is the second node in a document.",
-          ),
-        );
-      });
-
-      testWidgetsOnAllPlatforms("toggles an attribution across multiple fully attributed node", (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              _paragraphFullBoldThenParagraphFullyBold(),
-            )
-            .pump();
-
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Ensure bold attribution is applied throughout both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-
-        final firstNode = doc.getNodeById("1")!;
-        final secondNode = doc.getNodeById("2")!;
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {italicsAttribution},
-        );
-
-        // Ensure both bold and italic attributions were applied throughout the selection.
-        expect(
-          doc,
-          equalsMarkdown(
-            "***This is the first node in a document.***\n\n***This is the second node in a document.***",
-          ),
-        );
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {italicsAttribution},
-        );
-
-        // Ensure bold attribution was removed from both nodes.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-      });
-
-      testWidgetsOnAllPlatforms("toggles an attribution for a partial selection across multiple fully attributed node",
-          (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              _paragraphFullBoldThenParagraphFullyBold(),
-            )
-            .pump();
-
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Ensure bold attribution is applied throughout the selection.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-
-        final firstNode = doc.getNodeById("1")!;
-        final secondNode = doc.getNodeById("2")!;
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.atOffset(18),
-          attributions: {italicsAttribution},
-        );
-
-        // Ensure both bold and italic attributions were applied throughout
-        // the selection.
-        expect(
-          doc,
-          equalsMarkdown(
-            "***This is the first node in a document.***\n\n***This is the second* node in a document.**",
-          ),
-        );
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.atOffset(18),
-          attributions: {italicsAttribution},
-        );
-
-        // Ensure italic attribution was removed from the selection while keeping the bold
-        // attribution.
-        expect(
-          doc,
-          equalsMarkdown(
-            "**This is the first node in a document.**\n\n**This is the second node in a document.**",
-          ),
-        );
-      });
-
-      testWidgetsOnAllPlatforms("toggles multiple attributions throughout multiple nodes", (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              _paragraphThenParagraphDoc(),
-            )
-            .pump();
-
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Ensure no attributions are present.
-        expect(
-          doc,
-          equalsMarkdown(
-            "This is the first node in a document.\n\nThis is the second node in a document.",
-          ),
-        );
-
-        final firstNode = doc.getNodeById("1")!;
-        final secondNode = doc.getNodeById("2")!;
-
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {
-            italicsAttribution,
-            boldAttribution,
-          },
-        );
-
-        // Ensure both bold and italic attributions were applied throughout the selection.
-        expect(
-          doc,
-          equalsMarkdown(
-            "***This is the first node in a document.***\n\n***This is the second node in a document.***",
-          ),
-        );
-
-        // Toggle bold attribution for both nodes.
-        SuperEditorInspector.toggleAttributionsForDocumentSelection(
-          base: firstNode.beginningDocumentPosition,
-          extent: secondNode.endDocumentPosition,
-          attributions: {boldAttribution, italicsAttribution},
-        );
-
-        // Ensure both bold and italic attributions were removed from the selection.
-        expect(
-          doc,
-          equalsMarkdown(
-            "This is the first node in a document.\n\nThis is the second node in a document.",
-          ),
-        );
-      });
-    });
-
-    group("applies color attributions", () {
-      testWidgetsOnAllPlatforms("to full text", (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              singleParagraphFullColor(),
-            )
-            .pump();
-
-        // Ensure the text is colored orange.
-        expect(
-          SuperEditorInspector.findRichTextInParagraph("1").style?.color,
-          Colors.orange,
-        );
-      });
-
-      testWidgetsOnAllPlatforms("to partial text", (tester) async {
-        await tester //
-            .createDocument()
-            .withCustomContent(
-              singleParagraphWithPartialColor(),
-            )
-            .pump();
-
-        // Ensure the first span is colored black.
-        expect(
-          SuperEditorInspector.findRichTextInParagraph("1")
-              .getSpanForPosition(const TextPosition(offset: 0))!
-              .style!
-              .color,
-          Colors.black,
-        );
-
-        // Ensure the second span is colored orange.
-        expect(
-          SuperEditorInspector.findRichTextInParagraph("1")
-              .getSpanForPosition(const TextPosition(offset: 5))!
-              .style!
-              .color,
-          Colors.orange,
-        );
-      });
-    });
-
-    group("doesn't apply attributions", () {
-      testWidgetsOnAllPlatforms("when typing before the start of the attributed text", (tester) async {
-        await tester //
-            .createDocument()
-            .fromMarkdown("A **bold** text")
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        final doc = SuperEditorInspector.findDocument()!;
-
-        // Place the caret at |bold.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 2);
-
-        // Type some letters.
-        await tester.typeImeText("very ");
-
-        // Ensure the bold attribution wasn't applied to the inserted text.
-        expect(doc, equalsMarkdown("A very **bold** text"));
-      });
-    });
-
-    group("doesn't clear attributions", () {
-      testWidgetsOnAllPlatforms("when changing the selection affinity", (tester) async {
-        final context = await tester //
-            .createDocument()
-            .fromMarkdown("This text should be")
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        final doc = context.findEditContext().document;
-        final composer = context.findEditContext().composer;
-
-        // Place the caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 19);
-
-        // Toggle the bold attribution.
-        composer.preferences.toggleStyle(boldAttribution);
-        await tester.pump();
-
-        // Ensure we have an upstream selection.
-        expect((composer.selection!.extent.nodePosition as TextNodePosition).affinity, TextAffinity.upstream);
-
-        // Simulate the IME sending us a selection at the same offset
-        // but with a different affinity.
-        await tester.ime.sendDeltas(
-          [
-            const TextEditingDeltaNonTextUpdate(
-              oldText: ". This text should be",
-              selection: TextSelection.collapsed(offset: 21, affinity: TextAffinity.downstream),
-              composing: TextRange.empty,
+          // Ensure bold attribution is applied partially to first node and
+          // throughout the second node.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first** node in a document.\n\n**This is the second node in a document.**",
             ),
-          ],
-          getter: imeClientGetter,
-        );
+          );
 
-        // Type text at the end of the paragraph.
-        await tester.typeImeText(" bold");
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
 
-        // Ensure the bold attribution is applied.
-        expect(doc, equalsMarkdown("This text should be** bold**"));
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied throughout the both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles an attribution across multiple partially attributed node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphPartiallyBoldThenParagraphPartiallyBold(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied partially across both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first** node in a document.\n\n**This is the second** node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied throughout the both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles an attribution across multiple fully attributed node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphFullBoldThenParagraphFullyBold(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied throughout both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure both bold and italic attributions were applied throughout the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "***This is the first node in a document.***\n\n***This is the second node in a document.***",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution for a partial selection across multiple fully attributed node", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphFullBoldThenParagraphFullyBold(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure bold attribution is applied throughout the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.atOffset(18),
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure both bold and italic attributions were applied throughout
+          // the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "***This is the first node in a document.***\n\n***This is the second* node in a document.**",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.atOffset(18),
+            attributions: {italicsAttribution},
+          );
+
+          // Ensure italic attribution was removed from the selection while keeping the bold
+          // attribution.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles multiple attributions throughout multiple nodes", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphThenParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure no attributions are present.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {
+              italicsAttribution,
+              boldAttribution,
+            },
+          );
+
+          // Ensure both bold and italic attributions were applied throughout the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "***This is the first node in a document.***\n\n***This is the second node in a document.***",
+            ),
+          );
+
+          // Toggle bold attribution for both nodes.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution, italicsAttribution},
+          );
+
+          // Ensure both bold and italic attributions were removed from the selection.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+      });
+
+      group("applies color attributions", () {
+        testWidgetsOnAllPlatforms("to full text", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                singleParagraphFullColor(),
+              )
+              .pump();
+
+          // Ensure the text is colored orange.
+          expect(
+            SuperEditorInspector.findRichTextInParagraph("1").style?.color,
+            Colors.orange,
+          );
+        });
+
+        testWidgetsOnAllPlatforms("to partial text", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                singleParagraphWithPartialColor(),
+              )
+              .pump();
+
+          // Ensure the first span is colored black.
+          expect(
+            SuperEditorInspector.findRichTextInParagraph("1")
+                .getSpanForPosition(const TextPosition(offset: 0))!
+                .style!
+                .color,
+            Colors.black,
+          );
+
+          // Ensure the second span is colored orange.
+          expect(
+            SuperEditorInspector.findRichTextInParagraph("1")
+                .getSpanForPosition(const TextPosition(offset: 5))!
+                .style!
+                .color,
+            Colors.orange,
+          );
+        });
+      });
+
+      group("doesn't apply attributions", () {
+        testWidgetsOnAllPlatforms("when typing before the start of the attributed text", (tester) async {
+          await tester //
+              .createDocument()
+              .fromMarkdown("A **bold** text")
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Place the caret at |bold.
+          await tester.placeCaretInParagraph(doc.nodes.first.id, 2);
+
+          // Type some letters.
+          await tester.typeImeText("very ");
+
+          // Ensure the bold attribution wasn't applied to the inserted text.
+          expect(doc, equalsMarkdown("A very **bold** text"));
+        });
+      });
+
+      group("doesn't clear attributions", () {
+        testWidgetsOnAllPlatforms("when changing the selection affinity", (tester) async {
+          final context = await tester //
+              .createDocument()
+              .fromMarkdown("This text should be")
+              .withInputSource(TextInputSource.ime)
+              .pump();
+
+          final doc = context.findEditContext().document;
+          final composer = context.findEditContext().composer;
+
+          // Place the caret at the end of the paragraph.
+          await tester.placeCaretInParagraph(doc.nodes.first.id, 19);
+
+          // Toggle the bold attribution.
+          composer.preferences.toggleStyle(boldAttribution);
+          await tester.pump();
+
+          // Ensure we have an upstream selection.
+          expect((composer.selection!.extent.nodePosition as TextNodePosition).affinity, TextAffinity.upstream);
+
+          // Simulate the IME sending us a selection at the same offset
+          // but with a different affinity.
+          await tester.ime.sendDeltas(
+            [
+              const TextEditingDeltaNonTextUpdate(
+                oldText: ". This text should be",
+                selection: TextSelection.collapsed(offset: 21, affinity: TextAffinity.downstream),
+                composing: TextRange.empty,
+              ),
+            ],
+            getter: imeClientGetter,
+          );
+
+          // Type text at the end of the paragraph.
+          await tester.typeImeText(" bold");
+
+          // Ensure the bold attribution is applied.
+          expect(doc, equalsMarkdown("This text should be** bold**"));
+        });
       });
     });
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -194,7 +194,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are applied to the node.
+          // Ensure no attributions are present.
           expect(
             doc,
             equalsMarkdown(
@@ -204,14 +204,13 @@ void main() {
 
           final firstNode = doc.getNodeById("1")! as TextNode;
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is applied to the selection.
+          // Ensure attribution was applied throughout the selection.
           expect(
             doc,
             equalsMarkdown(
@@ -219,14 +218,13 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution was removed from the selection.
+          // Ensure attribution was removed from the.
           expect(
             doc,
             equalsMarkdown(
@@ -245,7 +243,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are applied to the node.
+          // Ensure no attributions are present.
           expect(
             doc,
             equalsMarkdown(
@@ -255,14 +253,13 @@ void main() {
 
           final firstNode = doc.getNodeById("1")!;
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is applied to the selection.
+          // Ensure attribution was applied.
           expect(
             doc,
             equalsMarkdown(
@@ -270,14 +267,13 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution was removed from the selection.
+          // Ensure attribution was removed.
           expect(
             doc,
             equalsMarkdown(
@@ -296,7 +292,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure bold attribution is applied to the node.
+          // Ensure bold attribution is present.
           expect(
             doc,
             equalsMarkdown(
@@ -306,14 +302,13 @@ void main() {
 
           final firstNode = doc.getNodeById("1")!;
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
             attributions: {boldAttribution},
           );
 
-          // Ensure bold attribution is removed for the selection.
+          // Ensure bold attribution is removed.
           expect(
             doc,
             equalsMarkdown(
@@ -321,7 +316,6 @@ void main() {
             ),
           );
 
-          // Toggle bold attribution for the selection.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
             base: firstNode.beginningDocumentPosition,
             extent: firstNode.atOffset(17),
@@ -396,7 +390,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are applied.
+          // Ensure no attributions are present.
           expect(
             doc,
             equalsMarkdown(
@@ -449,7 +443,7 @@ void main() {
 
           final doc = SuperEditorInspector.findDocument()!;
 
-          // Ensure no attributions are applied.
+          // Ensure no attributions are present.
           expect(
             doc,
             equalsMarkdown(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -233,7 +233,7 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles attribution for partial node selection", (tester) async {
+        testWidgetsOnAllPlatforms("toggles attribution on a partial node selection", (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -282,7 +282,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles attribution for a partially selected fully attributed node", (tester) async {
+        testWidgetsOnAllPlatforms("toggles an attribution within a sub-range of an existing same attribution",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -335,7 +336,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles a different attribution for fully attributed node", (tester) async {
+        testWidgetsOnAllPlatforms("toggles a different attribution within a sub-range of another existing attribution",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -439,7 +441,7 @@ void main() {
       });
 
       group("when multiple nodes are selected", () {
-        testWidgetsOnAllPlatforms("toggles attribution across multiple nodes", (tester) async {
+        testWidgetsOnAllPlatforms("toggles attribution throughout multiple nodes", (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -489,8 +491,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed node and a plain node",
-            (tester) async {
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution across nodes with the attribution applied throughout first node", (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -546,7 +548,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution across a partially attributed node and a plain node",
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution across nodes with the attribution applied partially within first node",
             (tester) async {
           await tester //
               .createDocument()
@@ -603,7 +606,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed and partially attributed node",
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution across nodes with the attribution applied throughout and partially within first and second node respectively",
             (tester) async {
           await tester //
               .createDocument()
@@ -661,7 +665,9 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution across multiple partially attributed node", (tester) async {
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution across nodes with the attribution applied partially within all nodes",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -717,7 +723,9 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution across multiple fully attributed node", (tester) async {
+        testWidgetsOnAllPlatforms(
+            "toggles a different attribution across nodes with an existing attribution applied throughout them",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -772,7 +780,8 @@ void main() {
         });
 
         testWidgetsOnAllPlatforms(
-            "toggles an attribution for a partial selection across multiple fully attributed node", (tester) async {
+            "toggles a different attribution partially across nodes with an existing attribution applied throughout them",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -1073,21 +1073,13 @@ MutableDocument _fullyBoldParagraphDoc() => MutableDocument(
         ParagraphNode(
           id: "1",
           text: AttributedText(
-              "This is the first node in a document.",
-              AttributedSpans(
-                attributions: [
-                  const SpanMarker(
-                    attribution: boldAttribution,
-                    offset: 0,
-                    markerType: SpanMarkerType.start,
-                  ),
-                  const SpanMarker(
-                    attribution: boldAttribution,
-                    offset: 36,
-                    markerType: SpanMarkerType.end,
-                  ),
-                ],
-              )),
+            "This is the first node in a document.",
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 36,
+            ),
+          ),
         ),
       ],
     );
@@ -1115,19 +1107,10 @@ MutableDocument _paragraphFullBoldThenParagraph() => MutableDocument(
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 36,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 36,
             ),
           ),
         ),
@@ -1146,19 +1129,10 @@ MutableDocument _paragraphPartiallyBoldThenParagraph() => MutableDocument(
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 16,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 16,
             ),
           ),
         ),
@@ -1177,19 +1151,10 @@ MutableDocument _paragraphFullyBoldThenParagraphPartiallyBold() => MutableDocume
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 16,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 16,
             ),
           ),
         ),
@@ -1197,19 +1162,10 @@ MutableDocument _paragraphFullyBoldThenParagraphPartiallyBold() => MutableDocume
           id: "2",
           text: AttributedText(
             "This is the second node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 37,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 37,
             ),
           ),
         ),
@@ -1222,19 +1178,10 @@ MutableDocument _paragraphPartiallyBoldThenParagraphPartiallyBold() => MutableDo
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 16,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 16,
             ),
           ),
         ),
@@ -1242,19 +1189,10 @@ MutableDocument _paragraphPartiallyBoldThenParagraphPartiallyBold() => MutableDo
           id: "2",
           text: AttributedText(
             "This is the second node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 17,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 17,
             ),
           ),
         ),
@@ -1267,19 +1205,10 @@ MutableDocument _paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 36,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 36,
             ),
           ),
         ),
@@ -1287,19 +1216,10 @@ MutableDocument _paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
           id: "2",
           text: AttributedText(
             "This is the second node in a document.",
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: boldAttribution,
-                  offset: 37,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
+            _createAttributedSpansForAttribution(
+              attribution: boldAttribution,
+              startOffset: 0,
+              endOffset: 37,
             ),
           ),
         ),
@@ -1329,4 +1249,27 @@ extension _GetDocumentPosition on DocumentNode {
       ),
     );
   }
+}
+
+/// Creates an [AttributedSpans] for the [attribution] starting at [startOffset]
+/// and ending at [endOffset].
+AttributedSpans _createAttributedSpansForAttribution({
+  required NamedAttribution attribution,
+  required int startOffset,
+  required int endOffset,
+}) {
+  return AttributedSpans(
+    attributions: [
+      SpanMarker(
+        attribution: attribution,
+        offset: startOffset,
+        markerType: SpanMarkerType.start,
+      ),
+      SpanMarker(
+        attribution: attribution,
+        offset: endOffset,
+        markerType: SpanMarkerType.end,
+      ),
+    ],
+  );
 }

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -286,7 +286,6 @@ void main() {
           );
         });
 
-        // toggles attribution for a partial text section within a fully attributed node
         testWidgetsOnAllPlatforms("toggles attribution for a partially selected fully attributed node", (tester) async {
           await tester //
               .createDocument()

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -890,6 +890,114 @@ void main() {
             true,
           );
         });
+
+        testWidgetsOnAllPlatforms(
+            "toggles attribution for a selection going halfway from first node and halfway within second node",
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphThenParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final secondNode = doc.getNodeById("2")! as TextNode;
+
+          // Ensure markers are empty for both nodes.
+          expect(
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.atOffset(18),
+              extent: secondNode.atOffset(18),
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure bold attribution was applied.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first **node in a document.**\n\n**This is the second** node in a document.",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.atOffset(18),
+              extent: secondNode.atOffset(18),
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure markers are empty for both nodes.
+          expect(
+            firstNode.text.spans.markers.isEmpty && secondNode.text.spans.markers.isEmpty,
+            true,
+          );
+        });
+
+        testWidgetsOnAllPlatforms(
+            "toggles attribution for a selection going halfway in first node till the halfway into the third node",
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphThenParagraphThenParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          final firstNode = doc.getNodeById("1")! as TextNode;
+          final thirdNode = doc.getNodeById("3")! as TextNode;
+
+          // Ensure no attributions are present.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.\n\nThis is the third node in a document.",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.atOffset(18),
+              extent: thirdNode.atOffset(18),
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure bold attributions were applied.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first **node in a document.**\n\n**This is the second node in a document.**\n\n**This is the third **node in a document.",
+            ),
+          );
+
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.atOffset(18),
+              extent: thirdNode.atOffset(18),
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure no attributions are present.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.\n\nThis is the third node in a document.",
+            ),
+          );
+        });
       });
 
       group("applies color attributions", () {
@@ -1146,6 +1254,29 @@ MutableDocument _paragraphThenParagraphDoc() => MutableDocument(
           id: "2",
           text: AttributedText(
             "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphThenParagraphThenParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "3",
+          text: AttributedText(
+            "This is the third node in a document.",
           ),
         ),
       ],

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -505,6 +505,34 @@ void main() {
   });
 }
 
+MutableDocument _paragraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument _paragraphThenParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
 MutableDocument _paragraphFullBoldThenParagraph() => MutableDocument(
       nodes: [
         ParagraphNode(
@@ -566,3 +594,28 @@ MutableDocument _paragraphPartiallyBoldThenParagraph() => MutableDocument(
         ),
       ],
     );
+
+extension _GetDocumentPosition on DocumentNode {
+  DocumentPosition get beginningDocumentPosition {
+    return DocumentPosition(
+      nodeId: id,
+      nodePosition: beginningPosition,
+    );
+  }
+
+  DocumentPosition get endDocumentPosition {
+    return DocumentPosition(
+      nodeId: id,
+      nodePosition: endPosition,
+    );
+  }
+
+  DocumentPosition atOffset(int offset) {
+    return DocumentPosition(
+      nodeId: id,
+      nodePosition: TextNodePosition(
+        offset: offset,
+      ),
+    );
+  }
+}

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -184,7 +184,60 @@ void main() {
       });
 
       group("when multiple nodes are selected", () {
-        testWidgetsOnAllPlatforms("toggles bold attribution across fully bold node and a plain node", (tester) async {
+        testWidgetsOnAllPlatforms("toggles attribution across multiple nodes", (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                _paragraphThenParagraphDoc(),
+              )
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Ensure no attributions are applied.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+
+          final firstNode = doc.getNodeById("1")!;
+          final secondNode = doc.getNodeById("2")!;
+
+          // Toggle bold attribution for both nodes.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied to both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "**This is the first node in a document.**\n\n**This is the second node in a document.**",
+            ),
+          );
+
+          // Toggle bold attribution for both nodes.
+          SuperEditorInspector.toggleAttributionsForDocumentSelection(
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
+            attributions: {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed from both nodes.
+          expect(
+            doc,
+            equalsMarkdown(
+              "This is the first node in a document.\n\nThis is the second node in a document.",
+            ),
+          );
+        });
+
+        testWidgetsOnAllPlatforms("toggles an attribution across a fully attributed node and a plain node",
+            (tester) async {
           await tester //
               .createDocument()
               .withCustomContent(
@@ -207,8 +260,8 @@ void main() {
 
           // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            selectionBaseNode: firstNode,
-            selectionExtentNode: secondNode,
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
@@ -222,8 +275,8 @@ void main() {
 
           // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            selectionBaseNode: firstNode,
-            selectionExtentNode: secondNode,
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
@@ -236,7 +289,7 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles bold attribution across partially bold node and a plain node",
+        testWidgetsOnAllPlatforms("toggles an attribution across a partially attributed node and a plain node",
             (tester) async {
           await tester //
               .createDocument()
@@ -260,8 +313,8 @@ void main() {
 
           // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            selectionBaseNode: firstNode,
-            selectionExtentNode: secondNode,
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 
@@ -275,8 +328,8 @@ void main() {
 
           // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            selectionBaseNode: firstNode,
-            selectionExtentNode: secondNode,
+            base: firstNode.beginningDocumentPosition,
+            extent: secondNode.endDocumentPosition,
             attributions: {boldAttribution},
           );
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -205,9 +205,11 @@ void main() {
           final firstNode = doc.getNodeById("1")! as TextNode;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure attribution was applied throughout the selection.
@@ -219,9 +221,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure attribution was removed from the selection.
@@ -254,9 +258,11 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {boldAttribution},
           );
 
           // Ensure attribution was applied to the selection.
@@ -268,9 +274,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {boldAttribution},
           );
 
           // Ensure attribution was removed from the selection.
@@ -303,9 +311,11 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is removed from the selection.
@@ -317,9 +327,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout the node.
@@ -351,9 +363,11 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {italicsAttribution},
           );
 
           // Ensure italic attribution is applied to the selection.
@@ -365,9 +379,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.atOffset(17),
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.atOffset(17),
+            ),
+            {italicsAttribution},
           );
 
           // Ensure bold attribution is applied throughout the node.
@@ -400,9 +416,11 @@ void main() {
           final firstNode = doc.getNodeById("1")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.endDocumentPosition,
-            attributions: {italicsAttribution, boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.endDocumentPosition,
+            ),
+            {italicsAttribution, boldAttribution},
           );
 
           // Ensure both bold and italic attributions were applied throughout the node.
@@ -414,9 +432,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: firstNode.endDocumentPosition,
-            attributions: {boldAttribution, italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: firstNode.endDocumentPosition,
+            ),
+            {boldAttribution, italicsAttribution},
           );
 
           // Ensure all attributions are removed from the node.
@@ -452,9 +472,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout both nodes.
@@ -466,9 +488,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -503,9 +527,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout both nodes.
@@ -517,9 +543,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -554,9 +582,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
@@ -568,9 +598,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -606,9 +638,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
@@ -620,9 +654,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -656,9 +692,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution is applied throughout the both nodes.
@@ -670,9 +708,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -706,9 +746,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {italicsAttribution},
           );
 
           // Ensure both bold and italic attributions were applied throughout the selection.
@@ -720,9 +762,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {italicsAttribution},
           );
 
           // Ensure bold attribution was removed from both nodes.
@@ -757,9 +801,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.atOffset(18),
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.atOffset(18),
+            ),
+            {italicsAttribution},
           );
 
           // Ensure both bold and italic attributions were applied throughout
@@ -772,9 +818,11 @@ void main() {
           );
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.atOffset(18),
-            attributions: {italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.atOffset(18),
+            ),
+            {italicsAttribution},
           );
 
           // Ensure italic attribution was removed from the selection while keeping the bold
@@ -809,9 +857,11 @@ void main() {
           final secondNode = doc.getNodeById("2")!;
 
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {
               italicsAttribution,
               boldAttribution,
             },
@@ -827,9 +877,11 @@ void main() {
 
           // Toggle bold attribution for both nodes.
           SuperEditorInspector.toggleAttributionsForDocumentSelection(
-            base: firstNode.beginningDocumentPosition,
-            extent: secondNode.endDocumentPosition,
-            attributions: {boldAttribution, italicsAttribution},
+            DocumentSelection(
+              base: firstNode.beginningDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution, italicsAttribution},
           );
 
           // Ensure both bold and italic attributions were removed from the selection.

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -44,6 +44,57 @@ MutableDocument singleParagraphDoc() => MutableDocument(
       ],
     );
 
+MutableDocument singleParagraphDocShortText() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument twoParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument threeParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "3",
+          text: AttributedText(
+            "This is the third node in a document.",
+          ),
+        ),
+      ],
+    );
+
 MutableDocument singleParagraphWithLinkDoc() => MutableDocument(
       nodes: [
         ParagraphNode(
@@ -278,58 +329,7 @@ MutableDocument singleParagraphFullColor() => MutableDocument(
       ],
     );
 
-MutableDocument paragraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument paragraphThenParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument paragraphThenParagraphThenParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "3",
-          text: AttributedText(
-            "This is the third node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument fullyBoldParagraphDoc() => MutableDocument(
+MutableDocument singleParagraphDocAllBold() => MutableDocument(
       nodes: [
         ParagraphNode(
           id: "1",
@@ -352,7 +352,7 @@ MutableDocument fullyBoldParagraphDoc() => MutableDocument(
       ],
     );
 
-MutableDocument paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
+MutableDocument twoParagraphDocAllBold() => MutableDocument(
       nodes: [
         ParagraphNode(
           id: "1",

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -277,3 +277,118 @@ MutableDocument singleParagraphFullColor() => MutableDocument(
         )
       ],
     );
+
+MutableDocument paragraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument paragraphThenParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument paragraphThenParagraphThenParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "3",
+          text: AttributedText(
+            "This is the third node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument fullyBoldParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 36,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+      ],
+    );
+
+MutableDocument paragraphFullBoldThenParagraphFullyBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 36,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 37,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+      ],
+    );

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -25,13 +25,6 @@ MutableDocument hrThenParagraphDoc() => MutableDocument(
 
 MutableDocument singleParagraphEmptyDoc() => MutableDocument.empty("1");
 
-MutableDocument twoParagraphEmptyDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(id: "1", text: AttributedText()),
-        ParagraphNode(id: "2", text: AttributedText()),
-      ],
-    );
-
 MutableDocument singleParagraphDoc() => MutableDocument(
       nodes: [
         ParagraphNode(
@@ -50,46 +43,6 @@ MutableDocument singleParagraphDocShortText() => MutableDocument(
           id: "1",
           text: AttributedText(
             "This is the first node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument twoParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-      ],
-    );
-
-MutableDocument threeParagraphDoc() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-          ),
-        ),
-        ParagraphNode(
-          id: "3",
-          text: AttributedText(
-            "This is the third node in a document.",
           ),
         ),
       ],
@@ -122,6 +75,167 @@ MutableDocument singleParagraphWithLinkDoc() => MutableDocument(
 MutableDocument singleBlockDoc() => MutableDocument(
       nodes: [
         HorizontalRuleNode(id: "1"),
+      ],
+    );
+
+MutableDocument singleParagraphWithPartialColor() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: '1',
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 5,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+
+MutableDocument singleParagraphFullColor() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: '1',
+          text: AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 9,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+
+MutableDocument singleParagraphDocAllBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 36,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+      ],
+    );
+
+MutableDocument twoParagraphEmptyDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(id: "1", text: AttributedText()),
+        ParagraphNode(id: "2", text: AttributedText()),
+      ],
+    );
+
+MutableDocument twoParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+      ],
+    );
+
+MutableDocument twoParagraphDocAllBold() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 36,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+            AttributedSpans(attributions: [
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: boldAttribution,
+                offset: 37,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+        ),
+      ],
+    );
+
+MutableDocument threeParagraphDoc() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText(
+            "This is the first node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText(
+            "This is the second node in a document.",
+          ),
+        ),
+        ParagraphNode(
+          id: "3",
+          text: AttributedText(
+            "This is the third node in a document.",
+          ),
+        ),
       ],
     );
 
@@ -274,120 +388,6 @@ MutableDocument longDoc() => MutableDocument(
           id: "20",
           text: AttributedText(
             'Etiam id lacus interdum, efficitur ex convallis, accumsan ipsum. Integer faucibus mollis mauris, a suscipit ante mollis vitae. Fusce justo metus, congue non lectus ac, luctus rhoncus tellus. Phasellus vitae fermentum orci, sit amet sodales orci. Fusce at ante iaculis nunc aliquet pharetra. Nam placerat, nisl in gravida lacinia, nisl nibh feugiat nunc, in sagittis nisl sapien nec arcu. Nunc gravida faucibus massa, sit amet accumsan dolor feugiat in. Mauris ut elementum leo.',
-          ),
-        ),
-      ],
-    );
-
-MutableDocument singleParagraphWithPartialColor() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: '1',
-          text: AttributedText(
-            'abcdefghij',
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: ColorAttribution(Colors.orange),
-                  offset: 5,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: ColorAttribution(Colors.orange),
-                  offset: 9,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
-            ),
-          ),
-        )
-      ],
-    );
-
-MutableDocument singleParagraphFullColor() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: '1',
-          text: AttributedText(
-            'abcdefghij',
-            AttributedSpans(
-              attributions: [
-                const SpanMarker(
-                  attribution: ColorAttribution(Colors.orange),
-                  offset: 0,
-                  markerType: SpanMarkerType.start,
-                ),
-                const SpanMarker(
-                  attribution: ColorAttribution(Colors.orange),
-                  offset: 9,
-                  markerType: SpanMarkerType.end,
-                ),
-              ],
-            ),
-          ),
-        )
-      ],
-    );
-
-MutableDocument singleParagraphDocAllBold() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-            AttributedSpans(attributions: [
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 0,
-                markerType: SpanMarkerType.start,
-              ),
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 36,
-                markerType: SpanMarkerType.end,
-              ),
-            ]),
-          ),
-        ),
-      ],
-    );
-
-MutableDocument twoParagraphDocAllBold() => MutableDocument(
-      nodes: [
-        ParagraphNode(
-          id: "1",
-          text: AttributedText(
-            "This is the first node in a document.",
-            AttributedSpans(attributions: [
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 0,
-                markerType: SpanMarkerType.start,
-              ),
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 36,
-                markerType: SpanMarkerType.end,
-              ),
-            ]),
-          ),
-        ),
-        ParagraphNode(
-          id: "2",
-          text: AttributedText(
-            "This is the second node in a document.",
-            AttributedSpans(attributions: [
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 0,
-                markerType: SpanMarkerType.start,
-              ),
-              const SpanMarker(
-                attribution: boldAttribution,
-                offset: 37,
-                markerType: SpanMarkerType.end,
-              ),
-            ]),
           ),
         ),
       ],


### PR DESCRIPTION
[SuperEditor][SuperReader] Fix setting attributions across multiple nodes (Resolves #1865)

### **Issue:** 

Toggling attributions across multiple nodes selection where one node has the attribution applied already and other doesn't results in a behaviour where the attribution would be toggled off for the node that already had it and toggled on for node that didn't had that attribution. 

https://private-user-images.githubusercontent.com/31278849/308606392-dcf43a36-9ad1-498c-82b0-787df49d9641.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDk3NDMyMDMsIm5iZiI6MTcwOTc0MjkwMywicGF0aCI6Ii8zMTI3ODg0OS8zMDg2MDYzOTItZGNmNDNhMzYtOWFkMS00OThjLTgyYjAtNzg3ZGY0OWQ5NjQxLm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAzMDYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMzA2VDE2MzUwM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWMxY2M3NjJiNTI0ZGVhZGVlODM5ZDY2ODg4YzhkOTUyZGRjZTdmMjc1YjA5YTg2MzI4YmM0ZDkzMTIzNjBhZTMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.dxpZ5L3oGi-qL4cXVqxCGvYyKCbj85b2CBEAV6G0vNw

### **Solution:**

`ToggleTextAttributionsCommand` attribution toggling mechanism doesn't seem to be considering the scenario presented in the issue when we want to apply an attribution across multiple nodes and some of those nodes already having that attribution turned on. 

This PR updates `ToggleTextAttributionsCommand` toggling mechanism to check for two things when deciding to toggle an incoming attribution on a node. 

1. Is the attribution already applied throughout the entire node.
2. Are the number of nodes having all of the incoming attributions applied to at least one of their characters, match the number of selected nodes.

Based on this checks, we validate when to toggle an attribution for the node or not. 

Toggles attribution for an node if: 

1. If a node has the attribution applied partially.
2. If all nodes have all of the incoming attributions applied already to any of their characters.

Avoid toggling attribution for an node if: 

1. If a node already has the attribution applied throughout it and all of the nodes have all of the incoming attributions applied to any of their characters.

**With this change:** 

You can see when toggling attributions across two nodes, with one of the nodes either having bold attribution partially or fully, toggles bold attribution across both nodes as expected.

https://github.com/superlistapp/super_editor/assets/65209850/b1f10d59-264e-4888-bf20-f5cef7a412ef


