### PR TITLE
[SuperEditor][SuperReader] Do not stop scroll momentum on mouse move (Resolves #1946)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -577,13 +577,6 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     }
   }
 
-  /// Beginning with Flutter 3.3.3, we are responsible for starting and
-  /// stopping scroll momentum. This method cancels any scroll momentum
-  /// in our scroll controller.
-  void _cancelScrollMomentum() {
-    widget.autoScroller.goIdle();
-  }
-
   void _updateDragSelection() {
     if (_dragEndGlobal == null) {
       // User isn't dragging. No need to update drag selection.
@@ -729,7 +722,6 @@ Updating drag selection:
   }
 
   void _onMouseMove(PointerHoverEvent event) {
-    _cancelScrollMomentum();
     _updateMouseCursor(event.position);
     _lastHoverOffset = event.position;
   }

--- a/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
@@ -185,7 +185,6 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
   }
 
   void _onMouseMove(PointerHoverEvent event) {
-    _cancelScrollMomentum();
     _updateMouseCursor(event.position);
     _lastHoverOffset = event.position;
   }
@@ -462,13 +461,6 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
   void _scrollVertically(double delta) {
     widget.autoScroller.jumpBy(delta);
     _updateDragSelection();
-  }
-
-  /// Beginning with Flutter 3.3.3, we are responsible for starting and
-  /// stopping scroll momentum. This method cancels any scroll momentum
-  /// in our scroll controller.
-  void _cancelScrollMomentum() {
-    widget.autoScroller.goIdle();
   }
 
   void _updateDragSelection() {

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -557,6 +557,37 @@ void main() {
       expect(SuperEditorInspector.findDocumentSelection(), isNull);
     });
 
+    testWidgetsOnArbitraryDesktop("does not stop momentum on mouse move", (tester) async {
+      final scrollController = ScrollController();
+
+      // Pump an editor with a small size to make it scrollable.
+      await tester //
+          .createDocument() //
+          .withLongDoc() //
+          .withScrollController(scrollController) //
+          .withEditorSize(const Size(300, 300))
+          .pump();
+
+      // Fling scroll with the trackpad to generate momentum.
+      await tester.trackpadFling(
+        find.byType(SuperEditor),
+        const Offset(0.0, -300),
+        300.0,
+      );
+
+      final scrollOffsetInMiddleOfMomentum = scrollController.offset;
+
+      // Move the mouse around.
+      final gesture = await tester.createGesture();
+      await gesture.moveTo(tester.getTopLeft(find.byType(SuperEditor)));
+
+      // Let any momentum run.
+      await tester.pumpAndSettle();
+
+      // Ensure that the momentum didn't stop due to mouse movement.
+      expect(scrollOffsetInMiddleOfMomentum, lessThan(scrollController.offset));
+    });
+
     testWidgetsOnAndroid("doesn't overscroll when dragging down", (tester) async {
       final scrollController = ScrollController();
 

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -343,6 +343,37 @@ void main() {
       expect(scrollController.offset, scrollController.position.maxScrollExtent);
     });
 
+    testWidgetsOnArbitraryDesktop("does not stop momentum on mouse move", (tester) async {
+      final scrollController = ScrollController();
+
+      // Pump a reader with a small size to make it scrollable.
+      await tester //
+          .createDocument() //
+          .withCustomContent(longTextDoc()) //
+          .withScrollController(scrollController) //
+          .withEditorSize(const Size(300, 300))
+          .pump();
+
+      // Fling scroll with the trackpad to generate momentum.
+      await tester.trackpadFling(
+        find.byType(SuperReader),
+        const Offset(0.0, -300),
+        300.0,
+      );
+
+      final scrollOffsetInMiddleOfMomentum = scrollController.offset;
+
+      // Move the mouse around.
+      final gesture = await tester.createGesture();
+      await gesture.moveTo(tester.getTopLeft(find.byType(SuperReader)));
+
+      // Let any momentum run.
+      await tester.pumpAndSettle();
+
+      // Ensure that the momentum didn't stop due to mouse movement.
+      expect(scrollOffsetInMiddleOfMomentum, lessThan(scrollController.offset));
+    });
+
     group("when all content fits in the viewport", () {
       testWidgetsOnDesktop(
         "trackpad doesn't scroll content",


### PR DESCRIPTION
[SuperEditor][SuperReader] Do not stop scroll momentum on mouse move. Resolves #1946

On desktop, moving the mouse while the content is scrolling causes the scrolling to stop.  We introduced this change sometime ago, when the Flutter team made changes related to scroll momentum.

Now, Flutter has a dedicated signal for cancelling the scroll momentum: `PointerScrollInertiaCancelEvent`, which is already handled by `Scrollable`. Therefore, we don't need to cancel momentum ourselves.

This PR changes the mouse interactor to avoid cancelling momentum on mouse move.

 