### PR TITLE
[SuperEditor][SuperTextField][iOS] - When user taps, place caret at word boundary (Resolves #2080)

### DIFF
--- a/super_editor/lib/src/default_editor/text_tools.dart
+++ b/super_editor/lib/src/default_editor/text_tools.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';

--- a/super_editor/lib/src/infrastructure/platforms/ios/selection_heuristics.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/selection_heuristics.dart
@@ -1,0 +1,41 @@
+import 'package:super_editor/src/infrastructure/strings.dart';
+
+/// User interaction heuristics that simulate observed behavior on
+/// iOS devices.
+class IosHeuristics {
+  /// Adjusts a user's tap offset within a text field, or a paragraph, by
+  /// moving the caret to a word boundary, as observed on iOS.
+  static int adjustTapOffset(String text, int tapOffset) {
+    assert(tapOffset >= 0 && tapOffset < text.length);
+    if (tapOffset == 0) {
+      return 0;
+    }
+
+    final upstreamWordStart = text.moveOffsetUpstreamByWord(tapOffset) ?? 0;
+    final upstreamWordEnd = text.moveOffsetDownstreamByWord(upstreamWordStart) ?? text.length;
+
+    final downstreamWordEnd = text.moveOffsetDownstreamByWord(tapOffset) ?? text.length;
+    final downstreamWordStart = text.moveOffsetUpstreamByWord(downstreamWordEnd) ?? 0;
+
+    late final int adjustedSelectionOffset;
+    if (text[tapOffset] == " ") {
+      // User tapped between words. Pick the nearest word.
+      adjustedSelectionOffset =
+          downstreamWordStart - tapOffset < tapOffset - upstreamWordEnd ? downstreamWordStart : upstreamWordEnd;
+    } else {
+      // User tapped within a word. Adjust the offset to the end of the
+      // word unless the user is within 1 character of the start of the word.
+      if (tapOffset <= upstreamWordEnd) {
+        // The tap position is within the upstream word.
+        adjustedSelectionOffset = tapOffset - upstreamWordStart <= 1 ? upstreamWordStart : upstreamWordEnd;
+      } else {
+        // The tap position is within the downstream word.
+        adjustedSelectionOffset = tapOffset - downstreamWordStart <= 1 ? downstreamWordStart : downstreamWordEnd;
+      }
+    }
+
+    return adjustedSelectionOffset;
+  }
+
+  const IosHeuristics._();
+}

--- a/super_editor/lib/src/infrastructure/platforms/ios/selection_heuristics.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/selection_heuristics.dart
@@ -17,24 +17,20 @@ class IosHeuristics {
     final downstreamWordEnd = text.moveOffsetDownstreamByWord(tapOffset) ?? text.length;
     final downstreamWordStart = text.moveOffsetUpstreamByWord(downstreamWordEnd) ?? 0;
 
-    late final int adjustedSelectionOffset;
     if (text[tapOffset] == " ") {
       // User tapped between words. Pick the nearest word.
-      adjustedSelectionOffset =
-          downstreamWordStart - tapOffset < tapOffset - upstreamWordEnd ? downstreamWordStart : upstreamWordEnd;
+      return downstreamWordStart - tapOffset < tapOffset - upstreamWordEnd ? downstreamWordStart : upstreamWordEnd;
     } else {
       // User tapped within a word. Adjust the offset to the end of the
       // word unless the user is within 1 character of the start of the word.
       if (tapOffset <= upstreamWordEnd) {
         // The tap position is within the upstream word.
-        adjustedSelectionOffset = tapOffset - upstreamWordStart <= 1 ? upstreamWordStart : upstreamWordEnd;
+        return tapOffset - upstreamWordStart <= 1 ? upstreamWordStart : upstreamWordEnd;
       } else {
         // The tap position is within the downstream word.
-        adjustedSelectionOffset = tapOffset - downstreamWordStart <= 1 ? downstreamWordStart : downstreamWordEnd;
+        return tapOffset - downstreamWordStart <= 1 ? downstreamWordStart : downstreamWordEnd;
       }
     }
-
-    return adjustedSelectionOffset;
   }
 
   const IosHeuristics._();

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -5,7 +5,9 @@ import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/flutter/text_selection.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
+import 'package:super_editor/src/infrastructure/platforms/ios/selection_heuristics.dart';
 import 'package:super_editor/src/super_textfield/super_textfield.dart';
+import 'package:super_editor/src/test/test_globals.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '_editing_controls.dart';
@@ -197,15 +199,18 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     }
 
     final exactTapTextPosition = _getTextPositionAtOffset(details.localPosition);
