### PR TITLE
[SuperEditor] Show software keyboard upon tap (Resolves #1816)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -12,7 +12,6 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
-import 'package:super_editor/src/default_editor/document_ime/document_input_ime.dart';
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
@@ -395,7 +394,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.document,
     required this.getDocumentLayout,
     required this.selection,
-    required this.softwareKeyboardController,
+    required this.openSoftwareKeyboard,
     required this.scrollController,
     this.contentTapHandler,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
@@ -410,7 +409,9 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
   final Document document;
   final DocumentLayout Function() getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
-  final SoftwareKeyboardController softwareKeyboardController;
+
+  /// A callback that should open the software keyboard when invoked.
+  final VoidCallback openSoftwareKeyboard;
 
   /// Optional handler that responds to taps on content, e.g., opening
   /// a link when the user taps on text with a link attribution.
@@ -796,13 +797,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     _showAndHideEditingControlsAfterTapSelection(didTapOnExistingSelection: didTapOnExistingSelection);
 
-    if (didTapOnExistingSelection && widget.softwareKeyboardController.hasDelegate) {
-      // The user tapped on the existing selection while the IME connection
-      // is open. Show the software keyboard.
+    if (didTapOnExistingSelection) {
+      // The user tapped on the existing selection. Show the software keyboard.
       //
       // If the user didn't tap on an existing selection, the software keyboard will
       // already be visible.
-      widget.softwareKeyboardController.open();
+      widget.openSoftwareKeyboard();
     }
 
     widget.focusNode.requestFocus();

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -12,6 +12,7 @@ import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/document_ime/document_input_ime.dart';
 import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/document_operations/selection_operations.dart';
@@ -394,6 +395,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.document,
     required this.getDocumentLayout,
     required this.selection,
+    required this.softwareKeyboardController,
     required this.scrollController,
     this.contentTapHandler,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
@@ -408,6 +410,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
   final Document document;
   final DocumentLayout Function() getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
+  final SoftwareKeyboardController softwareKeyboardController;
 
   /// Optional handler that responds to taps on content, e.g., opening
   /// a link when the user taps on text with a link attribution.
@@ -792,6 +795,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     }
 
     _showAndHideEditingControlsAfterTapSelection(didTapOnExistingSelection: didTapOnExistingSelection);
+
+    // Show the software keyboard.
+    widget.softwareKeyboardController.open();
 
     widget.focusNode.requestFocus();
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -796,8 +796,14 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     _showAndHideEditingControlsAfterTapSelection(didTapOnExistingSelection: didTapOnExistingSelection);
 
-    // Show the software keyboard.
-    widget.softwareKeyboardController.open();
+    if (didTapOnExistingSelection && widget.softwareKeyboardController.hasDelegate) {
+      // The user tapped on the existing selection while the IME connection
+      // is open. Show the software keyboard.
+      //
+      // If the user didn't tap on an existing selection, the software keyboard will
+      // already be visible.
+      widget.softwareKeyboardController.open();
+    }
 
     widget.focusNode.requestFocus();
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -631,8 +631,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
         selection != null &&
         !selection.isCollapsed &&
         widget.document.doesSelectionContainPosition(selection, docPosition)) {
-      // The user tapped on an expanded selection. Toggle the toolbar.
+      // The user tapped on an expanded selection. Toggle the toolbar and show
+      // the software keyboard.
       _controlsController!.toggleToolbar();
+      widget.openSoftwareKeyboard();
       return;
     }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -227,6 +227,7 @@ class IosDocumentTouchInteractor extends StatefulWidget {
     required this.document,
     required this.getDocumentLayout,
     required this.selection,
+    required this.openSoftwareKeyboard,
     required this.scrollController,
     required this.dragHandleAutoScroller,
     this.contentTapHandler,
@@ -241,6 +242,9 @@ class IosDocumentTouchInteractor extends StatefulWidget {
   final Document document;
   final DocumentLayout Function() getDocumentLayout;
   final ValueListenable<DocumentSelection?> selection;
+
+  /// A callback that should open the software keyboard when invoked.
+  final VoidCallback openSoftwareKeyboard;
 
   /// Optional handler that responds to taps on content, e.g., opening
   /// a link when the user taps on text with a link attribution.
@@ -663,6 +667,14 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
         // Place the document selection at the location where the
         // user tapped.
         _selectPosition(docPosition);
+      }
+
+      if (didTapOnExistingSelection) {
+        // The user tapped on the existing selection. Show the software keyboard.
+        //
+        // If the user didn't tap on an existing selection, the software keyboard will
+        // already be visible.
+        widget.openSoftwareKeyboard();
       }
     } else {
       widget.editor.execute([

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -588,6 +588,15 @@ class SuperEditorState extends State<SuperEditor> {
       widget.keyboardActions ??
       (inputSource == TextInputSource.ime ? defaultImeKeyboardActions : defaultKeyboardActions);
 
+  void _openSoftareKeyboard() {
+    if (!_softwareKeyboardController.hasDelegate) {
+      // There is no IME connection. It isn't possible to request the keyboard.
+      return;
+    }
+
+    _softwareKeyboardController.open();
+  }
+
   @override
   Widget build(BuildContext context) {
     return _buildGestureControlsScope(
@@ -795,7 +804,7 @@ class SuperEditorState extends State<SuperEditor> {
           document: editContext.document,
           getDocumentLayout: () => editContext.documentLayout,
           selection: editContext.composer.selectionNotifier,
-          softwareKeyboardController: _softwareKeyboardController,
+          openSoftwareKeyboard: _openSoftareKeyboard,
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,
@@ -808,6 +817,7 @@ class SuperEditorState extends State<SuperEditor> {
           document: editContext.document,
           getDocumentLayout: () => editContext.documentLayout,
           selection: editContext.composer.selectionNotifier,
+          openSoftwareKeyboard: _openSoftareKeyboard,
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -379,6 +379,8 @@ class SuperEditorState extends State<SuperEditor> {
   @visibleForTesting
   SingleColumnLayoutPresenter get presenter => _docLayoutPresenter!;
 
+  late SoftwareKeyboardController _softwareKeyboardController;
+
   @override
   void initState() {
     super.initState();
@@ -393,6 +395,8 @@ class SuperEditorState extends State<SuperEditor> {
     _docLayoutKey = widget.documentLayoutKey ?? GlobalKey();
 
     _selectionLinks = widget.selectionLayerLinks ?? SelectionLayerLinks();
+
+    _softwareKeyboardController = widget.softwareKeyboardController ?? SoftwareKeyboardController();
 
     widget.editor.context.put(
       Editor.layoutKey,
@@ -447,6 +451,10 @@ class SuperEditorState extends State<SuperEditor> {
 
     if (widget.scrollController != oldWidget.scrollController) {
       _scrollController = widget.scrollController ?? ScrollController();
+    }
+
+    if (widget.softwareKeyboardController != oldWidget.softwareKeyboardController) {
+      _softwareKeyboardController = widget.softwareKeyboardController ?? SoftwareKeyboardController();
     }
 
     _recomputeIfLayoutShouldShowCaret();
@@ -695,7 +703,7 @@ class SuperEditorState extends State<SuperEditor> {
           editContext: editContext,
           clearSelectionWhenEditorLosesFocus: widget.selectionPolicies.clearSelectionWhenEditorLosesFocus,
           clearSelectionWhenImeConnectionCloses: widget.selectionPolicies.clearSelectionWhenImeConnectionCloses,
-          softwareKeyboardController: widget.softwareKeyboardController,
+          softwareKeyboardController: _softwareKeyboardController,
           imePolicies: widget.imePolicies,
           imeConfiguration: widget.imeConfiguration ??
               SuperEditorImeConfiguration(
@@ -787,6 +795,7 @@ class SuperEditorState extends State<SuperEditor> {
           document: editContext.document,
           getDocumentLayout: () => editContext.documentLayout,
           selection: editContext.composer.selectionNotifier,
+          softwareKeyboardController: _softwareKeyboardController,
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1315,7 +1315,7 @@ Paragraph two
       });
     });
 
-    testWidgetsOnAndroid('shows software keyboard when tapping at the selected position', (tester) async {
+    testWidgetsOnMobile('shows software keyboard when tapping at the selected position', (tester) async {
       await tester
           .createDocument() //
           .withSingleParagraph()

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1315,6 +1315,41 @@ Paragraph two
       });
     });
 
+    testWidgetsOnAndroid('shows software keyboard when tapping at the selected position', (tester) async {
+      await tester
+          .createDocument() //
+          .withSingleParagraph()
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      // Place the caret at "Lorem| ipsum".
+      await tester.placeCaretInParagraph('1', 5);
+
+      // Hide the software keyboard using the system button.
+      tester.testTextInput.hide();
+
+      bool wasKeyboardShown = false;
+
+      // Intercept the messages sent to the platform to check if
+      // we showed the software keyboard.
+      tester
+          .interceptChannel(SystemChannels.textInput.name) //
+          .interceptMethod(
+        'TextInput.show',
+        (methodCall) {
+          wasKeyboardShown = true;
+
+          return null;
+        },
+      );
+
+      // Tap again on the same selected position.
+      await tester.placeCaretInParagraph('1', 5);
+
+      // Ensure the keyboard was shown.
+      expect(wasKeyboardShown, isTrue);
+    });
+
     testWidgetsOnAllPlatforms('clears composing region after losing focus', (tester) async {
       final focusNode = FocusNode();
 

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1315,7 +1315,7 @@ Paragraph two
       });
     });
 
-    testWidgetsOnMobile('shows software keyboard when tapping at the selected position', (tester) async {
+    testWidgetsOnMobile('opens software keyboard when tapping on caret', (tester) async {
       await tester
           .createDocument() //
           .withSingleParagraph()
@@ -1345,6 +1345,41 @@ Paragraph two
 
       // Tap again on the same selected position.
       await tester.placeCaretInParagraph('1', 5);
+
+      // Ensure the keyboard was shown.
+      expect(wasKeyboardShown, isTrue);
+    });
+
+    testWidgetsOnIos('opens software keyboard when tapping on an expanded selection', (tester) async {
+      await tester
+          .createDocument() //
+          .withSingleParagraph()
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      // Double tap to select "|Lorem| ipsum".
+      await tester.doubleTapInParagraph('1', 1);
+
+      // Hide the software keyboard using the system button.
+      tester.testTextInput.hide();
+
+      bool wasKeyboardShown = false;
+
+      // Intercept the messages sent to the platform to check if
+      // we showed the software keyboard.
+      tester
+          .interceptChannel(SystemChannels.textInput.name) //
+          .interceptMethod(
+        'TextInput.show',
+        (methodCall) {
+          wasKeyboardShown = true;
+
+          return null;
+        },
+      );
+
+      // Tap somewhere on the existing selection.
+      await tester.tapInParagraph('1', 3);
 
       // Ensure the keyboard was shown.
       expect(wasKeyboardShown, isTrue);


### PR DESCRIPTION
[SuperEditor] Show software keyboard upon tap. Resolves #1816

Steps to reproduce:

1. Place the selection at an arbitrary position
2. Close the software keyboard using the system button
3. Tap again on the same selected position

After that, the software keyboard isn't shown.

The reason is that we show the software keyboard when selection changes. Because the selection didn't change, the software keyboard isn't show.

This PR forwards `SoftwareKeyboardController` to the Android touch interactor so it can show the keyboard upon tap.

I couldn't reproduce this on iOS because I didn't find any system button to close the keyboard. We have an above-the-keyboard panel button to close the keyboard, but in reality we are closing the IME connection when tapping on it. I noticed that Flutter doesn't expose a method to close the software keyboard, so it's probably a good idea to file an issue for that.

Open questions:

- Should we remove the code that opens the keyboard when selection changes? 
- Should we replicate the same implementation to iOS?