### PR TITLE
[SuperEditor] Avoid throwing UnimplementedError in currentAutofillScope (Resolves #1923)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -160,7 +160,7 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   }
 
   @override
-  AutofillScope? get currentAutofillScope => throw UnimplementedError();
+  AutofillScope? get currentAutofillScope => null;
 
   @override
   TextEditingValue get currentTextEditingValue => _currentTextEditingValue;


### PR DESCRIPTION
[SuperEditor] Avoid throwing UnimplementedError in currentAutofillScope. Resolves #1923

In `DocumentImeInputClient` we have this override throwing an `UnimplementedError`:

https://github.com/superlistapp/super_editor/blob/98762748b1a666d81c2a48f0a8a5ee6927a2f963/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart#L163

This doesn't look like it's intentional. It's most likely that this is an auto-generated code. The docs for `currentAutofillScope` describe that we should return `null` if we don't support auto-fill. In `SuperTextField` we already do this.

This PR changes this method to return `null`. 