### PR TITLE
[super_editor_markdown] Prevent empty syntax from being converted (Resolves #2033)

### DIFF
--- a/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
+++ b/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
@@ -485,10 +485,17 @@ class StyleUpstreamMarkdownToken implements UpstreamMarkdownToken {
         }
 
         if (_openingSyntax == _closingSyntax) {
-          // We just found an opening syntax that matches our closing syntax.
-          // Therefore, we have found a complete Markdown run.
-          _isComplete = true;
-          _phase = _done;
+          if (_allParsedText.length == _openingSyntax.length * 2) {
+            // We just found an opening syntax that matches our closing syntax,
+            // but there is no text between the opening and closing syntax.
+            // Therefore, this is an invalid Markdown style.
+            _isValid = false;
+          } else {
+            // We just found an opening syntax that matches our closing syntax.
+            // Therefore, we have found a complete Markdown run.
+            _isComplete = true;
+            _phase = _done;
+          }
         }
       case _done:
         // More characters were added after already finding a complete Markdown

--- a/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
+++ b/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
@@ -376,6 +376,106 @@ void main() {
         expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers.toList(), isEmpty);
       });
     });
+
+    group("does not parse syntax with empty content >", () {
+      testWidgets("bold", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("****");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "****");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("italics > single trigger > star", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("**");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "**");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("italics > tripple trigger > star", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("******");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "******");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("italics > single trigger > underscore", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("__");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "__");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("italics > tripple trigger > underscore", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("______");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "______");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("strikethrough", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("~~");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "~~");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+
+      testWidgets("code", (tester) async {
+        final (document, _) = await _pumpScaffold(tester);
+
+        final nodeId = document.nodes.first.id;
+        await tester.placeCaretInParagraph(nodeId, 0);
+
+        // Type the trigger characters, without any content between them.
+        await tester.typeImeText("``");
+
+        // Ensure we didn't try to parse the trigger characters.
+        expect(SuperEditorInspector.findTextInComponent(nodeId).text, "``");
+        expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
[super_editor_markdown] Prevent empty syntax from being converted. Resolves #2033

Typing "~~" or "``" is causing the text to be removed.

This happens because the markdown plugin looks for opening and closing syntaxes, but does not check if there is any text between then. As a result, we try to apply strikethrough/code attributions to an empty text.

This PR changes the markdown plugin to check the parsed text length. If it's exactly the length of the opening + closing characters, we don't perform any conversion.