### PR TITLE
Cherry-pick "[attributed_text] - Add a copy() method for AttributedText (Resolves #1909) (#1913)" to stable

### DIFF
--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -451,6 +451,14 @@ class AttributedText {
     return spans.collapseSpans(contentLength: text.length);
   }
 
+  /// Returns a copy of this [AttributedText].
+  AttributedText copy() {
+    return AttributedText(
+      text,
+      spans.copy(),
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -828,6 +828,77 @@ void main() {
         expect(spans[1].end, 10);
       });
     });
+
+    group("copy >", () {
+      test("copies an AttributedText without any attributions", () {
+        final attributedText = AttributedText(
+          'Sample Text',
+        );
+
+        expect(attributedText.copy(), AttributedText('Sample Text'));
+      });
+
+      test("copies an AttributedText with attributions", () {
+        final attributedText = AttributedText(
+          'abcdefghij',
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(
+                attribution: ExpectedSpans.bold,
+                offset: 2,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: ExpectedSpans.italics,
+                offset: 4,
+                markerType: SpanMarkerType.start,
+              ),
+              const SpanMarker(
+                attribution: ExpectedSpans.bold,
+                offset: 5,
+                markerType: SpanMarkerType.end,
+              ),
+              const SpanMarker(
+                attribution: ExpectedSpans.italics,
+                offset: 7,
+                markerType: SpanMarkerType.end,
+              ),
+            ],
+          ),
+        );
+
+        expect(
+          attributedText.copy(),
+          AttributedText(
+            'abcdefghij',
+            AttributedSpans(
+              attributions: [
+                const SpanMarker(
+                  attribution: ExpectedSpans.bold,
+                  offset: 2,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ExpectedSpans.italics,
+                  offset: 4,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ExpectedSpans.bold,
+                  offset: 5,
+                  markerType: SpanMarkerType.end,
+                ),
+                const SpanMarker(
+                  attribution: ExpectedSpans.italics,
+                  offset: 7,
+                  markerType: SpanMarkerType.end,
+                ),
+              ],
+            ),
+          ),
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
This PR cherry-picks "[attributed_text] - Add a copy() method for AttributedText (Resolves #1909) (#1913)" to stable.