### PR TITLE
[SuperEditor] Split incompatible attributions (Resolves #1983)

### DIFF
--- a/attributed_text/lib/src/attributed_spans.dart
+++ b/attributed_text/lib/src/attributed_spans.dart
@@ -312,6 +312,7 @@ class AttributedSpans {
       attribution: newAttribution,
       start: start,
       end: end,
+      allowMerging: autoMerge,
     );
 
     if (conflicts.isNotEmpty && !splitConflictingAttributions) {

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -183,7 +183,7 @@ class AttributedText {
       newAttribution: attribution,
       start: range.start,
       end: range.end,
-      ignoreMergeableOverlaps: autoMerge,
+      autoMerge: autoMerge,
       overwriteConflictingSpans: false,
     );
     _notifyListeners();

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -179,7 +179,13 @@ class AttributedText {
     SpanRange range, {
     bool autoMerge = true,
   }) {
-    spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end, autoMerge: autoMerge);
+    spans.addAttribution(
+      newAttribution: attribution,
+      start: range.start,
+      end: range.end,
+      autoMerge: autoMerge,
+      splitConflictingAttributions: false,
+    );
     _notifyListeners();
   }
 

--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -183,8 +183,8 @@ class AttributedText {
       newAttribution: attribution,
       start: range.start,
       end: range.end,
-      autoMerge: autoMerge,
-      splitConflictingAttributions: false,
+      ignoreMergeableOverlaps: autoMerge,
+      overwriteConflictingSpans: false,
     );
     _notifyListeners();
   }

--- a/attributed_text/pubspec.yaml
+++ b/attributed_text/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.3.0
 homepage: https://github.com/superlistapp/super_editor
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   characters: ^1.2.0

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -601,8 +601,124 @@ void main() {
             newAttribution: _LinkAttribution(url: 'https://pub.dev'),
             start: 4,
             end: 12,
+            splitConflictingAttributions: false,
           );
         }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
+      });
+
+      test('splits incompatible attributions at the beginning', () {
+        final spans = AttributedSpans(
+          attributions: _createSpanMarkersForAttribution(
+            attribution: _LinkAttribution(url: 'https://flutter.dev'),
+            startOffset: 0,
+            endOffset: 6,
+          ),
+        );
+
+        // Add an overlapping link at the beginning.
+        spans.addAttribution(
+          newAttribution: _LinkAttribution(url: 'https://pub.dev'),
+          start: 0,
+          end: 4,
+        );
+
+        expect(
+          spans,
+          AttributedSpans(
+            attributions: [
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://pub.dev'),
+                startOffset: 0,
+                endOffset: 4,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://flutter.dev'),
+                startOffset: 5,
+                endOffset: 6,
+              ),
+            ],
+          ),
+        );
+      });
+
+      test('splits incompatible attributions at the middle', () {
+        final spans = AttributedSpans(attributions: [
+          ..._createSpanMarkersForAttribution(
+            attribution: _LinkAttribution(url: 'https://flutter.dev'),
+            startOffset: 0,
+            endOffset: 6,
+          ),
+          ..._createSpanMarkersForAttribution(
+            attribution: _LinkAttribution(url: 'https://pub.dev'),
+            startOffset: 10,
+            endOffset: 16,
+          ),
+        ]);
+
+        // Add an overlapping at the middle.
+        spans.addAttribution(
+          newAttribution: _LinkAttribution(url: 'https://google.com'),
+          start: 4,
+          end: 12,
+        );
+
+        expect(
+          spans,
+          AttributedSpans(
+            attributions: [
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://flutter.dev'),
+                startOffset: 0,
+                endOffset: 3,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://google.com'),
+                startOffset: 4,
+                endOffset: 12,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://pub.dev'),
+                startOffset: 13,
+                endOffset: 16,
+              ),
+            ],
+          ),
+        );
+      });
+
+      test('splits incompatible attributions at the end', () {
+        final spans = AttributedSpans(
+          attributions: _createSpanMarkersForAttribution(
+            attribution: _LinkAttribution(url: 'https://flutter.dev'),
+            startOffset: 0,
+            endOffset: 6,
+          ),
+        );
+
+        // Add an overlapping link at the end.
+        spans.addAttribution(
+          newAttribution: _LinkAttribution(url: 'https://pub.dev'),
+          start: 4,
+          end: 12,
+        );
+
+        expect(
+          spans,
+          AttributedSpans(
+            attributions: [
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://flutter.dev'),
+                startOffset: 0,
+                endOffset: 3,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://pub.dev'),
+                startOffset: 4,
+                endOffset: 12,
+              ),
+            ],
+          ),
+        );
       });
 
       test('compatible attributions are merged', () {

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -601,12 +601,12 @@ void main() {
             newAttribution: _LinkAttribution(url: 'https://pub.dev'),
             start: 4,
             end: 12,
-            splitConflictingAttributions: false,
+            overwriteConflictingSpans: false,
           );
         }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
       });
 
