### PR TITLE
[SuperEditor] Fix composing region mapping when using markdown plugin (Resolves #2028)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -180,14 +180,7 @@ class TextDeltasDocumentEditor {
       selection.value!,
       composingRegion.value,
       _serializedDoc.didPrependPlaceholder ? PrependedCharacterPolicy.include : PrependedCharacterPolicy.exclude,
-    )..imeText = _previousImeValue.text;
-
-    // The delta's composing region is based on the content after insertion, so we
-    // apply the composing region here instead of during insertion operation above.
-    final insertionComposingRegion = _serializedDoc.imeToDocumentRange(delta.composing);
-    editor.execute([
-      ChangeComposingRegionRequest(insertionComposingRegion),
-    ]);
+    );
   }
 
   void _applyReplacement(TextEditingDeltaReplacement delta) {
@@ -230,14 +223,7 @@ class TextDeltasDocumentEditor {
       selection.value!,
       composingRegion.value,
       _serializedDoc.didPrependPlaceholder ? PrependedCharacterPolicy.include : PrependedCharacterPolicy.exclude,
-    )..imeText = _previousImeValue.text;
-
-    // The delta's composing region is based on the content after insertion, so we
-    // apply the composing region here instead of during the replacement operation above.
-    final insertionComposingRegion = _serializedDoc.imeToDocumentRange(delta.composing);
-    editor.execute([
-      ChangeComposingRegionRequest(insertionComposingRegion),
-    ]);
+    );
   }
 
   void _applyDeletion(TextEditingDeltaDeletion delta) {
@@ -642,6 +628,20 @@ class TextDeltasDocumentEditor {
         ),
       );
     }
+
+    if (_serializedDoc.imeText.length < lastDelta.composing.end) {
+      // The IME is composing, but the composing region is out of our text bounds. This can happen if the delta
+      // handling causes our text to be smaller than the IME's text.
+      //
+      // For example, when using the markdown plugin, typing "~b~" causes the text to be converted to "b"
+      // with strikethrough. The ~ character triggers a composition start, but the IME's composing region is still
+      // at the end of "~b~", which is out of our text bounds. This out of bounds index causes our IME range
+      // mapping to fail.
+      //
+      // Clear the composing region.
+      return null;
+    }
+
     return _serializedDoc.imeToDocumentRange(lastDelta.composing);
   }
 }


### PR DESCRIPTION
[SuperEditor] Fix composing region mapping when using markdown plugin. Resolves #2028

Steps to reproduce:
- Run the app with a Brazilian Keyboard with the markdown plugin enable
- Add a new line
- Type "\~b~"

With these steps the following crash happens:

```console
════════ Exception caught by services library ══════════════════════════════════
The following _Exception was thrown during method call TextInputClient.updateEditingStateWithDeltas:
Exception: Couldn't map an IME position to a document position. 
TextEditingValue: '. ~b~'
IME position: TextPosition(offset: 4, affinity: TextAffinity.downstream)

When the exception was thrown, this was the stack:
#0      DocumentImeSerializer._imeToDocumentPosition (package:super_editor/src/default_editor/document_ime/document_serialization.dart:309:5)
#1      DocumentImeSerializer.imeToDocumentRange (package:super_editor/src/default_editor/document_ime/document_serialization.dart:218:14)
#2      TextDeltasDocumentEditor._applyInsertion (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:187:53)
#3      TextDeltasDocumentEditor.applyDeltas (package:super_editor/src/default_editor/document_ime/document_delta_editing.dart:81:9)
#4      DocumentImeInputClient.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:232:30)
#5      DeltaTextInputClientDecorator.updateEditingValueWithDeltas (package:super_editor/src/default_editor/document_ime/ime_decoration.dart:129:14)
#6      TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1906:63)
#7      TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1794:20)
#8      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:571:55)
#9      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:564:34)
#10     _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:581:35)
#11     _invoke2 (dart:ui/hooks.dart:344:13)
#12     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
#13     _Channel.push (dart:ui/channel_buffers.dart:135:31)
#14     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
#15     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:750:22)
#16     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)

call: MethodCall(TextInputClient.updateEditingStateWithDeltas, [2, {deltas: [{selectionBase: 5, oldText: . ~b, selectionAffinity: TextAffinity.downstream, deltaEnd: 4, deltaText: ~, deltaStart: 4, composingExtent: 5, selectionIsDirectional: false, selectionExtent: 5, composingBase: 4}]}])
════════════════════════════════════════════════════════════════════════════════
```

The issue happens when the character that triggers the syntax also triggers a character composition. For example: with a Brazilian keyboard, the `~` character starts a composition, so the user can input characters  like `ã` or `õ`. 

When the user inputs `~b~` the following happens.

- The IME reports the closing `~` insertion and starts a composition
- The markdown reaction reads the closing `~` and converts `~b~` to ~b~
- Our IME mapping code fails, because the composing region is now invalid, since it ends after our current text

Code blocks are also affected by this since the backtick also starts a character composition.

The solution I found is to discard the composing region if its outside of our editing value bounds.

This PR clears the composing region if it sits outside of our text bounds. It also removes the `ChangeComposingRegionRequest`s that are issued right after any insertion or replacement. Since we already issue a `ChangeComposingRegionRequest` after handling all deltas, these intermediate requests seem unnecessary.

Another issue that I found is that when we create a new serialized doc after insertions/replacements, we reset its `imeText` to the value that the IME thinks it is (directly applying the deltas to the previous value). This doesn't look correct, since at this point our editing value can be different from the IME editing value. I removed this code and tested on macOS, Android and iOS and it doesn't seem to break anything. We can keep this code if needed, and recompute the serialized doc right before we compute the new composing region.

Our tests didn't catch this bug because `typeImeText` doesn't report a composing region. I modified the tests to generate a delta containing a composing region, but we can change the `typeImeText` from the `flutter_test_robots` package to add an option to also change the composing region.


