### PR TITLE
Fix crash in linkification reaction, also add linkification to inline markdown parsing (Resolves #2074)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2391,10 +2391,19 @@ class PasteEditorCommand implements EditCommand {
           looseUrl: true,
         ),
       );
+
       final int linkCount = extractedLinks.fold(0, (value, element) => element is UrlElement ? value + 1 : value);
       if (linkCount == 1) {
         // The word is a single URL. Linkify it.
-        final uri = parseLink(word);
+        late final Uri uri;
+        try {
+          uri = parseLink(word);
+        } catch (exception) {
+          // Something went wrong when trying to parse links. This can happen, for example,
+          // due to Markdown syntax around a link, e.g., [My Link](www.something.com). I'm
+          // not sure why that case throws, but it does. We ignore any URL that throws.
+          continue;
+        }
 
         final startOffset = wordBoundary.start;
         // -1 because TextPosition's offset indexes the character after the

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -75,6 +75,19 @@ class PasteStructuredContentEditorCommand implements EditCommand {
           textToInsert: (pastedNode as TextNode).text,
         ),
       );
+      executor.executeCommand(
+        ChangeSelectionCommand(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: pastePosition.nodeId,
+              nodePosition: TextNodePosition(
+                  offset: (pastePosition.nodePosition as TextNodePosition).offset + pastedNode.text.length),
+            ),
+          ),
+          SelectionChangeType.insertContent,
+          SelectionReason.userInteraction,
+        ),
+      );
 
       return;
     }

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
 
 import '../supereditor_test_tools.dart';
 
@@ -2033,6 +2034,24 @@ void main() {
         ),
         isEmpty,
       );
+    });
+
+    testWidgetsOnAllPlatforms('plays nice with Markdown link when Markdown parsing is disabled', (tester) async {
+      // Based on bug #2074 - https://github.com/superlistapp/super_editor/issues/2074
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      await tester.placeCaretInParagraph("1", 0);
+
+      await tester.typeImeText("[google](www.google.com) ");
+
+      // Ensure that the Markdown was parsed and replaced with a link.
+      final text = SuperEditorInspector.findTextInComponent("1");
+      expect(text.text, "[google](www.google.com) ");
+      expect(text.getAttributionSpansByFilter((a) => true), isEmpty);
     });
 
     // TODO: once it's easier to configure task components (#1295), add a test that checks link attributions when inserting a new task

--- a/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
+++ b/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
@@ -310,6 +310,12 @@ class _UpstreamInlineMarkdownParser {
       return null;
     }
 