-      test('splits incompatible attributions at the beginning', () {
+      test('overwrites incompatible attributions at the beginning', () {
         final spans = AttributedSpans(
           attributions: _createSpanMarkersForAttribution(
             attribution: _LinkAttribution(url: 'https://flutter.dev'),
@@ -686,7 +686,7 @@ void main() {
         );
       });
 
-      test('splits incompatible attributions at the end', () {
+      test('overwrites incompatible attributions at the end', () {
         final spans = AttributedSpans(
           attributions: _createSpanMarkersForAttribution(
             attribution: _LinkAttribution(url: 'https://flutter.dev'),
@@ -716,6 +716,58 @@ void main() {
                 startOffset: 4,
                 endOffset: 12,
               ),
+            ],
+          ),
+        );
+      });
+
+      test('overwrites multiple incompatible attributions at the midle', () {
+        final spans = AttributedSpans(
+          attributions: [
+            ..._createSpanMarkersForAttribution(
+              attribution: _LinkAttribution(url: 'https://flutter.dev'),
+              startOffset: 0,
+              endOffset: 5,
+            ),
+            ..._createSpanMarkersForAttribution(
+              attribution: _LinkAttribution(url: 'https://pub.dev'),
+              startOffset: 10,
+              endOffset: 15,
+            ),
+            ..._createSpanMarkersForAttribution(
+              attribution: _LinkAttribution(url: 'https://google.com'),
+              startOffset: 20,
+              endOffset: 25,
+            ),
+          ],
+        );
+
+        // Add a link overlapping with all existing spans.
+        spans.addAttribution(
+          newAttribution: _LinkAttribution(url: 'https://youtube.com'),
+          start: 4,
+          end: 22,
+        );
+
+        expect(
+          spans,
+          AttributedSpans(
+            attributions: [
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://flutter.dev'),
+                startOffset: 0,
+                endOffset: 3,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://youtube.com'),
+                startOffset: 4,
+                endOffset: 22,
+              ),
+              ..._createSpanMarkersForAttribution(
+                attribution: _LinkAttribution(url: 'https://google.com'),
+                startOffset: 23,
+                endOffset: 25,
+              )
             ],
           ),
         );
@@ -902,121 +954,6 @@ void main() {
         final span2 = AttributedSpans(attributions: [italicStart, italicEnd]);
 
         expect(span1 == span2, isFalse);
-      });
-    });
-
-    group('findConflictingAttributions', () {
-      test('finds attribution at the beginning', () {
-        final spans = _createAttributedSpansForAttribution(
-          attribution: _LinkAttribution(url: 'a'),
-          startOffset: 0,
-          endOffset: 5,
-        );
-
-        expect(
-          spans.findConflictingAttributions(
-            attribution: _LinkAttribution(url: 'b'),
-            start: 0,
-            end: 2,
-            allowMerging: true,
-          ),
-          [
-            AttributionConflict(
-              newAttribution: _LinkAttribution(url: 'b'),
-              existingAttribution: _LinkAttribution(url: 'a'),
-              conflictStart: 0,
-              conflictEnd: 2,
-            )
-          ],
-        );
-      });
-
-      test('finds attribution at the end', () {
-        final spans = _createAttributedSpansForAttribution(
-          attribution: _LinkAttribution(url: 'a'),
-          startOffset: 0,
-          endOffset: 5,
-        );
-
-        expect(
-          spans.findConflictingAttributions(
-            attribution: _LinkAttribution(url: 'b'),
-            start: 4,
-            end: 5,
-            allowMerging: true,
-          ),
-          [
-            AttributionConflict(
-              newAttribution: _LinkAttribution(url: 'b'),
-              existingAttribution: _LinkAttribution(url: 'a'),
-              conflictStart: 4,
-              conflictEnd: 5,
-            )
-          ],
-        );
-      });
-
-      test('finds attribution at the middle', () {
-        final spans = _createAttributedSpansForAttribution(
-          attribution: _LinkAttribution(url: 'a'),
-          startOffset: 0,
-          endOffset: 5,
-        );
-
-        expect(
-          spans.findConflictingAttributions(
-            attribution: _LinkAttribution(url: 'b'),
-            start: 2,
-            end: 3,
-            allowMerging: true,
-          ),
-          [
-            AttributionConflict(
-              newAttribution: _LinkAttribution(url: 'b'),
-              existingAttribution: _LinkAttribution(url: 'a'),
-              conflictStart: 2,
-              conflictEnd: 3,
-            )
-          ],
-        );
-      });
-
-      test('finds non-contiguous conflicts', () {
-        final spans = AttributedSpans(attributions: [
-          ..._createSpanMarkersForAttribution(
-            attribution: _LinkAttribution(url: 'a'),
-            startOffset: 0,
-            endOffset: 5,
-          ),
-          ..._createSpanMarkersForAttribution(
-            attribution: _LinkAttribution(url: 'c'),
-            startOffset: 10,
-            endOffset: 15,
-          ),
-        ]);
-
-        expect(
-          spans.findConflictingAttributions(
-            attribution: _LinkAttribution(url: 'b'),
-            start: 4,
-            end: 12,
-            allowMerging: true,
-          ),
-          [
-            AttributionConflict(
-              newAttribution: _LinkAttribution(url: 'b'),
-              existingAttribution: _LinkAttribution(url: 'a'),
-              conflictStart: 4,
-              conflictEnd: 5,
-            ),
-            AttributionConflict(
-              newAttribution: _LinkAttribution(url: 'b'),
-              existingAttribution: _LinkAttribution(url: 'c'),
-              conflictStart: 10,
-              conflictEnd: 12,
-            ),
-          ],
-        );
       });
     });
   });

--- a/attributed_text/test/attributed_spans_test.dart
+++ b/attributed_text/test/attributed_spans_test.dart
@@ -606,7 +606,14 @@ void main() {
         }, throwsA(isA<IncompatibleOverlappingAttributionsException>()));
       });
 
