### PR TITLE
[SuperEditor][Android] Show expanded handles when expanding the selection (Resolves #1937)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1345,6 +1345,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
     _controlsController = SuperEditorAndroidControlsScope.rootOf(context);
     // TODO: Replace Cupertino aligner with a generic aligner because this code runs on Android.
     _toolbarAligner = CupertinoPopoverToolbarAligner();
+    widget.selection.addListener(_onSelectionChange);
   }
 
   @override
@@ -1383,22 +1384,33 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   bool get wantsToDisplayMagnifier => _controlsController!.shouldShowMagnifier.value;
 
   void _onSelectionChange() {
+    if (widget.selection.value != null &&
+        widget.selection.value?.isCollapsed == false &&
+        _controlsController!.shouldShowCollapsedHandle.value == true) {
+      // The selection is expanded, but the collapsed handle is visible. This can happen when the
+      // where the collapsed handle should be visible when the selection is expanded. Hide the collapsed
+      // selection is collapsed and the user taps the "Select All" button. There isn't any situation
+      _controlsController!
+      // handle and show the expanded handles.
+        ..hideCollapsedHandle()
+        ..hideMagnifier();
+        ..showExpandedHandles()
+    }
     if (widget.selection.value?.isCollapsed == true &&
         _controlsController!.shouldShowExpandedHandles.value == true &&
         _dragHandleType == null) {
-      // The selection is collapsed, but the expanded handles are visible and the user isn't dragging a handle.
       // This can happen when the selection is expanded, and the user deletes the selected text. The only situation
-      // where the expanded handles should be visible when the selection is collapsed is when the selection
+      // The selection is collapsed, but the expanded handles are visible and the user isn't dragging a handle.
       // collapses while the user is dragging an expanded handle, which isn't the case here. Hide the handles.
+      // where the expanded handles should be visible when the selection is collapsed is when the selection
       _controlsController!
         ..hideCollapsedHandle()
         ..hideExpandedHandles()
-        ..hideMagnifier()
         ..hideToolbar()
         ..blinkCaret();
-    }
+        ..hideMagnifier()
   }
-
+    }
   void _toggleToolbarOnCollapsedHandleTap() {
     _controlsController!.toggleToolbar();
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1389,7 +1389,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
       return;
     }
 
-    if (selection.isCollapsed == true &&
+    if (selection.isCollapsed &&
         _controlsController!.shouldShowExpandedHandles.value == true &&
         _dragHandleType == null) {
       // The selection is collapsed, but the expanded handles are visible and the user isn't dragging a handle.
@@ -1404,7 +1404,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
         ..blinkCaret();
     }
 
-    if (selection.isCollapsed == false && _controlsController!.shouldShowCollapsedHandle.value == true) {
+    if (!selection.isCollapsed && _controlsController!.shouldShowCollapsedHandle.value == true) {
       // The selection is expanded, but the collapsed handle is visible. This can happen when the
       // selection is collapsed and the user taps the "Select All" button. There isn't any situation
       // where the collapsed handle should be visible when the selection is expanded. Hide the collapsed

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1384,33 +1384,38 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   bool get wantsToDisplayMagnifier => _controlsController!.shouldShowMagnifier.value;
 
   void _onSelectionChange() {
-    if (widget.selection.value != null &&
-        widget.selection.value?.isCollapsed == false &&
-        _controlsController!.shouldShowCollapsedHandle.value == true) {
-      // The selection is expanded, but the collapsed handle is visible. This can happen when the
-      // where the collapsed handle should be visible when the selection is expanded. Hide the collapsed
-      // selection is collapsed and the user taps the "Select All" button. There isn't any situation
-      _controlsController!
-      // handle and show the expanded handles.
-        ..hideCollapsedHandle()
-        ..hideMagnifier();
-        ..showExpandedHandles()
+    final selection = widget.selection.value;
+    if (selection == null) {
+      return;
     }
-    if (widget.selection.value?.isCollapsed == true &&
+
+    if (selection.isCollapsed == true &&
         _controlsController!.shouldShowExpandedHandles.value == true &&
         _dragHandleType == null) {
-      // This can happen when the selection is expanded, and the user deletes the selected text. The only situation
       // The selection is collapsed, but the expanded handles are visible and the user isn't dragging a handle.
-      // collapses while the user is dragging an expanded handle, which isn't the case here. Hide the handles.
+      // This can happen when the selection is expanded, and the user deletes the selected text. The only situation
       // where the expanded handles should be visible when the selection is collapsed is when the selection
+      // collapses while the user is dragging an expanded handle, which isn't the case here. Hide the handles.
       _controlsController!
         ..hideCollapsedHandle()
         ..hideExpandedHandles()
+        ..hideMagnifier()
         ..hideToolbar()
         ..blinkCaret();
-        ..hideMagnifier()
-  }
     }
+
+    if (selection.isCollapsed == false && _controlsController!.shouldShowCollapsedHandle.value == true) {
+      // The selection is expanded, but the collapsed handle is visible. This can happen when the
+      // selection is collapsed and the user taps the "Select All" button. There isn't any situation
+      // where the collapsed handle should be visible when the selection is expanded. Hide the collapsed
+      // handle and show the expanded handles.
+      _controlsController!
+        ..hideCollapsedHandle()
+        ..showExpandedHandles()
+        ..hideMagnifier();
+    }
+  }
+
   void _toggleToolbarOnCollapsedHandleTap() {
     _controlsController!.toggleToolbar();
   }

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -214,6 +214,26 @@ void main() {
       expect(SuperEditorInspector.isCaretVisible(), isTrue);
     });
 
+    testWidgetsOnAndroid("shows expanded handles when expanding the selection", (tester) async {
+      final context = await _pumpSingleParagraphApp(tester);
+
+      // Place the caret at the beginning of the paragraph.
+      await tester.placeCaretInParagraph("1", 0);
+      await tester.pump();
+
+      // Ensure the collapsed handle is visible and the expanded handles aren't visible.
+      expect(SuperEditorInspector.findMobileCaretDragHandle(), findsOneWidget);
+      expect(SuperEditorInspector.findMobileExpandedDragHandles(), findsNothing);
+
+      // Select all of the text.
+      context.findEditContext().commonOps.selectAll();
+      await tester.pump();
+
+      // Ensure the handles are visible and the collapsed handle isn't visible.
+      expect(SuperEditorInspector.findMobileExpandedDragHandles(), findsNWidgets(2));
+      expect(SuperEditorInspector.findMobileCaretDragHandle(), findsNothing);
+    });
+
     testWidgetsOnAndroid("hides expanded handles and toolbar when deleting an expanded selection", (tester) async {
       // Configure BlinkController to animate, otherwise it won't blink. We want to make sure
       // the caret blinks after deleting the content.
@@ -545,8 +565,8 @@ void main() {
   });
 }
 
-Future<void> _pumpSingleParagraphApp(WidgetTester tester) async {
-  await tester
+Future<TestDocumentContext> _pumpSingleParagraphApp(WidgetTester tester) async {
+  return await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...
       .withSingleParagraph()


### PR DESCRIPTION
[SuperEditor][Android] Show expanded handles when expanding the selection. Resolves #1937

When the selection changes from collapsed to expanded, the collapsed handle is visible at the beginning of the selection, and the expanded handles aren't visible:

[collapsed.webm](https://github.com/superlistapp/super_editor/assets/7597082/c2eb5476-5887-4c2c-a33d-a30e693aa849)

This PR fixes the issue by changing the visibility of the handles when needed.