### PR TITLE
[SuperEditor][SuperReader][SuperTextField] Update iOS magnifier (Resolves #1958)

### DIFF
--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -14,7 +14,7 @@ class MobileEditingIOSDemo extends StatefulWidget {
   State<MobileEditingIOSDemo> createState() => _MobileEditingIOSDemoState();
 }
 
-class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> {
+class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> with SingleTickerProviderStateMixin {
   final GlobalKey _docLayoutKey = GlobalKey();
 
   late MutableDocument _doc;
@@ -133,12 +133,14 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> {
     );
   }
 
-  Widget _buildIosMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint) {
+  Widget _buildIosMagnifier(
+      BuildContext context, Key magnifierKey, LeaderLink focalPoint, AnimationController animationController) {
     return Center(
       child: IOSFollowingMagnifier.roundedRectangle(
         magnifierKey: magnifierKey,
         leaderLink: focalPoint,
-        offsetFromFocalPoint: const Offset(0, -72),
+        offsetFromFocalPoint: const Offset(0, -230),
+        animationController: animationController,
       ),
     );
   }

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -133,14 +133,13 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> with Single
     );
   }
 
-  Widget _buildIosMagnifier(
-      BuildContext context, Key magnifierKey, LeaderLink focalPoint, AnimationController animationController) {
+  Widget _buildIosMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool visible) {
     return Center(
       child: IOSFollowingMagnifier.roundedRectangle(
         magnifierKey: magnifierKey,
         leaderLink: focalPoint,
         offsetFromFocalPoint: const Offset(0, -230),
-        animationController: animationController,
+        show: visible,
       ),
     );
   }

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -133,13 +133,16 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> with Single
     );
   }
 
-  Widget _buildIosMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool visible) {
+  Widget _buildIosMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool isVisible) {
     return Center(
       child: IOSFollowingMagnifier.roundedRectangle(
         magnifierKey: magnifierKey,
         leaderLink: focalPoint,
-        offsetFromFocalPoint: const Offset(0, -230),
-        show: visible,
+        // The bottom of the magnifier sits above the focal point.
+        // Leave a few pixels between the bottom of the magnifier and the focal point. This
+        // value was chosen empirically.
+        offsetFromFocalPoint: const Offset(0, -20),
+        show: isVisible,
       ),
     );
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1735,8 +1735,8 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     );
   }
 
-  Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool visible) {
-    if (!visible) {
+  Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool isVisible) {
+    if (!isVisible) {
       return const SizedBox();
     }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1718,23 +1718,28 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     return ValueListenableBuilder(
       valueListenable: _controlsController!.shouldShowMagnifier,
       builder: (context, shouldShow, child) {
-        return shouldShow ? child! : const SizedBox();
+        return _controlsController!.magnifierBuilder != null //
+            ? _controlsController!.magnifierBuilder!(
+                context,
+                DocumentKeys.magnifier,
+                _controlsController!.magnifierFocalPoint,
+                shouldShow,
+              )
+            : _buildDefaultMagnifier(
+                context,
+                DocumentKeys.magnifier,
+                _controlsController!.magnifierFocalPoint,
+                shouldShow,
+              );
       },
-      child: _controlsController!.magnifierBuilder != null //
-          ? _controlsController!.magnifierBuilder!(
-              context,
-              DocumentKeys.magnifier,
-              _controlsController!.magnifierFocalPoint,
-            )
-          : _buildDefaultMagnifier(
-              context,
-              DocumentKeys.magnifier,
-              _controlsController!.magnifierFocalPoint,
-            ),
     );
   }
 
-  Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint) {
+  Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink focalPoint, bool visible) {
+    if (!visible) {
+      return const SizedBox();
+    }
+
     return Follower.withOffset(
       link: _controlsController!.magnifierFocalPoint,
       offset: const Offset(0, -150),

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1893,5 +1893,5 @@ class SuperEditorIosHandlesDocumentLayerBuilder implements SuperEditorLayerBuild
   }
 }
 
