### PR TITLE
[SuperEditor][DemoApp] Fix content being deleted on iOS textfield demo (Resolves #2006)

### DIFF
--- a/super_editor/example/lib/demos/supertextfield/_mobile_textfield_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_mobile_textfield_demo.dart
@@ -28,6 +28,7 @@ class _MobileSuperTextFieldDemoState extends State<MobileSuperTextFieldDemo> {
   late ImeAttributedTextEditingController _textController;
 
   _TextFieldSizeMode _sizeMode = _TextFieldSizeMode.short;
+  late MobileTextFieldDemoConfig _demoConfig;
 
   bool _showDebugPaint = false;
 
@@ -47,6 +48,8 @@ class _MobileSuperTextFieldDemoState extends State<MobileSuperTextFieldDemo> {
         text: widget.initialText.copyText(0),
       ),
     );
+
+    _demoConfig = _createDemoConfig();
   }
 
   @override
@@ -110,7 +113,7 @@ class _MobileSuperTextFieldDemoState extends State<MobileSuperTextFieldDemo> {
                       child: TapRegion(
                         groupId: widget.textFieldTapRegionGroupId,
                         onTapOutside: (_) => widget.textFieldFocusNode.unfocus(),
-                        child: widget.createTextField(_createDemoConfig()),
+                        child: widget.createTextField(_demoConfig),
                       ),
                     ),
                   ),
@@ -162,6 +165,8 @@ class _MobileSuperTextFieldDemoState extends State<MobileSuperTextFieldDemo> {
                     } else if (newIndex == 3) {
                       _sizeMode = _TextFieldSizeMode.empty;
                     }
+
+                    _demoConfig = _createDemoConfig();
                   });
                 },
               ),


### PR DESCRIPTION
[SuperEditor][DemoApp] Fix content being deleted on iOS textfield demo. Resolves #2006

On the iOS textfield demo using the "Empty" option, after typing something and pressing the action button the text is being deleted.

The issue is that we are calling the `_createDemoConfig()` during the build method. This method ends up changing the `_textController`'s text.

This PR removes that call from the build method and places in `initState` and when the user changes the selected demo.

https://github.com/superlistapp/super_editor/assets/7597082/7d6c1489-669f-4acd-81b1-e59f75483b20

