### PR TITLE
[SuperEditor] Prevent long-press to resolve when swiping to pop (Resolves #1947)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -710,6 +710,11 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     }
   }
 
+  void _onTapCancel() {
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
+  }
+
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
     _longPressStrategy = AndroidDocumentLongPressSelectionStrategy(
@@ -1251,6 +1256,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
           (TapSequenceGestureRecognizer recognizer) {
             recognizer
               ..onTapDown = _onTapDown
+              ..onTapCancel = _onTapCancel
               ..onTapUp = _onTapUp
               ..onDoubleTapDown = _onDoubleTapDown
               ..onTripleTapDown = _onTripleTapDown

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -586,6 +586,11 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     widget.focusNode.requestFocus();
   }
 
+  void _onTapCancel() {
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
+  }
+
   void _onTapUp(TapUpDetails details) {
     // Stop waiting for a long-press to start.
     _globalTapDownOffset = null;
@@ -1295,6 +1300,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
           (TapSequenceGestureRecognizer recognizer) {
             recognizer
               ..onTapDown = _onTapDown
+              ..onTapCancel = _onTapCancel
               ..onTapUp = _onTapUp
               ..onDoubleTapUp = _onDoubleTapUp
               ..onTripleTapUp = _onTripleTapUp

--- a/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
+++ b/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
@@ -204,7 +204,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
       // TapSequenceGestureRecognizer and a HorizontalDragGestureRecognizer, when the user taps down and
       // then drags horizontally, the onTapDown event is fired, and after that the HorizontalDragGestureRecognizer
       // declares itself as the winner. Invoke onTapCancel to cancel the gesture.
-      _checkCancel();
+      _notifyListenersOfCancellation();
       if (_trackers.isEmpty) {
         _reset();
       }
@@ -228,7 +228,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     if (_firstTap != null || _secondTap != null) {
       // We have a single or double tap registered, but the tracker isn't related to any of them.
       // It's not clear what this situation means.
-      _checkCancel();
+      _notifyListenersOfCancellation();
       if (_trackers.isEmpty) {
         _reset();
       }
@@ -279,7 +279,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     _stopTapTimer();
     if (_secondTap != null) {
       if (_trackers.isNotEmpty) {
-        _checkCancel();
+        _notifyListenersOfCancellation();
       }
       // Note, order is important below in order for the resolve -> reject logic
       // to work properly.
@@ -290,7 +290,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     }
     if (_firstTap != null) {
       if (_trackers.isNotEmpty) {
-        _checkCancel();
+        _notifyListenersOfCancellation();
       }
       // Note, order is important below in order for the resolve -> reject logic
       // to work properly.
@@ -398,20 +398,26 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     }
   }
 
-  void _checkCancel() {
-    // Cancel our tap tracking if we lost in the arena after an initial tap down.
-    //
-    // This tracker looks for tap downs and tap releases. It's possible that we're in the
-    // arena for a tap down, but we lose the arena before the user releases his finger.
-    // That's what this condition identifies, and then cancels our tracker.
-    if ((_firstTapDownDetails != null || _firstTap == null) && onTapCancel != null) {
-      invokeCallback<void>('onTapCancel', onTapCancel!);
+  void _notifyListenersOfCancellation() {
+    if (_secondTap != null) {
+      if (onTripleTapCancel != null) {
+        invokeCallback<void>('onTripleTapCancel', onTripleTapCancel!);
+      }
+      return;
     }
-    if (_firstTap != null && _secondTap == null && onDoubleTapCancel != null) {
-      invokeCallback<void>('onDoubleTapCancel', onDoubleTapCancel!);
+
+    if (_firstTap != null) {
+      if (onDoubleTapCancel != null) {
+        invokeCallback<void>('onDoubleTapCancel', onDoubleTapCancel!);
+      }
+      return;
     }
-    if (_secondTap != null && onTripleTapCancel != null) {
-      invokeCallback<void>('onTripleTapCancel', onTripleTapCancel!);
+
+    if (_firstTapDownDetails != null) {
+      if (onTapCancel != null) {
+        invokeCallback<void>('onTapCancel', onTapCancel!);
+      }
+      return;
     }
   }
 

--- a/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
+++ b/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
@@ -198,7 +198,10 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     _trackers.remove(tracker.pointer);
     tracker.entry.resolve(GestureDisposition.rejected);
     _freezeTracker(tracker);
-    if (_firstTap != null || _secondTap != null) {
+
+    // Check if we need to cancel even when both _firstTap and _secondTap are null,
+    // because if a tap down already happened, we need to call onCancel.
+    if (_firstTap != null || _secondTap != null || _firstTapDownDetails != null) {
       if (tracker == _firstTap || tracker == _secondTap) {
         _reset();
       } else {
@@ -275,6 +278,8 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
       GestureBinding.instance.gestureArena.release(tracker.pointer);
     }
     _clearTrackers();
+
+    _firstTapDownDetails = null;
   }
 
   void _registerFirstTap(PointerEvent event, _TapTracker tracker) {
@@ -372,7 +377,7 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
   }
 
   void _checkCancel() {
-    if (_firstTap == null && onTapCancel != null) {
+    if ((_firstTap == null || _firstTapDownDetails != null) && onTapCancel != null) {
       invokeCallback<void>('onTapCancel', onTapCancel!);
     }
     if (_firstTap != null && _secondTap == null && onDoubleTapCancel != null) {

--- a/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
+++ b/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
@@ -199,8 +199,14 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
     tracker.entry.resolve(GestureDisposition.rejected);
     _freezeTracker(tracker);
 
-    // Check if we need to cancel even when both _firstTap and _secondTap are null,
-    // because if a tap down already happened, we need to call onCancel.
+    // Both _firstTap and _secondTap are only set when a pointer up event is received,
+    // but we also need to handle cases when we already fired the onTapDown event, and
+    // we were defeated on the gesture arena before the onTapUp event. For example, if
+    // an app has both a TapSequenceGestureRecognizer and a HorizontalDragGestureRecognizer,
+    // when the user taps down and then drag horizontally, the onTapDown event is fired, and after that
+    // the HorizontalDragGestureRecognizer declares itself as the winner. In this case, we need to
+    // fire the onTapCancel event. Check if _firstTapDownDetails is not null to confirm if the tap
+    // down already happened.
     if (_firstTap != null || _secondTap != null || _firstTapDownDetails != null) {
       if (tracker == _firstTap || tracker == _secondTap) {
         _reset();
@@ -377,6 +383,9 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
   }
 
   void _checkCancel() {
+    // The _firstTap is only set after a pointer up event is received. Check if
+    // _firstTapDownDetails is not null, which signals we fired the onTapDown event and
+    // we were defeated on the arena before a pointer up event was received.
     if ((_firstTap == null || _firstTapDownDetails != null) && onTapCancel != null) {
       invokeCallback<void>('onTapCancel', onTapCancel!);
     }

--- a/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
+++ b/super_editor/lib/src/infrastructure/multi_tap_gesture.dart
@@ -399,10 +399,12 @@ class TapSequenceGestureRecognizer extends GestureRecognizer {
   }
 
   void _checkCancel() {
-    // The _firstTap is only set after a pointer up event is received. Check if
-    // _firstTapDownDetails is not null, which signals we fired the onTapDown event and
-    // we were defeated on the arena before a pointer up event was received.
-    if ((_firstTap == null || _firstTapDownDetails != null) && onTapCancel != null) {
+    // Cancel our tap tracking if we lost in the arena after an initial tap down.
+    //
+    // This tracker looks for tap downs and tap releases. It's possible that we're in the
+    // arena for a tap down, but we lose the arena before the user releases his finger.
+    // That's what this condition identifies, and then cancels our tracker.
+    if ((_firstTapDownDetails != null || _firstTap == null) && onTapCancel != null) {
       invokeCallback<void>('onTapCancel', onTapCancel!);
     }
     if (_firstTap != null && _secondTap == null && onDoubleTapCancel != null) {

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -500,6 +500,11 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     _tapDownLongPressTimer = Timer(kLongPressTimeout, _onLongPressDown);
   }
 
+  void _onTapCancel() {
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
+  }
+
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
     if (_isScrolling) {
@@ -1054,6 +1059,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
             (TapSequenceGestureRecognizer recognizer) {
               recognizer
                 ..onTapDown = _onTapDown
+                ..onTapCancel = _onTapCancel
                 ..onTapUp = _onTapUp
                 ..onDoubleTapDown = _onDoubleTapDown
                 ..onTripleTapDown = _onTripleTapDown

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -455,6 +455,11 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     _tapDownLongPressTimer = Timer(kLongPressTimeout, _onLongPressDown);
   }
 
+  void _onTapCancel() {
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
+  }
+
   // Runs when a tap down has lasted long enough to signify a long-press.
   void _onLongPressDown() {
     final interactorOffset = interactorBox.globalToLocal(_globalTapDownOffset!);
@@ -970,6 +975,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
           (TapSequenceGestureRecognizer recognizer) {
             recognizer
               ..onTapDown = _onTapDown
+              ..onTapCancel = _onTapCancel
               ..onTapUp = _onTapUp
               ..onDoubleTapUp = _onDoubleTapUp
               ..onTripleTapUp = _onTripleTapUp

--- a/super_editor/test/infrastructure/multi_tap_gesture_test.dart
+++ b/super_editor/test/infrastructure/multi_tap_gesture_test.dart
@@ -43,8 +43,7 @@ void main() {
         ),
       );
 
-      TestGesture gesture =
-          await tester.startGesture(tester.getCenter(tapTargetFinder));
+      TestGesture gesture = await tester.startGesture(tester.getCenter(tapTargetFinder));
       await tester.pump();
       expect(tapDownCount, 1);
       expect(tapCount, 0);
@@ -138,8 +137,7 @@ void main() {
         }),
       );
 
-      TestGesture gesture =
-          await tester.startGesture(tester.getCenter(tapTargetFinder));
+      TestGesture gesture = await tester.startGesture(tester.getCenter(tapTargetFinder));
       await tester.pump();
       expect(tapDownCount, 0);
       expect(tapCount, 0);
@@ -215,8 +213,7 @@ void main() {
         ),
       );
 
-      TestGesture gesture =
-          await tester.startGesture(tester.getCenter(tapTargetFinder));
+      TestGesture gesture = await tester.startGesture(tester.getCenter(tapTargetFinder));
       await tester.pump();
       expect(tapDownCount, 0);
       expect(tapCount, 0);
@@ -269,8 +266,7 @@ void main() {
       expect(timeoutCount, 1);
     });
 
-    testWidgets("can ignore single tap and double tap gestures",
-        (tester) async {
+    testWidgets("can ignore single tap and double tap gestures", (tester) async {
       final recognizer = TapSequenceGestureRecognizer(
         supportedDevices: {PointerDeviceKind.touch},
         reportPrecedingGestures: false,
@@ -311,8 +307,7 @@ void main() {
         ),
       );
 
-      TestGesture gesture =
-          await tester.startGesture(tester.getCenter(tapTargetFinder));
+      TestGesture gesture = await tester.startGesture(tester.getCenter(tapTargetFinder));
       await tester.pump();
       expect(tapDownCount, 0);
       expect(tapCount, 0);
@@ -374,6 +369,75 @@ void main() {
 
       await tester.pumpAndSettle();
     });
+
+    testWidgets("cancels tap if another recognizer wins after tap down", (tester) async {
+      int tapDownCount = 0;
+      int tapCancelCount = 0;
+      int tapUpCount = 0;
+      int dragUpdateCount = 0;
+
+      // Pump a tree with a tap recognizer and a drag recognizer to check if dragging
+      // after onTapDown was called causes the tap to be cancelled.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: RawGestureDetector(
+              gestures: {
+                HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
+                  () => HorizontalDragGestureRecognizer(),
+                  (HorizontalDragGestureRecognizer recognizer) {
+                    recognizer.onUpdate = (_) {
+                      dragUpdateCount += 1;
+                    };
+                  },
+                ),
+                TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
+                  () => TapSequenceGestureRecognizer(),
+                  (TapSequenceGestureRecognizer recognizer) {
+                    recognizer
+                      ..onTapDown = (_) {
+                        tapDownCount += 1;
+                      }
+                      ..onTapUp = (_) {
+                        tapUpCount += 1;
+                      }
+                      ..onTapCancel = () {
+                        tapCancelCount += 1;
+                      };
+                  },
+                ),
+              },
+              child: Container(
+                key: const ValueKey('tap-target'),
+                width: 48,
+                height: 48,
+                color: Colors.red,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Start the gesture, this should fire onTapDown.
+      final gesture = await tester.startGesture(tester.getCenter(tapTargetFinder));
+      await tester.pump(kTapMinTime);
+
+      // Trigger a horizontal drag.
+      await gesture.moveBy(Offset(20, 0));
+      await tester.pump();
+      await gesture.moveBy(Offset(20, 0));
+      await tester.pump();
+
+      // Release the gesture.
+      await gesture.up();
+      await tester.pump();
+
+      // Ensure that onTapCancel was called and onTapUp was not.
+      expect(tapDownCount, 1);
+      expect(tapCancelCount, 1);
+      expect(tapUpCount, 0);
+      expect(dragUpdateCount, 1);
+    });
   });
 }
 
@@ -391,8 +455,7 @@ Widget _buildGestureScaffold(
     home: Center(
       child: RawGestureDetector(
         gestures: {
-          TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<
-              TapSequenceGestureRecognizer>(
+          TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
             () => recognizer,
             (TapSequenceGestureRecognizer recognizer) {
               recognizer

--- a/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor', () {
+    testWidgetsOnIos('keeps current selection and does not show mobile controls when swipping to pop (on iOS)',
+        (tester) async {
+      // Run the test with a fixed size so we know how much we need to swipe
+      // to pop the page.
+      tester.view
+        ..devicePixelRatio = 1.0
+        ..platformDispatcher.textScaleFactorTestValue = 1.0
+        ..physicalSize = const Size(300, 600);
+      addTearDown(() => tester.platformDispatcher.clearAllTestValues());
+
+      // Pump an app with two routes to simulate a swipe-to-pop gesture.
+      //
+      // The app pushes the SuperEditor route automatically after the first frame.
+      await tester
+          .createDocument()
+          .withSingleParagraph()
+          .withCustomWidgetTreeBuilder(
+            (superEditor) => MaterialApp(
+              home: _AutoPushRoute(
+                route: MaterialPageRoute(
+                  builder: (context) => Scaffold(
+                    body: superEditor,
+                  ),
+                ),
+              ),
+            ),
+          )
+          .pump();
+
+      // Wait until the editor route is displayed.
+      await tester.pumpAndSettle();
+
+      // Ensure there is no selection.
+      expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+      // Start dragging approximately from the top left corner of the editor.
+      final gesture = await tester.startGesture(
+        tester.getTopLeft(find.byType(SuperEditor)) + const Offset(10, 10),
+      );
+
+      // Move a little bit to start the swipe to pop gesture.
+      await gesture.moveBy(Offset(20, 0));
+      await tester.pump();
+
+      // Move to the right side of the screen to trigger the route pop.
+      await gesture.moveBy(Offset(200, 0));
+      await tester.pump();
+
+      // Let the long press timer resolve.
+      await tester.pump(kLongPressTimeout);
+
+      // Ensure there is still no selection and the magnifier is not displayed.
+      expect(SuperEditorInspector.findDocumentSelection(), isNull);
+      expect(SuperEditorInspector.findMobileMagnifier(), findsNothing);
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Release the gesture.
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Ensure that the route was popped.
+      expect(find.byType(SuperEditor), findsNothing);
+    });
+  });
+}
+
+/// Displays a placeholder and automatically pushes the given [route]
+/// after the first frame.
+class _AutoPushRoute extends StatefulWidget {
+  const _AutoPushRoute({
+    required this.route,
+  });
+
+  final Route route;
+
+  @override
+  State<_AutoPushRoute> createState() => _AutoPushRouteState();
+}
+
+class _AutoPushRouteState extends State<_AutoPushRoute> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((duration) {
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(context).push(widget.route);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Placeholder();
+  }
+}


### PR DESCRIPTION
[SuperEditor] Prevent long-press to resolve when swiping to pop. Resolves #1947

On mobile, dragging from left to right starts a swipe-to-pop gesture. However, when doing so we are changing the selection on both mobile platforms, showing the magnifier on iOS and showing the mobile toolbar on Android:

[android_swipe_before.webm](https://github.com/superlistapp/super_editor/assets/7597082/dba2c11b-bc28-4b80-9758-ac26da7a9274)

https://github.com/superlistapp/super_editor/assets/7597082/ea9484bc-1c88-4897-b5f5-b2ca9f61c07b

The issue is that, even though the horizontal drag recognizer is winning in the gesture arena, the `onTapDown` is still called, causing the long-press timer to be started.

To resolve that, we need to cancel the timer when we lose on the arena. 

I found another issue, where the `onCancel` isn't being called after the recognizer was defeated in the arena, even if the `onTapDown` was already fired.

This PR changes the `TapSequenceGestureRecognizer` to call `onTapCancel` after we lose on the arena and change the mobile interactors to cancel the long-press timers on that callback.

I wasn't able to write a failing test for Android, I guess this back gesture is handled different for Android, since I'm not seeing any other recognizers on the arena after starting the swipe.

With this PR's implementation:

https://github.com/superlistapp/super_editor/assets/7597082/b5826302-65e3-4dc2-8ada-f3602f1eede4

[android_swipe_after.webm](https://github.com/superlistapp/super_editor/assets/7597082/4a976c98-da24-4448-bd11-a0dd16a31a4e)

