### PR TITLE
[SuperEditor][Android] Fix scrolling when dragging at empty space (Resolves #2001)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -994,8 +994,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     if (widget.selection.value?.isCollapsed == true) {
       final caretPosition = widget.selection.value!.extent;
       final tapDocumentOffset = widget.getDocumentLayout().getDocumentOffsetFromAncestorOffset(_globalTapDownOffset!);
-      final tapPosition = widget.getDocumentLayout().getDocumentPositionAtOffset(tapDocumentOffset)!;
-      final isTapOverCaret = caretPosition.isEquivalentTo(tapPosition);
+
+      final tapPosition = widget.getDocumentLayout().getDocumentPositionAtOffset(tapDocumentOffset);
+      final isTapOverCaret = tapPosition != null && caretPosition.isEquivalentTo(tapPosition);
 
       if (isTapOverCaret) {
         _onCaretDragPanStart(details);

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -711,6 +711,133 @@ void main() {
       expect(scrollController.offset, scrollController.position.maxScrollExtent);
     });
 
+    group('scrolls when dragging at empty space', () {
+      testWidgetsOnMobile("with collapsed selection", (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump an editor with horizontal padding, so we can drag from an offset where there is no text.
+        await tester //
+            .createDocument()
+            .withLongDoc()
+            .withEditorSize(Size(300, 300))
+            .withScrollController(scrollController)
+            .useStylesheet(
+              defaultStylesheet.copyWith(
+                documentPadding: EdgeInsets.symmetric(horizontal: 100),
+              ),
+            )
+            .pump();
+
+        // Place the caret at the beginning of the document.
+        await tester.placeCaretInParagraph('1', 0);
+
+        final scrollOffsetBeforeDrag = scrollController.offset;
+
+        // Drag from approximately the bottom of the editor until the top.
+        await tester.dragFrom(
+          tester.getBottomLeft(find.byType(SuperEditor)) + Offset(10, -10),
+          Offset(0, -300),
+        );
+        await tester.pump();
+
+        // Ensure the editor scrolled up and the selection didn't change.
+        expect(scrollController.offset, greaterThan(scrollOffsetBeforeDrag));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          )),
+        );
+
+        // Let the long-press timer resolve.
+        await tester.pump(kLongPressTimeout);
+      });
+
+      testWidgetsOnMobile("with expanded selection", (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump an editor with horizontal padding, so we can drag from an offset where there is no text.
+        await tester //
+            .createDocument()
+            .withLongDoc()
+            .withEditorSize(Size(300, 300))
+            .withScrollController(scrollController)
+            .useStylesheet(
+              defaultStylesheet.copyWith(
+                documentPadding: EdgeInsets.symmetric(horizontal: 100),
+              ),
+            )
+            .pump();
+
+        // Double tap the word "Lorem".
+        await tester.doubleTapInParagraph('1', 1);
+
+        final scrollOffsetBeforeDrag = scrollController.offset;
+
+        // Drag from approximately the bottom of the editor until the top.
+        await tester.dragFrom(
+          tester.getBottomLeft(find.byType(SuperEditor)) + Offset(10, -10),
+          Offset(0, -300),
+        );
+        await tester.pump();
+
+        // Ensure the editor scrolled up and the selection didn't change.
+        expect(scrollController.offset, greaterThan(scrollOffsetBeforeDrag));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(DocumentSelection(
+            base: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 5),
+            ),
+          )),
+        );
+
+        // Let the long-press timer resolve.
+        await tester.pump(kLongPressTimeout);
+      });
+
+      testWidgetsOnMobile("with no selection", (tester) async {
+        final scrollController = ScrollController();
+
+        // Pump an editor with horizontal padding, so we can drag from an offset where there is no text.
+        await tester //
+            .createDocument()
+            .withLongDoc()
+            .withEditorSize(Size(300, 300))
+            .withScrollController(scrollController)
+            .useStylesheet(
+              defaultStylesheet.copyWith(
+                documentPadding: EdgeInsets.symmetric(horizontal: 100),
+              ),
+            )
+            .pump();
+
+        final scrollOffsetBeforeDrag = scrollController.offset;
+
+        // Drag from approximately the bottom of the editor until the top.
+        await tester.dragFrom(
+          tester.getBottomLeft(find.byType(SuperEditor)) + Offset(10, -10),
+          Offset(0, -300),
+        );
+        await tester.pump();
+
+        // Ensure the editor scrolled up and the selection didn't change.
+        expect(scrollController.offset, greaterThan(scrollOffsetBeforeDrag));
+        expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+        // Let the long-press timer resolve.
+        await tester.pump(kLongPressTimeout);
+      });
+    });
+
     group("within an ancestor Scrollable", () {
       const screenSizeWithoutKeyboard = Size(390.0, 844.0);
       const screenSizeWithKeyboard = Size(390.0, 544.0);


### PR DESCRIPTION
[SuperEditor][Android] Fix scrolling when dragging at empty space. Resolves #2001

When the user drags starting from an empty space, for example, the area of the document padding, the following crash happens and the editor does not scroll:

```console
════════ Exception caught by gesture ═══════════════════════════════════════════
The following _TypeError was thrown while handling a gesture:
Null check operator used on a null value

When the exception was thrown, this was the stack:
#0      _AndroidDocumentTouchInteractorState._onPanStart (package:super_editor/src/default_editor/document_gestures_touch_android.dart:997:100)
document_gestures_touch_android.dart:997
#1      DragGestureRecognizer._checkStart.<anonymous closure> (package:flutter/src/gestures/monodrag.dart:785:53)
monodrag.dart:785
#2      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:344:24)
recognizer.dart:344
#3      DragGestureRecognizer._checkStart (package:flutter/src/gestures/monodrag.dart:785:7)
monodrag.dart:785
#4      DragGestureRecognizer._checkDrag (package:flutter/src/gestures/monodrag.dart:752:5)
monodrag.dart:752
#5      DragGestureRecognizer.acceptGesture (package:flutter/src/gestures/monodrag.dart:679:7)
monodrag.dart:679
#6      GestureArenaManager._resolveInFavorOf (package:flutter/src/gestures/arena.dart:282:12)
arena.dart:282
#7      GestureArenaManager._resolve (package:flutter/src/gestures/arena.dart:233:11)
arena.dart:233
```

The root cause is that, when we check if the user tapped over the caret, we assume that the tap down position can always be mapped to a `DocumentPosition`, which isn't the case. This only happens if the editor has a collapsed selection.

This PR fixes the issue and adds test for scenarios with collapsed selection, expanded selection and no selection.
 