-      test('overwrites incompatible attributions at the beginning', () {
+      test('overwrites incompatible attributions at the beginning of the span', () {
+        // Starting value:
+        // |aaaaaaa|
+        //
+        // Ending value:
+        // |-----aa|
+        // |bbbbb--|
+
         final spans = AttributedSpans(
           attributions: _createSpanMarkersForAttribution(
             attribution: _LinkAttribution(url: 'https://flutter.dev'),
@@ -641,7 +648,16 @@ void main() {
         );
       });
 
-      test('splits incompatible attributions at the middle', () {
+      test('splits incompatible attributions at the middle of the text', () {
+        // Starting value:
+        // |aaaaaaa----------|
+        // |----------bbbbbbb|
+        //
+        // Ending value:
+        // |aaaa-------------|
+        // |-------------bbbb|
+        // |----ccccccccc----|
+
         final spans = AttributedSpans(attributions: [
           ..._createSpanMarkersForAttribution(
             attribution: _LinkAttribution(url: 'https://flutter.dev'),
@@ -686,7 +702,14 @@ void main() {
         );
       });
 
-      test('overwrites incompatible attributions at the end', () {
+      test('overwrites incompatible attributions at the end of the span', () {
+        // Starting value:
+        // |aaaaaaa------|
+        //
+        // Ending value:
+        // |aaaa---------|
+        // |----bbbbbbbbb|
+
         final spans = AttributedSpans(
           attributions: _createSpanMarkersForAttribution(
             attribution: _LinkAttribution(url: 'https://flutter.dev'),
@@ -721,7 +744,17 @@ void main() {
         );
       });
 
-      test('overwrites multiple incompatible attributions at the midle', () {
+      test('overwrites multiple incompatible attributions at the midle of the text', () {
+        // Starting value:
+        // |aaaaaa--------------------|
+        // |----------bbbbbb----------|
+        // |--------------------cccccc|
+        //
+        // Ending value:
+        // |aaaa----------------------|
+        // |-----------------------ccc|
+        // |----ddddddddddddddddddd---|
+
         final spans = AttributedSpans(
           attributions: [
             ..._createSpanMarkersForAttribution(
@@ -980,29 +1013,6 @@ class _LinkAttribution implements Attribution {
 
   @override
   int get hashCode => url.hashCode;
-}
-
-/// Creates an [AttributedSpans] for the [attribution] starting at [startOffset]
-/// and ending at [endOffset].
-AttributedSpans _createAttributedSpansForAttribution({
-  required Attribution attribution,
-  required int startOffset,
-  required int endOffset,
-}) {
-  return AttributedSpans(
-    attributions: [
-      SpanMarker(
-        attribution: attribution,
-        offset: startOffset,
-        markerType: SpanMarkerType.start,
-      ),
-      SpanMarker(
-        attribution: attribution,
-        offset: endOffset,
-        markerType: SpanMarkerType.end,
-      ),
-    ],
-  );
 }
 
 /// Creates start and end markers for the [attribution], starting at [startOffset]

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1265,47 +1265,18 @@ class AddTextAttributionsCommand implements EditCommand {
         final range = entry.value.toSpanRange();
         editorDocLog.info(' - adding attribution: $attribution. Range: $range');
 
-        final newSpans = node.text.spans.copy();
-
-        // Finds and removes any conflicting attributions. For example, consider the following text,
-        // with a blue color attribution that spans the entire text:
-        //
-        //    blue green blue
-        //   |xxxxxxxxxxxxxxx|
-        //
-        // We can't apply a green color attribution to the word "green", because it's already
-        // attributed with blue. So, we need to remove the blue attribution from the word "green",
-        // which results in the following text:
-        //
-        //    blue green blue
-        //   |xxxxx-----xxxxx|
-        //
-        // After that, we can apply the desired attribution, because there isn't a conflicting attribution
-        // in this range anymore.
-        final conflicts = node.text.spans.findConflictingAttributions(
-          attribution: attribution,
-          start: range.start,
-          end: range.end,
-          allowMerging: autoMerge,
-        );
-        for (final conflict in conflicts) {
-          newSpans.removeAttribution(
-            attributionToRemove: conflict.existingAttribution,
-            start: conflict.conflictStart,
-            end: conflict.conflictEnd,
-          );
-        }
-
-        newSpans.addAttribution(
-          newAttribution: attribution,
-          start: range.start,
-          end: range.end,
-          autoMerge: autoMerge,
-        );
-
         // Create a new AttributedText with updated attribution spans, so that the presentation system can
         // see that we made a change, and re-renders the text in the document.
-        node.text = AttributedText(node.text.text, newSpans);
+        node.text = AttributedText(
+          node.text.text,
+          node.text.spans.copy()
+            ..addAttribution(
+              newAttribution: attribution,
+              start: range.start,
+              end: range.end,
+              autoMerge: autoMerge,
+            ),
+        );
 
         executor.logChanges([
           DocumentEdit(
@@ -1577,47 +1548,18 @@ class ToggleTextAttributionsCommand implements EditCommand {
 
           editorDocLog.info(' - Adding attribution: $attribution. Range: $range');
 
-          final newSpans = node.text.spans.copy();
-
-          // Finds and removes any conflicting attributions. For example, consider the following text,
-          // with a blue color attribution that spans the entire text:
-          //
-          //    blue green blue
-          //   |xxxxxxxxxxxxxxx|
-          //
-          // We can't apply a green color attribution to the word "green", because it's already
-          // attributed with blue. So, we need to remove the blue attribution from the word "green",
-          // which results in the following text:
-          //
-          //    blue green blue
-          //   |xxxxx-----xxxxx|
-          //
-          // After that, we can apply the desired attribution, because there isn't a conflicting attribution
-          // in this range anymore.
-          final conflicts = node.text.spans.findConflictingAttributions(
-            attribution: attribution,
-            start: range.start,
-            end: range.end,
-            allowMerging: true,
-          );
-          for (final conflict in conflicts) {
-            newSpans.removeAttribution(
-              attributionToRemove: conflict.existingAttribution,
-              start: conflict.conflictStart,
-              end: conflict.conflictEnd,
-            );
-          }
-
-          newSpans.addAttribution(
-            newAttribution: attribution,
-            start: range.start,
-            end: range.end,
-            autoMerge: true,
-          );
-
           // Create a new AttributedText with updated attribution spans, so that the presentation system can
           // see that we made a change, and re-renders the text in the document.
-          node.text = AttributedText(node.text.text, newSpans);
+          node.text = AttributedText(
+            node.text.text,
+            node.text.spans.copy()
+              ..addAttribution(
+                newAttribution: attribution,
+                start: range.start,
+                end: range.end,
+                autoMerge: true,
+              ),
+          );
         }
 
         final wasAttributionAdded = node.text.hasAttributionAt(range.start, attribution: attribution);

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1274,7 +1274,7 @@ class AddTextAttributionsCommand implements EditCommand {
               newAttribution: attribution,
               start: range.start,
               end: range.end,
-              ignoreMergeableOverlaps: autoMerge,
+              autoMerge: autoMerge,
             ),
         );
 
@@ -1557,7 +1557,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
                 newAttribution: attribution,
                 start: range.start,
                 end: range.end,
-                ignoreMergeableOverlaps: true,
+                autoMerge: true,
               ),
           );
         }

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1265,18 +1265,47 @@ class AddTextAttributionsCommand implements EditCommand {
         final range = entry.value.toSpanRange();
         editorDocLog.info(' - adding attribution: $attribution. Range: $range');
 
+        final newSpans = node.text.spans.copy();
+
+        // Finds and removes any conflicting attributions. For example, consider the following text,
+        // with a blue color attribution that spans the entire text:
+        //
+        //    blue green blue
+        //   |xxxxxxxxxxxxxxx|
+        //
+        // We can't apply a green color attribution to the word "green", because it's already
+        // attributed with blue. So, we need to remove the blue attribution from the word "green",
+        // which results in the following text:
+        //
+        //    blue green blue
+        //   |xxxxx-----xxxxx|
+        //
+        // After that, we can apply the desired attribution, because there isn't a conflicting attribution
+        // in this range anymore.
+        final conflicts = node.text.spans.findConflictingAttributions(
+          attribution: attribution,
+          start: range.start,
+          end: range.end,
+          allowMerging: autoMerge,
+        );
+        for (final conflict in conflicts) {
+          newSpans.removeAttribution(
+            attributionToRemove: conflict.existingAttribution,
+            start: conflict.conflictStart,
+            end: conflict.conflictEnd,
+          );
+        }
+
+        newSpans.addAttribution(
+          newAttribution: attribution,
+          start: range.start,
+          end: range.end,
+          autoMerge: autoMerge,
+        );
+
         // Create a new AttributedText with updated attribution spans, so that the presentation system can
         // see that we made a change, and re-renders the text in the document.
-        node.text = AttributedText(
-          node.text.text,
-          node.text.spans.copy()
-            ..addAttribution(
-              newAttribution: attribution,
-              start: range.start,
-              end: range.end,
-              autoMerge: autoMerge,
-            ),
-        );
+        node.text = AttributedText(node.text.text, newSpans);
 
         executor.logChanges([
           DocumentEdit(
@@ -1548,15 +1577,54 @@ class ToggleTextAttributionsCommand implements EditCommand {
 
           editorDocLog.info(' - Adding attribution: $attribution. Range: $range');
 
+          final newSpans = node.text.spans.copy();
+
+          // Finds and removes any conflicting attributions. For example, consider the following text,
+          // with a blue color attribution that spans the entire text:
+          //
+          //    blue green blue
+          //   |xxxxxxxxxxxxxxx|
+          //
+          // We can't apply a green color attribution to the word "green", because it's already
+          // attributed with blue. So, we need to remove the blue attribution from the word "green",
+          // which results in the following text:
+          //
+          //    blue green blue
+          //   |xxxxx-----xxxxx|
+          //
+          // After that, we can apply the desired attribution, because there isn't a conflicting attribution
+          // in this range anymore.
+          final conflicts = node.text.spans.findConflictingAttributions(
+            attribution: attribution,
+            start: range.start,
+            end: range.end,
+            allowMerging: true,
+          );
+          for (final conflict in conflicts) {
+            newSpans.removeAttribution(
+              attributionToRemove: conflict.existingAttribution,
+              start: conflict.conflictStart,
+              end: conflict.conflictEnd,
+            );
+          }
+
+          newSpans.addAttribution(
+            newAttribution: attribution,
+            start: range.start,
+            end: range.end,
+            autoMerge: true,
+          );
+
           // Create a new AttributedText with updated attribution spans, so that the presentation system can
           // see that we made a change, and re-renders the text in the document.
-          node.text = AttributedText(
-            node.text.text,
-            node.text.spans.copy(),
-          )..addAttribution(
-              attribution,
-              range,
-            );
+          node.text = AttributedText(node.text.text, newSpans);
+          // node.text = AttributedText(
+          //   node.text.text,
+          //   node.text.spans.copy(),
+          // )..addAttribution(
+          //     attribution,
+          //     range,
+          //   );
         }
 
         final wasAttributionAdded = node.text.hasAttributionAt(range.start, attribution: attribution);

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1618,13 +1618,6 @@ class ToggleTextAttributionsCommand implements EditCommand {
           // Create a new AttributedText with updated attribution spans, so that the presentation system can
           // see that we made a change, and re-renders the text in the document.
           node.text = AttributedText(node.text.text, newSpans);
-          // node.text = AttributedText(
-          //   node.text.text,
-          //   node.text.spans.copy(),
-          // )..addAttribution(
-          //     attribution,
-          //     range,
-          //   );
         }
 
         final wasAttributionAdded = node.text.hasAttributionAt(range.start, attribution: attribution);

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1274,7 +1274,7 @@ class AddTextAttributionsCommand implements EditCommand {
               newAttribution: attribution,
               start: range.start,
               end: range.end,
-              autoMerge: autoMerge,
+              ignoreMergeableOverlaps: autoMerge,
             ),
         );
 
@@ -1557,7 +1557,7 @@ class ToggleTextAttributionsCommand implements EditCommand {
                 newAttribution: attribution,
                 start: range.start,
                 end: range.end,
-                autoMerge: true,
+                ignoreMergeableOverlaps: true,
               ),
           );
         }

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -41,8 +41,8 @@ dependencies:
 dependency_overrides:
   #  # Override to local mono-repo path so devs can test this repo
   #  # against changes that they're making to other mono-repo packages
-#  attributed_text:
-#    path: ../attributed_text
+  attributed_text:
+    path: ../attributed_text
 #  super_text_layout:
 #    path: ../super_text_layout
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -1276,7 +1276,7 @@ void main() {
       });
     });
 
-    testWidgetsOnArbitraryDesktop('splits spans with different colors', (tester) async {
+    testWidgetsOnArbitraryDesktop('overwrites spans with different colors', (tester) async {
       // Pump an editor with a single paragraph with blue color across the entire paragraph.
       final testContext = await tester //
           .createDocument()
@@ -1317,7 +1317,7 @@ void main() {
       ]);
       await tester.pump();
 
-      // Ensure the spans were split.
+      // Ensure the spans were overwritten.
       expect(
         SuperEditorInspector.findTextInComponent('1').spans,
         AttributedSpans(
@@ -1342,7 +1342,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop('splits spans with different background colors', (tester) async {
+    testWidgetsOnArbitraryDesktop('overwrites spans with different background colors', (tester) async {
       // Pump an editor with a single paragraph with blue background color across the entire paragraph.
       final testContext = await tester //
           .createDocument()
@@ -1383,7 +1383,7 @@ void main() {
       ]);
       await tester.pump();
 
-      // Ensure the spans were split.
+      // Ensure the spans were overwritten.
       expect(
         SuperEditorInspector.findTextInComponent('1').spans,
         AttributedSpans(
@@ -1408,7 +1408,7 @@ void main() {
       );
     });
 
-    testWidgetsOnArbitraryDesktop('splits spans with different font sizes', (tester) async {
+    testWidgetsOnArbitraryDesktop('overwrites spans with different font sizes', (tester) async {
       // Pump an editor with a single paragraph with 16px font size across the entire paragraph.
       final testContext = await tester //
           .createDocument()
@@ -1449,7 +1449,7 @@ void main() {
       ]);
       await tester.pump();
 
-      // Ensure the spans were split.
+      // Ensure the spans were overwritten.
       expect(
         SuperEditorInspector.findTextInComponent('1').spans,
         AttributedSpans(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -1276,108 +1276,201 @@ void main() {
       });
     });
 
-    testWidgetsOnArbitraryDesktop('does not merge different colors', (tester) async {
-      final context = await tester //
+    testWidgetsOnArbitraryDesktop('splits spans with different colors', (tester) async {
+      // Pump an editor with a single paragraph with blue color across the entire paragraph.
+      final testContext = await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText(
+                    'blue orange pink',
+                    _createAttributedSpansForAttribution(
+                      attribution: const ColorAttribution(Colors.blue),
+                      startOffset: 0,
+                      endOffset: 15,
+                    ),
+                  ),
+                )
+              ],
+            ),
+          )
           .pump();
 
-      final editor = context.editor;
-
-      // Apply a yellow color to the word "Lorem".
-      editor.execute([
+      // Apply orange color to the word "orange".
+      testContext.editor.execute([
         AddTextAttributionsRequest(
-          documentRange: const DocumentRange(
-            start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
-          ),
-          attributions: {const ColorAttribution(Colors.yellow)},
+          documentRange: _creatSingleNodeTextRange('1', 5, 11),
+          attributions: {const ColorAttribution(Colors.orange)},
         ),
       ]);
+      await tester.pump();
 
-      // Try to apply a red color to the range "L|ore|m". This should fail
-      // because we can't apply two different colors to the same range.
+      // Apply pink color to the word "pink" by toggling the attribution.
+      testContext.editor.execute([
+        ToggleTextAttributionsRequest(
+          documentRange: _creatSingleNodeTextRange('1', 11, 16),
+          attributions: {const ColorAttribution(Colors.pink)},
+        ),
+      ]);
+      await tester.pump();
+
+      // Ensure the spans were split.
       expect(
-        () => editor.execute([
-          AddTextAttributionsRequest(
-            documentRange: const DocumentRange(
-              start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 1)),
-              end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 3)),
+        SuperEditorInspector.findTextInComponent('1').spans,
+        AttributedSpans(
+          attributions: [
+            ..._createSpanMarkersForAttribution(
+              attribution: const ColorAttribution(Colors.blue),
+              startOffset: 0,
+              endOffset: 4,
             ),
-            attributions: {const ColorAttribution(Colors.red)},
-          ),
-        ]),
-        throwsException,
+            ..._createSpanMarkersForAttribution(
+              attribution: const ColorAttribution(Colors.orange),
+              startOffset: 5,
+              endOffset: 10,
+            ),
+            ..._createSpanMarkersForAttribution(
+              attribution: const ColorAttribution(Colors.pink),
+              startOffset: 11,
+              endOffset: 15,
+            ),
+          ],
+        ),
       );
     });
 
-    testWidgetsOnArbitraryDesktop('does not merge different background colors', (tester) async {
-      final context = await tester //
+    testWidgetsOnArbitraryDesktop('splits spans with different background colors', (tester) async {
+      // Pump an editor with a single paragraph with blue background color across the entire paragraph.
+      final testContext = await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText(
+                    'blue orange pink',
+                    _createAttributedSpansForAttribution(
+                      attribution: const BackgroundColorAttribution(Colors.blue),
+                      startOffset: 0,
+                      endOffset: 15,
+                    ),
+                  ),
+                )
+              ],
+            ),
+          )
           .pump();
 
-      final editor = context.editor;
-
-      // Apply a yellow background to the word "Lorem".
-      editor.execute([
+      // Apply orange color to the word "orange".
+      testContext.editor.execute([
         AddTextAttributionsRequest(
-          documentRange: const DocumentRange(
-            start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
-          ),
-          attributions: {const BackgroundColorAttribution(Colors.yellow)},
+          documentRange: _creatSingleNodeTextRange('1', 5, 11),
+          attributions: {const BackgroundColorAttribution(Colors.orange)},
         ),
       ]);
+      await tester.pump();
 
-      // Try to apply a red background to the range "L|ore|m". This should fail
-      // because we can't apply two different background colors to the same range.
+      // Apply pink color to the word "pink" by toggling the attribution.
+      testContext.editor.execute([
+        ToggleTextAttributionsRequest(
+          documentRange: _creatSingleNodeTextRange('1', 11, 16),
+          attributions: {const BackgroundColorAttribution(Colors.pink)},
+        ),
+      ]);
+      await tester.pump();
+
+      // Ensure the spans were split.
       expect(
-        () => editor.execute([
-          AddTextAttributionsRequest(
-            documentRange: const DocumentRange(
-              start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 1)),
-              end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 3)),
+        SuperEditorInspector.findTextInComponent('1').spans,
+        AttributedSpans(
+          attributions: [
+            ..._createSpanMarkersForAttribution(
+              attribution: const BackgroundColorAttribution(Colors.blue),
+              startOffset: 0,
+              endOffset: 4,
             ),
-            attributions: {const BackgroundColorAttribution(Colors.red)},
-          ),
-        ]),
-        throwsException,
+            ..._createSpanMarkersForAttribution(
+              attribution: const BackgroundColorAttribution(Colors.orange),
+              startOffset: 5,
+              endOffset: 10,
+            ),
+            ..._createSpanMarkersForAttribution(
+              attribution: const BackgroundColorAttribution(Colors.pink),
+              startOffset: 11,
+              endOffset: 15,
+            ),
+          ],
+        ),
       );
     });
 
-    testWidgetsOnArbitraryDesktop('does not merge different font sizes', (tester) async {
-      final context = await tester //
+    testWidgetsOnArbitraryDesktop('splits spans with different font sizes', (tester) async {
+      // Pump an editor with a single paragraph with 16px font size across the entire paragraph.
+      final testContext = await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText(
+                    '16px 18px 14px',
+                    _createAttributedSpansForAttribution(
+                      attribution: const FontSizeAttribution(16),
+                      startOffset: 0,
+                      endOffset: 13,
+                    ),
+                  ),
+                )
+              ],
+            ),
+          )
           .pump();
 
-      final editor = context.editor;
-
-      // Apply a font size of 14 to the word "Lorem".
-      editor.execute([
+      // Apply 18px font size to the text "18px".
+      testContext.editor.execute([
         AddTextAttributionsRequest(
-          documentRange: const DocumentRange(
-            start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
-          ),
+          documentRange: _creatSingleNodeTextRange('1', 5, 9),
+          attributions: {const FontSizeAttribution(18)},
+        ),
+      ]);
+      await tester.pump();
+
+      // Apply 14px color to the text "14px" by toggling the attribution.
+      testContext.editor.execute([
+        ToggleTextAttributionsRequest(
+          documentRange: _creatSingleNodeTextRange('1', 9, 14),
           attributions: {const FontSizeAttribution(14)},
         ),
       ]);
+      await tester.pump();
 
-      // Try to apply a font size of 16 to the range "L|ore|m". This should fail
-      // because we can't apply two different font sizes to the same range.
+      // Ensure the spans were split.
       expect(
-        () => editor.execute([
-          AddTextAttributionsRequest(
-            documentRange: const DocumentRange(
-              start: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 1)),
-              end: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 3)),
+        SuperEditorInspector.findTextInComponent('1').spans,
+        AttributedSpans(
+          attributions: [
+            ..._createSpanMarkersForAttribution(
+              attribution: const FontSizeAttribution(16),
+              startOffset: 0,
+              endOffset: 4,
             ),
-            attributions: {const FontSizeAttribution(16)},
-          ),
-        ]),
-        throwsException,
+            ..._createSpanMarkersForAttribution(
+              attribution: const FontSizeAttribution(18),
+              startOffset: 5,
+              endOffset: 8,
+            ),
+            ..._createSpanMarkersForAttribution(
+              attribution: const FontSizeAttribution(14),
+              startOffset: 9,
+              endOffset: 13,
+            ),
+          ],
+        ),
       );
     });
   });
@@ -1515,7 +1608,7 @@ extension _ToggleAttributions on Editor {
 /// Creates an [AttributedSpans] for the [attribution] starting at [startOffset]
 /// and ending at [endOffset].
 AttributedSpans _createAttributedSpansForAttribution({
-  required NamedAttribution attribution,
+  required Attribution attribution,
   required int startOffset,
   required int endOffset,
 }) {
@@ -1532,5 +1625,41 @@ AttributedSpans _createAttributedSpansForAttribution({
         markerType: SpanMarkerType.end,
       ),
     ],
+  );
+}
+
+/// Creates start and end markers for the [attribution], starting at [startOffset]
+/// and ending at [endOffset].
+List<SpanMarker> _createSpanMarkersForAttribution({
+  required Attribution attribution,
+  required int startOffset,
+  required int endOffset,
+}) {
+  return [
+    SpanMarker(
+      attribution: attribution,
+      offset: startOffset,
+      markerType: SpanMarkerType.start,
+    ),
+    SpanMarker(
+      attribution: attribution,
+      offset: endOffset,
+      markerType: SpanMarkerType.end,
+    ),
+  ];
+}
+
+/// Creates a [DocumentRange] that starts at node [nodeId] at [start] and
+/// ends at [nodeId] at [end].
+DocumentRange _creatSingleNodeTextRange(String nodeId, int start, int end) {
+  return DocumentRange(
+    start: DocumentPosition(
+      nodeId: nodeId,
+      nodePosition: TextNodePosition(offset: start),
+    ),
+    end: DocumentPosition(
+      nodeId: nodeId,
+      nodePosition: TextNodePosition(offset: end),
+    ),
   );
 }


### PR DESCRIPTION
[SuperEditor] Split incompatible attributions. Resolves #1983

Valued attributions, like `ColorAttribution` can't be applied in a range where another `ColorAttribution` exists.

Although it doesn't make sense to have two `ColorAttribution`s in the same range, users should be able to change the color of an already attributed range.

For example, consider the following range, fully attributed with blue:

```
   blue green blue
b [xxxxxxxxxxxxxxx]
```

Users should be able to apply green color to the word "green", causing the blue attributed range to be split:

```
   blue green blue
b [xxxxx-----xxxxx]
g [-----xxxxx-----]
```

This PR changes `AddTextAttributionsCommand` and `ToggleTextAttributionsCommand` to find and remove any conflicting attributions in the range before trying to apply the desired attribution.

The following changes were made:

- Introduce `AttributedSpans.findConflictingAttributions` to return a list of conflicting attributions.
- Change `AddTextAttributionsCommand` and `ToggleTextAttributionsCommand` to remove conflicting attributions
- Update the tests that previously ensured we couldn't apply conflicting attributions

Also, I found a bug in `AttributedSpans.getMatchingAttributionsWithin`, where we always tried to get the attributions from the same index. This PR fixes this bug.

We'll need to release a new version of `attributed_text` because of this new method.