### PR TITLE
Ignore spurious metrics change notification

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -471,6 +472,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
   bool _isCaretDragInProgress = false;
 
+  // Cached view metrics to ignore unnecessary didChangeMetrics calls.
+  Size? _lastSize;
+  ViewPadding? _lastInsets;
+
   @override
   void initState() {
     super.initState();
@@ -493,6 +498,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
+    final view = View.of(context);
+    _lastSize = view.physicalSize;
+    _lastInsets = view.viewInsets;
 
     _controlsController = SuperEditorAndroidControlsScope.rootOf(context);
 
@@ -529,6 +538,20 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
   @override
   void didChangeMetrics() {
+    // It is possible to get the notification even though the metrics for view are same.
+    final view = View.of(context);
+    final size = view.physicalSize;
+    final insets = view.viewInsets;
+    if (size == _lastSize &&
+        _lastInsets?.left == insets.left &&
+        _lastInsets?.right == insets.right &&
+        _lastInsets?.top == insets.top &&
+        _lastInsets?.bottom == insets.bottom) {
+      return;
+    }
+    _lastSize = size;
+    _lastInsets = insets;
+
     // The available screen dimensions may have changed, e.g., due to keyboard
     // appearance/disappearance. Reflow the layout. Use a post-frame callback
     // to give the rest of the UI a chance to reflow, first.

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -1441,6 +1441,26 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgetsOnMobile('spurious metrics change is ignored', (tester) async {
+      final scrollController = ScrollController();
+      await tester //
+          .createDocument()
+          .withLongDoc()
+          .withEditorSize(const Size(300, 300))
+          .withScrollController(scrollController)
+          .pump();
+      await tester.tapInParagraph('1', 0);
+      final gesture = await tester.startGesture(Offset(100, 100), kind: PointerDeviceKind.touch);
+      await gesture.moveBy(Offset(0, -100));
+      await tester.pumpAndSettle();
+      final pixels = scrollController.position.pixels;
+      // This should not change scroll position.
+      WidgetsBinding.instance.handleMetricsChanged();
+      await Future.microtask(() {});
+      await tester.pump();
+      expect(scrollController.position.pixels, pixels);
+    });
   });
 }
 


### PR DESCRIPTION
On iOS with keyboard present there is occasional `didChangeMetrics` notification even if the metrics did not change. This is something that would be nice to fix in the engine, but the API itself does not make any guarantees about when the notification is called.

The problem with this is that the notification might come during scrolling, in which case it can interfere with scroll position when trying to position the cursor within the viewport.