### PR TITLE
[SuperTextField][iOS] Don't show the mobile toolbar upon first tap (Resolves #2005)

### DIFF
--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -210,7 +210,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     final didCaretStayInSamePlace = _selectionBeforeTap != null &&
         _selectionBeforeTap?.hasSameBoundsAs(widget.textController.selection) == true &&
         _selectionBeforeTap!.isCollapsed;
-    if (didCaretStayInSamePlace || didTapOnExistingSelection) {
+    if ((didCaretStayInSamePlace || didTapOnExistingSelection) && widget.focusNode.hasFocus) {
       // The user either tapped directly on the caret, or on an expanded selection,
       // or the user tapped in empty space but didn't move the caret, for example
       // the user tapped in empty space after the text and the caret was already

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -744,65 +745,56 @@ a scrollbar
       });
 
       testWidgetsOnMobile("tap up does not shows the toolbar if the field does not have focus", (tester) async {
-        await _pumpTestApp(
-          tester,
-          controller: AttributedTextEditingController(text: AttributedText('')),
-        );
+        await _pumpTestAppWithFakeToolbar(tester);
 
         // Tap down and up so the field is focused.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.tapAt(tester.getTopLeft(find.byKey(_textFieldKey)));
         await tester.pumpAndSettle();
 
         // Ensure the toolbar isn't visible.
-        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+        expect(find.byKey(_popoverToolbarKey), findsNothing);
       });
 
       testWidgetsOnIos("tap up shows the toolbar if the field already has focus", (tester) async {
-        await _pumpTestApp(
-          tester,
-          controller: AttributedTextEditingController(text: AttributedText('')),
-        );
+        await _pumpTestAppWithFakeToolbar(tester);
 
         // Tap down and up so the field is focused.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.tapAt(tester.getTopLeft(find.byKey(_textFieldKey)));
         await tester.pumpAndSettle();
 
         // Ensure the toolbar isn't visible.
-        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+        expect(find.byKey(_popoverToolbarKey), findsNothing);
 
         // Avoid a double tap.
         await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
 
         // Tap down and up again.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.tapAt(tester.getTopLeft(find.byKey(_textFieldKey)));
         await tester.pumpAndSettle();
 
         // Ensure the toolbar is visible.
-        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isTrue);
+        expect(find.byKey(_popoverToolbarKey), findsOneWidget);
       });
 
       testWidgetsOnAndroid("tap up does not shows the toolbar if the field already has focus", (tester) async {
-        await _pumpTestApp(
-          tester,
-          controller: AttributedTextEditingController(text: AttributedText('')),
-        );
+        await _pumpTestAppWithFakeToolbar(tester);
 
         // Tap down and up so the field is focused.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.tapAt(tester.getTopLeft(find.byKey(_textFieldKey)));
         await tester.pumpAndSettle();
 
         // Ensure the toolbar isn't visible.
-        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+        expect(find.byKey(_popoverToolbarKey), findsNothing);
 
         // Avoid a double tap.
         await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
 
         // Tap down and up again.
-        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.tapAt(tester.getTopLeft(find.byKey(_textFieldKey)));
         await tester.pumpAndSettle();
 
         // Ensure the toolbar is visible.
-        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+        expect(find.byKey(_popoverToolbarKey), findsNothing);
       });
     });
 
@@ -916,6 +908,47 @@ Future<void> _pumpSingleLineTextField(
   );
 }
 
