### PR TITLE
[SuperEditor][Web] Prevent Cmd + Z and Ctrl + Z shortcuts from bubbling up (Resolves #2060)

### DIFF
--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -938,6 +938,36 @@ ExecutionInstruction doNothingWithBackspaceOnWeb({
   return ExecutionInstruction.continueExecution;
 }
 
+ExecutionInstruction doNothingWithCtrlOrCmdAndZOnWeb({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (keyEvent.logicalKey != LogicalKeyboardKey.keyZ) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (!CurrentPlatform.isApple && !HardwareKeyboard.instance.isControlPressed) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (CurrentPlatform.isWeb) {
+    // On web, pressing Cmd + Z on Mac or Ctrl + Z on Windows and Linux
+    // triggers the UNDO action of the HTML text input, which doesn't work for us.
+    // Prevent the browser from handling the shortcut.
+    return ExecutionInstruction.haltExecution;
+  }
+
+  return ExecutionInstruction.continueExecution;
+}
+
 ExecutionInstruction doNothingWithDeleteOnWeb({
   required SuperEditorContext editContext,
   required KeyEvent keyEvent,

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1243,6 +1243,7 @@ final defaultImeKeyboardActions = <DocumentKeyboardAction>[
   cmdBToToggleBold,
   cmdIToToggleItalics,
   doNothingWithBackspaceOnWeb,
+  doNothingWithCtrlOrCmdAndZOnWeb,
   backspaceToConvertTaskToParagraph,
   backspaceToUnIndentListItem,
   backspaceToClearParagraphBlockType,


### PR DESCRIPTION
[SuperEditor][Web] Prevent Cmd + Z and Ctrl + Z shortcuts from bubbling up. Resolves #2060 

On Web, deleting a portion of a paragraph and then pressing the undo shortcut crashes the editor with the following exception: 

```console
══╡ EXCEPTION CAUGHT BY SERVICES LIBRARY ╞══════════════════════════════════════════════════════════
The following assertion was thrown during method call TextInputClient.updateEditingStateWithDeltas:
Assertion failed:
file:///Users/angelosilvestre/dev/flutter/packages/flutter/lib/src/services/text_editing_delta.dart:129:14
_debugTextRangeIsValid(newSelection, oldText)
"The selection range: TextSelection(baseOffset: 30, extentOffset: 104, isDirectional: false) is not
within the bounds of text: . Super Editor is a toolkit to of length: 30"

When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 296:3       throw_
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 29:3        assertFailed
packages/flutter/src/services/text_editing_delta.dart 129:58                      fromJSON
packages/flutter/src/services/text_input.dart 1900:30                             <fn>
packages/flutter/src/services/text_input.dart 1900:51                             _handleTextInputInvocation
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 84:54                runBody
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 127:5                _async
packages/flutter/src/services/text_input.dart 1809:45                             [_handleTextInputInvocation]
packages/flutter/src/services/text_input.dart 1794:20                             _loudlyHandleTextInputInvocation
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 84:54                runBody
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 127:5                _async
packages/flutter/src/services/text_input.dart 1792:51                             [_loudlyHandleTextInputInvocation]
packages/flutter/src/services/platform_channel.dart 571:55                        _handleAsMethodCall
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 84:54                runBody
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 127:5                _async
packages/flutter/src/services/platform_channel.dart 568:40                        [_handleAsMethodCall]
packages/flutter/src/services/platform_channel.dart 564:34                        <fn>
packages/flutter/src/services/binding.dart 576:35                                 <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 84:54                runBody
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 127:5                _async
packages/flutter/src/services/binding.dart 573:98                                 <fn>
lib/_engine/engine/platform_dispatcher.dart 1436:5                                invoke2
lib/ui/channel_buffers.dart 25:12                                                 invoke
lib/ui/channel_buffers.dart 65:7                                                  push
lib/ui/channel_buffers.dart 131:16                                                push
lib/_engine/engine/platform_dispatcher.dart 468:10                                invokeOnPlatformMessage
lib/_engine/engine/text_editing/text_editing.dart 2256:30                         updateEditingStateWithDelta
lib/_engine/engine/text_editing/text_editing.dart 2363:11                         <fn>
lib/_engine/engine/text_editing/text_editing.dart 1450:7                          handleChange
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 426:37  _checkAndCall
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 431:39  dcall

call:
  MethodCall(TextInputClient.updateEditingStateWithDeltas, [1, {deltas: [{oldText: . Super Editor is
  a toolkit to, deltaText: , deltaStart: -1, deltaEnd: -1, selectionBase: 30, selectionExtent: 104,
  composingBase: -1, composingExtent: -1}]}])
════════════════════════════════════════════════════════════════════════════════════════════════════

```

The issue is that Flutter Web uses the browser HTML input to handle the text input and this input responds to the undo shortcut.

This PR prevents the Cmd + Z and Ctrl + Z shortcuts from bubbling up, so they are not handled by the HTML input.

To be able to effectively test this, I think we would need integration tests.