-    final didTapOnExistingSelection = exactTapTextPosition != null &&
+    // final adjustedTapTextPosition =
+    //     exactTapTextPosition != null ? _moveTapPositionToWordBoundary(exactTapTextPosition) : null;
+    final adjustedTapTextPosition = exactTapTextPosition;
+    final didTapOnExistingSelection = adjustedTapTextPosition != null &&
         _selectionBeforeTap != null &&
         (_selectionBeforeTap!.isCollapsed
-            ? exactTapTextPosition.offset == _selectionBeforeTap!.extent.offset
-            : exactTapTextPosition.offset >= _selectionBeforeTap!.start &&
-                exactTapTextPosition.offset <= _selectionBeforeTap!.end);
+            ? adjustedTapTextPosition.offset == _selectionBeforeTap!.extent.offset
+            : adjustedTapTextPosition.offset >= _selectionBeforeTap!.start &&
+                adjustedTapTextPosition.offset <= _selectionBeforeTap!.end);
 
     // Select the text that's nearest to where the user tapped.
-    _selectAtOffset(details.localPosition);
+    _selectPosition(adjustedTapTextPosition);
 
     final didCaretStayInSamePlace = _selectionBeforeTap != null &&
         _selectionBeforeTap?.hasSameBoundsAs(widget.textController.selection) == true &&
@@ -227,18 +232,38 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
     _selectionBeforeTap = null;
   }
 
