### PR TITLE
[SuperEditor] Fix toggling attributions crash (Resolves #1948)

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1495,6 +1495,12 @@ class ToggleTextAttributionsCommand implements EditCommand {
         endOffset = max(textNode.text.length - 1, 0);
       }
 
+      if (startOffset >= textNode.text.length) {
+        // The selection begins after the last character in the node. There's no text
+        // to toggle any attributions. Skip this node.
+        continue;
+      }
+
       final selectionRange = SpanRange(startOffset, endOffset);
 
       alreadyHasAttributions = alreadyHasAttributions &&

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1480,6 +1480,14 @@ class ToggleTextAttributionsCommand implements EditCommand {
         editorDocLog.info(' - selecting part of the first node: ${textNode.id}');
         startOffset = (normalizedRange.start.nodePosition as TextPosition).offset;
         endOffset = max(textNode.text.length - 1, 0);
+
+        if (startOffset >= textNode.text.length) {
+          // The range spans multiple nodes, starting at the end of the first node of the
+          // range. From the first node's perspective, this is equivalent to a collapsed
+          // selection at the end of the node. There's no text to toggle any attributions.
+          // Skip this node.
+          continue;
+        }
       } else if (textNode == nodes.last) {
         // Handle partial node selection in last node.
         editorDocLog.info(' - toggling part of the last node: ${textNode.id}');
@@ -1488,17 +1496,19 @@ class ToggleTextAttributionsCommand implements EditCommand {
         // -1 because TextPosition's offset indexes the character after the
         // selection, not the final character in the selection.
         endOffset = (normalizedRange.end.nodePosition as TextPosition).offset - 1;
+
+        if (endOffset == 0) {
+          // The range spans multiple nodes, ending at the beginning of the last node of the
+          // range. From the last node's perspective, this is equivalent to a collapsed
+          // selection at the beginning of the node. There's no text to toggle any attributions.
+          // Skip this node.
+          continue;
+        }
       } else {
         // Handle full node selection.
         editorDocLog.info(' - toggling full node: ${textNode.id}');
         startOffset = 0;
         endOffset = max(textNode.text.length - 1, 0);
-      }
-
-      if (startOffset >= textNode.text.length) {
-        // The selection begins after the last character in the node. There's no text
-        // to toggle any attributions. Skip this node.
-        continue;
       }
 
       final selectionRange = SpanRange(startOffset, endOffset);

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1497,7 +1497,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
         // selection, not the final character in the selection.
         endOffset = (normalizedRange.end.nodePosition as TextPosition).offset - 1;
 
-        if (endOffset == 0) {
+        if (endOffset <= 0) {
           // The range spans multiple nodes, ending at the beginning of the last node of the
           // range. From the last node's perspective, this is equivalent to a collapsed
           // selection at the beginning of the node. There's no text to toggle any attributions.

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -584,7 +584,8 @@ void main() {
           );
         });
 
-        testWidgetsOnAllPlatforms("toggles an attribution when selection starts at the end of the upstream node",
+        testWidgetsOnAllPlatforms(
+            "toggles an attribution when selection spans multiple nodes and starts at the end of the first selected node",
             (tester) async {
           final context = await tester //
               .createDocument()

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -584,6 +584,50 @@ void main() {
           );
         });
 
+        testWidgetsOnAllPlatforms("toggles an attribution when selection starts at the end of the upstream node",
+            (tester) async {
+          final context = await tester //
+              .createDocument()
+              .fromMarkdown("First node\n\nSecond node")
+              .pump();
+
+          final editor = context.editor;
+          final document = context.document;
+
+          final firstNode = document.nodes[0] as ParagraphNode;
+          final secondNode = document.nodes[1] as ParagraphNode;
+
+          // Apply the bold attribution, starting after the last character of the first node.
+          editor.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.endDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure bold attribution is applied only to the second node. Since the selection starts at the
+          // end of the first node, there's no text there to apply the attribution to.
+          expect(
+            document,
+            equalsMarkdown(
+              "First node\n\n**Second node**",
+            ),
+          );
+
+          // Remove the bold attribution, starting after the last character of the first node.
+          editor.toggleAttributionsForDocumentSelection(
+            DocumentSelection(
+              base: firstNode.endDocumentPosition,
+              extent: secondNode.endDocumentPosition,
+            ),
+            {boldAttribution},
+          );
+
+          // Ensure bold attribution was removed.
+          expect(secondNode.text.spans.markers.isEmpty, true);
+        });
+
         testWidgetsOnAllPlatforms(
             "toggles an attribution across nodes with the attribution applied throughout and partially within first and second node respectively",
             (tester) async {


### PR DESCRIPTION
[SuperEditor] Fix toggling attributions crash. Resolves #1948

When selecting across nodes, starting from the end of the upstream node, and toggling any attribution the following exception happens:

```console
======== Exception caught by services library ======================================================
The following _Exception was thrown while processing the key message handler:
Exception: removeAttribution() did not satisfy start < 0 and start > end, start: 70, end: 69
```

https://github.com/superlistapp/super_editor/assets/31278849/f08bc48a-50ab-46ba-af45-7004c57ace8d

The cause is that we are trying to remove the attribution from an invalid range (start > end). Since the selection starts at the end of the upstream node, there isn't any selected text there to apply attributions.

This PR changes `ToggleTextAttributionsCommand` to ignore a nodes if the selection starts after the last character. 