-const defaultIosMagnifierAnimationDuration = Duration(milliseconds: 150);
-const defaultIosMagnifierExitAnimationDuration = Duration(milliseconds: 100);
+const defaultIosMagnifierAnimationDuration = Duration(milliseconds: 180);
+const defaultIosMagnifierExitAnimationDuration = Duration(milliseconds: 150);

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1507,7 +1507,9 @@ class SuperEditorIosMagnifierOverlayManagerState extends State<SuperEditorIosMag
       magnifierKey: magnifierKey,
       leaderLink: magnifierFocalPoint,
       show: visible,
-      offsetFromFocalPoint: const Offset(0, -230),
+      // The bottom of the magnifier sits above the focal point.
+      // Leave a few pixels between the bottom of the magnifier and the focal point.
+      offsetFromFocalPoint: const Offset(0, -20),
     );
   }
 }
@@ -1853,3 +1855,4 @@ class SuperEditorIosHandlesDocumentLayerBuilder implements SuperEditorLayerBuild
 const defaultIosMagnifierEnterAnimationDuration = Duration(milliseconds: 180);
 const defaultIosMagnifierExitAnimationDuration = Duration(milliseconds: 150);
 const defaultIosMagnifierAnimationCurve = Curves.easeInOut;
+const defaultIosMagnifierSize = Size(133, 96);

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -285,7 +285,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   Offset? _globalDragOffset;
 
   /// The [Offset] of the magnifier's focal point in the [DocumentLayout] coordinate space.
-  final _magnifierFocalPointInContentSpace = ValueNotifier<Offset?>(null);
+  final _magnifierFocalPointInDocumentSpace = ValueNotifier<Offset?>(null);
   Offset? _dragEndInInteractor;
   DragMode? _dragMode;
   // TODO: HandleType is the wrong type here, we need collapsed/base/extent,
@@ -1086,7 +1086,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   }
 
   void _updateMagnifierFocalPointOnAutoScrollFrame() {
-    if (_magnifierFocalPointInContentSpace.value != null) {
+    if (_magnifierFocalPointInDocumentSpace.value != null) {
       _placeFocalPointNearTouchOffset();
     }
   }
@@ -1257,7 +1257,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       _docLayout.getRectForPosition(docPositionToMagnify!)!.center,
     );
 
-    _magnifierFocalPointInContentSpace.value = centerOfContentAtOffset;
+    _magnifierFocalPointInDocumentSpace.value = centerOfContentAtOffset;
   }
 
   @override
