### PR TITLE
[SuperEditor] Fix ordered list items sequence computation (Resolves #1938)

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -112,10 +112,16 @@ class ListItemComponentBuilder implements ComponentBuilder {
 
     int? ordinalValue;
     if (node.type == ListItemType.ordered) {
+      // Counts the number of ordered list items above the current node with the same indentation level.
       ordinalValue = 1;
       DocumentNode? nodeAbove = document.getNodeBefore(node);
       while (nodeAbove != null && nodeAbove is ListItemNode && nodeAbove.indent >= node.indent) {
-        if (nodeAbove.type == ListItemType.ordered && nodeAbove.indent == node.indent) {
+        if (nodeAbove.indent == node.indent) {
+          if (nodeAbove.type != ListItemType.ordered) {
+            // We found an unordered list item with the same indentation level as the ordered list item.
+            // Other ordered list items aboce this one do not belong to the same list.
+            break;
+          }
           ordinalValue = ordinalValue! + 1;
         }
         nodeAbove = document.getNodeBefore(nodeAbove);

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -112,7 +112,9 @@ class ListItemComponentBuilder implements ComponentBuilder {
 
     int? ordinalValue;
     if (node.type == ListItemType.ordered) {
-      // Counts the number of ordered list items above the current node with the same indentation level.
+      // Counts the number of ordered list items above the current node with the same indentation level. Ordered
+      // list items with the same indentation level might be separated by ordered or unordered list items with
+      // different indentation levels.
       ordinalValue = 1;
       DocumentNode? nodeAbove = document.getNodeBefore(node);
       while (nodeAbove != null && nodeAbove is ListItemNode && nodeAbove.indent >= node.indent) {

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -115,7 +115,7 @@ class ListItemComponentBuilder implements ComponentBuilder {
       ordinalValue = 1;
       DocumentNode? nodeAbove = document.getNodeBefore(node);
       while (nodeAbove != null && nodeAbove is ListItemNode && nodeAbove.indent >= node.indent) {
-        if (nodeAbove.indent == node.indent) {
+        if (nodeAbove.type == ListItemType.ordered && nodeAbove.indent == node.indent) {
           ordinalValue = ordinalValue! + 1;
         }
         nodeAbove = document.getNodeBefore(nodeAbove);

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -217,6 +217,24 @@ class SuperEditorInspector {
     return findRichTextInParagraph(nodeId, superEditorFinder).style;
   }
 
+  /// Finds the ordered list item with the given [nodeId] and returns its index on the list.
+  ///
+  /// List items are indexed starting from 1.
+  ///
+  /// {@macro supereditor_finder}
+  static int findListItemOrdinal(String nodeId, [Finder? superEditorFinder]) {
+    final listItem = find
+        .ancestor(
+          of: find.byWidget(SuperEditorInspector.findWidgetForComponent(nodeId)),
+          matching: find.byType(OrderedListItemComponent),
+        )
+        .evaluate()
+        .single
+        .widget as OrderedListItemComponent;
+
+    return listItem.listIndex;
+  }
+
   /// Calculates the delta between the center of the character at [textOffset1] and and the
   /// center of the character at [textOffset2] within the node with the given [nodeId].
   ///

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -217,9 +217,9 @@ class SuperEditorInspector {
     return findRichTextInParagraph(nodeId, superEditorFinder).style;
   }
 
-  /// Finds the ordered list item with the given [nodeId] and returns its index on the list.
+  /// Finds the ordered list item with the given [nodeId] and returns its ordinal value.
   ///
-  /// List items are indexed starting from 1.
+  /// List items ordinals start from 1.
   ///
   /// {@macro supereditor_finder}
   static int findListItemOrdinal(String nodeId, [Finder? superEditorFinder]) {

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -539,21 +539,48 @@ void main() {
 
         // Ensure the sequence started only after the first ordered item, i.e., the unordered items
         // didn't affect the sequence.
-        final firstOrderedItem = tester.widget<OrderedListItemComponent>(
-          find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[2].id)),
-            matching: find.byType(OrderedListItemComponent),
-          ),
-        );
-        expect(firstOrderedItem.listIndex, 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[2].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[3].id), 2);
+      });
 
-        final secondOrderedItem = tester.widget<OrderedListItemComponent>(
-          find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[3].id)),
-            matching: find.byType(OrderedListItemComponent),
-          ),
-        );
-        expect(secondOrderedItem.listIndex, 2);
+      testWidgetsOnArbitraryDesktop('does not keep sequence for items split by unordered items', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("""
+1. First ordered item
+2. Second ordered item
+- First unordered item
+- Second unordered item
+1. First ordered item
+2. Second ordered item""") //
+            .pump();
+
+        expect(context.document.nodes.length, 6);
+
+        // Ensure the nodes have the correct type.
+        expect(context.document.nodes[0], isA<ListItemNode>());
+        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[1], isA<ListItemNode>());
+        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[2], isA<ListItemNode>());
+        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[3], isA<ListItemNode>());
+        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[4], isA<ListItemNode>());
+        expect((context.document.nodes[4] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[5], isA<ListItemNode>());
+        expect((context.document.nodes[5] as ListItemNode).type, ListItemType.ordered);
+
+        // Ensure the sequence restarted after the unordered items.
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[0].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[1].id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[4].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[5].id), 2);
       });
 
       testWidgetsOnArbitraryDesktop('does not keep sequence for items split by paragraphs', (tester) async {

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -512,6 +512,37 @@ void main() {
         expect(secondOrderedItem.listIndex, 2);
       });
 
+      testWidgetsOnArbitraryDesktop('keeps sequence for items split by ordered list items with higher indentation',
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("""
+ 1. list item 1
+ 2. list item 2
+    1. list item 2.1
+    2. list item 2.2
+ 3. list item 3
+    1. list item 3.1
+""") //
+            .pump();
+
+        expect(context.document.nodes.length, 6);
+
+        // Ensure the nodes have the correct type.
+        for (int i = 0; i < 6; i++) {
+          expect(context.document.nodes[i], isA<ListItemNode>());
+          expect((context.document.nodes[i] as ListItemNode).type, ListItemType.ordered);
+        }
+
+        // Ensure the sequence was kept.
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[0].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[1].id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[2].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[3].id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[4].id), 3);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[5].id), 1);
+      });
+
       testWidgetsOnArbitraryDesktop('restarts item order when separated by an unordered item', (tester) async {
         final context = await tester //
             .createDocument()

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -512,6 +512,50 @@ void main() {
         expect(secondOrderedItem.listIndex, 2);
       });
 
+      testWidgetsOnArbitraryDesktop('starts sequence in the first ordered item', (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown("""
+- First unordered item
+- Second unoredered item
+1. First ordered item
+2. Second ordered item""") //
+            .pump();
+
+        expect(context.document.nodes.length, 4);
+
+        // Ensure the nodes have the correct type.
+        expect(context.document.nodes[0], isA<ListItemNode>());
+        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[1], isA<ListItemNode>());
+        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.unordered);
+
+        expect(context.document.nodes[2], isA<ListItemNode>());
+        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.ordered);
+
+        expect(context.document.nodes[3], isA<ListItemNode>());
+        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.ordered);
+
+        // Ensure the sequence started only after the first ordered item, i.e., the unordered items
+        // didn't affect the sequence.
+        final firstOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[2].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(firstOrderedItem.listIndex, 1);
+
+        final secondOrderedItem = tester.widget<OrderedListItemComponent>(
+          find.ancestor(
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[3].id)),
+            matching: find.byType(OrderedListItemComponent),
+          ),
+        );
+        expect(secondOrderedItem.listIndex, 2);
+      });
+
       testWidgetsOnArbitraryDesktop('does not keep sequence for items split by paragraphs', (tester) async {
         final context = await tester //
             .createDocument()

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -512,38 +512,7 @@ void main() {
         expect(secondOrderedItem.listIndex, 2);
       });
 
-      testWidgetsOnArbitraryDesktop('starts sequence in the first ordered item', (tester) async {
-        final context = await tester //
-            .createDocument()
-            .fromMarkdown("""
-- First unordered item
-- Second unordered item
-1. First ordered item
-2. Second ordered item""") //
-            .pump();
-
-        expect(context.document.nodes.length, 4);
-
-        // Ensure the nodes have the correct type.
-        expect(context.document.nodes[0], isA<ListItemNode>());
-        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.unordered);
-
-        expect(context.document.nodes[1], isA<ListItemNode>());
-        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.unordered);
-
-        expect(context.document.nodes[2], isA<ListItemNode>());
-        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.ordered);
-
-        expect(context.document.nodes[3], isA<ListItemNode>());
-        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.ordered);
-
-        // Ensure the sequence started only after the first ordered item, i.e., the unordered items
-        // didn't affect the sequence.
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[2].id), 1);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[3].id), 2);
-      });
-
-      testWidgetsOnArbitraryDesktop('does not keep sequence for items split by unordered items', (tester) async {
+      testWidgetsOnArbitraryDesktop('restarts item order when separated by an unordered item', (tester) async {
         final context = await tester //
             .createDocument()
             .fromMarkdown("""

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -517,7 +517,7 @@ void main() {
             .createDocument()
             .fromMarkdown("""
 - First unordered item
-- Second unoredered item
+- Second unordered item
 1. First ordered item
 2. Second ordered item""") //
             .pump();


### PR DESCRIPTION
[SuperEditor] Fix ordered list items sequence computation. Resolves #1938

When an ordered list item is placed after an unordered list item, the unordered items are also being counted when we compute the ordered list item sequence. For example, consider the following markdown:

```
- First unordered item
- Second unordered item
1. First ordered item
2. Second ordered item
```

Instead of 1 and 2, the sequence is being computed as 2 and 3.

This PR fixes this issue by checking the list item type before incrementing the ordinal value.
