### PR TITLE
Revert "NonReparentingFocus - Reparent focus node in deactivate to match framework

### DIFF
--- a/super_editor/lib/src/infrastructure/focus.dart
+++ b/super_editor/lib/src/infrastructure/focus.dart
@@ -52,13 +52,6 @@ class _NonReparentingFocusState extends State<NonReparentingFocus> {
   }
 
   @override
-  void deactivate() {
-    super.deactivate();
-    // See _FocusState.deactivate.
-    _keyboardFocusAttachment.reparent();
-  }
-
-  @override
   void didUpdateWidget(NonReparentingFocus oldWidget) {
     super.didUpdateWidget(oldWidget);
 


### PR DESCRIPTION
This reverts commit 60bb4424a0da1027a0c2ce1b92118db24d7bca0c.

This causes some issues:
```
Tried to make a child into a parent of itself.
[***]: 'package:flutter/src/widgets/focus_manager.dart':
[***]: Failed assertion: line 1013 pos 12: 'child != this'
[***]: 
[***]: Either the assertion indicates an error in the framework itself, or we should provide substantially
[***]: more information in this error message to help you determine and fix the underlying cause.
[***]: In either case, please report this assertion by filing a bug on GitHub:
[***]:   https://github.com/flutter/flutter/issues/new?template=2_bug.yml
[***]: 
[***]: When the exception was thrown, this was the stack:
[***]: #2      FocusNode._reparent (package:flutter/src/widgets/focus_manager.dart:1013:12)
[***]: #3      FocusAttachment.reparent (package:flutter/src/widgets/focus_manager.dart:255:14)
[***]: #4      _NonReparentingFocusState.deactivate (package:super_editor/src/infrastructure/focus.dart:58:30)
[***]: #5      StatefulElement.deactivate (package:flutter/src/widgets/framework.dart:5683:11)
```

I think the reason for this is that `FocusState` from framework reparents itself to parent during `build()` for reasons not entirely clean to me. It's a fragile system and rolling custom focus widget seem to break some assumptions that rest of the framework does (i.e. related focus scope caching that was added recently).

I think we should figure out whether `NonReparentingNode` is necessary at all in the presence of `OverlayPortal` and if not remove it completely. 