### PR TITLE
[SuperEditor] Remove empty task on pressing enter/return

### DIFF
--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -312,12 +312,17 @@ ExecutionInstruction enterToInsertNewTask({
 
   final splitOffset = (selection.extent.nodePosition as TextNodePosition).offset;
 
-  editContext.editor.execute([
-    SplitExistingTaskRequest(
-      existingNodeId: node.id,
-      splitOffset: splitOffset,
-    ),
-  ]);
+  // If the task text is empty, convert it to paragraph.
+  if (node.text.text.isEmpty) {
+    editContext.commonOps.convertToParagraph();
+  } else {
+    editContext.editor.execute([
+      SplitExistingTaskRequest(
+        existingNodeId: node.id,
+        splitOffset: splitOffset,
+      ),
+    ]);
+  }
 
   return ExecutionInstruction.haltExecution;
 }


### PR DESCRIPTION
Fixes #1898 
Converting task to paragraph if enter/return is pressed on an empty task (similar to ordered and unordered lists). 
If you have any suggestions, do let me know.

https://github.com/superlistapp/super_editor/assets/43390808/1140e30f-0a26-4719-8041-a12c8842f729

