### PR TITLE
Upgrade markdown package to v7.2.0

### DIFF
--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -24,18 +24,18 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
         );
 
   @override
-  md.Node? close(
+  Iterable<md.Node>? close(
     md.InlineParser parser,
     covariant md.SimpleDelimiter opener,
     md.Delimiter? closer, {
     String? tag,
     required List<md.Node> Function() getChildren,
   }) {
-    var text = parser.source!.substring(opener.endPos, parser.pos);
+    var text = parser.source.substring(opener.endPos, parser.pos);
     // The current character is the `]` that closed the link text. Examine the
     // next character, to determine what type of link we might have (a '('
     // means a possible inline link; otherwise a possible reference link).
-    if (parser.pos + 1 >= parser.source!.length) {
+    if (parser.pos + 1 >= parser.source.length) {
       // The `]` is at the end of the document, but this may still be a valid
       // shortcut reference link.
       return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
@@ -51,7 +51,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       var leftParenIndex = parser.pos;
       var inlineLink = _parseInlineLink(parser);
       if (inlineLink != null) {
-        return _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren);
+        return [_tryCreateInlineLink(parser, inlineLink, getChildren: getChildren)];
       }
       // At this point, we've matched `[...](`, but that `(` did not pan out to
       // be an inline link. We must now check if `[...]` is simply a shortcut
@@ -67,7 +67,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       parser.advanceBy(1);
       // At this point, we've matched `[...][`. Maybe a *full* reference link,
       // like `[foo][bar]` or a *collapsed* reference link, like `[foo][]`.
-      if (parser.pos + 1 < parser.source!.length && parser.charAt(parser.pos + 1) == AsciiTable.rightBracket) {
+      if (parser.pos + 1 < parser.source.length && parser.charAt(parser.pos + 1) == AsciiTable.rightBracket) {
         // That opening `[` is not actually part of the link. Maybe a
         // *shortcut* reference link (followed by a `[`).
         parser.advanceBy(1);
@@ -100,7 +100,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     // Parse an optional width.
     final width = _tryParseNumber(parser);
 
-    final downstreamCharacter = parser.source!.substring(parser.pos, parser.pos + 1);
+    final downstreamCharacter = parser.source.substring(parser.pos, parser.pos + 1);
     if (downstreamCharacter.toLowerCase() != 'x') {
       // The image size must have a "x" between the width and height, but the input doesn't.  Fizzle.
       return null;
@@ -140,9 +140,10 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   /// Tries to create a reference link node.
   ///
   /// Returns the link if it was successfully created, `null` otherwise.
-  md.Node? _tryCreateReferenceLink(md.InlineParser parser, String label,
+  Iterable<md.Node>? _tryCreateReferenceLink(md.InlineParser parser, String label,
       {required List<md.Node> Function() getChildren}) {
-    return _resolveReferenceLink(label, parser.document.linkReferences, getChildren: getChildren);
+    final node = _resolveReferenceLink(label, parser.document.linkReferences, getChildren: getChildren);
+    return [if (node != null) node];
   }
 
   // Tries to create an inline link node.
@@ -480,6 +481,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     }
   }
 
+  @override
   md.Element createNode(
     String destination,
     String? title, {

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   super_editor: ^0.2.5
   logging: ^1.0.1
-  markdown: ^4.0.0
+  markdown: ^7.2.0
 
 dependency_overrides:
   # Override to local mono-repo path so devs can test this repo

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -22,26 +22,26 @@ class CalloutBlockSyntax extends md.BlockSyntax {
   // This method was adapted from the standard Blockquote parser, and
   // the standard code fence block parser.
   @override
-  List<String> parseChildLines(md.BlockParser parser) {
+  List<md.Line?> parseChildLines(md.BlockParser parser) {
     // Grab all of the lines that form the custom block, stripping off the
     // first line, e.g., "@@@ customBlock", and the last line, e.g., "@@@".
-    var childLines = <String>[];
+    var childLines = <md.Line?>[];
 
     while (!parser.isDone) {
-      final openingLine = pattern.firstMatch(parser.current);
+      final openingLine = pattern.firstMatch(parser.current.content);
       if (openingLine != null) {
         // This is the first line. Ignore it.
         parser.advance();
         continue;
       }
-      final closingLine = _endLinePattern.firstMatch(parser.current);
+      final closingLine = _endLinePattern.firstMatch(parser.current.content);
       if (closingLine != null) {
         // This is the closing line. Ignore it.
         parser.advance();
 
         // If we're followed by a blank line, skip it, so that we don't end
         // up with an extra paragraph for that blank line.
-        if (parser.current.trim().isEmpty) {
+        if (parser.current.isBlankLine) {
           parser.advance();
         }
 
@@ -95,7 +95,7 @@ _InlineMarkdownToDocument _parseInline(md.Element element) {
     element.textContent,
     md.Document(
       inlineSyntaxes: [
-        md.StrikethroughSyntax(),
+        StrikethroughSyntaxFix(),
         UnderlineSyntax(),
       ],
     ),

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1131,16 +1131,18 @@ This is some code
       });
 
       test('unordered list followd by empty list item', () {
-        const markdown = """- list item 1
-    - """;
-
+        const markdown = "- list item 1\n- ";
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
+        expect(document.nodes.length, 2);
 
         expect(document.nodes[0], isA<ListItemNode>());
         expect((document.nodes[0] as ListItemNode).type, ListItemType.unordered);
         expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+
+        expect(document.nodes[1], isA<ListItemNode>());
+        expect((document.nodes[1] as ListItemNode).type, ListItemType.unordered);
+        expect((document.nodes[1] as ListItemNode).text.text, '');
       });
 
       test('parses mixed unordered and ordered items', () {
@@ -1434,8 +1436,20 @@ with multiple lines
         expect(document.nodes[25], isA<ParagraphNode>());
       });
 
-      test('paragraph with strikethrough', () {
+      test('paragraph with strikethrough with single tilda', () {
         final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
+        final styledText = (doc.nodes[0] as ParagraphNode).text;
+
+        // Ensure text within the range is attributed.
+        expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), true);
+        expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), true);
+
+        // Ensure text outside the range isn't attributed.
+        expect(styledText.getAllAttributionsAt(7).contains(strikethroughAttribution), false);
+      });
+
+      test('paragraph with strikethrough with two tildas', () {
+        final doc = deserializeMarkdownToDocument('~~This is~~ a paragraph.');
         final styledText = (doc.nodes[0] as ParagraphNode).text;
 
         // Ensure text within the range is attributed.

--- a/super_text_layout/lib/src/text_layout.dart
+++ b/super_text_layout/lib/src/text_layout.dart
@@ -253,7 +253,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
     // If no text is currently displayed, we can't use a character box
     // to measure, but we may be able to use related metrics.
     if (_textLength == 0) {
-      final estimatedLineHeight = _renderParagraph.getFullHeightForCaret(position);
+      final estimatedLineHeight = _renderParagraph.getFullHeightForCaret(position) ?? 0;
       return estimatedLineHeight * lineHeightMultiplier;
     }
 
@@ -323,7 +323,7 @@ class RenderParagraphProseTextLayout implements ProseTextLayout {
 
     final plainText = _richText.toPlainText();
     if (plainText.isEmpty) {
-      final lineHeightEstimate = _renderParagraph.getFullHeightForCaret(const TextPosition(offset: 0));
+      final lineHeightEstimate = _renderParagraph.getFullHeightForCaret(const TextPosition(offset: 0)) ?? 0;
       return TextBox.fromLTRBD(0, 0, 0, lineHeightEstimate, TextDirection.ltr);
     }
 


### PR DESCRIPTION
Additionally, I found a bug in the `unordered list followd by empty list item` test.

In previous versions of the markdown package, parsing this markdown `- list item 1\n   - ` resulted in the following structure:
A list (li) consisting of one item (ul). And in this item, there was a header (h2) containing the text `list item 1`

The header appeared in the first list item because during internal transformations, the text initially turned into `list item 1\n  - `, which was then interpreted as header syntax. In the new version of the package, this behavior has been corrected, and now this markdown is parsed as a list with one item containing the text `list item 1\n  -`

I modified the test to accurately reflect its description. That is, now it indeed contains a list of two items, the last of which is empty