### PR TITLE
Document usage of density independent pixels

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -38,7 +38,10 @@ class IOSFollowingMagnifier extends StatefulWidget {
   final Key? magnifierKey;
   final LeaderLink leaderLink;
   final bool show;
+
+  /// The distance, in density independent pixels, from the focal point to the magnifier.
   final Offset offsetFromFocalPoint;
+
   final Color? handleColor;
   final MagnifierBuilder magnifierBuilder;
 
@@ -171,6 +174,7 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
     required this.borderColor,
   });
 
+  /// The distance, in density independent pixels, from the focal point to the magnifier.
   final Offset offsetFromFocalPoint;
   final double animationValue;
   final Color borderColor;
@@ -240,6 +244,7 @@ class IOSCircleMagnifyingGlass extends StatelessWidget {
     this.offsetFromFocalPoint = Offset.zero,
   });
 
+  /// The distance, in density independent pixels, from the focal point to the magnifier.
   final Offset offsetFromFocalPoint;
 
   @override
@@ -292,7 +297,9 @@ class IosMagnifierViewModel {
     required this.borderColor,
   });
 
+  /// The distance, in density independent pixels, from the focal point to the magnifier.
   final Offset offsetFromFocalPoint;
+
   final double animationValue;
   final AnimationDirection animationDirection;
   final Color borderColor;

--- a/super_editor/lib/src/super_textfield/infrastructure/magnifier.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/magnifier.dart
@@ -27,7 +27,7 @@ class MagnifyingGlass extends StatelessWidget {
   }) : super(key: key);
 
   /// The offset from where the magnification is applied, to where this
-  /// magnifier is displayed.
+  /// magnifier is displayed, in density independent pixels.
   ///
   /// An [offsetFromFocalPoint] of `Offset.zero` would indicate that this
   /// [MagnifyingGlass] is displayed directly over the point of magnification.


### PR DESCRIPTION
Document usage of density independent pixels

After the work done in https://github.com/superlistapp/super_editor/pull/1973, this PR documents that the `Offset`s used in the magnifier are expected to be in density independent pixels.

It seems that the only place where real pixel values are used is in follow_the_leader.