### PR TITLE
[Quill] - Serialize MutableDocument to Quill Deltas document (Resolves #2117)

### DIFF
--- a/super_editor_quill/lib/src/serializing/serializers.dart
+++ b/super_editor_quill/lib/src/serializing/serializers.dart
@@ -5,6 +5,7 @@ import 'package:super_editor/super_editor.dart';
 import 'package:super_editor_quill/src/content/formatting.dart';
 import 'package:super_editor_quill/src/content/multimedia.dart';
 
+/// A [DeltaSerializer] that serializes [ParagraphNode]s into deltas.
 const paragraphDeltaSerializer = ParagraphDeltaSerializer();
 
 class ParagraphDeltaSerializer extends TextBlockDeltaSerializer {
@@ -28,6 +29,7 @@ class ParagraphDeltaSerializer extends TextBlockDeltaSerializer {
   }
 }
 
+/// A [DataSerializer] that serializes [ListItemNode]s into deltas.
 const listItemDeltaSerializer = ListItemDeltaSerializer();
 
 class ListItemDeltaSerializer extends TextBlockDeltaSerializer {
@@ -54,6 +56,7 @@ class ListItemDeltaSerializer extends TextBlockDeltaSerializer {
   }
 }
 
+/// A [DeltaSerializer] that serializes [TaskNode]s into deltas.
 const taskDeltaSerializer = TaskDeltaSerializer();
 
 class TaskDeltaSerializer extends TextBlockDeltaSerializer {
@@ -75,6 +78,7 @@ class TaskDeltaSerializer extends TextBlockDeltaSerializer {
   }
 }
 
+/// A [DeltaSerializer] that serializes [ImageNode]s into deltas.
 const imageDeltaSerializer = FunctionalDeltaSerializer(_serializeImage);
 bool _serializeImage(node, deltas) {
   if (node is! ImageNode) {
@@ -90,6 +94,7 @@ bool _serializeImage(node, deltas) {
   return true;
 }
 
+/// A [DeltaSerializer] that serializes [VideoNode]s into deltas.
 const videoDeltaSerializer = FunctionalDeltaSerializer(_serializeVideo);
 bool _serializeVideo(node, deltas) {
   if (node is! VideoNode) {
@@ -105,6 +110,7 @@ bool _serializeVideo(node, deltas) {
   return true;
 }
 
+/// A [DeltaSerializer] that serializes [AudioNode]s to deltas.
 const audioDeltaSerializer = FunctionalDeltaSerializer(_serializeAudio);
 bool _serializeAudio(node, deltas) {
   if (node is! AudioNode) {
@@ -120,6 +126,7 @@ bool _serializeAudio(node, deltas) {
   return true;
 }
 
+/// A [DeltaSerializer] that serializes [FileNode]s into deltas.
 const fileDeltaSerializer = FunctionalDeltaSerializer(_serializeFile);
 bool _serializeFile(node, deltas) {
   if (node is! FileNode) {
@@ -159,7 +166,6 @@ class TextBlockDeltaSerializer implements DeltaSerializer {
     for (int i = 0; i < spans.length; i += 1) {
       final span = spans[i];
       final text = textBlock.text.text.substring(span.start, textBlock.text.text.isNotEmpty ? span.end + 1 : span.end);
-      print(" - span: '${text.toNewlineString()}'");
       final inlineAttributes = getInlineAttributesFor(span.attributions);
 
       final previousDelta = deltas.operations.lastOrNull;
@@ -168,15 +174,10 @@ class TextBlockDeltaSerializer implements DeltaSerializer {
         inlineAttributes.isNotEmpty ? inlineAttributes : null,
       );
       if (previousDelta != null && newDelta.canMergeWith(previousDelta)) {
-        print(
-            " - Merging '${(previousDelta.value as String).toNewlineString()}' + '${(newDelta.value as String).toNewlineString()}'");
         deltas.operations[deltas.operations.length - 1] = newDelta.mergeWith(previousDelta);
-        print(
-            " - Merged with previous delta: '${(deltas.operations[deltas.operations.length - 1].value as String).toNewlineString()}'");
         continue;
       }
 
-      print(" - Adding a new delta to the document list");
       deltas.operations.add(newDelta);
     }
 
@@ -188,11 +189,8 @@ class TextBlockDeltaSerializer implements DeltaSerializer {
     final newlineDelta = Operation.insert("\n", blockFormats);
     final previousDelta = deltas.operations[deltas.operations.length - 1];
     if (newlineDelta.canMergeWith(previousDelta)) {
-      print(
-          "Merging a post-paragraph newline with previous delta: '${(previousDelta.value as String).toNewlineString()}'");
       deltas.operations[deltas.operations.length - 1] = newlineDelta.mergeWith(previousDelta);
     } else {
-      print("Adding a standalone post-paragraph newline delta: ${(newlineDelta.value as String).toNewlineString()}");
       deltas.operations.add(newlineDelta);
     }
 

--- a/super_editor_quill/lib/src/serializing/serializers.dart
+++ b/super_editor_quill/lib/src/serializing/serializers.dart
@@ -80,7 +80,7 @@ class TaskDeltaSerializer extends TextBlockDeltaSerializer {
 
 /// A [DeltaSerializer] that serializes [ImageNode]s into deltas.
 const imageDeltaSerializer = FunctionalDeltaSerializer(_serializeImage);
-bool _serializeImage(node, deltas) {
+bool _serializeImage(DocumentNode node, Delta deltas) {
   if (node is! ImageNode) {
     return false;
   }
@@ -96,7 +96,7 @@ bool _serializeImage(node, deltas) {
 
 /// A [DeltaSerializer] that serializes [VideoNode]s into deltas.
 const videoDeltaSerializer = FunctionalDeltaSerializer(_serializeVideo);
-bool _serializeVideo(node, deltas) {
+bool _serializeVideo(DocumentNode node, Delta deltas) {
   if (node is! VideoNode) {
     return false;
   }
@@ -112,7 +112,7 @@ bool _serializeVideo(node, deltas) {
 
 /// A [DeltaSerializer] that serializes [AudioNode]s to deltas.
 const audioDeltaSerializer = FunctionalDeltaSerializer(_serializeAudio);
-bool _serializeAudio(node, deltas) {
+bool _serializeAudio(DocumentNode node, Delta deltas) {
   if (node is! AudioNode) {
     return false;
   }
@@ -128,7 +128,7 @@ bool _serializeAudio(node, deltas) {
 
 /// A [DeltaSerializer] that serializes [FileNode]s into deltas.
 const fileDeltaSerializer = FunctionalDeltaSerializer(_serializeFile);
-bool _serializeFile(node, deltas) {
+bool _serializeFile(DocumentNode node, Delta deltas) {
   if (node is! FileNode) {
     return false;
   }
@@ -251,39 +251,51 @@ class TextBlockDeltaSerializer implements DeltaSerializer {
     for (final attribution in superEditorAttributions) {
       if (attribution == boldAttribution) {
         attributes["bold"] = true;
+        continue;
       }
       if (attribution == italicsAttribution) {
         attributes["italic"] = true;
+        continue;
       }
       if (attribution == strikethroughAttribution) {
         attributes["strike"] = true;
+        continue;
       }
       if (attribution == underlineAttribution) {
         attributes["underline"] = true;
+        continue;
       }
       if (attribution == superscriptAttribution) {
         attributes["script"] = "super";
+        continue;
       }
       if (attribution == subscriptAttribution) {
         attributes["script"] = "sub";
+        continue;
       }
       if (attribution is ColorAttribution) {
         attributes["color"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+        continue;
       }
       if (attribution is BackgroundColorAttribution) {
         attributes["background"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+        continue;
       }
       if (attribution is FontFamilyAttribution) {
         attributes["font"] = attribution.fontFamily;
+        continue;
       }
       if (attribution is NamedFontSizeAttribution) {
         attributes["size"] = attribution.fontSizeName;
+        continue;
       }
       if (attribution is FontSizeAttribution) {
         attributes["size"] = attribution.fontSize;
+        continue;
       }
       if (attribution is LinkAttribution) {
         attributes["link"] = attribution.url;
+        continue;
       }
     }
 

--- a/super_editor_quill/lib/src/serializing/serializers.dart
+++ b/super_editor_quill/lib/src/serializing/serializers.dart
@@ -1,0 +1,365 @@
+import 'package:collection/collection.dart';
+import 'package:dart_quill_delta/dart_quill_delta.dart';
+import 'package:flutter/foundation.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_quill/src/content/formatting.dart';
+import 'package:super_editor_quill/src/content/multimedia.dart';
+
+const paragraphDeltaSerializer = ParagraphDeltaSerializer();
+
+class ParagraphDeltaSerializer extends TextBlockDeltaSerializer {
+  const ParagraphDeltaSerializer();
+
+  @override
+  bool shouldSerialize(DocumentNode node) => node is ParagraphNode;
+
+  @override
+  Map<String, dynamic> getBlockFormats(TextNode textBlock) {
+    if (textBlock is! ParagraphNode) {
+      // This shouldn't happen, but we do a sane thing if it does.
+      return super.getBlockFormats(textBlock);
+    }
+
+    final formats = super.getBlockFormats(textBlock);
+    if (textBlock.indent != 0) {
+      formats["indent"] = textBlock.indent;
+    }
+    return formats;
+  }
+}
+
+const listItemDeltaSerializer = ListItemDeltaSerializer();
+
+class ListItemDeltaSerializer extends TextBlockDeltaSerializer {
+  const ListItemDeltaSerializer();
+
+  @override
+  bool shouldSerialize(DocumentNode node) => node is ListItemNode;
+
+  @override
+  Map<String, dynamic> getBlockFormats(TextNode textBlock) {
+    if (textBlock is! ListItemNode) {
+      // This shouldn't happen, but we do a sane thing if it does.
+      return super.getBlockFormats(textBlock);
+    }
+
+    final formats = super.getBlockFormats(textBlock);
+    switch (textBlock.type) {
+      case ListItemType.ordered:
+        formats["list"] = "ordered";
+      case ListItemType.unordered:
+        formats["list"] = "bullet";
+    }
+    return formats;
+  }
+}
+
+const taskDeltaSerializer = TaskDeltaSerializer();
+
+class TaskDeltaSerializer extends TextBlockDeltaSerializer {
+  const TaskDeltaSerializer();
+
+  @override
+  bool shouldSerialize(DocumentNode node) => node is TaskNode;
+
+  @override
+  Map<String, dynamic> getBlockFormats(TextNode textBlock) {
+    if (textBlock is! TaskNode) {
+      // This shouldn't happen, but we do a sane thing if it does.
+      return super.getBlockFormats(textBlock);
+    }
+
+    final formats = super.getBlockFormats(textBlock);
+    formats["list"] = textBlock.isComplete ? "checked" : "unchecked";
+    return formats;
+  }
+}
+
+const imageDeltaSerializer = FunctionalDeltaSerializer(_serializeImage);
+bool _serializeImage(node, deltas) {
+  if (node is! ImageNode) {
+    return false;
+  }
+
+  deltas.operations.add(
+    Operation.insert({
+      "image": node.imageUrl,
+    }),
+  );
+
+  return true;
+}
+
+const videoDeltaSerializer = FunctionalDeltaSerializer(_serializeVideo);
+bool _serializeVideo(node, deltas) {
+  if (node is! VideoNode) {
+    return false;
+  }
+
+  deltas.operations.add(
+    Operation.insert({
+      "video": node.url,
+    }),
+  );
+
+  return true;
+}
+
+const audioDeltaSerializer = FunctionalDeltaSerializer(_serializeAudio);
+bool _serializeAudio(node, deltas) {
+  if (node is! AudioNode) {
+    return false;
+  }
+
+  deltas.operations.add(
+    Operation.insert({
+      "audio": node.url,
+    }),
+  );
+
+  return true;
+}
+
+const fileDeltaSerializer = FunctionalDeltaSerializer(_serializeFile);
+bool _serializeFile(node, deltas) {
+  if (node is! FileNode) {
+    return false;
+  }
+
+  deltas.operations.add(
+    Operation.insert({
+      "file": node.url,
+    }),
+  );
+
+  return true;
+}
+
+/// A [DeltaSerializer] that includes standard Quill Delta rules for
+/// serializing text blocks, e.g., paragraphs, lists, and tasks.
+class TextBlockDeltaSerializer implements DeltaSerializer {
+  const TextBlockDeltaSerializer();
+
+  @override
+  bool serialize(DocumentNode node, Delta deltas) {
+    if (!shouldSerialize(node)) {
+      return false;
+    }
+    final textBlock = node as TextNode;
+
+    final blockFormats = getBlockFormats(textBlock);
+
+    var spans = textBlock.text.computeAttributionSpans().toList();
+    if (spans.isEmpty) {
+      // The text is empty. Inject a span so that our standard delta generation
+      // behavior below still works.
+      spans = [const MultiAttributionSpan(attributions: {}, start: 0, end: 0)];
+    }
+
+    for (int i = 0; i < spans.length; i += 1) {
+      final span = spans[i];
+      final text = textBlock.text.text.substring(span.start, textBlock.text.text.isNotEmpty ? span.end + 1 : span.end);
+      print(" - span: '${text.toNewlineString()}'");
+      final inlineAttributes = getInlineAttributesFor(span.attributions);
+
+      final previousDelta = deltas.operations.lastOrNull;
+      final newDelta = Operation.insert(
+        text,
+        inlineAttributes.isNotEmpty ? inlineAttributes : null,
+      );
+      if (previousDelta != null && newDelta.canMergeWith(previousDelta)) {
+        print(
+            " - Merging '${(previousDelta.value as String).toNewlineString()}' + '${(newDelta.value as String).toNewlineString()}'");
+        deltas.operations[deltas.operations.length - 1] = newDelta.mergeWith(previousDelta);
+        print(
+            " - Merged with previous delta: '${(deltas.operations[deltas.operations.length - 1].value as String).toNewlineString()}'");
+        continue;
+      }
+
+      print(" - Adding a new delta to the document list");
+      deltas.operations.add(newDelta);
+    }
+
+    if (textBlock.text.text.endsWith("\n")) {
+      // There's already a trailing newline. No need to add another one.
+      return true;
+    }
+
+    final newlineDelta = Operation.insert("\n", blockFormats);
+    final previousDelta = deltas.operations[deltas.operations.length - 1];
+    if (newlineDelta.canMergeWith(previousDelta)) {
+      print(
+          "Merging a post-paragraph newline with previous delta: '${(previousDelta.value as String).toNewlineString()}'");
+      deltas.operations[deltas.operations.length - 1] = newlineDelta.mergeWith(previousDelta);
+    } else {
+      print("Adding a standalone post-paragraph newline delta: ${(newlineDelta.value as String).toNewlineString()}");
+      deltas.operations.add(newlineDelta);
+    }
+
+    return true;
+  }
+
+  @protected
+  bool shouldSerialize(DocumentNode node) {
+    return node is TextNode;
+  }
+
+  /// Given the [textBlock], decides what combination of block-level attributes
+  /// should be applied to the Quill Delta for this text block.
+  @protected
+  Map<String, dynamic> getBlockFormats(TextNode textBlock) {
+    final blockAttributes = <String, dynamic>{};
+
+    // Add all the block-level formats that aren't mutually exclusive.
+    if (textBlock.metadata["textAlign"] != null) {
+      blockAttributes["align"] = textBlock.metadata["textAlign"];
+    }
+
+    final blockType = textBlock.metadata["blockType"] as Attribution?;
+    if (blockType == null) {
+      return blockAttributes;
+    }
+
+    // Add the mutually exclusive block format.
+    switch (blockType) {
+      case header1Attribution:
+        blockAttributes["header"] = 1;
+      case header2Attribution:
+        blockAttributes["header"] = 2;
+      case header3Attribution:
+        blockAttributes["header"] = 3;
+      case header4Attribution:
+        blockAttributes["header"] = 4;
+      case header5Attribution:
+        blockAttributes["header"] = 5;
+      case header6Attribution:
+        blockAttributes["header"] = 6;
+      case blockquoteAttribution:
+        blockAttributes["blockquote"] = true;
+      case codeAttribution:
+        blockAttributes["code-block"] = "plain";
+    }
+
+    return blockAttributes;
+  }
+
+  /// Given a set of [superEditorAttributions], serializes those into Quill Delta
+  /// inline text attributes, returning all attributes in a map that should be set as
+  /// the "attributes" in an insertion delta.
+  @protected
+  Map<String, dynamic> getInlineAttributesFor(Set<Attribution> superEditorAttributions) {
+    final attributes = <String, dynamic>{};
+
+    for (final attribution in superEditorAttributions) {
+      if (attribution == boldAttribution) {
+        attributes["bold"] = true;
+      }
+      if (attribution == italicsAttribution) {
+        attributes["italic"] = true;
+      }
+      if (attribution == strikethroughAttribution) {
+        attributes["strike"] = true;
+      }
+      if (attribution == underlineAttribution) {
+        attributes["underline"] = true;
+      }
+      if (attribution == superscriptAttribution) {
+        attributes["script"] = "super";
+      }
+      if (attribution == subscriptAttribution) {
+        attributes["script"] = "sub";
+      }
+      if (attribution is ColorAttribution) {
+        attributes["color"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+      }
+      if (attribution is BackgroundColorAttribution) {
+        attributes["background"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+      }
+      if (attribution is FontFamilyAttribution) {
+        attributes["font"] = attribution.fontFamily;
+      }
+      if (attribution is NamedFontSizeAttribution) {
+        attributes["size"] = attribution.fontSizeName;
+      }
+      if (attribution is FontSizeAttribution) {
+        attributes["size"] = attribution.fontSize;
+      }
+      if (attribution is LinkAttribution) {
+        attributes["link"] = attribution.url;
+      }
+    }
+
+    return attributes;
+  }
+}
+
+/// A [DeltaSerializer] that forwards to a given delegate function.
+class FunctionalDeltaSerializer implements DeltaSerializer {
+  const FunctionalDeltaSerializer(this._delegate);
+
+  final DeltaSerializerDelegate _delegate;
+
+  @override
+  bool serialize(DocumentNode node, Delta deltas) => _delegate(node, deltas);
+}
+
+typedef DeltaSerializerDelegate = bool Function(DocumentNode node, Delta deltas);
+
+/// Serializes some part of a [MutableDocument] to a Quill Delta document.
+///
+/// For example, a [DeltaSerializer] might serialize a [ParagraphNode], or
+/// an [ImageNode].
+abstract interface class DeltaSerializer {
+  /// Tries to serialize the given [DocumentNode] into the given [deltas],
+  /// returning `true` if this serializer was able to serialize the [node],
+  /// or `false` if this serializer wasn't made to serialize this kind of [node].
+  ///
+  /// For example, serializing a [ParagraphNode], or an [ImageNode], into
+  /// an insertion operation.
+  bool serialize(DocumentNode node, Delta deltas);
+}
+
+extension DeltaSerialization on Operation {
+  bool canMergeWith(Operation previousDelta) {
+    if (!isInsert) {
+      // We've only implement this for insertions, for now.
+      // TODO: Add support for retain/delete.
+      return false;
+    }
+
+    if (value is! String || previousDelta.value is! String) {
+      // One or both of the deltas aren't text. Only text can be merged.
+      return false;
+    }
+
+    // If the attributes are equivalent then we can merge the text deltas.
+    if (const DeepCollectionEquality().equals(previousDelta.attributes, attributes)) {
+      return true;
+    }
+    if (previousDelta.attributes == null && attributes!.isEmpty) {
+      return true;
+    }
+    if (attributes == null && previousDelta.attributes!.isEmpty) {
+      return true;
+    }
+
+    // There's a difference in the attributes. We need separate deltas.
+    return false;
+  }
+
+  Operation mergeWith(Operation previousDelta) {
+    if (!canMergeWith(previousDelta)) {
+      throw Exception(
+          "Tried to merge two deltas that can't be merged. Previous delta: $previousDelta. Next delta: $this");
+    }
+
+    return Operation.insert(
+      "${previousDelta.value as String}${value as String}",
+      previousDelta.attributes,
+    );
+  }
+}
+
+extension NewlineCharacter on String {
+  String toNewlineString() => toString().replaceAll("\n", "⏎");
+}

--- a/super_editor_quill/lib/src/serializing/serializing.dart
+++ b/super_editor_quill/lib/src/serializing/serializing.dart
@@ -1,0 +1,277 @@
+import 'package:collection/collection.dart';
+import 'package:dart_quill_delta/dart_quill_delta.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_quill/src/content/formatting.dart';
+import 'package:super_editor_quill/src/content/multimedia.dart';
+
+extension QuillDelta on MutableDocument {
+  Delta toQuillDeltas() {
+    final deltaDocument = Delta();
+
+    for (final node in nodes) {
+      if (node is ParagraphNode) {
+        print("Serializing paragraph (${node.id}): ${node.text.text}");
+        _serializeParagraph(node, deltaDocument);
+
+        print(
+          "After serializing paragraph, latest delta: '${(deltaDocument.operations[deltaDocument.operations.length - 1].value as String).toNewlineString()}'",
+        );
+        print("");
+      } else if (node is ListItemNode) {
+        print("Serializing list item (${node.id}): ${node.text.text}");
+        // TODO:
+        print("");
+      } else if (node is TaskNode) {
+        print("Serializing task (${node.id}): ${node.text.text}");
+        // TODO:
+        print("");
+      } else if (node is ImageNode) {
+        _serializeImage(node, deltaDocument);
+      } else if (node is VideoNode) {
+        _serializeVideo(node, deltaDocument);
+      } else if (node is AudioNode) {
+        _serializeAudio(node, deltaDocument);
+      } else if (node is FileNode) {
+        _serializeFile(node, deltaDocument);
+      }
+    }
+
+    return deltaDocument;
+  }
+
+  void _serializeParagraph(ParagraphNode paragraph, Delta deltas) {
+    print("Inserting text: '${paragraph.text.text.toNewlineString()}'");
+    final blockFormat = _serializeBlockFormat(paragraph);
+
+    var spans = paragraph.text.computeAttributionSpans().toList();
+    if (spans.isEmpty) {
+      // The text is empty. Inject a span so that our standard delta generation
+      // behavior below still works.
+      spans = [const MultiAttributionSpan(attributions: {}, start: 0, end: 0)];
+    }
+
+    for (int i = 0; i < spans.length; i += 1) {
+      final span = spans[i];
+      final text = paragraph.text.text.substring(span.start, paragraph.text.text.isNotEmpty ? span.end + 1 : span.end);
+      print(" - span: '${text.toNewlineString()}'");
+
+      // When we reach the end of the paragraph text, we want to insert a newline
+      // as long as we don't need to apply any block format. Applying a block
+      // format requires adding the newline in a different insert operation.
+      final isNewlineNeeded = i == spans.length - 1 && blockFormat == null;
+
+      final previousDelta = deltas.operations.lastOrNull;
+      final newDelta = Operation.insert(
+        text,
+        // "$text${isNewlineNeeded ? "\n" : ""}",
+        _serializeInlineAttributes(span.attributions),
+      );
+      if (previousDelta != null && newDelta.canMergeWith(previousDelta)) {
+        print(
+            " - Merging '${(previousDelta.value as String).toNewlineString()}' + '${(newDelta.value as String).toNewlineString()}'");
+        deltas.operations[deltas.operations.length - 1] = newDelta.mergeWith(previousDelta);
+        print(
+            " - Merged with previous delta: '${(deltas.operations[deltas.operations.length - 1].value as String).toNewlineString()}'");
+        continue;
+      }
+
+      print(" - Adding a new delta to the document list");
+      deltas.operations.addAll([
+        Operation.insert(
+          text,
+          // "$text${isNewlineNeeded ? "\n" : ""}",
+          _serializeInlineAttributes(span.attributions),
+        ),
+      ]);
+    }
+
+    // if (blockFormat != null && blockFormat.isNotEmpty) {
+    //   // Block formats are achieved by following the text with an insert
+    //   // that contains a single newline and a block format that applies
+    //   // to the previous insert.
+    //   print(" - Adding a standalone newline delta because we need to apply a block format");
+    final newlineDelta = Operation.insert("\n", blockFormat);
+    final previousDelta = deltas.operations[deltas.operations.length - 1];
+    if (newlineDelta.canMergeWith(previousDelta)) {
+      print(
+          "Merging a post-paragraph newline with previous delta: '${(previousDelta.value as String).toNewlineString()}'");
+      deltas.operations[deltas.operations.length - 1] = newlineDelta.mergeWith(previousDelta);
+    } else {
+      print("Adding a standalone post-paragraph newline delta: ${(newlineDelta.value as String).toNewlineString()}");
+      deltas.operations.add(newlineDelta);
+    }
+    // }
+  }
+
+  void _serializeListItem(ListItemNode listItem, Delta deltas) {
+    //
+  }
+
+  void _serializeTask(TaskNode task, Delta deltas) {
+    //
+  }
+
+  Map<String, dynamic>? _serializeBlockFormat(ParagraphNode paragraph) {
+    final blockAttributes = <String, dynamic>{};
+
+    // Add all the block-level formats that aren't mutually exclusive.
+    if (paragraph.metadata["textAlign"] != null) {
+      blockAttributes["align"] = paragraph.metadata["textAlign"];
+    }
+    if (paragraph.indent != 0) {
+      blockAttributes["indent"] = paragraph.indent;
+    }
+
+    final blockType = paragraph.metadata["blockType"] as Attribution?;
+    if (blockType == null) {
+      return blockAttributes.isNotEmpty ? blockAttributes : null;
+    }
+
+    // Add the mutually exclusive block format.
+    switch (blockType) {
+      case header1Attribution:
+        blockAttributes["header"] = 1;
+      case header2Attribution:
+        blockAttributes["header"] = 2;
+      case header3Attribution:
+        blockAttributes["header"] = 3;
+      case header4Attribution:
+        blockAttributes["header"] = 4;
+      case header5Attribution:
+        blockAttributes["header"] = 5;
+      case header6Attribution:
+        blockAttributes["header"] = 6;
+      case blockquoteAttribution:
+        blockAttributes["blockquote"] = true;
+      case codeAttribution:
+        blockAttributes["code-block"] = "plain";
+    }
+
+    return blockAttributes.isNotEmpty ? blockAttributes : null;
+  }
+
+  /// Given a set of [AttributedText] [attributions], serializes those into Quill Delta
+  /// inline text attributes, returning all attributes in a map that should be set as
+  /// the "attributes" in an insertion delta.
+  Map<String, dynamic>? _serializeInlineAttributes(Set<Attribution> attributions) {
+    final attributes = <String, dynamic>{};
+
+    for (final attribution in attributions) {
+      if (attribution == boldAttribution) {
+        attributes["bold"] = true;
+      }
+      if (attribution == italicsAttribution) {
+        attributes["italic"] = true;
+      }
+      if (attribution == strikethroughAttribution) {
+        attributes["strike"] = true;
+      }
+      if (attribution == underlineAttribution) {
+        attributes["underline"] = true;
+      }
+      if (attribution == superscriptAttribution) {
+        attributes["script"] = "super";
+      }
+      if (attribution == subscriptAttribution) {
+        attributes["script"] = "sub";
+      }
+      if (attribution is ColorAttribution) {
+        attributes["color"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+      }
+      if (attribution is BackgroundColorAttribution) {
+        attributes["background"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
+      }
+      if (attribution is FontFamilyAttribution) {
+        attributes["font"] = attribution.fontFamily;
+      }
+      if (attribution is NamedFontSizeAttribution) {
+        attributes["size"] = attribution.fontSizeName;
+      }
+      if (attribution is FontSizeAttribution) {
+        attributes["size"] = attribution.fontSize;
+      }
+      if (attribution is LinkAttribution) {
+        attributes["link"] = attribution.url;
+      }
+    }
+
+    return attributes.isEmpty ? null : attributes;
+  }
+
+  void _serializeImage(ImageNode image, Delta deltas) {
+    deltas.operations.add(
+      Operation.insert({
+        "image": image.imageUrl,
+      }),
+    );
+  }
+
+  void _serializeVideo(VideoNode video, Delta deltas) {
+    deltas.operations.add(
+      Operation.insert({
+        "video": video.url,
+      }),
+    );
+  }
+
+  void _serializeAudio(AudioNode audio, Delta deltas) {
+    deltas.operations.add(
+      Operation.insert({
+        "audio": audio.url,
+      }),
+    );
+  }
+
+  void _serializeFile(FileNode file, Delta deltas) {
+    deltas.operations.add(
+      Operation.insert({
+        "file": file.url,
+      }),
+    );
+  }
+}
+
+extension DeltaSerialization on Operation {
+  bool canMergeWith(Operation previousDelta) {
+    if (!isInsert) {
+      // We've only implement this for insertions, for now.
+      // TODO: Add support for retain/delete.
+      return false;
+    }
+
+    if (value is! String || previousDelta.value is! String) {
+      // One or both of the deltas aren't text. Only text can be merged.
+      return false;
+    }
+
+    // If the attributes are equivalent then we can merge the text deltas.
+    if (const DeepCollectionEquality().equals(previousDelta.attributes, attributes)) {
+      return true;
+    }
+    if (previousDelta.attributes == null && attributes!.isEmpty) {
+      return true;
+    }
+    if (attributes == null && previousDelta.attributes!.isEmpty) {
+      return true;
+    }
+
+    // There's a difference in the attributes. We need separate deltas.
+    return false;
+  }
+
+  Operation mergeWith(Operation previousDelta) {
+    if (!canMergeWith(previousDelta)) {
+      throw Exception(
+          "Tried to merge two deltas that can't be merged. Previous delta: $previousDelta. Next delta: $this");
+    }
+
+    return Operation.insert(
+      "${previousDelta.value as String}${value as String}",
+      previousDelta.attributes,
+    );
+  }
+}
+
+extension Newlines on String {
+  String toNewlineString() => toString().replaceAll("\n", "⏎");
+}

--- a/super_editor_quill/lib/src/serializing/serializing.dart
+++ b/super_editor_quill/lib/src/serializing/serializing.dart
@@ -1,277 +1,58 @@
-import 'package:collection/collection.dart';
 import 'package:dart_quill_delta/dart_quill_delta.dart';
 import 'package:super_editor/super_editor.dart';
-import 'package:super_editor_quill/src/content/formatting.dart';
-import 'package:super_editor_quill/src/content/multimedia.dart';
+import 'package:super_editor_quill/src/serializing/serializers.dart';
 
+/// Extensions on [MutableDocument] for serializing a [MutableDocument]
+/// to a Quill Delta document.
 extension QuillDelta on MutableDocument {
-  Delta toQuillDeltas() {
+  /// Serializes this [MutableDocument] to a Quill [Delta] document.
+  ///
+  /// The [MutableDocument] is converted to deltas, node-by-node. For
+  /// each type of [DocumentNode] there is a [DeltaSerializer]. The
+  /// serializers that are used to convert [DocumentNode]s into deltas
+  /// can be configured by providing a custom list of [serializers].
+  Delta toQuillDeltas({
+    List<DeltaSerializer> serializers = defaultDeltaSerializers,
+  }) {
     final deltaDocument = Delta();
 
     for (final node in nodes) {
-      if (node is ParagraphNode) {
-        print("Serializing paragraph (${node.id}): ${node.text.text}");
-        _serializeParagraph(node, deltaDocument);
+      if (node is ParagraphNode && node == nodes.last && node.text.text.isEmpty && nodes.length > 1) {
+        // This final, empty paragraph in the document represents the final
+        // newline "\n" in the Delta document. But, due to how we serialize
+        // deltas, the node/delta before this one already inserted a newline,
+        // so we don't need to do anything with this empty node. Ignore it.
+        continue;
+      }
 
-        print(
-          "After serializing paragraph, latest delta: '${(deltaDocument.operations[deltaDocument.operations.length - 1].value as String).toNewlineString()}'",
-        );
-        print("");
-      } else if (node is ListItemNode) {
-        print("Serializing list item (${node.id}): ${node.text.text}");
-        // TODO:
-        print("");
-      } else if (node is TaskNode) {
-        print("Serializing task (${node.id}): ${node.text.text}");
-        // TODO:
-        print("");
-      } else if (node is ImageNode) {
-        _serializeImage(node, deltaDocument);
-      } else if (node is VideoNode) {
-        _serializeVideo(node, deltaDocument);
-      } else if (node is AudioNode) {
-        _serializeAudio(node, deltaDocument);
-      } else if (node is FileNode) {
-        _serializeFile(node, deltaDocument);
+      // Try out each serializer until we find one that successfully serializes
+      // this document node.
+      bool didSerialize = false;
+      for (int i = 0; i < serializers.length; i += 1) {
+        didSerialize = serializers[i].serialize(node, deltaDocument);
+        if (didSerialize) {
+          // Go to next Super Editor document node.
+          break;
+        }
+      }
+
+      if (!didSerialize) {
+        throw Exception("Failed to serialize Document to Quill Deltas. Couldn't find a serializer for node: $node");
       }
     }
 
     return deltaDocument;
   }
-
-  void _serializeParagraph(ParagraphNode paragraph, Delta deltas) {
-    print("Inserting text: '${paragraph.text.text.toNewlineString()}'");
-    final blockFormat = _serializeBlockFormat(paragraph);
-
-    var spans = paragraph.text.computeAttributionSpans().toList();
-    if (spans.isEmpty) {
-      // The text is empty. Inject a span so that our standard delta generation
-      // behavior below still works.
-      spans = [const MultiAttributionSpan(attributions: {}, start: 0, end: 0)];
-    }
-
-    for (int i = 0; i < spans.length; i += 1) {
-      final span = spans[i];
-      final text = paragraph.text.text.substring(span.start, paragraph.text.text.isNotEmpty ? span.end + 1 : span.end);
-      print(" - span: '${text.toNewlineString()}'");
-
-      // When we reach the end of the paragraph text, we want to insert a newline
-      // as long as we don't need to apply any block format. Applying a block
-      // format requires adding the newline in a different insert operation.
-      final isNewlineNeeded = i == spans.length - 1 && blockFormat == null;
-
-      final previousDelta = deltas.operations.lastOrNull;
-      final newDelta = Operation.insert(
-        text,
-        // "$text${isNewlineNeeded ? "\n" : ""}",
-        _serializeInlineAttributes(span.attributions),
-      );
-      if (previousDelta != null && newDelta.canMergeWith(previousDelta)) {
-        print(
-            " - Merging '${(previousDelta.value as String).toNewlineString()}' + '${(newDelta.value as String).toNewlineString()}'");
-        deltas.operations[deltas.operations.length - 1] = newDelta.mergeWith(previousDelta);
-        print(
-            " - Merged with previous delta: '${(deltas.operations[deltas.operations.length - 1].value as String).toNewlineString()}'");
-        continue;
-      }
-
-      print(" - Adding a new delta to the document list");
-      deltas.operations.addAll([
-        Operation.insert(
-          text,
-          // "$text${isNewlineNeeded ? "\n" : ""}",
-          _serializeInlineAttributes(span.attributions),
-        ),
-      ]);
-    }
-
-    // if (blockFormat != null && blockFormat.isNotEmpty) {
-    //   // Block formats are achieved by following the text with an insert
-    //   // that contains a single newline and a block format that applies
-    //   // to the previous insert.
-    //   print(" - Adding a standalone newline delta because we need to apply a block format");
-    final newlineDelta = Operation.insert("\n", blockFormat);
-    final previousDelta = deltas.operations[deltas.operations.length - 1];
-    if (newlineDelta.canMergeWith(previousDelta)) {
-      print(
-          "Merging a post-paragraph newline with previous delta: '${(previousDelta.value as String).toNewlineString()}'");
-      deltas.operations[deltas.operations.length - 1] = newlineDelta.mergeWith(previousDelta);
-    } else {
-      print("Adding a standalone post-paragraph newline delta: ${(newlineDelta.value as String).toNewlineString()}");
-      deltas.operations.add(newlineDelta);
-    }
-    // }
-  }
-
-  void _serializeListItem(ListItemNode listItem, Delta deltas) {
-    //
-  }
-
-  void _serializeTask(TaskNode task, Delta deltas) {
-    //
-  }
-
-  Map<String, dynamic>? _serializeBlockFormat(ParagraphNode paragraph) {
-    final blockAttributes = <String, dynamic>{};
-
-    // Add all the block-level formats that aren't mutually exclusive.
-    if (paragraph.metadata["textAlign"] != null) {
-      blockAttributes["align"] = paragraph.metadata["textAlign"];
-    }
-    if (paragraph.indent != 0) {
-      blockAttributes["indent"] = paragraph.indent;
-    }
-
-    final blockType = paragraph.metadata["blockType"] as Attribution?;
-    if (blockType == null) {
-      return blockAttributes.isNotEmpty ? blockAttributes : null;
-    }
-
-    // Add the mutually exclusive block format.
-    switch (blockType) {
-      case header1Attribution:
-        blockAttributes["header"] = 1;
-      case header2Attribution:
-        blockAttributes["header"] = 2;
-      case header3Attribution:
-        blockAttributes["header"] = 3;
-      case header4Attribution:
-        blockAttributes["header"] = 4;
-      case header5Attribution:
-        blockAttributes["header"] = 5;
-      case header6Attribution:
-        blockAttributes["header"] = 6;
-      case blockquoteAttribution:
-        blockAttributes["blockquote"] = true;
-      case codeAttribution:
-        blockAttributes["code-block"] = "plain";
-    }
-
-    return blockAttributes.isNotEmpty ? blockAttributes : null;
-  }
-
-  /// Given a set of [AttributedText] [attributions], serializes those into Quill Delta
-  /// inline text attributes, returning all attributes in a map that should be set as
-  /// the "attributes" in an insertion delta.
-  Map<String, dynamic>? _serializeInlineAttributes(Set<Attribution> attributions) {
-    final attributes = <String, dynamic>{};
-
-    for (final attribution in attributions) {
-      if (attribution == boldAttribution) {
-        attributes["bold"] = true;
-      }
-      if (attribution == italicsAttribution) {
-        attributes["italic"] = true;
-      }
-      if (attribution == strikethroughAttribution) {
-        attributes["strike"] = true;
-      }
-      if (attribution == underlineAttribution) {
-        attributes["underline"] = true;
-      }
-      if (attribution == superscriptAttribution) {
-        attributes["script"] = "super";
-      }
-      if (attribution == subscriptAttribution) {
-        attributes["script"] = "sub";
-      }
-      if (attribution is ColorAttribution) {
-        attributes["color"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
-      }
-      if (attribution is BackgroundColorAttribution) {
-        attributes["background"] = "#${attribution.color.value.toRadixString(16).substring(2)}";
-      }
-      if (attribution is FontFamilyAttribution) {
-        attributes["font"] = attribution.fontFamily;
-      }
-      if (attribution is NamedFontSizeAttribution) {
-        attributes["size"] = attribution.fontSizeName;
-      }
-      if (attribution is FontSizeAttribution) {
-        attributes["size"] = attribution.fontSize;
-      }
-      if (attribution is LinkAttribution) {
-        attributes["link"] = attribution.url;
-      }
-    }
-
-    return attributes.isEmpty ? null : attributes;
-  }
-
-  void _serializeImage(ImageNode image, Delta deltas) {
-    deltas.operations.add(
-      Operation.insert({
-        "image": image.imageUrl,
-      }),
-    );
-  }
-
-  void _serializeVideo(VideoNode video, Delta deltas) {
-    deltas.operations.add(
-      Operation.insert({
-        "video": video.url,
-      }),
-    );
-  }
-
-  void _serializeAudio(AudioNode audio, Delta deltas) {
-    deltas.operations.add(
-      Operation.insert({
-        "audio": audio.url,
-      }),
-    );
-  }
-
-  void _serializeFile(FileNode file, Delta deltas) {
-    deltas.operations.add(
-      Operation.insert({
-        "file": file.url,
-      }),
-    );
-  }
 }
 
-extension DeltaSerialization on Operation {
-  bool canMergeWith(Operation previousDelta) {
-    if (!isInsert) {
-      // We've only implement this for insertions, for now.
-      // TODO: Add support for retain/delete.
-      return false;
-    }
-
-    if (value is! String || previousDelta.value is! String) {
-      // One or both of the deltas aren't text. Only text can be merged.
-      return false;
-    }
-
-    // If the attributes are equivalent then we can merge the text deltas.
-    if (const DeepCollectionEquality().equals(previousDelta.attributes, attributes)) {
-      return true;
-    }
-    if (previousDelta.attributes == null && attributes!.isEmpty) {
-      return true;
-    }
-    if (attributes == null && previousDelta.attributes!.isEmpty) {
-      return true;
-    }
-
-    // There's a difference in the attributes. We need separate deltas.
-    return false;
-  }
-
-  Operation mergeWith(Operation previousDelta) {
-    if (!canMergeWith(previousDelta)) {
-      throw Exception(
-          "Tried to merge two deltas that can't be merged. Previous delta: $previousDelta. Next delta: $this");
-    }
-
-    return Operation.insert(
-      "${previousDelta.value as String}${value as String}",
-      previousDelta.attributes,
-    );
-  }
-}
-
-extension Newlines on String {
-  String toNewlineString() => toString().replaceAll("\n", "⏎");
-}
+/// The serializers the are used by default to convert a Super Editor [Document] to a
+/// Quill [Delta] document.
+const defaultDeltaSerializers = [
+  paragraphDeltaSerializer,
+  listItemDeltaSerializer,
+  taskDeltaSerializer,
+  imageDeltaSerializer,
+  videoDeltaSerializer,
+  audioDeltaSerializer,
+  fileDeltaSerializer,
+];

--- a/super_editor_quill/lib/super_editor_quill.dart
+++ b/super_editor_quill/lib/super_editor_quill.dart
@@ -4,5 +4,8 @@ export 'src/parsing/block_formats.dart';
 export 'src/parsing/inline_formats.dart';
 export 'src/parsing/parser.dart';
 
+export 'src/serializing/serializing.dart';
+export 'src/serializing/serializers.dart';
+
 export 'src/content/formatting.dart';
 export 'src/content/multimedia.dart';

--- a/super_editor_quill/pubspec.yaml
+++ b/super_editor_quill/pubspec.yaml
@@ -26,5 +26,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
+  text_table: ^4.0.3
 
 flutter:

--- a/super_editor_quill/pubspec.yaml
+++ b/super_editor_quill/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   super_editor: ^0.3.0-dev
   logging: ^1.0.1
   dart_quill_delta: ^9.4.1
+  collection: ^1.18.0
 
 dependency_overrides:
   super_editor:

--- a/super_editor_quill/test/parsing_test.dart
+++ b/super_editor_quill/test/parsing_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor_quill/super_editor_quill.dart';
 
+import 'test_documents.dart';
+
 // Useful links:
 //  - create a Delta document in the browser: https://quilljs.com/docs/delta
 //  - list of supported formats (bold, italics, header, etc): https://quilljs.com/docs/formats
@@ -39,7 +41,7 @@ void main() {
       });
 
       test("all text blocks and styles", () {
-        final document = parseQuillDeltaOps(_allTextStylesDocument);
+        final document = parseQuillDeltaOps(allTextStylesDeltaDocument);
 
         final nodes = document.nodes.iterator..moveNext();
         DocumentNode? node = nodes.current;
@@ -307,6 +309,48 @@ void main() {
         expect(node.metadata["blockType"], codeAttribution);
       });
 
+      test("overlapping styles", () {
+        final document = parseQuillDeltaDocument(
+          {
+            "ops": [
+              {"insert": "This "},
+              {
+                "attributes": {"bold": true},
+                "insert": "paragraph ",
+              },
+              {
+                "attributes": {"italic": true, "bold": true},
+                "insert": "has ",
+              },
+              {
+                "attributes": {"underline": true, "italic": true, "bold": true},
+                "insert": "some",
+              },
+              {
+                "attributes": {"underline": true, "italic": true},
+                "insert": " overlapping",
+              },
+              {
+                "attributes": {"underline": true},
+                "insert": " styles",
+              },
+              {"insert": ".\n"},
+            ],
+          },
+        );
+
+        final paragraph = document.nodes.first as ParagraphNode;
+        expect(paragraph.text.text, "This paragraph has some overlapping styles.");
+        expect(
+          paragraph.text.getAttributionSpansByFilter((a) => true),
+          {
+            const AttributionSpan(attribution: boldAttribution, start: 5, end: 22),
+            const AttributionSpan(attribution: italicsAttribution, start: 15, end: 34),
+            const AttributionSpan(attribution: underlineAttribution, start: 19, end: 41),
+          },
+        );
+      });
+
       test("gracefully handles unknown inline text format", () {
         final document = parseQuillDeltaOps([
           {"insert": "Paragraph "},
@@ -477,146 +521,3 @@ void main() {
     });
   });
 }
-
-const _allTextStylesDocument = [
-  {"insert": "All Text Styles"},
-  {
-    "attributes": {"header": 1},
-    "insert": "\n"
-  },
-  {"insert": "Samples of styles: "},
-  {
-    "attributes": {"bold": true},
-    "insert": "bold"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"italic": true},
-    "insert": "italics"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"underline": true},
-    "insert": "underline"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"strike": true},
-    "insert": "strikethrough"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"color": "#e60000"},
-    "insert": "text color"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"background": "#e60000"},
-    "insert": "background color"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"font": "serif"},
-    "insert": "font change"
-  },
-  {"insert": ", "},
-  {
-    "attributes": {"link": "google.com"},
-    "insert": "link"
-  },
-  {"insert": "\n\nLeft aligned\nCenter aligned"},
-  {
-    "attributes": {"align": "center"},
-    "insert": "\n"
-  },
-  {"insert": "Right aligned"},
-  {
-    "attributes": {"align": "right"},
-    "insert": "\n"
-  },
-  {"insert": "Justified"},
-  {
-    "attributes": {"align": "justify"},
-    "insert": "\n"
-  },
-  {"insert": "\nOrdered item 1"},
-  {
-    "attributes": {"list": "ordered"},
-    "insert": "\n"
-  },
-  {"insert": "Ordered item 2"},
-  {
-    "attributes": {"list": "ordered"},
-    "insert": "\n"
-  },
-  {"insert": "\nUnordered item 1"},
-  {
-    "attributes": {"list": "bullet"},
-    "insert": "\n"
-  },
-  {"insert": "Unordered item 2"},
-  {
-    "attributes": {"list": "bullet"},
-    "insert": "\n"
-  },
-  {"insert": "\nI'm a task that's incomplete"},
-  {
-    "attributes": {"list": "unchecked"},
-    "insert": "\n"
-  },
-  {"insert": "I'm a task that's complete"},
-  {
-    "attributes": {"list": "checked"},
-    "insert": "\n"
-  },
-  {"insert": "\nI'm an indented paragraph at level 1"},
-  {
-    "attributes": {"indent": 1},
-    "insert": "\n"
-  },
-  {"insert": "I'm a paragraph indented at level 2"},
-  {
-    "attributes": {"indent": 2},
-    "insert": "\n"
-  },
-  {"insert": "\nSome content"},
-  {
-    "attributes": {"script": "sub"},
-    "insert": "This is a subscript"
-  },
-  {"insert": "\nSome content"},
-  {
-    "attributes": {"script": "super"},
-    "insert": "This is a superscript"
-  },
-  {"insert": "\n\n"},
-  {
-    "attributes": {"size": "huge"},
-    "insert": "HUGE"
-  },
-  {"insert": "\n"},
-  {
-    "attributes": {"size": "large"},
-    "insert": "Large"
-  },
-  {"insert": "\n"},
-  {
-    "attributes": {"size": "small"},
-    "insert": "small"
-  },
-  {"insert": "\n\nThis is a blockquote"},
-  {
-    "attributes": {"blockquote": true},
-    "insert": "\n"
-  },
-  {"insert": "\nThis is a code block"},
-  {
-    "attributes": {"code-block": "plain"},
-    "insert": "\n"
-  },
-  {"insert": "\n"},
-  {
-    "attributes": {"align": "justify"},
-    "insert": "\n\n"
-  }
-];

--- a/super_editor_quill/test/quill_delta_comparison.dart
+++ b/super_editor_quill/test/quill_delta_comparison.dart
@@ -1,0 +1,115 @@
+import 'dart:math';
+
+import 'package:dart_quill_delta/dart_quill_delta.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:text_table/text_table.dart';
+
+/// Creates a [Matcher] that compares an actual Quill [Delta] document
+/// to the given [expectedDocument].
+Matcher quillDocumentEquivalentTo(Delta expectedDocument) => EquivalentQuillDocumentMatcher(expectedDocument);
+
+class EquivalentQuillDocumentMatcher extends Matcher {
+  const EquivalentQuillDocumentMatcher(this._expectedDocument);
+
+  final Delta _expectedDocument;
+
+  @override
+  Description describe(Description description) {
+    return description.add("a Quill document that looks like:\n$_expectedDocument");
+  }
+
+  @override
+  bool matches(covariant Object target, Map<dynamic, dynamic> matchState) {
+    return _calculateMismatchReason(target, matchState) == null;
+  }
+
+  @override
+  Description describeMismatch(
+    covariant Object target,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    final mismatchReason = _calculateMismatchReason(target, matchState);
+    if (mismatchReason != null) {
+      mismatchDescription.add(mismatchReason);
+    }
+    return mismatchDescription;
+  }
+
+  String? _calculateMismatchReason(
+    Object target,
+    Map<dynamic, dynamic> matchState,
+  ) {
+    if (target is! Delta) {
+      return "the given document isn't a Delta document: $target";
+    }
+    final actualDocument = target;
+
+    final messages = <String>[];
+    bool nodeCountMismatch = false;
+    bool nodeTypeOrContentMismatch = false;
+
+    if (_expectedDocument.operations.length != actualDocument.operations.length) {
+      messages.add(
+          "expected ${_expectedDocument.operations.length} document operations but found ${actualDocument.operations.length}");
+      nodeCountMismatch = true;
+    } else {
+      messages.add("documents have the same number of operations");
+    }
+
+    final maxOpCount = max(_expectedDocument.operations.length, actualDocument.operations.length);
+    final opComparisons = List.generate(maxOpCount, (index) => ["", "", " "]);
+    for (int i = 0; i < maxOpCount; i += 1) {
+      if (i < _expectedDocument.operations.length && i < actualDocument.operations.length) {
+        opComparisons[i][0] = _expectedDocument.operations[i].describe();
+        opComparisons[i][1] = actualDocument.operations[i].describe();
+
+        if (_expectedDocument.operations[i].runtimeType != actualDocument.operations[i].runtimeType) {
+          opComparisons[i][2] = "Wrong Type";
+          nodeTypeOrContentMismatch = true;
+        } else if (_expectedDocument.operations[i] != actualDocument.operations[i]) {
+          if (_expectedDocument.operations[i].value != actualDocument.operations[i].value) {
+            opComparisons[i][2] = "Different value";
+          } else {
+            opComparisons[i][2] =
+                "Different attributes - Expected: ${_expectedDocument.operations[i].attributes}, Actual: ${actualDocument.operations[i].value}";
+          }
+          nodeTypeOrContentMismatch = true;
+        }
+      } else if (i < _expectedDocument.operations.length) {
+        opComparisons[i][0] = _expectedDocument.operations[i].describe();
+        opComparisons[i][1] = "NA";
+        opComparisons[i][2] = "Missing Node";
+      } else if (i < actualDocument.operations.length) {
+        opComparisons[i][0] = "NA";
+        opComparisons[i][1] = actualDocument.operations[i].describe();
+        opComparisons[i][2] = "Missing Node";
+      }
+    }
+
+    if (nodeCountMismatch || nodeTypeOrContentMismatch) {
+      String messagesList = messages.join(", ");
+      messagesList += "\n";
+      messagesList += const TableRenderer().render(opComparisons, columns: ["Expected", "Actual", "Difference"]);
+      return messagesList;
+    }
+
+    return null;
+  }
+}
+
+extension on Operation {
+  String describe() {
+    final writtenValue = value.toString().replaceAll("\n", "⏎");
+    if (isInsert) {
+      return "Insert: $writtenValue";
+    } else if (isRetain) {
+      return "Retain: $writtenValue";
+    } else if (isDelete) {
+      return "Delete: $writtenValue";
+    }
+
+    throw Exception("Unknown operation type: $this");
+  }
+}

--- a/super_editor_quill/test/serializing_test.dart
+++ b/super_editor_quill/test/serializing_test.dart
@@ -1,0 +1,101 @@
+import 'package:dart_quill_delta/dart_quill_delta.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor_quill/src/parsing/parser.dart';
+import 'package:super_editor_quill/src/serializing/serializing.dart';
+
+import 'test_documents.dart';
+
+void main() {
+  group("Delta document serializing >", () {
+    group("text >", () {
+      test("all text blocks and styles", () {
+        final deltas = createAllTextStylesSuperEditorDocument().toQuillDeltas();
+        final expectedDeltas = Delta.fromJson(allTextStylesDeltaDocument);
+
+        expect(deltas, expectedDeltas);
+      });
+    });
+
+    group("media >", () {
+      test("image", () {
+        final deltas = parseQuillDeltaDocument({
+          "ops": [
+            {"insert": "This is paragraph 1\n"},
+            {
+              "insert": {"image": "https://quilljs.com/assets/images/icon.png"},
+            },
+            {"insert": "This is paragraph 2\n"},
+          ]
+        }).toQuillDeltas();
+
+        expect(deltas.operations, [
+          Operation.insert("This is paragraph 1\n"),
+          Operation.insert({
+            "image": "https://quilljs.com/assets/images/icon.png",
+          }),
+          Operation.insert("This is paragraph 2\n"),
+        ]);
+      });
+
+      test("video", () {
+        final deltas = parseQuillDeltaDocument({
+          "ops": [
+            {"insert": "This is paragraph 1\n"},
+            {
+              "insert": {"video": "https://quilljs.com/assets/videos/video.mp4"},
+            },
+            {"insert": "This is paragraph 2\n"},
+          ]
+        }).toQuillDeltas();
+
+        expect(deltas.operations, [
+          Operation.insert("This is paragraph 1\n"),
+          Operation.insert({
+            "video": "https://quilljs.com/assets/videos/video.mp4",
+          }),
+          Operation.insert("This is paragraph 2\n"),
+        ]);
+      });
+
+      test("audio", () {
+        final deltas = parseQuillDeltaDocument({
+          "ops": [
+            {"insert": "This is paragraph 1\n"},
+            {
+              "insert": {"audio": "https://quilljs.com/assets/audio/audio.mp3"},
+            },
+            {"insert": "This is paragraph 2\n"},
+          ]
+        }).toQuillDeltas();
+
+        expect(deltas.operations, [
+          Operation.insert("This is paragraph 1\n"),
+          Operation.insert({
+            "audio": "https://quilljs.com/assets/audio/audio.mp3",
+          }),
+          Operation.insert("This is paragraph 2\n"),
+        ]);
+      });
+
+      test("file", () {
+        final deltas = parseQuillDeltaDocument({
+          "ops": [
+            {"insert": "This is paragraph 1\n"},
+            {
+              "insert": {"file": "https://quilljs.com/assets/files/file.pdf"},
+            },
+            {"insert": "This is paragraph 2\n"},
+          ]
+        }).toQuillDeltas();
+
+        expect(deltas.operations, [
+          Operation.insert("This is paragraph 1\n"),
+          Operation.insert({
+            "file": "https://quilljs.com/assets/files/file.pdf",
+          }),
+          Operation.insert("This is paragraph 2\n"),
+        ]);
+      });
+    });
+  });
+}

--- a/super_editor_quill/test/serializing_test.dart
+++ b/super_editor_quill/test/serializing_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor_quill/src/parsing/parser.dart';
 import 'package:super_editor_quill/src/serializing/serializing.dart';
 
+import 'quill_delta_comparison.dart';
 import 'test_documents.dart';
 
 void main() {
@@ -12,7 +13,7 @@ void main() {
         final deltas = createAllTextStylesSuperEditorDocument().toQuillDeltas();
         final expectedDeltas = Delta.fromJson(allTextStylesDeltaDocument);
 
-        expect(deltas, expectedDeltas);
+        expect(deltas, quillDocumentEquivalentTo(expectedDeltas));
       });
     });
 

--- a/super_editor_quill/test/test_documents.dart
+++ b/super_editor_quill/test/test_documents.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/painting.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_quill/src/content/formatting.dart';
+
+/// A Quill Delta document that uses every type of standard editor styles.
+///
+/// This is the Quill version of [createAllTextStylesSuperEditorDocument].
+const allTextStylesDeltaDocument = [
+  {"insert": "All Text Styles"},
+  {
+    "attributes": {"header": 1},
+    "insert": "\n"
+  },
+  {"insert": "Samples of styles: "},
+  {
+    "attributes": {"bold": true},
+    "insert": "bold"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"italic": true},
+    "insert": "italics"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"underline": true},
+    "insert": "underline"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"strike": true},
+    "insert": "strikethrough"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"color": "#e60000"},
+    "insert": "text color"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"background": "#e60000"},
+    "insert": "background color"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"font": "serif"},
+    "insert": "font change"
+  },
+  {"insert": ", "},
+  {
+    "attributes": {"link": "google.com"},
+    "insert": "link"
+  },
+  {"insert": "\n\nLeft aligned\nCenter aligned"},
+  {
+    "attributes": {"align": "center"},
+    "insert": "\n"
+  },
+  {"insert": "Right aligned"},
+  {
+    "attributes": {"align": "right"},
+    "insert": "\n"
+  },
+  {"insert": "Justified"},
+  {
+    "attributes": {"align": "justify"},
+    "insert": "\n"
+  },
+  {"insert": "\nOrdered item 1"},
+  {
+    "attributes": {"list": "ordered"},
+    "insert": "\n"
+  },
+  {"insert": "Ordered item 2"},
+  {
+    "attributes": {"list": "ordered"},
+    "insert": "\n"
+  },
+  {"insert": "\nUnordered item 1"},
+  {
+    "attributes": {"list": "bullet"},
+    "insert": "\n"
+  },
+  {"insert": "Unordered item 2"},
+  {
+    "attributes": {"list": "bullet"},
+    "insert": "\n"
+  },
+  {"insert": "\nI'm a task that's incomplete"},
+  {
+    "attributes": {"list": "unchecked"},
+    "insert": "\n"
+  },
+  {"insert": "I'm a task that's complete"},
+  {
+    "attributes": {"list": "checked"},
+    "insert": "\n"
+  },
+  {"insert": "\nI'm an indented paragraph at level 1"},
+  {
+    "attributes": {"indent": 1},
+    "insert": "\n"
+  },
+  {"insert": "I'm a paragraph indented at level 2"},
+  {
+    "attributes": {"indent": 2},
+    "insert": "\n"
+  },
+  {"insert": "\nSome content"},
+  {
+    "attributes": {"script": "sub"},
+    "insert": "This is a subscript"
+  },
+  {"insert": "\nSome content"},
+  {
+    "attributes": {"script": "super"},
+    "insert": "This is a superscript"
+  },
+  {"insert": "\n\n"},
+  {
+    "attributes": {"size": "huge"},
+    "insert": "HUGE"
+  },
+  {"insert": "\n"},
+  {
+    "attributes": {"size": "large"},
+    "insert": "Large"
+  },
+  {"insert": "\n"},
+  {
+    "attributes": {"size": "small"},
+    "insert": "small"
+  },
+  {"insert": "\n\nThis is a blockquote"},
+  {
+    "attributes": {"blockquote": true},
+    "insert": "\n"
+  },
+  {"insert": "\nThis is a code block"},
+  {
+    "attributes": {"code-block": "plain"},
+    "insert": "\n"
+  },
+  {"insert": "\n"},
+  {
+    "attributes": {"align": "justify"},
+    "insert": "\n\n"
+  }
+];
+
+/// A Super Editor document that uses every type editor style that appears in
+/// a standard Quill editor.
+///
+/// This is the Super Editor version of [allTextStylesDeltaDocument].
+MutableDocument createAllTextStylesSuperEditorDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: "1",
+        text: AttributedText("All Text Styles"),
+        metadata: {
+          "blockType": header1Attribution,
+        },
+      ),
+      ParagraphNode(
+        id: "2",
+        text: AttributedText(
+          "Samples of styles: bold, italics, underline, strikethrough, text color, background color, font change, link",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: boldAttribution, offset: 19, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 22, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: italicsAttribution, offset: 25, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: italicsAttribution, offset: 31, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: underlineAttribution, offset: 34, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: underlineAttribution, offset: 42, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: strikethroughAttribution, offset: 45, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: strikethroughAttribution, offset: 57, markerType: SpanMarkerType.end),
+              const SpanMarker(
+                  attribution: ColorAttribution(Color(0xFFe60000)), offset: 60, markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: ColorAttribution(Color(0xFFe60000)), offset: 69, markerType: SpanMarkerType.end),
+              const SpanMarker(
+                  attribution: BackgroundColorAttribution(Color(0xFFe60000)),
+                  offset: 72,
+                  markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: BackgroundColorAttribution(Color(0xFFe60000)),
+                  offset: 87,
+                  markerType: SpanMarkerType.end),
+              const SpanMarker(
+                  attribution: FontFamilyAttribution("serif"), offset: 90, markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: FontFamilyAttribution("serif"), offset: 100, markerType: SpanMarkerType.end),
+              const SpanMarker(
+                  attribution: LinkAttribution("google.com"), offset: 103, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: LinkAttribution("google.com"), offset: 106, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(id: "3", text: AttributedText("")),
+      ParagraphNode(id: "4", text: AttributedText("Left aligned")),
+      ParagraphNode(id: "5", text: AttributedText("Center aligned"), metadata: {"textAlign": "center"}),
+      ParagraphNode(id: "6", text: AttributedText("Right aligned"), metadata: {"textAlign": "right"}),
+      ParagraphNode(id: "7", text: AttributedText("Justified"), metadata: {"textAlign": "justify"}),
+      ParagraphNode(id: "8", text: AttributedText("")),
+      ListItemNode(id: "9", itemType: ListItemType.ordered, text: AttributedText("Ordered item 1")),
+      ListItemNode(id: "10", itemType: ListItemType.ordered, text: AttributedText("Ordered item 2")),
+      ParagraphNode(id: "11", text: AttributedText("")),
+      ListItemNode(id: "12", itemType: ListItemType.ordered, text: AttributedText("Unordered item 1")),
+      ListItemNode(id: "13", itemType: ListItemType.ordered, text: AttributedText("Unordered item 2")),
+      ParagraphNode(id: "14", text: AttributedText("")),
+      TaskNode(id: "15", text: AttributedText("I'm a task that's incomplete"), isComplete: false),
+      TaskNode(id: "16", text: AttributedText("I'm a task that's complete"), isComplete: true),
+      ParagraphNode(id: "17", text: AttributedText("")),
+      ParagraphNode(id: "18", text: AttributedText("I'm an indented paragraph at level 1"), indent: 1),
+      ParagraphNode(id: "19", text: AttributedText("I'm an indented paragraph at level 2"), indent: 2),
+      ParagraphNode(id: "20", text: AttributedText("")),
+      ParagraphNode(
+        id: "21",
+        text: AttributedText(
+          "Some contentThis is a subscript",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: subscriptAttribution, offset: 12, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: subscriptAttribution, offset: 30, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(
+        id: "22",
+        text: AttributedText(
+          "Some contentThis is a superscript",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: subscriptAttribution, offset: 12, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: subscriptAttribution, offset: 32, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(id: "23", text: AttributedText("")),
+      ParagraphNode(
+        id: "24",
+        text: AttributedText(
+          "HUGE",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("huge"), offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("huge"), offset: 3, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(
+        id: "25",
+        text: AttributedText(
+          "Large",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("large"), offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("large"), offset: 4, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(
+        id: "26",
+        text: AttributedText(
+          "small",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("small"), offset: 0, markerType: SpanMarkerType.start),
+              const SpanMarker(
+                  attribution: NamedFontSizeAttribution("small"), offset: 4, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ),
+      ),
+      ParagraphNode(id: "27", text: AttributedText("")),
+      ParagraphNode(
+        id: "28",
+        text: AttributedText("This is a blockquote"),
+        metadata: {"blockType": blockquoteAttribution},
+      ),
+      ParagraphNode(id: "29", text: AttributedText("")),
+      ParagraphNode(
+        id: "30",
+        text: AttributedText("This is a code block"),
+        metadata: {"blockType": codeAttribution},
+      ),
+    ],
+  );
+}

--- a/super_editor_quill/test/test_documents.dart
+++ b/super_editor_quill/test/test_documents.dart
@@ -140,11 +140,6 @@ const allTextStylesDeltaDocument = [
   {
     "attributes": {"code-block": "plain"},
     "insert": "\n"
-  },
-  {"insert": "\n"},
-  {
-    "attributes": {"align": "justify"},
-    "insert": "\n\n"
   }
 ];
 
@@ -208,14 +203,14 @@ MutableDocument createAllTextStylesSuperEditorDocument() {
       ListItemNode(id: "9", itemType: ListItemType.ordered, text: AttributedText("Ordered item 1")),
       ListItemNode(id: "10", itemType: ListItemType.ordered, text: AttributedText("Ordered item 2")),
       ParagraphNode(id: "11", text: AttributedText("")),
-      ListItemNode(id: "12", itemType: ListItemType.ordered, text: AttributedText("Unordered item 1")),
-      ListItemNode(id: "13", itemType: ListItemType.ordered, text: AttributedText("Unordered item 2")),
+      ListItemNode(id: "12", itemType: ListItemType.unordered, text: AttributedText("Unordered item 1")),
+      ListItemNode(id: "13", itemType: ListItemType.unordered, text: AttributedText("Unordered item 2")),
       ParagraphNode(id: "14", text: AttributedText("")),
       TaskNode(id: "15", text: AttributedText("I'm a task that's incomplete"), isComplete: false),
       TaskNode(id: "16", text: AttributedText("I'm a task that's complete"), isComplete: true),
       ParagraphNode(id: "17", text: AttributedText("")),
       ParagraphNode(id: "18", text: AttributedText("I'm an indented paragraph at level 1"), indent: 1),
-      ParagraphNode(id: "19", text: AttributedText("I'm an indented paragraph at level 2"), indent: 2),
+      ParagraphNode(id: "19", text: AttributedText("I'm a paragraph indented at level 2"), indent: 2),
       ParagraphNode(id: "20", text: AttributedText("")),
       ParagraphNode(
         id: "21",
@@ -235,8 +230,8 @@ MutableDocument createAllTextStylesSuperEditorDocument() {
           "Some contentThis is a superscript",
           AttributedSpans(
             attributions: [
-              const SpanMarker(attribution: subscriptAttribution, offset: 12, markerType: SpanMarkerType.start),
-              const SpanMarker(attribution: subscriptAttribution, offset: 32, markerType: SpanMarkerType.end),
+              const SpanMarker(attribution: superscriptAttribution, offset: 12, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: superscriptAttribution, offset: 32, markerType: SpanMarkerType.end),
             ],
           ),
         ),


### PR DESCRIPTION
[Quill] - Serialize MutableDocument to Quill Deltas document (Resolves #2117)

The Quill serializer takes a list `DeltaSerializer`s, which know how to turn some kind of `DocumentNode` into a series of insertion deltas.

The serialization process is mostly straight-forward. The only unusual aspect of the Delta format is the rules about how block-level styles (like header, alignment, etc) are applied. The block level styles are applied in the delta immediately after them. Related to that, we need to be careful where we insert newline characters to comply with the spec.