### PR TITLE
[SuperEditor][Android] Hide expanded drag handles after deleting the selected text (Resolves #1936)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1323,6 +1323,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   void initState() {
     super.initState();
     _overlayController.show();
+    widget.selection.addListener(_onSelectionChange);
   }
 
   @override
@@ -1332,7 +1333,6 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     _controlsController = SuperEditorAndroidControlsScope.rootOf(context);
     // TODO: Replace Cupertino aligner with a generic aligner because this code runs on Android.
     _toolbarAligner = CupertinoPopoverToolbarAligner();
-    widget.document.addListener(_onDocumentChange);
   }
 
   @override
@@ -1347,9 +1347,9 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       }
     }
 
-    if (widget.document != oldWidget.document) {
-      oldWidget.document.removeListener(_onDocumentChange);
-      widget.document.addListener(_onDocumentChange);
+    if (widget.selection != oldWidget.selection) {
+      oldWidget.selection.removeListener(_onSelectionChange);
+      widget.selection.addListener(_onSelectionChange);
     }
   }
 
@@ -1359,7 +1359,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     // stop listening for document scroll changes.
     widget.dragHandleAutoScroller.value?.stopAutoScrollHandleMonitoring();
     widget.scrollChangeSignal.removeListener(_onDocumentScroll);
-    widget.document.removeListener(_onDocumentChange);
+    widget.selection.removeListener(_onSelectionChange);
 
     super.dispose();
   }
@@ -1370,7 +1370,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   @visibleForTesting
   bool get wantsToDisplayMagnifier => _controlsController!.shouldShowMagnifier.value;
 
-  void _onDocumentChange(_) {
+  void _onSelectionChange() {
     if (widget.selection.value?.isCollapsed == true &&
         _controlsController!.shouldShowExpandedHandles.value == true &&
         _dragHandleType == null) {

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor_test.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../../test_runners.dart';
 import '../supereditor_test_tools.dart';
@@ -107,6 +109,50 @@ void main() {
       // Resolve the gesture so that we don't have pending gesture timers.
       await gesture.up();
       await tester.pump(const Duration(milliseconds: 100));
+    });
+
+    testWidgetsOnIos("hides expanded handles and toolbar when deleting an expanded selection", (tester) async {
+      // Configure BlinkController to animate, otherwise it won't blink. We want to make sure
+      // the caret blinks after deleting the content.
+      BlinkController.indeterminateAnimationsEnabled = true;
+      addTearDown(() => BlinkController.indeterminateAnimationsEnabled = false);
+
+      await _pumpSingleParagraphApp(tester);
+
+      // Double tap to select "Lorem".
+      await tester.doubleTapInParagraph("1", 1);
+      await tester.pump();
+
+      // Ensure the toolbar and the drag handles are visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+      expect(SuperEditorInspector.findMobileExpandedDragHandles(), findsNWidgets(2));
+
+      // Press backspace to delete the word "Lorem" while the expanded handles are visible.
+      await tester.ime.backspace(getter: imeClientGetter);
+
+      // Ensure the toolbar and the drag handles were hidden.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+      expect(SuperEditorInspector.findMobileExpandedDragHandles(), findsNothing);
+
+      // Ensure caret is blinking.
+
+      expect(SuperEditorInspector.isCaretVisible(), true);
+
+      // Duration to switch between visible and invisible.
+      final flashPeriod = SuperEditorInspector.caretFlashPeriod();
+
+      // Trigger a frame with an ellapsed time equal to the flashPeriod,
+      // so the caret should change from visible to invisible.
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is invisible after the flash period.
+      expect(SuperEditorInspector.isCaretVisible(), false);
+
+      // Trigger another frame to make caret visible again.
+      await tester.pump(flashPeriod);
+
+      // Ensure caret is visible.
+      expect(SuperEditorInspector.isCaretVisible(), true);
     });
 
     group("on device and web > shows ", () {


### PR DESCRIPTION
[SuperEditor][Android] Hide expanded drag handles after deleting the selected text. Resolves #1936

On Android with an expanded selection, performing any action that causes text to be deleted, such as cutting, deleting, pasting or typing to replace the text, keeps the expanded handles visible. Trying to drag those handles throws an exception:

```console
════════ Exception caught by gesture ═══════════════════════════════════════════
The following _Exception was thrown while handling a gesture:
Exception: Tried to drag an expanded Android handle but the selection is collapsed.
```

The expanded handles are kept visible because of https://github.com/superlistapp/super_editor/pull/1754, where we changed the expanded handles to be allowed to be visible even with a collapsed selection. However, this should happen when the user is dragging the handles, not when the selection collapses due to a deletion.

Looking at other Android apps, it seems that the expected behavior is that no handle should be visible after deleting the selected text, not even the collapsed drag handle.

This PR changes the Android touch interactor to hide the expanded handles and any other controls when text is deleted, causing the selection to collapse. 

We could also implement this by adding a listener directly to the editor and then listening for selection change events. If a better solution would be to find a way to make `shouldShowExpandedHandles` to be `false` if the user is not dragging then I can dig into that.

On iOS this issue doesn't happen, because the expanded handles are never visible when the selection is collapsed. I added the same test I added for android.