-  /// Places the caret in the field's text based on the given [localOffset],
-  /// and displays the drag handle.
-  void _selectAtOffset(Offset localOffset) {
-    final tapTextPosition = _getTextPositionNearestToOffset(localOffset);
-    if (tapTextPosition == null || tapTextPosition.offset < 0) {
+  TextPosition _moveTapPositionToWordBoundary(TextPosition textPosition) {
+    if (Testing.isInTest) {
+      // Don't adjust the tap location in tests because we want tests to be
+      // able to precisely position the caret at a given offset.
+      // TODO: Make this decision configurable, similar to SuperEditor, so that
+      //       we can add tests for this behavior.
+      return textPosition;
+    }
+
+    if (textPosition.offset < 0) {
+      return textPosition;
+    }
+
+    final text = widget.textController.text.text;
+    final tapOffset = textPosition.offset;
+    if (tapOffset == text.length) {
+      return textPosition;
+    }
+    final adjustedSelectionOffset = IosHeuristics.adjustTapOffset(text, tapOffset);
+
+    return TextPosition(offset: adjustedSelectionOffset);
+  }
+
+  void _selectPosition(TextPosition? textPosition) {
+    if (textPosition == null || textPosition.offset < 0) {
       // This situation indicates the user tapped in empty space
       widget.textController.selection = TextSelection.collapsed(offset: widget.textController.text.length);
       return;
     }
 
     // Update the text selection to a collapsed selection where the user tapped.
-    widget.textController.selection = TextSelection.collapsed(offset: tapTextPosition.offset);
+    widget.textController.selection = TextSelection.collapsed(offset: textPosition.offset);
     widget.textController.composingRegion = TextRange.empty;
   }
 

--- a/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/_user_interaction.dart
@@ -198,10 +198,9 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
       widget.focusNode.requestFocus();
     }
 
-    final exactTapTextPosition = _getTextPositionAtOffset(details.localPosition);
-    // final adjustedTapTextPosition =
-    //     exactTapTextPosition != null ? _moveTapPositionToWordBoundary(exactTapTextPosition) : null;
-    final adjustedTapTextPosition = exactTapTextPosition;
+    final exactTapTextPosition = _getTextPositionNearestToOffset(details.localPosition);
+    final adjustedTapTextPosition =
+        exactTapTextPosition != null ? _moveTapPositionToWordBoundary(exactTapTextPosition) : null;
     final didTapOnExistingSelection = adjustedTapTextPosition != null &&
         _selectionBeforeTap != null &&
         (_selectionBeforeTap!.isCollapsed

--- a/super_editor/lib/src/test/test_globals.dart
+++ b/super_editor/lib/src/test/test_globals.dart
@@ -1,0 +1,5 @@
+class Testing {
+  static bool isInTest = false;
+
+  const Testing._();
+}

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -77,6 +77,7 @@ export 'src/infrastructure/platforms/ios/ios_document_controls.dart';
 export 'src/infrastructure/platforms/ios/floating_cursor.dart';
 export 'src/infrastructure/platforms/ios/toolbar.dart';
 export 'src/infrastructure/platforms/ios/magnifier.dart';
+export 'src/infrastructure/platforms/ios/selection_heuristics.dart';
 export 'src/infrastructure/platforms/mac/mac_ime.dart';
 export 'src/infrastructure/platforms/mobile_documents.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';

--- a/super_editor/test/flutter_test_config.dart
+++ b/super_editor/test/flutter_test_config.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
+import 'package:super_editor/src/test/test_globals.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Disable indeterminate animations
   BlinkController.indeterminateAnimationsEnabled = false;
+
+  Testing.isInTest = true;
 
   return testMain();
 }

--- a/super_editor/test/infrastructure/multi_tap_gesture_test.dart
+++ b/super_editor/test/infrastructure/multi_tap_gesture_test.dart
@@ -423,9 +423,9 @@ void main() {
       await tester.pump(kTapMinTime);
 
       // Trigger a horizontal drag.
-      await gesture.moveBy(Offset(20, 0));
+      await gesture.moveBy(const Offset(20, 0));
       await tester.pump();
-      await gesture.moveBy(Offset(20, 0));
+      await gesture.moveBy(const Offset(20, 0));
       await tester.pump();
 
       // Release the gesture.

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -16,11 +16,11 @@ void main() {
           // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod...",
           await _pumpAppWithLongText(tester);
 
-          // Tap near the end of a word "consectet|ur"
+          // Tap near the end of a word "consectet|ur".
           await tester.tapInParagraph("1", 37);
           await tester.pumpAndSettle();
 
-          // Ensure that the caret is at the end of the world "consectetur|"
+          // Ensure that the caret is at the end of the world "consectetur|".
           expect(
             SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
@@ -31,11 +31,11 @@ void main() {
             ),
           );
 
-          // Tap near the middle of a word "adipi|scing"
+          // Tap near the middle of a word "adipi|scing".
           await tester.tapInParagraph("1", 45);
           await tester.pumpAndSettle();
 
-          // Ensure that the caret is at the end of the world "adipiscing|"
+          // Ensure that the caret is at the end of the world "adipiscing|".
           expect(
             SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
@@ -46,11 +46,11 @@ void main() {
             ),
           );
 
-          // Tap near the beginning of a word "co|nsectetur"
+          // Tap near the beginning of a word "co|nsectetur".
           await tester.tapInParagraph("1", 30);
           await tester.pumpAndSettle();
 
-          // Ensure that the caret is at the end of the word "consectetur|"
+          // Ensure that the caret is at the end of the word "consectetur|".
           expect(
             SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
@@ -67,11 +67,11 @@ void main() {
           // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod...",
           await _pumpAppWithLongText(tester);
 
-          // Tap just before first character of word " |consectetur"
+          // Tap just before first character of word " |consectetur".
           await tester.tapInParagraph("1", 28);
           await tester.pumpAndSettle();
 
-          // Ensure that the caret is at the start of the world "|consectetur"
+          // Ensure that the caret is at the start of the world "|consectetur".
           expect(
             SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
@@ -82,11 +82,11 @@ void main() {
             ),
           );
 
-          // Tap just after the start of the word " a|dipiscing"
+          // Tap just after the start of the word " a|dipiscing".
           await tester.tapInParagraph("1", 41);
           await tester.pumpAndSettle();
 
-          // Ensure that the caret is at the start of the word " |adipiscing"
+          // Ensure that the caret is at the start of the word " |adipiscing".
           expect(
             SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
@@ -106,7 +106,7 @@ void main() {
           // Ensure that no overlay controls are visible.
           _expectNoControlsAreVisible();
 
-          // Long press on the middle of "conse|ctetur"
+          // Long press on the middle of "conse|ctetur".
           await tester.longPressInParagraph("1", 33);
           await tester.pumpAndSettle();
 
@@ -124,7 +124,7 @@ void main() {
 
           await _pumpAppWithLongText(tester);
 
-          // Long press down on the middle of "conse|ctetur"
+          // Long press down on the middle of "conse|ctetur".
           final gesture = await tester.longPressDownInParagraph("1", 33);
           await tester.pump();
 

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -10,6 +10,95 @@ import '../supereditor_test_tools.dart';
 void main() {
   group("SuperEditor mobile selection >", () {
     group("iOS >", () {
+      group("on tap >", () {
+        testWidgetsOnIos("when beyond first character > places caret at end of word", (tester) async {
+          // Note: We pump the following text.
+          // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod...",
+          await _pumpAppWithLongText(tester);
+
+          // Tap near the end of a word "consectet|ur"
+          await tester.tapInParagraph("1", 37);
+          await tester.pumpAndSettle();
+
+          // Ensure that the caret is at the end of the world "consectetur|"
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 39),
+              ),
+            ),
+          );
+
+          // Tap near the middle of a word "adipi|scing"
+          await tester.tapInParagraph("1", 45);
+          await tester.pumpAndSettle();
+
+          // Ensure that the caret is at the end of the world "adipiscing|"
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 50),
+              ),
+            ),
+          );
+
+          // Tap near the beginning of a word "co|nsectetur"
+          await tester.tapInParagraph("1", 30);
+          await tester.pumpAndSettle();
+
+          // Ensure that the caret is at the end of the word "consectetur|"
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 39),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnIos("when near first character > places caret at start of word", (tester) async {
+          // Note: We pump the following text.
+          // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod...",
+          await _pumpAppWithLongText(tester);
+
+          // Tap just before first character of word " |consectetur"
+          await tester.tapInParagraph("1", 28);
+          await tester.pumpAndSettle();
+
+          // Ensure that the caret is at the start of the world "|consectetur"
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 28),
+              ),
+            ),
+          );
+
+          // Tap just after the start of the word " a|dipiscing"
+          await tester.tapInParagraph("1", 41);
+          await tester.pumpAndSettle();
+
+          // Ensure that the caret is at the start of the word " |adipiscing"
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 40),
+              ),
+            ),
+          );
+        });
+      });
+
       group("long press >", () {
         testWidgetsOnIos("selects word under finger", (tester) async {
           await _pumpAppWithLongText(tester);
@@ -311,6 +400,7 @@ Future<void> _pumpAppWithLongText(WidgetTester tester) async {
       .createDocument()
       // "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod...",
       .withSingleParagraph()
+      .useIosSelectionHeuristics(true)
       .withiOSToolbarBuilder((context, mobileToolbarKey, focalPoint) =>
           IOSTextEditingFloatingToolbar(key: mobileToolbarKey, focalPoint: focalPoint))
       .pump();

--- a/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
@@ -50,11 +50,11 @@ void main() {
       );
 
       // Move a little bit to start the swipe to pop gesture.
-      await gesture.moveBy(Offset(20, 0));
+      await gesture.moveBy(const Offset(20, 0));
       await tester.pump();
 
       // Move to the right side of the screen to trigger the route pop.
-      await gesture.moveBy(Offset(200, 0));
+      await gesture.moveBy(const Offset(200, 0));
       await tester.pump();
 
       // Let the long press timer resolve.
@@ -103,6 +103,6 @@ class _AutoPushRouteState extends State<_AutoPushRoute> {
 
   @override
   Widget build(BuildContext context) {
-    return Placeholder();
+    return const Placeholder();
   }
 }

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -102,11 +102,10 @@ void main() {
           ..physicalSize = screenSizeBigger;
 
         final docKey = GlobalKey();
-        await tester.pumpWidget(
-          _createTestApp(
-            gestureMode: DocumentGestureMode.mouse,
-            docKey: docKey,
-          ),
+        await _pumpScaffold(
+          tester,
+          gestureMode: DocumentGestureMode.mouse,
+          docKey: docKey,
         );
         await tester.pumpAndSettle();
 
@@ -134,11 +133,10 @@ void main() {
           ..physicalSize = screenSizeSmaller;
 
         final docKey = GlobalKey();
-        await tester.pumpWidget(
-          _createTestApp(
-            gestureMode: DocumentGestureMode.mouse,
-            docKey: docKey,
-          ),
+        await _pumpScaffold(
+          tester,
+          gestureMode: DocumentGestureMode.mouse,
+          docKey: docKey,
         );
         await tester.pumpAndSettle();
 
@@ -172,11 +170,10 @@ void main() {
             ..physicalSize = screenSizePortrait;
 
           final docKey = GlobalKey();
-          await tester.pumpWidget(
-            _createTestApp(
-              gestureMode: DocumentGestureMode.android,
-              docKey: docKey,
-            ),
+          await _pumpScaffold(
+            tester,
+            gestureMode: DocumentGestureMode.android,
+            docKey: docKey,
           );
           await tester.pumpAndSettle();
 
@@ -206,11 +203,10 @@ void main() {
             ..physicalSize = screenSizeLandscape;
 
           final docKey = GlobalKey();
-          await tester.pumpWidget(
-            _createTestApp(
-              gestureMode: DocumentGestureMode.android,
-              docKey: docKey,
-            ),
+          await _pumpScaffold(
+            tester,
+            gestureMode: DocumentGestureMode.android,
+            docKey: docKey,
           );
           await tester.pumpAndSettle();
 
@@ -245,11 +241,10 @@ void main() {
             ..physicalSize = screenSizePortrait;
 
           final docKey = GlobalKey();
-          await tester.pumpWidget(
-            _createTestApp(
-              gestureMode: DocumentGestureMode.iOS,
-              docKey: docKey,
-            ),
+          await _pumpScaffold(
+            tester,
+            gestureMode: DocumentGestureMode.iOS,
+            docKey: docKey,
           );
           await tester.pumpAndSettle();
 
@@ -282,11 +277,10 @@ void main() {
             ..physicalSize = screenSizeLandscape;
 
           final docKey = GlobalKey();
-          await tester.pumpWidget(
-            _createTestApp(
-              gestureMode: DocumentGestureMode.iOS,
-              docKey: docKey,
-            ),
+          await _pumpScaffold(
+            tester,
+            gestureMode: DocumentGestureMode.iOS,
+            docKey: docKey,
           );
           await tester.pumpAndSettle();
 
@@ -378,22 +372,17 @@ void main() {
   });
 }
 
-Widget _createTestApp({required DocumentGestureMode gestureMode, required GlobalKey docKey}) {
-  final doc = _createTestDocument();
-  final composer = MutableDocumentComposer();
-  final editor = createDefaultDocumentEditor(document: doc, composer: composer);
-
-  return MaterialApp(
-    home: Scaffold(
-      body: SuperEditor(
-        documentLayoutKey: docKey,
-        editor: editor,
-        document: doc,
-        composer: composer,
-        gestureMode: gestureMode,
-      ),
-    ),
-  );
+Future<TestDocumentContext> _pumpScaffold(
+  WidgetTester tester, {
+  required DocumentGestureMode gestureMode,
+  required GlobalKey docKey,
+}) async {
+  return await tester
+      .createDocument()
+      .withCustomContent(_createTestDocument())
+      .withGestureMode(gestureMode)
+      .withLayoutKey(docKey)
+      .pump();
 }
 
 /// Given a [textPosition], compute the expected (x,y) for the caret within the document layout.

--- a/super_editor/test/super_editor/supereditor_component_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_component_selection_test.dart
@@ -175,17 +175,17 @@ void main() {
             ]),
           )
           .withAddedComponents(
-            [_ButtonComponentBuilder()],
+            [const _ButtonComponentBuilder()],
           )
           .withSelectionStyles(
-            SelectionStyles(selectionColor: Colors.red),
+            const SelectionStyles(selectionColor: Colors.red),
           )
           .pump();
 
       // Drag to select all content.
       await tester.dragSelectDocumentFromPositionByOffset(
-        from: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-        delta: Offset(0, 100),
+        from: const DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+        delta: const Offset(0, 100),
       );
 
       // Ensure the selection color from the selection style was applied.
@@ -721,14 +721,14 @@ class _ButtonComponent extends StatelessWidget {
             selectionColor: selectionColor,
             child: BoxComponent(
               key: componentKey,
-              child: SizedBox(),
+              child: const SizedBox(),
             ),
           ),
         ),
         Center(
           child: ElevatedButton(
             onPressed: () {},
-            child: Text('My Button'),
+            child: const Text('My Button'),
           ),
         ),
       ],

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -58,14 +58,10 @@ void main() {
                       'Lorem ipsum dolor',
                       AttributedSpans(
                         attributions: [
-                          SpanMarker(
-                              attribution: const ColorAttribution(Colors.green),
-                              offset: 0,
-                              markerType: SpanMarkerType.start),
-                          SpanMarker(
-                              attribution: const ColorAttribution(Colors.green),
-                              offset: 16,
-                              markerType: SpanMarkerType.end),
+                          const SpanMarker(
+                              attribution: ColorAttribution(Colors.green), offset: 0, markerType: SpanMarkerType.start),
+                          const SpanMarker(
+                              attribution: ColorAttribution(Colors.green), offset: 16, markerType: SpanMarkerType.end),
                         ],
                       ),
                     ),

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -163,6 +163,11 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  TestSuperEditorConfigurator useIosSelectionHeuristics(bool shouldUse) {
+    _config.useIosSelectionHeuristics = shouldUse;
+    return this;
+  }
+
   TestSuperEditorConfigurator withCaretPolicies({
     bool? displayCaretWithExpandedSelection,
   }) {
@@ -526,8 +531,10 @@ class _TestSuperEditorState extends State<_TestSuperEditor> {
     super.initState();
 
     _iOsControlsController = SuperEditorIosControlsController(
+      useIosSelectionHeuristics: widget.testConfiguration.useIosSelectionHeuristics,
       toolbarBuilder: widget.testConfiguration.iOSToolbarBuilder,
     );
+
     _androidControlsController = SuperEditorAndroidControlsController(
       toolbarBuilder: widget.testConfiguration.androidToolbarBuilder,
     );
@@ -670,6 +677,9 @@ class SuperEditorTestConfiguration {
   bool displayCaretWithExpandedSelection = true;
   CaretStyle? caretStyle;
 
+  // By default we don't use iOS-style selection heuristics in tests because in tests
+  // we want to know exactly where we're placing the caret.
+  bool useIosSelectionHeuristics = false;
   double? iosCaretWidth;
   Color? iosHandleColor;
   double? iosHandleBallDiameter;

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -9,9 +9,25 @@ import 'package:super_editor/super_text_field.dart';
 import '../super_textfield_inspector.dart';
 
 void main() {
-  group("SuperTextField > selection >", () {
+  group("SuperTextField mobile selection > iOS", () {
+    group("on tap >", () {
+      testWidgetsOnIos("when beyond first character > places caret at end of word", (tester) async {
+        // TODO: Add this test - for an example, see the Super Editor version: super_editor_ios_selection_test.dart
+        //       This test isn't implemented because when I got to it we didn't have any WidgetTester
+        //       extensions to tap to place the caret. Create those extensions and then implement this.
+        //       Issue: https://github.com/superlistapp/super_editor/issues/2098
+      }, skip: true);
+
+      testWidgetsOnIos("when near first character > places caret at start of word", (tester) async {
+        // TODO: Add this test - for an example, see the Super Editor version: super_editor_ios_selection_test.dart
+        //       This test isn't implemented because when I got to it we didn't have any WidgetTester
+        //       extensions to tap to place the caret. Create those extensions and then implement this.
+        //       Issue: https://github.com/superlistapp/super_editor/issues/2098
+      }, skip: true);
+    });
+
     testWidgetsOnIos("tapping on caret toggles the toolbar", (tester) async {
-      await _pumpTestApp(tester);
+      await _pumpScaffold(tester);
 
       // Ensure there's no selection to begin with, and no toolbar is displayed.
       expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: -1));
@@ -40,20 +56,20 @@ void main() {
   });
 }
 
-Future<void> _pumpTestApp(
+Future<void> _pumpScaffold(
   WidgetTester tester, {
   AttributedTextEditingController? controller,
   EdgeInsets? padding,
   TextAlign? textAlign,
 }) async {
   final textFieldFocusNode = FocusNode();
-  const tapRegionGroupdId = "test_super_text_field";
+  const tapRegionGroupId = "test_super_text_field";
 
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
         body: TapRegion(
-          groupId: tapRegionGroupdId,
+          groupId: tapRegionGroupId,
           onTapOutside: (_) {
             // Unfocus on tap outside so that we're sure that all gesture tests
             // pass when using TapRegion's for focus, because apps should be able
@@ -71,7 +87,7 @@ Future<void> _pumpTestApp(
                   ),
                   child: SuperTextField(
                     focusNode: textFieldFocusNode,
-                    tapRegionGroupId: tapRegionGroupdId,
+                    tapRegionGroupId: tapRegionGroupId,
                     padding: padding,
                     textAlign: textAlign ?? TextAlign.left,
                     textController: controller ??

--- a/super_editor/test_goldens/editor/supereditor_caret_test.dart
+++ b/super_editor/test_goldens/editor/supereditor_caret_test.dart
@@ -302,7 +302,7 @@ Future<TestDocumentContext> _pumpTestAppWithGoldenBricksFont(WidgetTester tester
           StyleRule(
             BlockSelector.all,
             (doc, docNode) => {
-              Styles.textStyle: TextStyle(
+              Styles.textStyle: const TextStyle(
                 fontFamily: goldenBricks,
               )
             },


### PR DESCRIPTION
[SuperEditor][SuperTextField][iOS] - When user taps, place caret at word boundary (Resolves #2080)

On iOS, when a user taps on text, the caret isn't placed where the user tapped - it's placed at a word boundary.

This PR updates `SuperEditor` and `SuperTextField` to use a similar heuristic for placing the caret. This PR also disables that behavior in tests by default, so that our tests can explicitly target desired caret positions.

There's some followup work in #2098 