+    final characterAtCaret = attributedText.text[caretOffset - 1]; // -1 because caret sits after character
+    if (characterAtCaret != " ") {
+      // Don't linkify unless the user just inserted a space after the token.
+      return null;
+    }
+
     final endOfTokenOffset = caretOffset - 2;
     if (attributedText.text[endOfTokenOffset] != ")") {
       // All links end with a ")", therefore we know the upstream token

--- a/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
+++ b/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
@@ -340,7 +340,7 @@ class _UpstreamInlineMarkdownParser {
 
         return _InlineMarkdownRun(
           AttributedText(
-            linkName,
+            "$linkName ", // Explicitly add the trailing space so the caret stays after the space.
             AttributedSpans(attributions: [
               SpanMarker(
                 attribution: linkAttribution,
@@ -355,7 +355,7 @@ class _UpstreamInlineMarkdownParser {
             ]),
           ),
           match.start,
-          match.end,
+          match.end + 1, // +1 to include the space after the link so the caret stays in same place.
         );
       }
     }

--- a/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
+++ b/super_editor_markdown/lib/src/markdown_inline_upstream_plugin.dart
@@ -53,10 +53,7 @@ const defaultUpstreamInlineMarkdownParsers = [
 /// caret and converts it into attributions.
 ///
 /// Inline Markdown syntax includes things like `**token**` for bold, `*token*` for
-/// italics, and `~token~` for strikethrough. Links aren't included because their complex
-/// syntax makes upstream parsing a poor strategy for identifying them. For linkification,
-/// consider using a batch Markdown parsing approach, or consider identifying URLs directly,
-/// without requiring any Markdown syntax.
+/// italics, `~token~` for strikethrough, and `[name](url)` for links.
 ///
 /// When this reaction finds inline Markdown syntax, that syntax is removed when the corresponding
 /// attribution is applied. For example, "**bold**" becomes "bold" with a bold attribution
@@ -65,6 +62,10 @@ const defaultUpstreamInlineMarkdownParsers = [
 /// This reaction only identifies spans of Markdown styles within individual [TextNode]s, which
 /// immediately precedes the caret. For example, "Hello **bold**|" will apply the bold style,
 /// but "Hello **bold** wo|" won't apply bold.
+///
+/// Parsing of links is handled differently than all other upstream syntax. Links use a fairly
+/// complicated syntax, so they're identified with a regular expression. All other upstream
+/// inline syntaxes are parsed character by character, moving upstream from the caret position.
 class MarkdownInlineUpstreamSyntaxReaction implements EditReaction {
   const MarkdownInlineUpstreamSyntaxReaction(this._parsers);
 
@@ -237,6 +238,14 @@ class _UpstreamInlineMarkdownParser {
       return null;
     }
 
+    // Run the special case of parsing a link. This is a special case because the syntax
+    // is complicated enough that we don't want to try to accumulate characters as the
+    // user types.
+    final linkRun = _tryCreateLinkRun();
+    if (linkRun != null) {
+      return linkRun;
+    }
+
     int offset = caretOffset - 1;
 
     // Start visiting upstream characters by visiting the first character
@@ -293,6 +302,60 @@ class _UpstreamInlineMarkdownParser {
       // Note: end offset is exclusive.
       caretOffset,
     );
+  }
+
+  _InlineMarkdownRun? _tryCreateLinkRun() {
+    if (caretOffset < 2) {
+      // There's not enough text before the caret to possibly hold a link. Fizzle.
+      return null;
+    }
+
+    final endOfTokenOffset = caretOffset - 2;
+    if (attributedText.text[endOfTokenOffset] != ")") {
+      // All links end with a ")", therefore we know the upstream token
+      // isn't a link. Short-circuit return.
+      return null;
+    }
+
+    final markdownLinkRegex = RegExp(r'\[([\w\s\d]+)]\(((?:|https?://)[\w\d./?=#]+)\)');
+    final matches = markdownLinkRegex.allMatches(attributedText.text);
+    if (matches.isEmpty) {
+      // Didn't find any links.
+      return null;
+    }
+
+    // Found some links. See if any of them are immediately upstream.
+    for (final match in matches) {
+      if (match.end - 1 == endOfTokenOffset) {
+        // We found a Markdown link immediately upstream. Return it.
+        final linkName = match.group(1)!;
+        final linkUrl = match.group(2)!;
+        final linkAttribution = LinkAttribution(linkUrl);
+
+        return _InlineMarkdownRun(
+          AttributedText(
+            linkName,
+            AttributedSpans(attributions: [
+              SpanMarker(
+                attribution: linkAttribution,
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              SpanMarker(
+                attribution: linkAttribution,
+                offset: linkName.length - 1,
+                markerType: SpanMarkerType.end,
+              ),
+            ]),
+          ),
+          match.start,
+          match.end,
+        );
+      }
+    }
+
+    // We found links, but none of them are immediately upstream.
+    return null;
   }
 
   void _updatePossibleSyntaxes(String character, int characterIndex) {

--- a/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
+++ b/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
@@ -476,6 +476,26 @@ void main() {
         expect(SuperEditorInspector.findTextInComponent(nodeId).spans.markers, isEmpty);
       });
     });
+
+    testWidgets("parses Markdown link syntax and plays nice with built-in linkification reaction", (tester) async {
+      final (document, _) = await _pumpScaffold(tester);
+
+      final nodeId = document.nodes.first.id;
+      await tester.placeCaretInParagraph(nodeId, 0);
+
+      await tester.typeImeText("[google](www.google.com) ");
+
+      // Ensure that the Markdown was parsed and replaced with a link.
+      final text = SuperEditorInspector.findTextInComponent(nodeId);
+      expect(text.text, "google ");
+      expect(text.getAttributionSpansByFilter((a) => true), {
+        const AttributionSpan(
+          attribution: LinkAttribution("www.google.com"),
+          start: 0,
+          end: 5,
+        ),
+      });
+    });
   });
 }
 

--- a/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
+++ b/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
@@ -527,6 +527,15 @@ void main() {
             end: 5,
           ),
         });
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: nodeId,
+              nodePosition: const TextNodePosition(offset: 7),
+            ),
+          ),
+        );
       });
     });
   });

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -351,6 +351,41 @@ Phasellus sed sagittis urna.
 Aenean mattis ante justo, quis sollicitudin metus interdum id.''',
       );
     });
+
+    testWidgetsOnMac("can paste a link", (tester) async {
+      final (_, document, composer) = await _pumpSuperEditor(
+        tester,
+        deserializeMarkdownToDocument(""),
+      );
+
+      // Place the caret in empty paragraph.
+      final paragraph = document.nodes.first as TextNode;
+      await tester.placeCaretInParagraph(paragraph.id, 0);
+
+      // Simulate the user copying a markdown snippet.
+      tester
+        ..simulateClipboard()
+        ..setSimulatedClipboardContent("Hello [link](www.google.com)");
+
+      // Paste the markdown content into the empty document.
+      await tester.pressCmdV();
+
+      // Ensure that the Markdown link was linkified.
+      expect(SuperEditorInspector.findTextInComponent(paragraph.id).text, "Hello link");
+      const expectedAttribution = LinkAttribution("www.google.com");
+      expect(SuperEditorInspector.findTextInComponent(paragraph.id).getAttributionSpansByFilter((a) => true), {
+        const AttributionSpan(attribution: expectedAttribution, start: 6, end: 9),
+      });
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: paragraph.id,
+            nodePosition: const TextNodePosition(offset: 10),
+          ),
+        ),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Fix crash in linkification reaction, also add linkification to inline markdown parsing (Resolves #2074)

Repro: Type `[google](www.google.com)`.

Result: Crash due to the (non-Markdown) linkification reaction.

This PR does two things:

1. Don't crash in the non-Markdown linkification reaction.
2. Linkify the Markdown syntax.

Previously, I didn't include Markdown linkification in the upstream Markdown parser reaction. That's because the link syntax is a lot more complicated to parse character by character.

In this PR, I carved out the link syntax as a special case within the parser reaction. In that carve-out I use a `RegExp` to find the link. So now that parser also parses link syntax.