### PR TITLE
Changed LinkAttribution to allow invalid (unchecked) URLs (Resolves #1927)

### DIFF
--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -137,11 +137,11 @@ MutableDocument _createInitialDocument() {
             AttributedSpans(
               attributions: [
                 SpanMarker(
-                    attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                    attribution: LinkAttribution.fromUri(Uri.https('example.org', '')),
                     offset: 30,
                     markerType: SpanMarkerType.start),
                 SpanMarker(
-                    attribution: LinkAttribution(url: Uri.https('example.org', '')),
+                    attribution: LinkAttribution.fromUri(Uri.https('example.org', '')),
                     offset: 35,
                     markerType: SpanMarkerType.end),
               ],

--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -384,7 +384,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
 
     final trimmedRange = _trimTextRangeWhitespace(text, selectionRange);
 
-    final linkAttribution = LinkAttribution(url: Uri.parse(url));
+    final linkAttribution = LinkAttribution.fromUri(Uri.parse(url));
 
     widget.editor!.execute([
       AddTextAttributionsRequest(

--- a/super_editor/example/lib/demos/super_reader/example_document.dart
+++ b/super_editor/example/lib/demos/super_reader/example_document.dart
@@ -98,11 +98,11 @@ Document createInitialDocument() {
           "Built by the Flutter Bounty Hunters",
           AttributedSpans(attributions: [
             SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse("https://flutterbountyhunters.com")),
+                attribution: LinkAttribution.fromUri(Uri.parse("https://flutterbountyhunters.com")),
                 offset: 13,
                 markerType: SpanMarkerType.start),
             SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse("https://flutterbountyhunters.com")),
+                attribution: LinkAttribution.fromUri(Uri.parse("https://flutterbountyhunters.com")),
                 offset: 34,
                 markerType: SpanMarkerType.end),
           ]),

--- a/super_editor/example_docs/lib/toolbar.dart
+++ b/super_editor/example_docs/lib/toolbar.dart
@@ -263,7 +263,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
 
     final trimmedRange = _trimTextRangeWhitespace(text, selectionRange);
 
-    final linkAttribution = LinkAttribution(url: Uri.parse(url));
+    final linkAttribution = LinkAttribution.fromUri(Uri.parse(url));
 
     widget.editor.execute([
       AddTextAttributionsRequest(

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -163,6 +163,11 @@ class LinkAttribution implements Attribution {
   /// The URL associated with the attributed text, as a `String`.
   final String url;
 
+  /// Attempts to parse the [url] as a [Uri], and returns `true` if the [url]
+  /// is successfully parsed, or `false` if parsing fails, such as due to the [url]
+  /// including an invalid scheme, separator syntax, extra segments, etc.
+  bool get hasValidUri => Uri.tryParse(url) != null;
+
   /// The URL associated with the attributed text, as a `Uri`.
   ///
   /// Accessing the [uri] throws an exception if the [url] isn't valid.

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -151,14 +151,24 @@ class FontSizeAttribution implements Attribution {
 /// within [AttributedText]. This class doesn't have a special
 /// relationship with [AttributedText].
 class LinkAttribution implements Attribution {
-  LinkAttribution({
-    required this.url,
-  });
+  factory LinkAttribution.fromUri(Uri uri) {
+    return LinkAttribution(uri.toString());
+  }
+
+  const LinkAttribution(this.url);
 
   @override
   String get id => 'link';
 
-  final Uri url;
+  /// The URL associated with the attributed text, as a `String`.
+  final String url;
+
+  /// The URL associated with the attributed text, as a `Uri`.
+  ///
+  /// Accessing the [uri] throws an exception if the [url] isn't valid.
+  /// To access a URL that might not be valid, consider accessing the [url],
+  /// instead.
+  Uri get uri => Uri.parse(url);
 
   @override
   bool canMergeWith(Attribution other) {

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2380,7 +2380,7 @@ class PasteEditorCommand implements EditCommand {
 
       if (link != null && link.hasScheme && link.hasAuthority) {
         // Valid url. Apply [LinkAttribution] to the url
-        final linkAttribution = LinkAttribution(url: link);
+        final linkAttribution = LinkAttribution.fromUri(link);
 
         final startOffset = wordBoundary.start;
         // -1 because TextPosition's offset indexes the character after the

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -637,7 +637,7 @@ class LinkifyReaction implements EditReaction {
       final uri = _parseLink(word);
 
       text.addAttribution(
-        LinkAttribution(url: uri),
+        LinkAttribution.fromUri(uri),
         SpanRange(wordStartOffset, endOffset - 1),
       );
     }
@@ -798,8 +798,8 @@ class LinkifyReaction implements EditReaction {
     // link attribution that reflects the edited URL text. We do that below.
     if (updatePolicy == LinkUpdatePolicy.update) {
       changedNodeText.addAttribution(
-        LinkAttribution(
-          url: _parseLink(changedNodeText.text.substring(rangeToUpdate.start, rangeToUpdate.end + 1)),
+        LinkAttribution.fromUri(
+          _parseLink(changedNodeText.text.substring(rangeToUpdate.start, rangeToUpdate.end + 1)),
         ),
         rangeToUpdate,
       );

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1564,7 +1564,7 @@ class SuperEditorLaunchLinkTapHandler extends ContentTapDelegate {
     final tappedAttributions = textNode.text.getAllAttributionsAt(nodePosition.offset);
     for (final tappedAttribution in tappedAttributions) {
       if (tappedAttribution is LinkAttribution) {
-        return tappedAttribution.url;
+        return tappedAttribution.uri;
       }
     }
 

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -703,7 +703,7 @@ class SuperReaderLaunchLinkTapHandler extends ContentTapDelegate {
     final tappedAttributions = textNode.text.getAllAttributionsAt(nodePosition.offset);
     for (final tappedAttribution in tappedAttributions) {
       if (tappedAttribution is LinkAttribution) {
-        return tappedAttribution.url;
+        return tappedAttribution.uri;
       }
     }
 

--- a/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
+++ b/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
@@ -198,12 +198,12 @@ MutableDocument _singleParagraphWithLinkDoc() {
           AttributedSpans(
             attributions: [
               SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+                attribution: LinkAttribution.fromUri(Uri.parse('https://google.com')),
                 offset: 0,
                 markerType: SpanMarkerType.start,
               ),
               SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+                attribution: LinkAttribution.fromUri(Uri.parse('https://google.com')),
                 offset: 17,
                 markerType: SpanMarkerType.end,
               ),

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1467,12 +1467,12 @@ MutableDocument _singleParagraphWithLinkDoc() {
           AttributedSpans(
             attributions: [
               SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+                attribution: LinkAttribution.fromUri(Uri.parse('https://google.com')),
                 offset: 0,
                 markerType: SpanMarkerType.start,
               ),
               SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+                attribution: LinkAttribution.fromUri(Uri.parse('https://google.com')),
                 offset: 17,
                 markerType: SpanMarkerType.end,
               ),

--- a/super_editor/test/super_editor/test_documents.dart
+++ b/super_editor/test/super_editor/test_documents.dart
@@ -57,14 +57,16 @@ MutableDocument singleParagraphWithLinkDoc() => MutableDocument(
             "This paragraph includes a link that the user can tap",
             AttributedSpans(
               attributions: [
-                SpanMarker(
-                    attribution: LinkAttribution(url: Uri.parse("https://fake.url")),
-                    offset: 26,
-                    markerType: SpanMarkerType.start),
-                SpanMarker(
-                    attribution: LinkAttribution(url: Uri.parse("https://fake.url")),
-                    offset: 30,
-                    markerType: SpanMarkerType.end),
+                const SpanMarker(
+                  attribution: LinkAttribution("https://fake.url"),
+                  offset: 26,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: LinkAttribution("https://fake.url"),
+                  offset: 30,
+                  markerType: SpanMarkerType.end,
+                ),
               ],
             ),
           ),

--- a/super_editor/test/super_editor/text_entry/attributions_test.dart
+++ b/super_editor/test/super_editor/text_entry/attributions_test.dart
@@ -10,7 +10,7 @@ void main() {
 
         // Add link across "one two"
         text.addAttribution(
-          LinkAttribution(url: Uri.parse('https://flutter.dev')),
+          const LinkAttribution('https://flutter.dev'),
           const SpanRange(0, 6),
         );
 
@@ -18,7 +18,7 @@ void main() {
         // an exception
         expect(() {
           text.addAttribution(
-            LinkAttribution(url: Uri.parse('https://pub.dev')),
+            const LinkAttribution('https://pub.dev'),
             const SpanRange(4, 12),
           );
         }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
@@ -27,7 +27,7 @@ void main() {
       test('identical link attributions can overlap', () {
         final text = AttributedText('one two three');
 
-        final linkAttribution = LinkAttribution(url: Uri.parse('https://flutter.dev'));
+        const linkAttribution = LinkAttribution('https://flutter.dev');
 
         // Add link across "one two"
         text.addAttribution(
@@ -36,7 +36,7 @@ void main() {
         );
 
         text.addAttribution(
-          LinkAttribution(url: Uri.parse('https://flutter.dev')),
+          const LinkAttribution('https://flutter.dev'),
           const SpanRange(4, 12),
         );
 

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -45,7 +45,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(0, text.length - 2),
           ),
@@ -88,7 +88,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -138,7 +138,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -189,7 +189,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -242,7 +242,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -293,7 +293,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -347,7 +347,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -397,7 +397,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(5, text.length - 1),
           ),
@@ -447,7 +447,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -500,7 +500,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(5, text.length - 1),
           ),
@@ -553,7 +553,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -606,7 +606,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(5, text.length - 1),
           ),
@@ -660,7 +660,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -726,7 +726,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(15, text.length - 1),
           ),
@@ -792,7 +792,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -861,7 +861,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(15, text.length - 1),
           ),
@@ -930,7 +930,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -999,7 +999,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(15, text.length - 1),
           ),
@@ -1068,7 +1068,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
             },
             range: SpanRange(12, text.length - 1),
           ),
@@ -1102,7 +1102,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
+            LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
           },
           range: const SpanRange(0, 21),
         ),
@@ -1112,7 +1112,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("https://flutter.dev")),
+            LinkAttribution.fromUri(Uri.parse("https://flutter.dev")),
           },
           range: const SpanRange(27, 45),
         ),
@@ -1155,7 +1155,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("https://google.com")),
+            LinkAttribution.fromUri(Uri.parse("https://google.com")),
           },
           range: SpanRange(0, text.length - 2),
         ),
@@ -1187,7 +1187,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("https://www.google.com")),
+            LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
           },
           range: SpanRange(0, text.length - 2),
         ),
@@ -1359,7 +1359,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1389,7 +1389,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.googoooole.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.googoooole.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1447,7 +1447,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1480,7 +1480,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://google.com")),
+              LinkAttribution.fromUri(Uri.parse("https://google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1565,7 +1565,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1603,7 +1603,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.duckduckgo.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.duckduckgo.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1661,7 +1661,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1692,7 +1692,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.google.c")),
+              LinkAttribution.fromUri(Uri.parse("https://www.google.c")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1745,7 +1745,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("www.google.com")),
+              LinkAttribution.fromUri(Uri.parse("www.google.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1775,7 +1775,7 @@ void main() {
         expect(
           text.hasAttributionsThroughout(
             attributions: {
-              LinkAttribution(url: Uri.parse("https://www.duckduckgo.com")),
+              LinkAttribution.fromUri(Uri.parse("https://www.duckduckgo.com")),
             },
             range: SpanRange(0, text.length - 1),
           ),
@@ -1832,7 +1832,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
+            LinkAttribution.fromUri(Uri.parse("www.google.com")),
           },
           range: const SpanRange(0, 12),
         ),
@@ -1841,7 +1841,7 @@ void main() {
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution(url: Uri.parse("www.google.com")),
+            LinkAttribution.fromUri(Uri.parse("www.google.com")),
           },
           range: SpanRange(13, text.length - 1),
         ),

--- a/super_editor/test/super_editor/text_entry/super_editor_content_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/super_editor_content_conversion_test.dart
@@ -218,13 +218,13 @@ MutableDocument _singleParagraphWithLinkDoc() {
           "https://google.com",
           AttributedSpans(
             attributions: [
-              SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+              const SpanMarker(
+                attribution: LinkAttribution('https://google.com'),
                 offset: 0,
                 markerType: SpanMarkerType.start,
               ),
-              SpanMarker(
-                attribution: LinkAttribution(url: Uri.parse('https://google.com')),
+              const SpanMarker(
+                attribution: LinkAttribution('https://google.com'),
                 offset: 17,
                 markerType: SpanMarkerType.end,
               ),

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -495,7 +495,7 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
       );
     } else if (element.tag == 'a') {
       styledText.addAttribution(
-        LinkAttribution(url: Uri.parse(element.attributes['href']!)),
+        LinkAttribution.fromUri(Uri.parse(element.attributes['href']!)),
         SpanRange(0, styledText.text.length - 1),
       );
     }

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -175,7 +175,7 @@ class _InlineMarkdownToDocument implements md.NodeVisitor {
       );
     } else if (element.tag == 'a') {
       styledText.addAttribution(
-        LinkAttribution(url: Uri.parse(element.attributes['href']!)),
+        LinkAttribution.fromUri(Uri.parse(element.attributes['href']!)),
         SpanRange(0, styledText.text.length - 1),
       );
     }

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -982,7 +982,7 @@ This is some code
         expect(styledText.getAllAttributionsAt(8).contains(boldAttribution), true);
         expect(styledText.getAllAttributionsAt(13).containsAll([boldAttribution, italicsAttribution]), true);
         expect(styledText.getAllAttributionsAt(19).isEmpty, true);
-        expect(styledText.getAllAttributionsAt(40).single, LinkAttribution(url: Uri.https('example.org', '')));
+        expect(styledText.getAllAttributionsAt(40).single, LinkAttribution.fromUri(Uri.https('example.org', '')));
       });
 
       test('paragraph with special HTML symbols keeps the symbols by default', () {
@@ -1027,9 +1027,8 @@ This is some code
         expect(styledText.getAllAttributionsAt(8).contains(boldAttribution), true);
         expect(styledText.getAllAttributionsAt(13).containsAll([boldAttribution, italicsAttribution]), true);
         expect(
-            styledText
-                .getAllAttributionsAt(20)
-                .containsAll([boldAttribution, italicsAttribution, LinkAttribution(url: Uri.https('example.org', ''))]),
+            styledText.getAllAttributionsAt(20).containsAll(
+                [boldAttribution, italicsAttribution, LinkAttribution.fromUri(Uri.https('example.org', ''))]),
             true);
         expect(styledText.getAllAttributionsAt(25).containsAll([boldAttribution, italicsAttribution]), true);
       });
@@ -1051,7 +1050,7 @@ This is some code
         expect(
             styledText
                 .getAllAttributionsAt(13)
-                .containsAll([boldAttribution, LinkAttribution(url: Uri.https('example.org', ''))]),
+                .containsAll([boldAttribution, LinkAttribution.fromUri(Uri.https('example.org', ''))]),
             true);
       });
 
@@ -1069,7 +1068,7 @@ This is some code
         expect(styledText.text, 'This **is a** link test');
 
         expect(styledText.getAllAttributionsAt(9).isEmpty, true);
-        expect(styledText.getAllAttributionsAt(12).single, LinkAttribution(url: Uri.https('example.org', '')));
+        expect(styledText.getAllAttributionsAt(12).single, LinkAttribution.fromUri(Uri.https('example.org', '')));
       });
 
       test('empty link', () {
@@ -1085,7 +1084,7 @@ This is some code
         final styledText = paragraph.text;
         expect(styledText.text, 'This is a link test');
 
-        expect(styledText.getAllAttributionsAt(12).single, LinkAttribution(url: Uri.parse('')));
+        expect(styledText.getAllAttributionsAt(12).single, LinkAttribution.fromUri(Uri.parse('')));
       });
 
       test('unordered list', () {


### PR DESCRIPTION
Changed LinkAttribution to allow invalid (unchecked) URLs (Resolves #1927)

The `LinkAttribution`'s `url` property is now a `String` instead of a `Uri`, so that `LinkAttribution`s can hold invalid URLs.

For easy `Uri` access, I added a `uri` property, which parses the `url` when it's accessed. This is a convenience so that users don't have to explicitly parse a `Uri` all over the place.

FYI: The motivation for this change is that an existing document, possibly from another source, is parsed and loaded into `SuperEditor`. This process fails for a document that happens to contain links for invalid URLs.