### PR TITLE
Cherry-pick "NonReparentingFocus - Reparent focus node in deactivate to match framework (#1961)" to stable

### DIFF
--- a/super_editor/lib/src/infrastructure/focus.dart
+++ b/super_editor/lib/src/infrastructure/focus.dart
@@ -52,6 +52,13 @@ class _NonReparentingFocusState extends State<NonReparentingFocus> {
   }
 
   @override
+  void deactivate() {
+    super.deactivate();
+    // See _FocusState.deactivate.
+    _keyboardFocusAttachment.reparent();
+  }
+
+  @override
   void didUpdateWidget(NonReparentingFocus oldWidget) {
     super.didUpdateWidget(oldWidget);
 


### PR DESCRIPTION
This PR cherry-picks "NonReparentingFocus - Reparent focus node in deactivate to match framework (#1961)" to stable