### PR TITLE
[SuperEditor][Web] Fix crash when merging paragraphs (Resolves #1921)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -237,8 +237,11 @@ class DocumentImeSerializer {
     }
 
     if (imePosition.offset <= -1) {
-      // This isn't a valid text position. For example, when a composing region is reported
-      // with an offset of `-1`, it means that there isn't a composing region on the IME.
+      // The given imePosition might be a selection or a composing region.
+      // The IME composing position always has a value. When the IME wants
+      // to describe the absence of a composing region, the offset is set to -1.
+      // Therefore, this position refers to the absence of a composing region, so
+      // this position isn't sitting in the placeholder.
       return false;
     }
 

--- a/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_serialization.dart
@@ -236,6 +236,12 @@ class DocumentImeSerializer {
       return false;
     }
 
+    if (imePosition.offset <= -1) {
+      // This isn't a valid text position. For example, when a composing region is reported
+      // with an offset of `-1`, it means that there isn't a composing region on the IME.
+      return false;
+    }
+
     if (imePosition.offset >= _prependedPlaceholder.length) {
       return false;
     }


### PR DESCRIPTION
[SuperEditor][Web] Fix crash when merging paragraphs. Resolves #1921 

When pressing BACKSPACE at the beginning of a paragraph to merge it with the previous paragraph, the following crash happens:

```console
══╡ EXCEPTION CAUGHT BY SERVICES LIBRARY ╞══════════════════════════════════════════════════════════


The following TypeErrorImpl was thrown during method call


TextInputClient.updateEditingStateWithDeltas:


Unexpected null value.

```

The issue was introduced in https://github.com/superlistapp/super_editor/pull/1860, where we changed our IME code to adjust the composing region if it was reported on the invisible range.

The root cause is that the `isPositionInsidePlaceholder` method doesn't account for invalid position ( offset of `-1`).

This PR changes `isPositionInsidePlaceholder` to return false for a `-1` offset.