### PR TITLE
[SuperEditor] Allow custom view models to be aware of node selection (Resolves #1944)

### DIFF
--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -76,14 +76,14 @@ class HorizontalRuleComponentBuilder implements ComponentBuilder {
 
 class HorizontalRuleComponentViewModel extends SingleColumnLayoutComponentViewModel with SelectionAwareViewModelMixin {
   HorizontalRuleComponentViewModel({
-    required String nodeId,
-    double? maxWidth,
-    EdgeInsetsGeometry padding = EdgeInsets.zero,
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
     DocumentNodeSelection? selection,
     Color selectionColor = Colors.transparent,
     this.caret,
     required this.caretColor,
-  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding) {
+  }) {
     super.selection = selection;
     super.selectionColor = selectionColor;
   }

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -1,5 +1,6 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/selection_aware_viewmodel.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 
 import '../core/document.dart';
@@ -65,7 +66,7 @@ class HorizontalRuleComponentBuilder implements ComponentBuilder {
 
     return HorizontalRuleComponent(
       componentKey: componentContext.componentKey,
-      selection: componentViewModel.selection,
+      selection: componentViewModel.selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
       selectionColor: componentViewModel.selectionColor,
       showCaret: componentViewModel.caret != null,
       caretColor: componentViewModel.caretColor,
@@ -73,19 +74,20 @@ class HorizontalRuleComponentBuilder implements ComponentBuilder {
   }
 }
 
-class HorizontalRuleComponentViewModel extends SingleColumnLayoutComponentViewModel {
+class HorizontalRuleComponentViewModel extends SingleColumnLayoutComponentViewModel with SelectionAwareViewModelMixin {
   HorizontalRuleComponentViewModel({
     required String nodeId,
     double? maxWidth,
     EdgeInsetsGeometry padding = EdgeInsets.zero,
-    this.selection,
-    required this.selectionColor,
+    DocumentNodeSelection? selection,
+    Color selectionColor = Colors.transparent,
     this.caret,
     required this.caretColor,
-  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding);
+  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding) {
+    super.selection = selection;
+    super.selectionColor = selectionColor;
+  }
 
-  UpstreamDownstreamNodeSelection? selection;
-  Color selectionColor;
   UpstreamDownstreamNodePosition? caret;
   Color caretColor;
 

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -1,5 +1,6 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/selection_aware_viewmodel.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 
 import '../core/document.dart';
@@ -122,27 +123,28 @@ class ImageComponentBuilder implements ComponentBuilder {
       componentKey: componentContext.componentKey,
       imageUrl: componentViewModel.imageUrl,
       expectedSize: componentViewModel.expectedSize,
-      selection: componentViewModel.selection,
+      selection: componentViewModel.selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
       selectionColor: componentViewModel.selectionColor,
     );
   }
 }
 
-class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel {
+class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel with SelectionAwareViewModelMixin {
   ImageComponentViewModel({
     required String nodeId,
     double? maxWidth,
     EdgeInsetsGeometry padding = EdgeInsets.zero,
     required this.imageUrl,
     this.expectedSize,
-    this.selection,
-    required this.selectionColor,
-  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding);
+    DocumentNodeSelection? selection,
+    Color selectionColor = Colors.transparent,
+  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding) {
+    this.selection = selection;
+    this.selectionColor = selectionColor;
+  }
 
   String imageUrl;
   ExpectedSize? expectedSize;
-  UpstreamDownstreamNodeSelection? selection;
-  Color selectionColor;
 
   @override
   ImageComponentViewModel copy() {

--- a/super_editor/lib/src/default_editor/image.dart
+++ b/super_editor/lib/src/default_editor/image.dart
@@ -131,14 +131,14 @@ class ImageComponentBuilder implements ComponentBuilder {
 
 class ImageComponentViewModel extends SingleColumnLayoutComponentViewModel with SelectionAwareViewModelMixin {
   ImageComponentViewModel({
-    required String nodeId,
-    double? maxWidth,
-    EdgeInsetsGeometry padding = EdgeInsets.zero,
+    required super.nodeId,
+    super.maxWidth,
+    super.padding = EdgeInsets.zero,
     required this.imageUrl,
     this.expectedSize,
     DocumentNodeSelection? selection,
     Color selectionColor = Colors.transparent,
-  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding) {
+  }) {
     this.selection = selection;
     this.selectionColor = selectionColor;
   }

--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -4,10 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/styles.dart';
-import 'package:super_editor/src/default_editor/horizontal_rule.dart';
-import 'package:super_editor/src/default_editor/image.dart';
-import 'package:super_editor/src/default_editor/selection_aware_viewmodel.dart';
-import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/selection_aware_viewmodel.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 
@@ -154,20 +151,6 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
           ..selectionColor = _selectionStyles.selectionColor
           ..highlightWhenEmpty = highlightWhenEmpty;
       }
-    }
-    if (viewModel is ImageComponentViewModel) {
-      final selection = nodeSelection == null ? null : nodeSelection.nodeSelection as UpstreamDownstreamNodeSelection;
-
-      viewModel
-        ..selection = selection
-        ..selectionColor = _selectionStyles.selectionColor;
-    }
-    if (viewModel is HorizontalRuleComponentViewModel) {
-      final selection = nodeSelection == null ? null : nodeSelection.nodeSelection as UpstreamDownstreamNodeSelection;
-
-      viewModel
-        ..selection = selection
-        ..selectionColor = _selectionStyles.selectionColor;
     }
     if (viewModel is SelectionAwareViewModelMixin) {
       viewModel

--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -6,6 +6,7 @@ import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/horizontal_rule.dart';
 import 'package:super_editor/src/default_editor/image.dart';
+import 'package:super_editor/src/default_editor/selection_aware_viewmodel.dart';
 import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -166,6 +167,11 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
 
       viewModel
         ..selection = selection
+        ..selectionColor = _selectionStyles.selectionColor;
+    }
+    if (viewModel is SelectionAwareViewModelMixin) {
+      viewModel
+        ..selection = nodeSelection
         ..selectionColor = _selectionStyles.selectionColor;
     }
 

--- a/super_editor/lib/src/default_editor/layout_single_column/selection_aware_viewmodel.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/selection_aware_viewmodel.dart
@@ -4,7 +4,7 @@ import 'package:super_editor/src/default_editor/layout_single_column/layout_sing
 
 /// Allows a [SingleColumnLayoutComponentViewModel] to be aware of the selection within its node.
 ///
-/// This mixin enables non-text components defined by the app, to render their selection.
+/// This mixin enables non-text components, to render their selection.
 ///
 /// During the styling pipeline, any [SingleColumnLayoutComponentViewModel] that mixes in
 /// [SelectionAwareViewModelMixin] will have its [selection] and [selectionColor] properties set.

--- a/super_editor/lib/src/default_editor/selection_aware_viewmodel.dart
+++ b/super_editor/lib/src/default_editor/selection_aware_viewmodel.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/src/core/styles.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
+
+/// Allows a [SingleColumnLayoutComponentViewModel] to be aware of the selection within its node.
+///
+/// This mixin enables non-text components defined by the app, to render their selection.
+///
+/// During the styling pipeline, any [SingleColumnLayoutComponentViewModel] that mixes in
+/// [SelectionAwareViewModelMixin] will have its [selection] and [selectionColor] properties set.
+///
+/// In the [SingleColumnLayoutComponentViewModel.copy] subclass implementation, both [selection] and
+/// [selectionColor] must be copied to the new instance.
+mixin SelectionAwareViewModelMixin on SingleColumnLayoutComponentViewModel {
+  /// The selection within the node represented by this view model.
+  DocumentNodeSelection? selection;
+
+  /// The color to be applied to the selection.
+  ///
+  /// During the styling pass, this color is set according to the [SelectionStyles] used.
+  Color selectionColor = Colors.transparent;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is SelectionAwareViewModelMixin &&
+          runtimeType == other.runtimeType &&
+          nodeId == other.nodeId &&
+          selection == other.selection &&
+          selectionColor == other.selectionColor;
+
+  @override
+  int get hashCode => super.hashCode ^ nodeId.hashCode ^ selection.hashCode ^ selectionColor.hashCode;
+}

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -39,7 +39,7 @@ export 'src/default_editor/layout_single_column/layout_single_column.dart';
 export 'src/default_editor/list_items.dart';
 export 'src/default_editor/multi_node_editing.dart';
 export 'src/default_editor/paragraph.dart';
-export 'src/default_editor/selection_aware_viewmodel.dart';
+export 'src/default_editor/layout_single_column/selection_aware_viewmodel.dart';
 export 'src/default_editor/selection_binary.dart';
 export 'src/default_editor/selection_upstream_downstream.dart';
 export 'src/default_editor/super_editor.dart';

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -39,6 +39,7 @@ export 'src/default_editor/layout_single_column/layout_single_column.dart';
 export 'src/default_editor/list_items.dart';
 export 'src/default_editor/multi_node_editing.dart';
 export 'src/default_editor/paragraph.dart';
+export 'src/default_editor/selection_aware_viewmodel.dart';
 export 'src/default_editor/selection_binary.dart';
 export 'src/default_editor/selection_upstream_downstream.dart';
 export 'src/default_editor/super_editor.dart';

--- a/super_editor/test/super_editor/supereditor_component_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_component_selection_test.dart
@@ -163,6 +163,37 @@ void main() {
         ),
       );
     });
+
+    testWidgetsOnArbitraryDesktop("defined by the app receives selection color", (tester) async {
+      await tester //
+          .createDocument()
+          .withCustomContent(
+            MutableDocument(nodes: [
+              ParagraphNode(id: '1', text: AttributedText('Paragraph 1')),
+              _ButtonNode(id: '2'),
+              ParagraphNode(id: '3', text: AttributedText('Paragraph 3')),
+            ]),
+          )
+          .withAddedComponents(
+            [_ButtonComponentBuilder()],
+          )
+          .withSelectionStyles(
+            SelectionStyles(selectionColor: Colors.red),
+          )
+          .pump();
+
+      // Drag to select all content.
+      await tester.dragSelectDocumentFromPositionByOffset(
+        from: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+        delta: Offset(0, 100),
+      );
+
+      // Ensure the selection color from the selection style was applied.
+      expect(
+        tester.widget<SelectableBox>(find.byType(SelectableBox)).selectionColor,
+        Colors.red,
+      );
+    });
   });
 
   group("Unselectable component", () {
@@ -604,6 +635,130 @@ class _UnselectableHorizontalRuleComponent extends StatelessWidget {
           thickness: 1.0,
         ),
       ),
+    );
+  }
+}
+
+/// A [DocumentNode] used to display a button.
+class _ButtonNode extends BlockNode with ChangeNotifier {
+  _ButtonNode({
+    required this.id,
+  });
+
+  @override
+  final String id;
+
+  @override
+  String? copyContent(dynamic selection) => '';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _ButtonNode && //
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+class _ButtonViewModel extends SingleColumnLayoutComponentViewModel with SelectionAwareViewModelMixin {
+  _ButtonViewModel({
+    required String nodeId,
+    double? maxWidth,
+    EdgeInsetsGeometry padding = EdgeInsets.zero,
+    DocumentNodeSelection? selection,
+    Color selectionColor = Colors.transparent,
+  }) : super(nodeId: nodeId, maxWidth: maxWidth, padding: padding) {
+    this.selection = selection;
+    this.selectionColor = selectionColor;
+  }
+
+  @override
+  _ButtonViewModel copy() {
+    return _ButtonViewModel(
+      nodeId: nodeId,
+      maxWidth: maxWidth,
+      padding: padding,
+      selection: selection,
+      selectionColor: selectionColor,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is _ButtonViewModel &&
+          runtimeType == other.runtimeType &&
+          nodeId == other.nodeId &&
+          selection == other.selection &&
+          selectionColor == other.selectionColor;
+
+  @override
+  int get hashCode => super.hashCode ^ nodeId.hashCode ^ selection.hashCode ^ selectionColor.hashCode;
+}
+
+class _ButtonComponent extends StatelessWidget {
+  const _ButtonComponent({
+    Key? key,
+    required this.componentKey,
+    this.selectionColor = Colors.blue,
+    this.selection,
+  }) : super(key: key);
+
+  final GlobalKey componentKey;
+  final Color selectionColor;
+  final DocumentNodeSelection? selection;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: SelectableBox(
+            selection: selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
+            selectionColor: selectionColor,
+            child: BoxComponent(
+              key: componentKey,
+              child: SizedBox(),
+            ),
+          ),
+        ),
+        Center(
+          child: ElevatedButton(
+            onPressed: () {},
+            child: Text('My Button'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ButtonComponentBuilder implements ComponentBuilder {
+  const _ButtonComponentBuilder();
+
+  @override
+  SingleColumnLayoutComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! _ButtonNode) {
+      return null;
+    }
+
+    return _ButtonViewModel(nodeId: node.id);
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! _ButtonViewModel) {
+      return null;
+    }
+
+    return _ButtonComponent(
+      componentKey: componentContext.componentKey,
+      selection: componentViewModel.selection,
+      selectionColor: componentViewModel.selectionColor,
     );
   }
 }

--- a/super_editor/test/super_editor/supereditor_components_test.dart
+++ b/super_editor/test/super_editor/supereditor_components_test.dart
@@ -194,7 +194,7 @@ class _FakeImageComponentBuilder implements ComponentBuilder {
     return ImageComponent(
       componentKey: componentContext.componentKey,
       imageUrl: componentViewModel.imageUrl,
-      selection: componentViewModel.selection,
+      selection: componentViewModel.selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
       selectionColor: componentViewModel.selectionColor,
       imageBuilder: (context, imageUrl) => const SizedBox(height: 100, width: 100),
     );

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -922,7 +922,7 @@ class FakeImageComponentBuilder implements ComponentBuilder {
     return ImageComponent(
       componentKey: componentContext.componentKey,
       imageUrl: componentViewModel.imageUrl,
-      selection: componentViewModel.selection,
+      selection: componentViewModel.selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
       selectionColor: componentViewModel.selectionColor,
       imageBuilder: (context, imageUrl) => ColoredBox(
         color: fillColor ?? Colors.transparent,

--- a/super_editor_markdown/test/test_tools.dart
+++ b/super_editor_markdown/test/test_tools.dart
@@ -25,7 +25,7 @@ class FakeImageComponentBuilder implements ComponentBuilder {
     return ImageComponent(
       componentKey: componentContext.componentKey,
       imageUrl: componentViewModel.imageUrl,
-      selection: componentViewModel.selection,
+      selection: componentViewModel.selection?.nodeSelection as UpstreamDownstreamNodeSelection?,
       selectionColor: componentViewModel.selectionColor,
       imageBuilder: (context, imageUrl) => SizedBox(
         height: size.height,


### PR DESCRIPTION
[SuperEditor] Allow custom view models to be aware of node selection. Resolves #1944

Currently, during the styling pass, we only apply the selection and selection color to our own viewmodels: `TextComponentViewModel`, `ImageComponentViewModel` and `HorizontalRuleComponentViewModel`.

Because of that, app-level view models, don't receive this information

https://github.com/superlistapp/super_editor/assets/7597082/e0e89088-f030-4013-bd64-0db68ae2f5e7

This PR introduces a `SelectionAwareViewModelMixin`. Any view model that mixes it in will receive the `DocumentNodeSelection` and selection color during the style pass.

Using this mixin, app-level components can easily render their selection:

https://github.com/superlistapp/super_editor/assets/7597082/c9c01546-b601-49f7-bd77-e1d145c88d9d


