### PR TITLE
[SuperEditor][Android] Fix auto-scrolling start region (Resolves #2000)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1335,18 +1335,6 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   final _dragHandleSelectionGlobalFocalPoint = ValueNotifier<Offset?>(null);
   final _magnifierFocalPoint = ValueNotifier<Offset?>(null);
 
-  /// Returns the `RenderBox` for the scrolling viewport.
-  ///
-  /// If this widget has an ancestor `Scrollable`, then the returned
-  /// `RenderBox` belongs to that ancestor `Scrollable`.
-  ///
-  /// If this widget doesn't have an ancestor `Scrollable`, then this
-  /// widget includes a `ScrollView` and this `State`'s render object
-  /// is the viewport `RenderBox`.
-  RenderBox get viewportBox =>
-      (context.findAncestorScrollableWithVerticalScroll?.context.findRenderObject() ?? context.findRenderObject())
-          as RenderBox;
-
   @override
   void initState() {
     super.initState();
@@ -1398,6 +1386,18 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
 
   @visibleForTesting
   bool get wantsToDisplayMagnifier => _controlsController!.shouldShowMagnifier.value;
+
+  /// Returns the `RenderBox` for the scrolling viewport.
+  ///
+  /// If this widget has an ancestor `Scrollable`, then the returned
+  /// `RenderBox` belongs to that ancestor `Scrollable`.
+  ///
+  /// If this widget doesn't have an ancestor `Scrollable`, then this
+  /// widget includes a `ScrollView` and this `State`'s render object
+  /// is the viewport `RenderBox`.
+  RenderBox get viewportBox =>
+      (context.findAncestorScrollableWithVerticalScroll?.context.findRenderObject() ?? context.findRenderObject())
+          as RenderBox;
 
   void _onSelectionChange() {
     final selection = widget.selection.value;

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -262,6 +262,14 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  /// Configures the [SuperEditor] to display an [AppBar] with the given height above the [SuperEditor].
+  ///
+  /// If [withCustomWidgetTreeBuilder] is used, this setting is ignored.
+  TestSuperEditorConfigurator withAppBar(double height) {
+    _config.appBarHeight = height;
+    return this;
+  }
+
   /// Configures the [SuperEditor] to use the given [scrollController]
   TestSuperEditorConfigurator withScrollController(ScrollController? scrollController) {
     _config.scrollController = scrollController;
@@ -438,6 +446,17 @@ class TestSuperEditorConfigurator {
       // Flutter to pick the web shortcuts.
       shortcuts: defaultFlutterShortcuts,
       home: Scaffold(
+        appBar: _config.appBarHeight != null
+            ? PreferredSize(
+                preferredSize: ui.Size(double.infinity, _config.appBarHeight!),
+                child: SafeArea(
+                  child: SizedBox(
+                    height: _config.appBarHeight!,
+                    child: ColoredBox(color: Colors.yellow),
+                  ),
+                ),
+              )
+            : null,
         body: superEditor,
       ),
       debugShowCheckedModeBanner: false,
@@ -674,6 +693,7 @@ class SuperEditorTestConfiguration {
   final plugins = <SuperEditorPlugin>{};
 
   WidgetTreeBuilder? widgetTreeBuilder;
+  double? appBarHeight;
 }
 
 /// Must return a widget tree containing the given [superEditor]


### PR DESCRIPTION
[SuperEditor][Android] Fix auto-scrolling start region. Resolves #2000

On Android, the auto-scrolling only starts when the user drags near the top of the screen. This causes problems when there are widgets above the editor, like an `AppBar`:

[before.webm](https://github.com/superlistapp/super_editor/assets/7597082/2961af48-10c5-4937-982f-ca3bede79daf)

The reason is that we are not converting the `Offset` to the offset inside the viewport.

This PR fixes the issue by converting the `Offset`:

[after.webm](https://github.com/superlistapp/super_editor/assets/7597082/1fc6e8fb-cbec-4af0-ad86-df28279a678c)

