### PR TITLE
[SuperEditor] Convert empty task to paragraph on ENTER (Resolves #1898)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1792,6 +1792,11 @@ class CommonEditorOperations {
         ]);
       }
     } else if (extentNode is TaskNode) {
+      if (extentNode.text.text.isEmpty) {
+        // The task is empty. Convert it to a paragraph.
+        return convertToParagraph();
+      }
+
       final splitOffset = (composer.selection!.extent.nodePosition as TextNodePosition).offset;
 
       editor.execute([

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -529,6 +529,14 @@ class TextDeltasDocumentEditor {
         ]);
       }
     } else if (extentNode is TaskNode) {
+      if (extentNode.text.text.isEmpty) {
+        // The task is empty. Convert it to a paragraph.
+        editor.execute([
+          ConvertTextNodeToParagraphRequest(nodeId: extentNode.id),
+        ]);
+        return;
+      }
+
       final splitOffset = (caretPosition.nodePosition as TextNodePosition).offset;
 
       editor.execute([

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -310,6 +310,14 @@ ExecutionInstruction enterToInsertNewTask({
     return ExecutionInstruction.continueExecution;
   }
 
+  if (node.text.text.isEmpty) {
+    // The task is empty. Convert it to a paragraph.
+    editContext.editor.execute([
+      ConvertTextNodeToParagraphRequest(nodeId: node.id),
+    ]);
+    return ExecutionInstruction.haltExecution;
+  }
+
   final splitOffset = (selection.extent.nodePosition as TextNodePosition).offset;
 
   editContext.editor.execute([


### PR DESCRIPTION
[SuperEditor] Convert empty task to paragraph on ENTER. Resolves #1898

Pressing enter on an empty task isn't  converting it to a paragraph. This is the default behavior for list items.

This PR change the new line handling, both with keyboard and deltas to convert empty list items to paragraphs.