### PR TITLE
Reparent focus node in deactivate

### DIFF
--- a/super_editor/lib/src/infrastructure/focus.dart
+++ b/super_editor/lib/src/infrastructure/focus.dart
@@ -52,6 +52,13 @@ class _NonReparentingFocusState extends State<NonReparentingFocus> {
   }
 
   @override
+  void deactivate() {
+    super.deactivate();
+    // See _FocusState.deactivate.
+    _keyboardFocusAttachment.reparent();
+  }
+
+  @override
   void didUpdateWidget(NonReparentingFocus oldWidget) {
     super.didUpdateWidget(oldWidget);
 


### PR DESCRIPTION
Fixes the following exception that we're getting
```
SEVERE: 'package:flutter/src/widgets/focus_manager.dart': Failed assertion: line 1299 pos 12: '_focusedChildren.isEmpty || _focusedChildren.last.enclosingScope == this': Focused child does not have the same idea of its enclosing scope as the scope does.
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:50:61)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:40:5)
#2      FocusScopeNode.focusedChild (package:flutter/src/widgets/focus_manager.dart:1299:12)
#3      FocusNodeDirectionalExtension.isSelected (package:superlist/ui/focus/focus.dart:25:40)
#4      _TaskListTileScaffoldState.build.<anonymous closure> (package:superlist/ui/task_list/private/task_list_tile_scaffold.dart:444:48)
#5      _HoverBuilderState.build (package:super_utils/src/widgets/hover_builder.dart:78:32)
#6      StatefulElement.build (package:flutter/src/widgets/framework.dart:5593:27)
```

It seems to be caused by NonReparentingNode moving to another part of widget hierarchy using global key, which causes the focus node to be stuck with wrong parent. Alternatively we should reconsider if NonReparentingNode is necessary at all, given that the overlays should now be handled by overlay portal.