### PR TITLE
[SuperEditor] Fix missing default task component builder (Resolves #2048)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -136,7 +136,7 @@ class SuperEditor extends StatefulWidget {
         selectionStyles = selectionStyle ?? defaultSelectionStyle,
         componentBuilders = componentBuilders != null
             ? [...componentBuilders, const UnknownComponentBuilder()]
-            : [...defaultComponentBuilders, const UnknownComponentBuilder()],
+            : [...defaultComponentBuilders, TaskComponentBuilder(editor), const UnknownComponentBuilder()],
         super(key: key);
 
   /// [FocusNode] for the entire `SuperEditor`.

--- a/super_editor/lib/src/default_editor/unknown_component.dart
+++ b/super_editor/lib/src/default_editor/unknown_component.dart
@@ -9,7 +9,10 @@ class UnknownComponentBuilder implements ComponentBuilder {
 
   @override
   SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
-    return null;
+    return _UnkownViewModel(
+      nodeId: node.id,
+      padding: EdgeInsets.zero,
+    );
   }
 
   @override
@@ -21,6 +24,25 @@ class UnknownComponentBuilder implements ComponentBuilder {
       width: double.infinity,
       height: 100,
       child: const Placeholder(),
+    );
+  }
+}
+
+/// A [SingleColumnLayoutComponentViewModel] that represents an unknown content.
+///
+/// This is used so the editor doesn't crash when it encounters a node that it
+/// doesn't know how to render.
+class _UnkownViewModel extends SingleColumnLayoutComponentViewModel {
+  _UnkownViewModel({
+    required super.nodeId,
+    required super.padding,
+  });
+
+  @override
+  SingleColumnLayoutComponentViewModel copy() {
+    return _UnkownViewModel(
+      nodeId: nodeId,
+      padding: padding,
     );
   }
 }

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -589,6 +589,33 @@ void main() {
       expect(document.nodes.first, isA<ParagraphNode>());
       expect((document.nodes.first as ParagraphNode).text.text, "");
     });
+
+    testWidgetsOnAllPlatforms("allows using tasks without explicit configuration", (tester) async {
+      final document = MutableDocument(
+        nodes: [
+          TaskNode(id: "1", text: AttributedText(), isComplete: false),
+        ],
+      );
+
+      final composer = MutableDocumentComposer();
+      final editor = createDefaultDocumentEditor(document: document, composer: composer);
+
+      // Pump an editor without an explicit configuration for tasks.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuperEditor(
+              editor: editor,
+              document: document,
+              composer: composer,
+            ),
+          ),
+        ),
+      );
+
+      // Ensure the default task component is rendered.
+      expect(find.byType(TaskComponent), findsOneWidget);
+    });
   });
 }
 

--- a/super_editor/test/super_editor/supereditor_components_test.dart
+++ b/super_editor/test/super_editor/supereditor_components_test.dart
@@ -78,6 +78,21 @@ void main() {
         expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
       });
     });
+
+    testWidgetsOnArbitraryDesktop('does not crash when if finds an unkown node type', (tester) async {
+      // Pump an editor with a node that has no corresponding component builder.
+      await tester //
+          .createDocument()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [_UnkownNode(id: '1')],
+            ),
+          )
+          .pump();
+
+      // Reaching this point means the editor did not crash because of the
+      // unkown node.
+    });
   });
 }
 
@@ -184,4 +199,18 @@ class _FakeImageComponentBuilder implements ComponentBuilder {
       imageBuilder: (context, imageUrl) => const SizedBox(height: 100, width: 100),
     );
   }
+}
+
+/// A [DocumentNode] without any content.
+///
+/// Used to simulate an app-level node type that the editor
+/// doesn't know about.
+class _UnkownNode extends BlockNode with ChangeNotifier {
+  _UnkownNode({required this.id});
+
+  @override
+  String? copyContent(NodeSelection selection) => '';
+
+  @override
+  final String id;
 }


### PR DESCRIPTION
[SuperEditor] Fix missing default task component builder. Resolves #2048

`SuperEditor` crashes with the default configuration if the content contains a task:

```console
======== Exception caught by widgets library =======================================================
The following _Exception was thrown building _StandardEditor(state: _StandardEditorState#cb5c0):
Exception: Couldn't find styler to create component for document node: TaskNode
```

The reason is that we don't add the task component builder by default.

This PR adds a `TaskComponentBuilder` when the app uses the default component builders.

Additionally, we have an `UnknownComponentBuilder` to render unknown components, but it only creates the component, not the view model. As a result, any unknown node causes the editor to crash. I think that it's better to display a placeholder instead of crashing the editor if we find an unknown node. I modified the `UnknownComponentBuilder` to return a new view model instead of returning `null`. Since the `UnknownComponentBuilder` is always the last, this change shouldn't cause any issues, but I can remove this change if it's not desired.