+/// Pump a test app with either a [SuperAndroidTextField] or a [SuperIOSTextField] with a fake toolbar.
+///
+/// The textfield is bound to [_textFieldKey] and the toolbar is bound to [_popoverToolbarKey].
+///
+/// This is used because we cannot configure the toolbar with [SuperTextField]'s public API.
+Future<void> _pumpTestAppWithFakeToolbar(
+  WidgetTester tester, {
+  ImeAttributedTextEditingController? controller,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 400,
+            child: DecoratedBox(
+              decoration: BoxDecoration(border: Border.all(color: Colors.red)),
+              child: defaultTargetPlatform == TargetPlatform.android
+                  ? SuperAndroidTextField(
+                      key: _textFieldKey,
+                      caretStyle: const CaretStyle(),
+                      textController: controller,
+                      selectionColor: Colors.blue,
+                      handlesColor: Colors.blue,
+                      popoverToolbarBuilder: (context, controller, config) => SizedBox(key: _popoverToolbarKey),
+                    )
+                  : SuperIOSTextField(
+                      key: _textFieldKey,
+                      caretStyle: const CaretStyle(),
+                      selectionColor: Colors.blue,
+                      handlesColor: Colors.blue,
+                      popoverToolbarBuilder: (context, controller) => SizedBox(key: _popoverToolbarKey),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 // Custom gesture settings that ensure panSlop equal to touchSlop
 class _GestureSettings extends DeviceGestureSettings {
   const _GestureSettings({
@@ -926,3 +959,6 @@ class _GestureSettings extends DeviceGestureSettings {
   @override
   final double panSlop;
 }
+
+final _popoverToolbarKey = GlobalKey();
+final _textFieldKey = GlobalKey();

--- a/super_editor/test/super_textfield/super_textfield_gestures_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_gestures_test.dart
@@ -742,6 +742,68 @@ a scrollbar
         // Ensure we are connected again.
         expect(controller.isAttachedToIme, true);
       });
+
+      testWidgetsOnMobile("tap up does not shows the toolbar if the field does not have focus", (tester) async {
+        await _pumpTestApp(
+          tester,
+          controller: AttributedTextEditingController(text: AttributedText('')),
+        );
+
+        // Tap down and up so the field is focused.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure the toolbar isn't visible.
+        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+      });
+
+      testWidgetsOnIos("tap up shows the toolbar if the field already has focus", (tester) async {
+        await _pumpTestApp(
+          tester,
+          controller: AttributedTextEditingController(text: AttributedText('')),
+        );
+
+        // Tap down and up so the field is focused.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure the toolbar isn't visible.
+        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+
+        // Avoid a double tap.
+        await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
+
+        // Tap down and up again.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure the toolbar is visible.
+        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isTrue);
+      });
+
+      testWidgetsOnAndroid("tap up does not shows the toolbar if the field already has focus", (tester) async {
+        await _pumpTestApp(
+          tester,
+          controller: AttributedTextEditingController(text: AttributedText('')),
+        );
+
+        // Tap down and up so the field is focused.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure the toolbar isn't visible.
+        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+
+        // Avoid a double tap.
+        await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
+
+        // Tap down and up again.
+        await tester.tapAt(tester.getTopLeft(find.byType(SuperTextField)));
+        await tester.pumpAndSettle();
+
+        // Ensure the toolbar is visible.
+        expect(SuperTextFieldInspector.wantsMobileToolbarToBeVisible(), isFalse);
+      });
     });
 
     testWidgetsOnAllPlatforms("loses focus when user taps outside in a TapRegion", (tester) async {

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:super_editor/src/super_textfield/android/_editing_controls.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/super_textfield/android/_editing_controls.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
@@ -291,6 +292,45 @@ class SuperTextFieldInspector {
 
     throw Exception(
         "Couldn't find the caret rectangle because we couldn't find a SuperTextField. Finder: $superTextFieldFinder");
+  }
+
+  /// Returns `true` if the mobile text field is configured to display a toolbar.
+  ///
+  /// {@macro supertextfield_finder}
+  ///
+  /// Throws if a mobile text field isn't found.
+  static bool wantsMobileToolbarToBeVisible([Finder? superTextFieldFinder]) {
+    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
+
+    final fieldFinder = findInnerPlatformTextField(finder);
+    final match = fieldFinder.evaluate().single.widget;
+
+    switch (match.runtimeType) {
+      case SuperAndroidTextField:
+        final touchInteractor = (find
+                .descendant(
+                  of: fieldFinder,
+                  matching: find.byType(AndroidEditingOverlayControls),
+                )
+                .evaluate()
+                .single as StatefulElement)
+            .widget as AndroidEditingOverlayControls;
+
+        return touchInteractor.editingController.isToolbarVisible;
+      case SuperIOSTextField:
+        final touchInteractor = (find
+                .descendant(
+                  of: fieldFinder,
+                  matching: find.byType(IOSTextFieldTouchInteractor),
+                )
+                .evaluate()
+                .single as StatefulElement)
+            .widget as IOSTextFieldTouchInteractor;
+
+        return touchInteractor.editingOverlayController.isToolbarVisible;
+      default:
+        throw Exception("Didn't find a mobile SuperTextField");
+    }
   }
 
   static Rect? _findCaretRectInViewportOnDesktop(Finder desktopTextField) {

--- a/super_editor/test/super_textfield/super_textfield_inspector.dart
+++ b/super_editor/test/super_textfield/super_textfield_inspector.dart
@@ -294,45 +294,6 @@ class SuperTextFieldInspector {
         "Couldn't find the caret rectangle because we couldn't find a SuperTextField. Finder: $superTextFieldFinder");
   }
 
-  /// Returns `true` if the mobile text field is configured to display a toolbar.
-  ///
-  /// {@macro supertextfield_finder}
-  ///
-  /// Throws if a mobile text field isn't found.
-  static bool wantsMobileToolbarToBeVisible([Finder? superTextFieldFinder]) {
-    final finder = superTextFieldFinder ?? find.byType(SuperTextField);
-
-    final fieldFinder = findInnerPlatformTextField(finder);
-    final match = fieldFinder.evaluate().single.widget;
-
-    switch (match.runtimeType) {
-      case SuperAndroidTextField:
-        final touchInteractor = (find
-                .descendant(
-                  of: fieldFinder,
-                  matching: find.byType(AndroidEditingOverlayControls),
-                )
-                .evaluate()
-                .single as StatefulElement)
-            .widget as AndroidEditingOverlayControls;
-
-        return touchInteractor.editingController.isToolbarVisible;
-      case SuperIOSTextField:
-        final touchInteractor = (find
-                .descendant(
-                  of: fieldFinder,
-                  matching: find.byType(IOSTextFieldTouchInteractor),
-                )
-                .evaluate()
-                .single as StatefulElement)
-            .widget as IOSTextFieldTouchInteractor;
-
-        return touchInteractor.editingOverlayController.isToolbarVisible;
-      default:
-        throw Exception("Didn't find a mobile SuperTextField");
-    }
-  }
-
   static Rect? _findCaretRectInViewportOnDesktop(Finder desktopTextField) {
     final viewport = find
         .descendant(of: desktopTextField, matching: find.byType(SuperTextFieldScrollview))


### PR DESCRIPTION
[SuperTextField][iOS] Don't show the mobile toolbar upon first tap. Resolves #2005 

On iOS, tapping to focus the textfield is showing the toolbar. Looking at some iOS app, it seems the toolbar should only be displayed on tap if the textfield already has focus.

This PR changes the iOS textfield to only show the toolbar on tap if it already has focus.

For Android, it seems that doesn't show the toolbar even if the textfield already has focus.