### PR TITLE
[SuperEditor][Android] Fix magnified area (Resolves #1957)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1750,11 +1750,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
         child: AndroidMagnifyingGlass(
           key: magnifierKey,
           magnificationScale: 1.5,
-          // In theory, the offsetFromFocalPoint should either be `-150` to match the actual
-          // offset, or it should be `-150 / magnificationLevel`. Neither of those align the
-          // focal point correctly. The following offset was found empirically to give the
-          // desired results, no matter how high the magnification.
-          offsetFromFocalPoint: const Offset(0, -58),
+          offsetFromFocalPoint: Offset(0, -150 / MediaQuery.devicePixelRatioOf(context)),
         ),
       ),
     );


### PR DESCRIPTION
[SuperEditor][Android] Fix magnified area (Resolves #1957)

On some Android devices, the magnified area is wrong:

![Screenshot_1713780723](https://github.com/superlistapp/super_editor/assets/6229343/77effa40-f1a6-49b2-8c56-3a0a03e7bdd8)

This is caused because we use a magic number on the offset from focal point, which doesn't work for different pixel densities.

This PR fixes this issue by calculating the offset taking the pixel density into account.

[pixel_3a.webm](https://github.com/superlistapp/super_editor/assets/7597082/65f6e592-857c-41eb-bc68-7aee5c30f12e)

[pixel_7_pro.webm](https://github.com/superlistapp/super_editor/assets/7597082/a89fa960-6ccf-4764-ba1f-4e176ea277ea)

https://github.com/superlistapp/super_editor/pull/1973 should fix the issue for iOS