### PR TITLE
Undo/Redo (with snapshots + one-way commands)

### DIFF
--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -298,7 +298,7 @@ class ConvertSelectedTextNodeRequest implements EditRequest {
   int get hashCode => newType.hashCode;
 }
 
-class ConvertSelectedTextNodeCommand implements EditCommand {
+class ConvertSelectedTextNodeCommand extends EditCommand {
   ConvertSelectedTextNodeCommand(this.newType);
 
   final TextNodeType newType;

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -381,6 +381,8 @@ abstract class DocumentNode implements ChangeNotifier {
   /// Returns a copy of this node's metadata.
   Map<String, dynamic> copyMetadata() => Map.from(_metadata);
 
+  DocumentNode copy();
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -25,10 +25,13 @@ class DocumentLayoutEditable implements Editable {
   DocumentLayout get documentLayout => _documentLayoutResolver();
 
   @override
+  void onTransactionStart() {}
+
+  @override
   void onTransactionEnd(List<EditEvent> edits) {}
 
   @override
-  void onTransactionStart() {}
+  void reset() {}
 }
 
 /// Abstract representation of a document layout.

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -246,6 +246,9 @@ class ConvertBlockquoteToParagraphCommand implements EditCommand {
   final String nodeId;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId);
@@ -334,6 +337,9 @@ class SplitBlockquoteCommand implements EditCommand {
   final String nodeId;
   final TextPosition splitPosition;
   final String newNodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -316,6 +316,9 @@ class DeleteUpstreamAtBeginningOfBlockNodeCommand implements EditCommand {
   final DocumentNode node;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2258,6 +2258,9 @@ class PasteEditorCommand implements EditCommand {
   final DocumentComposer _composer;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final currentNodeWithSelection = document.getNodeById(_pastePosition.nodeId);
@@ -2418,6 +2421,9 @@ class DeleteUpstreamCharacterCommand implements EditCommand {
   const DeleteUpstreamCharacterCommand();
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
@@ -2467,6 +2473,9 @@ class DeleteDownstreamCharacterRequest implements EditRequest {
 
 class DeleteDownstreamCharacterCommand implements EditCommand {
   const DeleteDownstreamCharacterCommand();
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -70,6 +70,10 @@ class TextDeltasDocumentEditor {
       composing: _serializedDoc.documentToImeRange(_serializedDoc.composingRegion),
     );
 
+    // Start an editor transaction so that all changes made during this delta
+    // application is considered a single undo-able change.
+    editor.startTransaction();
+
     for (final delta in textEditingDeltas) {
       editorImeLog.info("---------------------------------------------------");
 
@@ -106,6 +110,9 @@ class TextDeltasDocumentEditor {
       ]);
     }
     editorImeLog.fine("Document composing region: ${composingRegion.value}");
+
+    // End the editor transaction for all deltas in this call.
+    editor.endTransaction();
 
     _nextImeValue = null;
   }

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -33,6 +33,11 @@ class HorizontalRuleNode extends BlockNode with ChangeNotifier {
   }
 
   @override
+  HorizontalRuleNode copy() {
+    return HorizontalRuleNode(id: id);
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) || other is HorizontalRuleNode && runtimeType == other.runtimeType && id == other.id;
 

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -82,6 +82,17 @@ class ImageNode extends BlockNode with ChangeNotifier {
   }
 
   @override
+  ImageNode copy() {
+    return ImageNode(
+      id: id,
+      imageUrl: imageUrl,
+      expectedBitmapSize: expectedBitmapSize,
+      altText: altText,
+      metadata: Map.from(metadata),
+    );
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ImageNode &&

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -82,6 +82,17 @@ class ListItemNode extends TextNode {
   }
 
   @override
+  ListItemNode copy() {
+    return ListItemNode(
+      id: id,
+      text: text.copyText(0),
+      itemType: type,
+      indent: indent,
+      metadata: Map.from(metadata),
+    );
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       super == other &&
@@ -522,6 +533,9 @@ class IndentListItemCommand implements EditCommand {
   final String nodeId;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId);
@@ -555,6 +569,9 @@ class UnIndentListItemCommand implements EditCommand {
   });
 
   final String nodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -601,6 +618,9 @@ class ConvertListItemToParagraphCommand implements EditCommand {
   final Map<String, dynamic>? paragraphMetadata;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId);
@@ -645,6 +665,9 @@ class ConvertParagraphToListItemCommand implements EditCommand {
   final ListItemType type;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId);
@@ -683,6 +706,9 @@ class ChangeListItemTypeCommand implements EditCommand {
 
   final String nodeId;
   final ListItemType newType;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -726,6 +752,9 @@ class SplitListItemCommand implements EditCommand {
   final String nodeId;
   final TextPosition splitPosition;
   final String newNodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -39,6 +39,9 @@ class PasteStructuredContentEditorCommand implements EditCommand {
   final DocumentPosition _pastePosition;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     if (_content.isEmpty) {
       // Nothing to paste. Return.
@@ -608,6 +611,9 @@ class ReplaceNodeWithEmptyParagraphWithCaretCommand implements EditCommand {
   final String nodeId;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
 
@@ -659,6 +665,9 @@ class DeleteContentCommand implements EditCommand {
   });
 
   final DocumentRange documentRange;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -1036,6 +1045,9 @@ class DeleteNodeCommand implements EditCommand {
   });
 
   final String nodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -33,6 +33,11 @@ class ParagraphNode extends TextNode {
       putMetadataValue("blockType", paragraphAttribution);
     }
   }
+
+  @override
+  ParagraphNode copy() {
+    return ParagraphNode(id: id, text: text.copyText(0), metadata: Map.from(metadata));
+  }
 }
 
 class ParagraphComponentBuilder implements ComponentBuilder {
@@ -231,6 +236,9 @@ class ChangeParagraphAlignmentCommand implements EditCommand {
   final TextAlign alignment;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
 
@@ -294,6 +302,9 @@ class ChangeParagraphBlockTypeCommand implements EditCommand {
   final Attribution? blockType;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
 
@@ -335,6 +346,9 @@ class CombineParagraphsCommand implements EditCommand {
 
   final String firstNodeId;
   final String secondNodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -445,6 +459,9 @@ class SplitParagraphCommand implements EditCommand {
   final bool replicateExistingMetadata;
   // TODO: remove the attribution filter and move the decision to an EditReaction in #1296
   final AttributionFilter attributionsToExtendToNewParagraph;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -562,6 +579,9 @@ class DeleteUpstreamAtBeginningOfParagraphCommand implements EditCommand {
   DeleteUpstreamAtBeginningOfParagraphCommand(this.node);
 
   final DocumentNode node;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -770,6 +790,9 @@ class DeleteParagraphCommand implements EditCommand {
   });
 
   final String nodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -32,6 +32,7 @@ import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
 import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/infrastructure/signal_notifier.dart';
 import 'package:super_editor/src/infrastructure/text_input.dart';
+import 'package:super_editor/src/undo_redo.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../infrastructure/document_gestures_interaction_overrides.dart';
@@ -1177,6 +1178,8 @@ final defaultKeyboardActions = <DocumentKeyboardAction>[
   pasteWhenCmdVIsPressed,
   copyWhenCmdCIsPressed,
   cutWhenCmdXIsPressed,
+  undoWhenCmdZOrCtrlZIsPressed,
+  redoWhenCmdShiftZOrCtrlShiftZIsPressed,
   collapseSelectionWhenEscIsPressed,
   selectAllWhenCmdAIsPressed,
   moveLeftAndRightWithArrowKeys,
@@ -1218,6 +1221,8 @@ final defaultImeKeyboardActions = <DocumentKeyboardAction>[
   pasteWhenCmdVIsPressed,
   copyWhenCmdCIsPressed,
   cutWhenCmdXIsPressed,
+  undoWhenCmdZOrCtrlZIsPressed,
+  redoWhenCmdShiftZOrCtrlShiftZIsPressed,
   selectAllWhenCmdAIsPressed,
   cmdBToToggleBold,
   cmdIToToggleItalics,

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -47,6 +47,16 @@ class TaskNode extends TextNode {
   }
 
   @override
+  TaskNode copy() {
+    return TaskNode(
+      id: id,
+      text: text.copyText(0),
+      metadata: Map.from(metadata),
+      isComplete: isComplete,
+    );
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       super == other && other is TaskNode && runtimeType == other.runtimeType && isComplete == other.isComplete;
@@ -383,6 +393,9 @@ class ChangeTaskCompletionCommand implements EditCommand {
   final bool isComplete;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final taskNode = context.find<MutableDocument>(Editor.documentKey).getNodeById(nodeId);
     if (taskNode is! TaskNode) {
@@ -430,6 +443,9 @@ class ConvertParagraphToTaskCommand implements EditCommand {
   final bool isComplete;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final existingNode = document.getNodeById(nodeId);
@@ -459,6 +475,9 @@ class ConvertTaskToParagraphCommand implements EditCommand {
 
   final String nodeId;
   final Map<String, dynamic>? paragraphMetadata;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -505,6 +524,9 @@ class SplitExistingTaskCommand implements EditCommand {
   final String nodeId;
   final int splitOffset;
   final String? newNodeId;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext editContext, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -165,6 +165,11 @@ class TextNode extends DocumentNode with ChangeNotifier {
   }
 
   @override
+  TextNode copy() {
+    return TextNode(id: id, text: text.copyText(0), metadata: Map.from(metadata));
+  }
+
+  @override
   String toString() => '[TextNode] - text: $text, metadata: ${copyMetadata()}';
 
   @override
@@ -1198,6 +1203,9 @@ class AddTextAttributionsCommand implements EditCommand {
   final bool autoMerge;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing AddTextAttributionsCommand');
     final document = context.find<MutableDocument>(Editor.documentKey);
@@ -1307,6 +1315,9 @@ class RemoveTextAttributionsCommand implements EditCommand {
 
   final DocumentRange documentRange;
   final Set<Attribution> attributions;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -1421,6 +1432,9 @@ class ToggleTextAttributionsCommand implements EditCommand {
 
   final DocumentRange documentRange;
   final Set<Attribution> attributions;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   // TODO: The structure of this command looks nearly identical to the two other attribution
   // commands above. We collect nodes and then we loop through them to apply an operation.
@@ -1545,6 +1559,9 @@ class ChangeSingleColumnLayoutComponentStylesCommand implements EditCommand {
   final SingleColumnLayoutComponentStyles styles;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final node = document.getNodeById(nodeId)!;
@@ -1583,6 +1600,9 @@ class InsertTextCommand implements EditCommand {
   final Set<Attribution> attributions;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
 
@@ -1592,6 +1612,8 @@ class InsertTextCommand implements EditCommand {
       return;
     }
 
+    print("Inserting text: '$textToInsert'");
+
     final textPosition = documentPosition.nodePosition as TextPosition;
     final textOffset = textPosition.offset;
     textNode.text = textNode.text.insertString(
@@ -1599,6 +1621,7 @@ class InsertTextCommand implements EditCommand {
       startOffset: textOffset,
       applyAttributions: attributions,
     );
+    print("Updated node text: '${textNode.text}'");
 
     executor.logChanges([
       DocumentEdit(
@@ -1733,6 +1756,9 @@ class InsertAttributedTextCommand implements EditCommand {
 
   final DocumentPosition documentPosition;
   final AttributedText textToInsert;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -114,6 +114,9 @@ class SubmitComposingActionTagRequest implements EditRequest {
 
 class SubmitComposingActionTagCommand implements EditCommand {
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
@@ -187,6 +190,9 @@ class CancelComposingActionTagCommand implements EditCommand {
   const CancelComposingActionTagCommand(this._tagRule);
 
   final TagRule _tagRule;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
@@ -173,6 +173,11 @@ class PatternTagIndex with ChangeNotifier implements Editable {
       notifyListeners();
     }
   }
+
+  @override
+  void reset() {
+    _tags.clear();
+  }
 }
 
 /// An [EditReaction] that creates, updates, and removes pattern tags.

--- a/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
@@ -172,6 +172,9 @@ class FillInComposingUserTagCommand implements EditCommand {
   final TagRule _tagRule;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
@@ -282,6 +285,9 @@ class CancelComposingStableTagCommand implements EditCommand {
   const CancelComposingStableTagCommand(this._tagRule);
 
   final TagRule _tagRule;
+
+  @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
@@ -1075,6 +1081,13 @@ class StableTagIndex with ChangeNotifier implements Editable {
       _didChange = false;
       notifyListeners();
     }
+  }
+
+  @override
+  void reset() {
+    _composingStableTag.value = null;
+    _committedTags.clear();
+    _cancelledTags.clear();
   }
 }
 

--- a/super_editor/lib/src/undo_redo.dart
+++ b/super_editor/lib/src/undo_redo.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/services.dart';
+import 'package:super_editor/src/core/edit_context.dart';
+import 'package:super_editor/src/infrastructure/keyboard.dart';
+
+/// Undoes the most recent change within the [Editor].
+ExecutionInstruction undoWhenCmdZOrCtrlZIsPressed({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (keyEvent.logicalKey != LogicalKeyboardKey.keyZ ||
+      !keyEvent.isPrimaryShortcutKeyPressed ||
+      HardwareKeyboard.instance.isShiftPressed) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  editContext.editor.undo();
+
+  return ExecutionInstruction.haltExecution;
+}
+
+/// Re-runs the most recently undone change within the [Editor].
+ExecutionInstruction redoWhenCmdShiftZOrCtrlShiftZIsPressed({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (keyEvent.logicalKey != LogicalKeyboardKey.keyZ ||
+      !keyEvent.isPrimaryShortcutKeyPressed ||
+      !HardwareKeyboard.instance.isShiftPressed) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  editContext.editor.redo();
+
+  return ExecutionInstruction.haltExecution;
+}

--- a/super_editor/test/super_editor/infrastructure/editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/editor_test.dart
@@ -696,6 +696,9 @@ class _ExpandingCommand implements EditCommand {
   final _ExpandingCommandRequest request;
 
   @override
+  HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
+
+  @override
   void execute(EditContext context, CommandExecutor executor) {
     final document = context.find<MutableDocument>(Editor.documentKey);
     final paragraph = document.getNodeAt(0) as ParagraphNode;

--- a/super_editor/test/super_editor/super_editor_undo_redo_test.dart
+++ b/super_editor/test/super_editor/super_editor_undo_redo_test.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group("Super Editor > undo redo >", () {
+    testWidgets("insert a word", (widgetTester) async {
+      final document = deserializeMarkdownToDocument("Hello  world");
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+      final paragraphId = document.nodes.first.id;
+
+      editor.execute([
+        ChangeSelectionRequest(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: paragraphId,
+              nodePosition: const TextNodePosition(offset: 6),
+            ),
+          ),
+          SelectionChangeType.placeCaret,
+          SelectionReason.userInteraction,
+        )
+      ]);
+
+      editor.execute([
+        InsertTextRequest(
+          documentPosition: DocumentPosition(
+            nodeId: paragraphId,
+            nodePosition: const TextNodePosition(offset: 6),
+          ),
+          textToInsert: "another",
+          attributions: {},
+        ),
+      ]);
+
+      expect(serializeDocumentToMarkdown(document), "Hello another world");
+      expect(
+        composer.selection,
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: paragraphId,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+
+      // Undo the event.
+      editor.undo();
+
+      expect(serializeDocumentToMarkdown(document), "Hello  world");
+      expect(
+        composer.selection,
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: paragraphId,
+            nodePosition: const TextNodePosition(offset: 6),
+          ),
+        ),
+      );
+
+      // Redo the event.
+      editor.redo();
+
+      expect(serializeDocumentToMarkdown(document), "Hello another world");
+      expect(
+        composer.selection,
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: paragraphId,
+            nodePosition: const TextNodePosition(offset: 13),
+          ),
+        ),
+      );
+    });
+
+    testWidgetsOnMac("type by character", (widgetTester) async {
+      final editContext = await widgetTester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+      final editor = editContext.editor;
+
+      await widgetTester.placeCaretInParagraph("1", 0);
+
+      // Type characters.
+      await widgetTester.typeImeText("Hello");
+      // editor.execute([
+      //   InsertTextRequest(
+      //     documentPosition: const DocumentPosition(
+      //       nodeId: "1",
+      //       nodePosition: TextNodePosition(offset: 0),
+      //     ),
+      //     textToInsert: "H",
+      //     attributions: {},
+      //   ),
+      // ]);
+      // await widgetTester.pump();
+
+      // editor.execute([
+      //   InsertTextRequest(
+      //     documentPosition: const DocumentPosition(
+      //       nodeId: "1",
+      //       nodePosition: TextNodePosition(offset: 1),
+      //     ),
+      //     textToInsert: "e",
+      //     attributions: {},
+      //   ),
+      // ]);
+      // await widgetTester.pump();
+      //
+      // editor.execute([
+      //   InsertTextRequest(
+      //     documentPosition: const DocumentPosition(
+      //       nodeId: "1",
+      //       nodePosition: TextNodePosition(offset: 2),
+      //     ),
+      //     textToInsert: "l",
+      //     attributions: {},
+      //   ),
+      // ]);
+      // await widgetTester.pump();
+      //
+      // editor.execute([
+      //   InsertTextRequest(
+      //     documentPosition: const DocumentPosition(
+      //       nodeId: "1",
+      //       nodePosition: TextNodePosition(offset: 3),
+      //     ),
+      //     textToInsert: "l",
+      //     attributions: {},
+      //   ),
+      // ]);
+      // await widgetTester.pump();
+      //
+      // editor.execute([
+      //   InsertTextRequest(
+      //     documentPosition: const DocumentPosition(
+      //       nodeId: "1",
+      //       nodePosition: TextNodePosition(offset: 4),
+      //     ),
+      //     textToInsert: "o",
+      //     attributions: {},
+      //   ),
+      // ]);
+      // await widgetTester.pump();
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hello");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 5),
+          ),
+        ),
+      );
+
+      print("------ STARTING UNDOS --------");
+
+      // Undo the event.
+      await widgetTester.pressCmdZ(); // Undo composing region.
+      await widgetTester.pressCmdZ(); // Undo text.
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hell");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 4),
+          ),
+        ),
+      );
+
+      await widgetTester.pressCmdZ(); // Undo composing region.
+      await widgetTester.pressCmdZ(); // Undo text.
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "Hel");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 3),
+          ),
+        ),
+      );
+
+      await widgetTester.pressCmdZ(); // Undo composing region.
+      await widgetTester.pressCmdZ(); // Undo text.
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "He");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 2),
+          ),
+        ),
+      );
+
+      await widgetTester.pressCmdZ(); // Undo composing region.
+      await widgetTester.pressCmdZ(); // Undo text.
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "H");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 1),
+          ),
+        ),
+      );
+
+      await widgetTester.pressCmdZ(); // Undo composing region.
+      await widgetTester.pressCmdZ(); // Undo text.
+
+      expect(SuperEditorInspector.findTextInComponent("1").text, "");
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+        ),
+      );
+
+      print("---------- STARTING REDOS -----------");
+
+      await widgetTester.pressCmdShiftZ(); // Insert text
+      await widgetTester.pressCmdShiftZ(); // Change composing region
+      _expectDocumentWithCaret("H", "1", 1);
+      print("--------");
+
+      await widgetTester.pressCmdShiftZ(); // Insert text
+      await widgetTester.pressCmdShiftZ(); // Change composing region
+      _expectDocumentWithCaret("He", "1", 2);
+      print("--------");
+
+      await widgetTester.pressCmdShiftZ(); // Insert text
+      await widgetTester.pressCmdShiftZ(); // Change composing region
+      _expectDocumentWithCaret("Hel", "1", 3);
+      print("--------");
+
+      await widgetTester.pressCmdShiftZ(); // Insert text
+      await widgetTester.pressCmdShiftZ(); // Change composing region
+      _expectDocumentWithCaret("Hell", "1", 4);
+
+      await widgetTester.pressCmdShiftZ(); // Insert text
+      await widgetTester.pressCmdShiftZ(); // Change composing region
+      _expectDocumentWithCaret("Hello", "1", 5);
+    });
+  });
+}
+
+void _expectDocumentWithCaret(String documentContent, String caretNodeId, int caretOffset) {
+  expect(serializeDocumentToMarkdown(SuperEditorInspector.findDocument()!), documentContent);
+  expect(
+    SuperEditorInspector.findDocumentSelection(),
+    DocumentSelection.collapsed(
+      position: DocumentPosition(
+        nodeId: caretNodeId,
+        nodePosition: TextNodePosition(offset: caretOffset),
+      ),
+    ),
+  );
+}
+
+extension on WidgetTester {
+  Future<void> pressCmdZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await sendKeyEvent(LogicalKeyboardKey.keyZ);
+    await sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+    await pump();
+  }
+
+  Future<void> pressCmdShiftZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+
+    await sendKeyEvent(LogicalKeyboardKey.keyZ);
+
+    await sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+    await pump();
+  }
+
+  Future<void> pressCtrlZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await sendKeyEvent(LogicalKeyboardKey.keyZ);
+    await sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    await pump();
+  }
+
+  Future<void> pressCtrlShiftZ() async {
+    await sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+
+    await sendKeyEvent(LogicalKeyboardKey.keyZ);
+
+    await sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    await pump();
+  }
+}

--- a/super_editor/test/super_editor/super_editor_undo_redo_test.dart
+++ b/super_editor/test/super_editor/super_editor_undo_redo_test.dart
@@ -80,75 +80,15 @@ void main() {
     });
 
     testWidgetsOnMac("type by character", (widgetTester) async {
-      final editContext = await widgetTester //
+      await widgetTester //
           .createDocument()
           .withSingleEmptyParagraph()
           .pump();
-      final editor = editContext.editor;
 
       await widgetTester.placeCaretInParagraph("1", 0);
 
       // Type characters.
       await widgetTester.typeImeText("Hello");
-      // editor.execute([
-      //   InsertTextRequest(
-      //     documentPosition: const DocumentPosition(
-      //       nodeId: "1",
-      //       nodePosition: TextNodePosition(offset: 0),
-      //     ),
-      //     textToInsert: "H",
-      //     attributions: {},
-      //   ),
-      // ]);
-      // await widgetTester.pump();
-
-      // editor.execute([
-      //   InsertTextRequest(
-      //     documentPosition: const DocumentPosition(
-      //       nodeId: "1",
-      //       nodePosition: TextNodePosition(offset: 1),
-      //     ),
-      //     textToInsert: "e",
-      //     attributions: {},
-      //   ),
-      // ]);
-      // await widgetTester.pump();
-      //
-      // editor.execute([
-      //   InsertTextRequest(
-      //     documentPosition: const DocumentPosition(
-      //       nodeId: "1",
-      //       nodePosition: TextNodePosition(offset: 2),
-      //     ),
-      //     textToInsert: "l",
-      //     attributions: {},
-      //   ),
-      // ]);
-      // await widgetTester.pump();
-      //
-      // editor.execute([
-      //   InsertTextRequest(
-      //     documentPosition: const DocumentPosition(
-      //       nodeId: "1",
-      //       nodePosition: TextNodePosition(offset: 3),
-      //     ),
-      //     textToInsert: "l",
-      //     attributions: {},
-      //   ),
-      // ]);
-      // await widgetTester.pump();
-      //
-      // editor.execute([
-      //   InsertTextRequest(
-      //     documentPosition: const DocumentPosition(
-      //       nodeId: "1",
-      //       nodePosition: TextNodePosition(offset: 4),
-      //     ),
-      //     textToInsert: "o",
-      //     attributions: {},
-      //   ),
-      // ]);
-      // await widgetTester.pump();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "Hello");
       expect(
@@ -164,8 +104,7 @@ void main() {
       print("------ STARTING UNDOS --------");
 
       // Undo the event.
-      await widgetTester.pressCmdZ(); // Undo composing region.
-      await widgetTester.pressCmdZ(); // Undo text.
+      await widgetTester.pressCmdZ();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "Hell");
       expect(
@@ -178,8 +117,7 @@ void main() {
         ),
       );
 
-      await widgetTester.pressCmdZ(); // Undo composing region.
-      await widgetTester.pressCmdZ(); // Undo text.
+      await widgetTester.pressCmdZ();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "Hel");
       expect(
@@ -192,8 +130,7 @@ void main() {
         ),
       );
 
-      await widgetTester.pressCmdZ(); // Undo composing region.
-      await widgetTester.pressCmdZ(); // Undo text.
+      await widgetTester.pressCmdZ();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "He");
       expect(
@@ -206,8 +143,7 @@ void main() {
         ),
       );
 
-      await widgetTester.pressCmdZ(); // Undo composing region.
-      await widgetTester.pressCmdZ(); // Undo text.
+      await widgetTester.pressCmdZ();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "H");
       expect(
@@ -220,8 +156,7 @@ void main() {
         ),
       );
 
-      await widgetTester.pressCmdZ(); // Undo composing region.
-      await widgetTester.pressCmdZ(); // Undo text.
+      await widgetTester.pressCmdZ();
 
       expect(SuperEditorInspector.findTextInComponent("1").text, "");
       expect(
@@ -236,27 +171,22 @@ void main() {
 
       print("---------- STARTING REDOS -----------");
 
-      await widgetTester.pressCmdShiftZ(); // Insert text
-      await widgetTester.pressCmdShiftZ(); // Change composing region
+      await widgetTester.pressCmdShiftZ();
       _expectDocumentWithCaret("H", "1", 1);
       print("--------");
 
-      await widgetTester.pressCmdShiftZ(); // Insert text
-      await widgetTester.pressCmdShiftZ(); // Change composing region
+      await widgetTester.pressCmdShiftZ();
       _expectDocumentWithCaret("He", "1", 2);
       print("--------");
 
-      await widgetTester.pressCmdShiftZ(); // Insert text
-      await widgetTester.pressCmdShiftZ(); // Change composing region
+      await widgetTester.pressCmdShiftZ();
       _expectDocumentWithCaret("Hel", "1", 3);
       print("--------");
 
-      await widgetTester.pressCmdShiftZ(); // Insert text
-      await widgetTester.pressCmdShiftZ(); // Change composing region
+      await widgetTester.pressCmdShiftZ();
       _expectDocumentWithCaret("Hell", "1", 4);
 
-      await widgetTester.pressCmdShiftZ(); // Insert text
-      await widgetTester.pressCmdShiftZ(); // Change composing region
+      await widgetTester.pressCmdShiftZ();
       _expectDocumentWithCaret("Hello", "1", 5);
     });
   });


### PR DESCRIPTION
Undo/Redo (with snapshots + one-way commands)

This is an undo/redo concept that's intended to avoid some of the complexities of the reversible command undo/redo version (#1881) by using `Editable` state snapshots, combined with a history of one-way `EditCommand`s. 

With this approach, when the user wants to undo a change, the `Editable`s are completely reverted to their most recent "snapshot" and then all historical `EditCommand`s are replayed, except the most recent `EditCommand`, thus achieving undo.

This approach requires that `Editable`s be capable of providing some kind of immutable snapshot. It might be a Dart data structure, it might be JSON, etc. The format doesn't matter. Each `Editable` needs to be able to provide some kind of snapshot, and then restore itself with that snapshot. This approach also re-runs a number of commands when undo'ing the previous command. This extra compute cost allows us to avoid the complexity of implementing reversible commands.

