### PR TITLE
[SuperEditor][iOS] Fix IME mapping error after pressing the newline button (Resolve #2007)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -71,6 +72,9 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
   ///
   /// This value is updated on [updateFloatingCursor].
   bool _isFloatingCursorVisible = false;
+
+  /// Whether or not a `TextInputAction.newline` was performed on the current frame.
+  bool _hasPerformedNewLineActionThisFrame = false;
 
   void _onContentChange() {
     if (!attached) {
@@ -202,6 +206,15 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
       return;
     }
 
+    if (_hasPerformedNewLineActionThisFrame && defaultTargetPlatform == TargetPlatform.iOS) {
+      // On iOS, pressing the new line action button can trigger the IME to try to apply suggestions
+      // after we have already processed the new line insertion. This causes the deltas related to suggestions
+      // to have offsets that are invalid for us. Ignore any new deltas on the same frame and forcefully
+      // update the IME with our current state.
+      imeConnection.value?.setEditingState(_currentTextEditingValue);
+      return;
+    }
+
     editorImeLog.fine("Received edit deltas from platform: ${textEditingDeltas.length} deltas");
     for (final delta in textEditingDeltas) {
       editorImeLog.fine("$delta");
@@ -272,6 +285,13 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
     editorImeLog.fine("IME says to perform action: $action");
     if (action == TextInputAction.newline) {
       textDeltasDocumentEditor.insertNewline();
+
+      // TODO: add comment.
+      // See https://github.com/superlistapp/super_editor/issues/2007 for more information.
+      _hasPerformedNewLineActionThisFrame = true;
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        _hasPerformedNewLineActionThisFrame = false;
+      });
     }
   }
 

--- a/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_ime_communication.dart
@@ -286,7 +286,10 @@ class DocumentImeInputClient extends TextInputConnectionDecorator with TextInput
     if (action == TextInputAction.newline) {
       textDeltasDocumentEditor.insertNewline();
 
-      // TODO: add comment.
+      // Keep track that we have performed a new line action on this frame to work around an iOS timing issue,
+      // where the iOS IME might report text deltas related to keyboard suggestions after we already processed
+      // the new line action.
+      //
       // See https://github.com/superlistapp/super_editor/issues/2007 for more information.
       _hasPerformedNewLineActionThisFrame = true;
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -905,6 +905,59 @@ Paragraph two
       });
     });
 
+    group('on iPhone 15 (iOS 17.5)', () {
+      testWidgetsOnIos('ignores keyboard suggestions when pressing the newline button', (tester) async {
+        final testContext = await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the start of the paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Type some text.
+        await tester.typeImeText('run tom');
+
+        // Press the new line button.
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+
+        // Simulate the IME sending a delta replacing "tom" with "Tom".
+        // At this point, we already added a new paragraph to the document,
+        // so these text ranges are invalid for us.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaReplacement(
+            oldText: '. Run tom',
+            replacementText: 'Tom',
+            replacedRange: TextRange(start: 6, end: 9),
+            selection: TextSelection.collapsed(offset: 9),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaInsertion(
+            oldText: '. Run Tom',
+            textInserted: '\n',
+            insertionOffset: 9,
+            selection: TextSelection.collapsed(
+              offset: 10,
+              affinity: TextAffinity.downstream,
+            ),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+        await tester.pump();
+
+        final document = testContext.document;
+
+        // Ensure the replacement was ignored and a new empty node was added.
+        expect(document.nodes.length, 2);
+        expect((document.nodes[0] as TextNode).text.text, 'run tom');
+        expect((document.nodes[1] as TextNode).text.text, '');
+      });
+    });
+
     group('moves caret', () {
       testWidgetsOnDesktopAndWeb('to end of previous node when LEFT_ARROW is pressed at the beginning of a paragraph',
           (tester) async {


### PR DESCRIPTION
[SuperEditor][iOS] Fix IME mapping error after pressing the newline button (Resolve #2007)

On iOS, typing "run tom" and pressing the new line button causes the following crash:

```console
======== Exception caught by services library ======================================================
The following _Exception was thrown during method call TextInputClient.updateEditingStateWithDeltas:
Exception: Couldn't map an IME position to a document position. 
TextEditingValue: '. '
IME position: TextPosition(offset: 6, affinity: TextAffinity.downstream)

When the exception was thrown, this was the stack: 
#0      DocumentImeSerializer._imeToDocumentPosition (package:super_editor/src/default_editor/document_ime/document_serialization.dart:309:5)
#1      DocumentImeSerializer.imeToDocumentSelection (package:super_editor/src/default_editor/document_ime/document_serialization.dart:166:18)
#2      TextDeltasDocumentEditor.replace (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:360:49)
#3      TextDeltasDocumentEditor._applyReplacement (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:220:5)
#4      TextDeltasDocumentEditor.applyDeltas (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:83:9)
#5      DocumentImeInputClient.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:219:30)
#6      DeltaTextInputClientDecorator.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/ime_decoration.dart:129:14)
#7      TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1904:63)
#8      TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1795:20)
#9      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:571:55)
#10     MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:564:34)
#11     _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:597:35)
#12     _invoke2 (dart:ui/hooks.dart:344:13)
#13     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
#14     _Channel.push (dart:ui/channel_buffers.dart:135:31)
#15     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
#16     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:750:22)
#17     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)
call: MethodCall(TextInputClient.updateEditingStateWithDeltas, [1, {deltas: [{selectionBase: 9, oldText: . Run tom, selectionAffinity: TextAffinity.downstream, deltaEnd: 9, deltaText: Tom, deltaStart: 6, composingExtent: -1, selectionIsDirectional: false, selectionExtent: 9, composingBase: -1}]}])
====================================================================================================
```

The cause is an IME timing issue. This is what's happening:

- The current editing value is "run tom"
- The user presses the new line button
- We receive the a `TextInputAction.newline`
- SuperEditor handles this action, adds a new paragraph, and sends `. ` as the new editing text
- We receive a replacement delta from the IME, replacing "run tom" with "run Tom". Since our editing value is already `. `, the offsets reported in the delta are invalid for us, causing the crash.
- We receive a `\n` insertion from the IME.

We had some other timing issues in the past, like https://github.com/superlistapp/super_editor/issues/1828, https://github.com/superlistapp/super_editor/issues/1592 and https://github.com/flutter/flutter/issues/118759.

This PR adds a workaround to ignore any deltas that are reported in the same frame as a `TextInputAction.newline`, only for iOS. This is a fragile solution that can cause and hide other bugs, but I think it's the best we can do right now. I'll file a ticket in the Flutter repo to see if there is some change that could be done in the Flutter IME code to avoid that.

I've done some manual testing and nothing seems to break. This issue doesn't seem to happen on other platforms.