### PR TITLE
[SuperEditor] Make selected text color strategy consider each colored span (Resolves #2093)

### DIFF
--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -88,6 +88,79 @@ void main() {
         expect(richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color, Colors.green);
         expect(richText.getSpanForPosition(const TextPosition(offset: 16))!.style!.color, Colors.green);
       });
+
+      testWidgetsOnArbitraryDesktop("overrides each colored span", (tester) async {
+        final stylesheet = defaultStylesheet.copyWith(
+          selectedTextColorStrategy: ({required Color originalTextColor, required Color selectionHighlightColor}) {
+            if (originalTextColor == Colors.green) {
+              return Colors.red;
+            }
+
+            if (originalTextColor == Colors.yellow) {
+              return Colors.blue;
+            }
+
+            return Colors.white;
+          },
+        );
+
+        // Pump an editor with a paragraph with the following colors:
+        // Lorem ipsum dolor
+        // gggggg-----------
+        // ------yyyyyy-----
+        // ------------bbbbb (black, the default color)
+        await tester //
+            .createDocument()
+            .withCustomContent(
+              MutableDocument(
+                nodes: [
+                  ParagraphNode(
+                    id: '1',
+                    text: AttributedText(
+                      'Lorem ipsum dolor',
+                      AttributedSpans(
+                        attributions: [
+                          SpanMarker(
+                              attribution: const ColorAttribution(Colors.green),
+                              offset: 0,
+                              markerType: SpanMarkerType.start),
+                          SpanMarker(
+                              attribution: const ColorAttribution(Colors.green),
+                              offset: 5,
+                              markerType: SpanMarkerType.end),
+                          SpanMarker(
+                              attribution: const ColorAttribution(Colors.yellow),
+                              offset: 6,
+                              markerType: SpanMarkerType.start),
+                          SpanMarker(
+                              attribution: const ColorAttribution(Colors.yellow),
+                              offset: 11,
+                              markerType: SpanMarkerType.end),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            )
+            .useStylesheet(stylesheet)
+            .pump();
+
+        // Triple tap to select the whole paragraph.
+        await tester.tripleTapInParagraph('1', 2);
+
+        // Ensure that all spans changed colors.
+        final richText = SuperEditorInspector.findRichTextInParagraph('1');
+
+        expect(richText.getSpanForPosition(const TextPosition(offset: 0))!.style!.color, Colors.red);
+        expect(richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color, Colors.red);
+
+        expect(richText.getSpanForPosition(const TextPosition(offset: 6))!.style!.color, Colors.blue);
+        expect(richText.getSpanForPosition(const TextPosition(offset: 11))!.style!.color, Colors.blue);
+
+        expect(richText.getSpanForPosition(const TextPosition(offset: 12))!.style!.color, Colors.white);
+        expect(richText.getSpanForPosition(const TextPosition(offset: 16))!.style!.color, Colors.white);
+      });
     });
 
     testWidgetsOnArbitraryDesktop("calculates upstream document selection within a single node", (tester) async {


### PR DESCRIPTION
[SuperEditor] Make selected text color strategy consider each colored span. Resolves #2093

`SingleColumnLayoutComponentViewModel` invokes the `SelectedTextColorStrategy` using only the default text color for the node as the `originalColor` argument, ignoring any `ColorAttribution`s. If we return the same original color, we loose the color attribution:

![SCR-20240622-oxai](https://github.com/superlistapp/super_editor/assets/7597082/71abd8be-112e-4a2b-9428-b8ed09b9715f)

![SCR-20240622-oxck](https://github.com/superlistapp/super_editor/assets/7597082/fdb961a1-617e-4f29-b37d-ce9bea309b8d)

This PR changes `SingleColumnLayoutComponentViewModel` to consider each colored span and call `SelectedTextColorStrategy` for each of then:

![SCR-20240622-oxlx](https://github.com/superlistapp/super_editor/assets/7597082/5711d8cd-6e8e-4d0f-a34a-69d62e1c62ef)

