### PR TITLE
Cherry-pick "Revert "NonReparentingFocus - Reparent focus node in deactivate to match framework (#1969)" to stable

### DIFF
--- a/super_editor/lib/src/infrastructure/focus.dart
+++ b/super_editor/lib/src/infrastructure/focus.dart
@@ -52,13 +52,6 @@ class _NonReparentingFocusState extends State<NonReparentingFocus> {
   }
 
   @override
-  void deactivate() {
-    super.deactivate();
-    // See _FocusState.deactivate.
-    _keyboardFocusAttachment.reparent();
-  }
-
-  @override
   void didUpdateWidget(NonReparentingFocus oldWidget) {
     super.didUpdateWidget(oldWidget);
 


### PR DESCRIPTION
This PR cherry-picks "Revert "NonReparentingFocus - Reparent focus node in deactivate to match framework (#1969)" to stable