@@ -1335,7 +1335,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   Widget _buildMagnifierFocalPoint() {
     return ValueListenableBuilder(
-      valueListenable: _magnifierFocalPointInContentSpace,
+      valueListenable: _magnifierFocalPointInDocumentSpace,
       builder: (context, magnifierFocalPoint, child) {
         if (magnifierFocalPoint == null) {
           return const SizedBox();
@@ -1497,7 +1497,8 @@ class SuperEditorIosMagnifierOverlayManagerState extends State<SuperEditorIosMag
     );
   }
 
-  Widget _buildDefaultMagnifier(BuildContext context, Key magnifierKey, LeaderLink magnifierFocalPoint, bool visible) {
+  Widget _buildDefaultMagnifier(
+      BuildContext context, Key magnifierKey, LeaderLink magnifierFocalPoint, bool isVisible) {
     if (CurrentPlatform.isWeb) {
       // Defer to the browser to display overlay controls on mobile.
       return const SizedBox();
@@ -1506,10 +1507,12 @@ class SuperEditorIosMagnifierOverlayManagerState extends State<SuperEditorIosMag
     return IOSFollowingMagnifier.roundedRectangle(
       magnifierKey: magnifierKey,
       leaderLink: magnifierFocalPoint,
-      show: visible,
+      show: isVisible,
       // The bottom of the magnifier sits above the focal point.
-      // Leave a few pixels between the bottom of the magnifier and the focal point.
+      // Leave a few pixels between the bottom of the magnifier and the focal point. This
+      // value was chosen empirically.
       offsetFromFocalPoint: const Offset(0, -20),
+      handleColor: _controlsController!.handleColor,
     );
   }
 }

--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -112,33 +112,33 @@ class _IOSFollowingMagnifierState extends State<IOSFollowingMagnifier> with Sing
         animation: _animationController,
         builder: (context, child) {
           final percentage = _animationController.value;
+          final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
 
           return Follower.withOffset(
             link: widget.leaderLink,
+            // Center-align the magnifier with the focal point, so when the animation starts
+            // the magnifier is displayed in the same position as the focal point.
             leaderAnchor: Alignment.center,
-            followerAnchor: Alignment.topLeft,
+            followerAnchor: Alignment.center,
             offset: Offset(
-              widget.offsetFromFocalPoint.dx,
+              widget.offsetFromFocalPoint.dx * devicePixelRatio,
               // Animate the magnfier up on entrance and down on exit.
-              widget.offsetFromFocalPoint.dy * percentage,
+              widget.offsetFromFocalPoint.dy * devicePixelRatio * percentage,
             ),
-            // Theoretically, we should be able to use a leaderAnchor and followerAnchor of "center"
-            // and avoid the following FractionalTranslation. However, when centering the follower,
-            // we don't get the expect focal point within the magnified area. It's off-center. I'm not
-            // sure why that happens, but using a followerAnchor of "topLeft" and then pulling back
-            // by 50% solve the problem.
+            // Translate the magnifier so it's displayed above the focal point
+            // when the animation ends.
             child: FractionalTranslation(
-              translation: const Offset(-0.5, -0.5),
+              translation: Offset(0.0, -0.5 * percentage),
               child: widget.magnifierBuilder(
                 context,
                 IosMagnifierViewModel(
                   // In theory, the offsetFromFocalPoint should either be `widget.offsetFromFocalPoint.dy` to match
                   // the actual offset, or it should be `widget.offsetFromFocalPoint.dy / magnificationLevel`. Neither
                   // of those align the focal point correctly. The following offset was found empirically to give the
-                  // desired results.
+                  // desired results. These values seem to work even with different pixel densities.
                   offsetFromFocalPoint: Offset(
-                    widget.offsetFromFocalPoint.dx - 23,
-                    (widget.offsetFromFocalPoint.dy + 140) * percentage,
+                    -22 * percentage,
+                    (-defaultIosMagnifierSize.height + 14) * percentage,
                   ),
                   animationValue: _animationController.value,
                   animationDirection: _animationController.status,
@@ -189,8 +189,8 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
   Widget build(BuildContext context) {
     final percent = defaultIosMagnifierAnimationCurve.transform(animationValue);
 
-    final height = lerpDouble(30, 96, percent)!;
-    final width = lerpDouble(4, 133, percent)!;
+    final height = lerpDouble(30, defaultIosMagnifierSize.height, percent)!;
+    final width = lerpDouble(4, defaultIosMagnifierSize.width, percent)!;
     final size = Size(width, height);
 
     final tintOpacity = 1.0 - Curves.easeIn.transform(animationValue);

--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -140,7 +140,8 @@ class _IOSFollowingMagnifierState extends State<IOSFollowingMagnifier> with Sing
                     widget.offsetFromFocalPoint.dx - 23,
                     (widget.offsetFromFocalPoint.dy + 140) * percentage,
                   ),
-                  animationPercentage: _animationController.value,
+                  animationValue: _animationController.value,
+                  animationDirection: _animationController.status,
                   borderColor: handleColor,
                 ),
                 widget.magnifierKey,
@@ -160,7 +161,7 @@ Widget _roundedRectangleMagnifierBuilder(BuildContext context, IosMagnifierViewM
     IOSRoundedRectangleMagnifyingGlass(
       key: magnifierKey,
       offsetFromFocalPoint: magnifierInfo.offsetFromFocalPoint,
-      animationPercentage: magnifierInfo.animationPercentage,
+      animationValue: magnifierInfo.animationValue,
       borderColor: magnifierInfo.borderColor,
     );
 
@@ -176,23 +177,23 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
   const IOSRoundedRectangleMagnifyingGlass({
     super.key,
     this.offsetFromFocalPoint = Offset.zero,
-    this.animationPercentage = 1.0,
+    this.animationValue = 1.0,
     required this.borderColor,
   });
 
   final Offset offsetFromFocalPoint;
-  final double animationPercentage;
+  final double animationValue;
   final Color borderColor;
 
   @override
   Widget build(BuildContext context) {
-    final percent = defaultIosMagnifierAnimationCurve.transform(animationPercentage);
+    final percent = defaultIosMagnifierAnimationCurve.transform(animationValue);
 
     final height = lerpDouble(30, 96, percent)!;
     final width = lerpDouble(4, 133, percent)!;
     final size = Size(width, height);
 
-    final tintOpacity = 1.0 - Curves.easeIn.transform(animationPercentage);
+    final tintOpacity = 1.0 - Curves.easeIn.transform(animationValue);
     final borderRadius = lerpDouble(30.0, 50.0, percent)!;
     final borderWidth = lerpDouble(15.0, 3.0, percent)!;
 
@@ -296,11 +297,13 @@ class IOSCircleMagnifyingGlass extends StatelessWidget {
 class IosMagnifierViewModel {
   IosMagnifierViewModel({
     required this.offsetFromFocalPoint,
-    this.animationPercentage = 100.0,
+    this.animationValue = 1.0,
+    this.animationDirection = AnimationStatus.forward,
     required this.borderColor,
   });
 
   final Offset offsetFromFocalPoint;
-  final double animationPercentage;
+  final double animationValue;
+  final AnimationStatus animationDirection;
   final Color borderColor;
 }

--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -76,7 +76,7 @@ class _IOSFollowingMagnifierState extends State<IOSFollowingMagnifier> {
             translation: const Offset(-0.5, -0.5),
             child: widget.magnifierBuilder(
               context,
-              MagnifierInfo(
+              IosMagnifierViewModel(
                 // In theory, the offsetFromFocalPoint should either be `widget.offsetFromFocalPoint.dy` to match
                 // the actual offset, or it should be `widget.offsetFromFocalPoint.dy / magnificationLevel`. Neither
                 // of those align the focal point correctly. The following offset was found empirically to give the
@@ -97,9 +97,10 @@ class _IOSFollowingMagnifierState extends State<IOSFollowingMagnifier> {
   }
 }
 
-typedef MagnifierBuilder = Widget Function(BuildContext, MagnifierInfo magnifierInfo, [Key? magnifierKey]);
+typedef MagnifierBuilder = Widget Function(BuildContext, IosMagnifierViewModel magnifierInfo, [Key? magnifierKey]);
 
-Widget _roundedRectangleMagnifierBuilder(BuildContext context, MagnifierInfo magnifierInfo, [Key? magnifierKey]) =>
+Widget _roundedRectangleMagnifierBuilder(BuildContext context, IosMagnifierViewModel magnifierInfo,
+        [Key? magnifierKey]) =>
     IOSRoundedRectangleMagnifyingGlass(
       key: magnifierKey,
       offsetFromFocalPoint: magnifierInfo.offsetFromFocalPoint,
@@ -107,7 +108,7 @@ Widget _roundedRectangleMagnifierBuilder(BuildContext context, MagnifierInfo mag
       borderColor: magnifierInfo.borderColor,
     );
 
-Widget _circleMagnifierBuilder(BuildContext context, MagnifierInfo magnifierInfo, [Key? magnifierKey]) =>
+Widget _circleMagnifierBuilder(BuildContext context, IosMagnifierViewModel magnifierInfo, [Key? magnifierKey]) =>
     IOSCircleMagnifyingGlass(
       key: magnifierKey,
       offsetFromFocalPoint: magnifierInfo.offsetFromFocalPoint,
@@ -129,7 +130,7 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final percent = Curves.easeOut.transform(animationPercentage);
+    final percent = defaultIosMagnifierAnimationCurve.transform(animationPercentage);
 
     final height = lerpDouble(30, 96, percent)!;
     final width = lerpDouble(4, 133, percent)!;
@@ -235,9 +236,9 @@ class IOSCircleMagnifyingGlass extends StatelessWidget {
   }
 }
 
-/// Parameters used to render the magnifier.
-class MagnifierInfo {
-  MagnifierInfo({
+/// Parameters used to render an iOS magnifier.
+class IosMagnifierViewModel {
+  IosMagnifierViewModel({
     required this.offsetFromFocalPoint,
     this.animationPercentage = 100.0,
     required this.borderColor,

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -108,6 +108,12 @@ typedef DocumentFloatingToolbarBuilder = Widget Function(
 /// Builds a full-screen magnifier display, with the magnifier following the given [focalPoint],
 /// and with the magnifier attached to the given [magnifierKey].
 ///
+/// The [visible] parameter is used to let the magnifier animate its appearance and disappearance.
+/// For example, [visible] can be `false` and the magnifier can still be present in the widget tree
+/// while an exit animation runs. Upon animation end, the widget bound to [magnifierKey] should be
+/// removed from the widget tree. If an animation isn't desired, a [SizedBox] can be returned when
+/// [visible] is `false`.
+///
 /// The [magnifierKey] is used to find the magnifier in the widget tree for various purposes,
 /// e.g., within tests to verify the presence or absence of a magnifier. If your builder chooses
 /// not to build a magnifier, e.g., returns a `SizedBox()` instead of a magnifier, then
@@ -130,11 +136,7 @@ typedef DocumentFloatingToolbarBuilder = Widget Function(
 ///   );
 /// }
 /// ```
-typedef DocumentMagnifierBuilder = Widget Function(BuildContext, Key magnifierKey, LeaderLink focalPoint);
-
-/// A [DocumentMagnifierBuilder] that animates the magnifier's appearance and disappearance.
-typedef DocumentAnimatedMagnifierBuilder = Widget Function(
-    BuildContext, Key magnifierKey, LeaderLink focalPoint, AnimationController animationController);
+typedef DocumentMagnifierBuilder = Widget Function(BuildContext, Key magnifierKey, LeaderLink focalPoint, bool visible);
 
 /// Global flag that disables long-press selection for Android and iOS, as a hack for Superlist, because
 /// Superlist has a custom long-press behavior per-component.

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -136,7 +136,8 @@ typedef DocumentFloatingToolbarBuilder = Widget Function(
 ///   );
 /// }
 /// ```
-typedef DocumentMagnifierBuilder = Widget Function(BuildContext, Key magnifierKey, LeaderLink focalPoint, bool visible);
+typedef DocumentMagnifierBuilder = Widget Function(
+    BuildContext, Key magnifierKey, LeaderLink focalPoint, bool isVisible);
 
 /// Global flag that disables long-press selection for Android and iOS, as a hack for Superlist, because
 /// Superlist has a custom long-press behavior per-component.

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -132,6 +132,10 @@ typedef DocumentFloatingToolbarBuilder = Widget Function(
 /// ```
 typedef DocumentMagnifierBuilder = Widget Function(BuildContext, Key magnifierKey, LeaderLink focalPoint);
 
+/// A [DocumentMagnifierBuilder] that animates the magnifier's appearance and disappearance.
+typedef DocumentAnimatedMagnifierBuilder = Widget Function(
+    BuildContext, Key magnifierKey, LeaderLink focalPoint, AnimationController animationController);
+
 /// Global flag that disables long-press selection for Android and iOS, as a hack for Superlist, because
 /// Superlist has a custom long-press behavior per-component.
 ///

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -484,7 +484,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
       return;
     }
 
-    _updateMagnifierFocalPoint();
+    _placeFocalPointNearTouchOffset();
     _controlsController!
       ..hideToolbar()
       ..showMagnifier();
@@ -764,7 +764,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
 
     _controlsController!.showMagnifier();
 
-    _updateMagnifierFocalPoint();
+    _placeFocalPointNearTouchOffset();
   }
 
   void _updateSelectionForNewDragHandleLocation() {
@@ -907,7 +907,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
 
   void _updateMagnifierFocalPointOnAutoScrollFrame() {
     if (_magnifierFocalPoint.value != null) {
-      _updateMagnifierFocalPoint();
+      _placeFocalPointNearTouchOffset();
     }
   }
 
@@ -923,7 +923,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
   }
 
   /// Updates the magnifier focal point in relation to the current drag position.
-  void _updateMagnifierFocalPoint() {
+  void _placeFocalPointNearTouchOffset() {
     late DocumentPosition? docPositionToMagnify;
 
     if (_globalTapDownOffset != null) {
@@ -1179,7 +1179,11 @@ class SuperReaderIosMagnifierOverlayManagerState extends State<SuperReaderIosMag
       magnifierKey: magnifierKey,
       show: visible,
       leaderLink: magnifierFocalPoint,
-      offsetFromFocalPoint: const Offset(0, -230),
+      // The bottom of the magnifier sits above the focal point.
+      // Leave a few pixels between the bottom of the magnifier and the focal point. This
+      // value was chosen empirically.
+      offsetFromFocalPoint: const Offset(0, -20),
+      handleColor: _controlsContext!.handleColor,
     );
   }
 }

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -1138,7 +1138,7 @@ class SuperReaderIosMagnifierOverlayManagerState extends State<SuperReaderIosMag
     super.initState();
     _animationController = AnimationController(
       vsync: this,
-      duration: defaultIosMagnifierAnimationDuration,
+      duration: defaultIosMagnifierEnterAnimationDuration,
       reverseDuration: defaultIosMagnifierExitAnimationDuration,
     );
     _animationController.addStatusListener(_hideMagnifierOnAnimationEnd);

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -125,7 +125,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls>
 
     _animationController = AnimationController(
       vsync: this,
-      duration: defaultIosMagnifierAnimationDuration,
+      duration: defaultIosMagnifierEnterAnimationDuration,
       reverseDuration: defaultIosMagnifierExitAnimationDuration,
     );
   }

--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -534,7 +534,10 @@ class _IOSEditingControlsState extends State<IOSEditingControls>
         return IOSFollowingMagnifier.roundedRectangle(
           leaderLink: widget.editingController.magnifierFocalPoint,
           show: showMagnifier,
-          offsetFromFocalPoint: const Offset(0, -230),
+          // The bottom of the magnifier sits above the focal point.
+          // Leave a few pixels between the bottom of the magnifier and the focal point. This
+          // value was chosen empirically.
+          offsetFromFocalPoint: const Offset(0, -20),
         );
       },
     );

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -554,7 +554,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
   ///
   /// The extent widget is tracked via [_draggingHandleLink]
   Widget _buildExtentTrackerForMagnifier() {
-    if (!widget.textController.selection.isValid || !_isDraggingCaret) {
+    if (!widget.textController.selection.isValid || _dragOffset == null) {
       return const SizedBox();
     }
 


### PR DESCRIPTION
[SuperEditor][SuperReader][SuperTextField] Update iOS magnifier. Resolves #1958

The current appearance and behavior of our iOS magnifier doesn't match the native appearance and behavior.

Native iOS:

[native ios magnifier.webm](https://github.com/superlistapp/super_editor/assets/6229343/0825347e-4264-4819-a513-df6c2702e542)

SuperEditor:

[supereditor ios magnifier.webm](https://github.com/superlistapp/super_editor/assets/6229343/62d2f692-571f-4884-bd1b-2b15a3e8c13b)

This PR adds entrance/exit animations and updates the size and shape of the magnifier:


https://github.com/superlistapp/super_editor/assets/7597082/f0de708a-2efa-4f58-b74c-05515f371e6c

Here's the appearance with slow animations:

https://github.com/superlistapp/super_editor/assets/7597082/a83a351c-5349-4a89-bab2-bbff88391a75

This PR also includes the fix for the issue iOS described in https://github.com/superlistapp/super_editor/issues/1957