### PR TITLE
1962 slack mention clone minor changes

### DIFF
--- a/super_editor/lib/src/clones/slack/slack_tags.dart
+++ b/super_editor/lib/src/clones/slack/slack_tags.dart
@@ -31,12 +31,13 @@ class SlackTagPlugin extends SuperEditorPlugin {
   /// The key used to access the [SlackTagIndex] in an attached [Editor].
   static const slackTagIndexKey = "slackTagIndex";
 
-  static const _trigger = "@";
-
-  SlackTagPlugin({List<EditRequestHandler> customRequestHandlers = const []}) : tagIndex = SlackTagIndex() {
+  SlackTagPlugin({
+    List<EditRequestHandler> customRequestHandlers = const [],
+    this.trigger = "@",
+  }) : tagIndex = SlackTagIndex() {
     _requestHandlers = <EditRequestHandler>[
       (request) =>
-          request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(_trigger, request.tag) : null,
+          request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(trigger, request.tag) : null,
       (request) => request is CancelComposingSlackTagRequest //
           ? const CancelComposingSlackTagCommand()
           : null,
@@ -45,12 +46,15 @@ class SlackTagPlugin extends SuperEditorPlugin {
 
     _reactions = [
       SlackTagReaction(
-        trigger: _trigger,
+        trigger: trigger,
         onUpdateComposingTag: tagIndex.setTag,
       ),
-      const AdjustSelectionAroundSlackTagReaction(_trigger),
+      AdjustSelectionAroundSlackTagReaction(trigger),
     ];
   }
+
+  /// The character that triggers a tag. Default is "@".
+  final String trigger;
 
   /// Index of all slack tags in the document, which changes as the user adds and removes tags.
   final SlackTagIndex tagIndex;
@@ -129,11 +133,11 @@ class FillInComposingSlackTagRequest implements EditRequest {
 
 class FillInComposingSlackTagCommand implements EditCommand {
   const FillInComposingSlackTagCommand(
-    this._trigger,
+    this.trigger,
     this._tag,
   );
 
-  final String _trigger;
+  final String trigger;
   final String _tag;
 
   @override
@@ -182,7 +186,7 @@ class FillInComposingSlackTagCommand implements EditCommand {
       InsertAttributedTextCommand(
         documentPosition: textNode.positionAt(startOfToken),
         textToInsert: AttributedText(
-          "$_trigger$_tag ",
+          "$trigger$_tag ",
           AttributedSpans(
             attributions: [
               SpanMarker(attribution: slackTagAttribution, offset: 0, markerType: SpanMarkerType.start),

--- a/super_editor/lib/src/clones/slack/slack_tags.dart
+++ b/super_editor/lib/src/clones/slack/slack_tags.dart
@@ -33,13 +33,14 @@ class SlackTagPlugin extends SuperEditorPlugin {
 
   static const _trigger = "@";
 
-  SlackTagPlugin() : tagIndex = SlackTagIndex() {
+  SlackTagPlugin({List<EditRequestHandler> customRequestHandlers = const []}) : tagIndex = SlackTagIndex() {
     _requestHandlers = <EditRequestHandler>[
-      // (request) =>
-      //     request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(_trigger, request.tag) : null,
+      (request) =>
+          request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(_trigger, request.tag) : null,
       (request) => request is CancelComposingSlackTagRequest //
           ? const CancelComposingSlackTagCommand()
           : null,
+      ...customRequestHandlers,
     ];
 
     _reactions = [

--- a/super_editor/lib/src/clones/slack/slack_tags.dart
+++ b/super_editor/lib/src/clones/slack/slack_tags.dart
@@ -212,8 +212,8 @@ class FillInComposingSlackTagCommand implements EditCommand {
     // FIXME: Use a transaction to bundle these changes so order doesn't matter.
     if (removeComposingAttributionCommand != null) {
       executor.executeCommand(removeComposingAttributionCommand);
-      print("Attributions immediately after removing composing attribution:");
-      print("${textNode.text.getAttributionSpansByFilter((a) => true)}");
+      editorSlackTagsLog.info("Attributions immediately after removing composing attribution:");
+      editorSlackTagsLog.info("${textNode.text.getAttributionSpansByFilter((a) => true)}");
     }
 
     // Reset the tag index so that we're no longer composing a tag.
@@ -275,14 +275,14 @@ class CancelComposingSlackTagCommand implements EditCommand {
 }
 
 EditCommand? removeSlackComposingTokenAttribution(Document document, SlackTagIndex tagIndex) {
-  print("REMOVING COMPOSING ATTRIBUTION");
+  editorSlackTagsLog.info("REMOVING COMPOSING ATTRIBUTION");
   // Remove any composing attribution for the previous state of the tag.
   // It's possible that the previous composing region disappeared, e.g., due to a deletion.
   final previousTag = tagIndex._composingSlackTag.value!;
   final previousTagNode =
       document.getNodeById(previousTag.contentBounds.start.nodeId); // We assume tags don't cross node boundaries.
   if (previousTagNode == null || previousTagNode is! TextNode) {
-    print("Couldn't find composing attribution. Fizzling.");
+    editorSlackTagsLog.info("Couldn't find composing attribution. Fizzling.");
     return null;
   }
 
@@ -344,7 +344,7 @@ class SlackTagReaction implements EditReaction {
     editorSlackTagsLog.info("Is already composing a tag? ${tagIndex.isComposing}");
 
     if (changeList.length == 1 && changeList.first is SelectionChangeEvent) {
-      print("Selection change event: ${(changeList.first as SelectionChangeEvent).changeType}");
+      editorSlackTagsLog.info("Selection change event: ${(changeList.first as SelectionChangeEvent).changeType}");
     }
 
     // Update the current tag composition.
@@ -425,7 +425,7 @@ class SlackTagReaction implements EditReaction {
     onUpdateComposingTag?.call(newTag);
 
     // Add composing attribution for the updated tag bounds.
-    print("Updating composing attribution with bounds: ${newTag.contentBounds}");
+    editorSlackTagsLog.info("Updating composing attribution with bounds: ${newTag.contentBounds}");
     requestDispatcher.execute([
       AddTextAttributionsRequest(
         documentRange: newTag.contentBounds,
@@ -974,7 +974,7 @@ class AdjustSelectionAroundSlackTagReaction implements EditReaction {
       );
     }
 
-    print(
+    editorSlackTagsLog.fine(
         "Selection after adjusting for tag: ${editContext.find<MutableDocumentComposer>(Editor.composerKey).selection?.extent.nodePosition}");
   }
 
@@ -1241,7 +1241,7 @@ class AdjustSelectionAroundSlackTagReaction implements EditReaction {
       case TextAffinity.downstream:
         // Move to ending edge.
         textOffset = tagAroundCaret.indexedTag.endOffset;
-        print("Pushing to text offset: $textOffset");
+        editorSlackTagsLog.fine("Pushing to text offset: $textOffset");
         break;
     }
 
@@ -1264,7 +1264,7 @@ class AdjustSelectionAroundSlackTagReaction implements EditReaction {
             ),
           );
 
-    print("Setting selection to: $newSelection");
+    editorSlackTagsLog.fine("Setting selection to: $newSelection");
 
     requestDispatcher.execute([
       ChangeSelectionRequest(

--- a/super_editor/lib/src/clones/slack/slack_tags.dart
+++ b/super_editor/lib/src/clones/slack/slack_tags.dart
@@ -1102,10 +1102,7 @@ class AdjustSelectionAroundSlackTagReaction implements EditReaction {
       case SelectionChangeType.placeCaret:
       case SelectionChangeType.pushCaret:
       case SelectionChangeType.collapseSelection:
-      // throw AssertionError(
-      //     "An expanded selection reported a SelectionChangeType for a collapsed selection: ${selectionChangeEvent.changeType}\n${selectionChangeEvent.newSelection}");
       case SelectionChangeType.clearSelection:
-      // throw AssertionError("Expected a collapsed selection but there was no selection.");
     }
   }
 

--- a/super_editor/lib/src/clones/slack/slack_tags.dart
+++ b/super_editor/lib/src/clones/slack/slack_tags.dart
@@ -35,8 +35,8 @@ class SlackTagPlugin extends SuperEditorPlugin {
 
   SlackTagPlugin() : tagIndex = SlackTagIndex() {
     _requestHandlers = <EditRequestHandler>[
-      (request) =>
-          request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(_trigger, request.tag) : null,
+      // (request) =>
+      //     request is FillInComposingSlackTagRequest ? FillInComposingSlackTagCommand(_trigger, request.tag) : null,
       (request) => request is CancelComposingSlackTagRequest //
           ? const CancelComposingSlackTagCommand()
           : null,
@@ -45,7 +45,7 @@ class SlackTagPlugin extends SuperEditorPlugin {
     _reactions = [
       SlackTagReaction(
         trigger: _trigger,
-        onUpdateComposingTag: tagIndex._onComposingTagFound,
+        onUpdateComposingTag: tagIndex.setTag,
       ),
       const AdjustSelectionAroundSlackTagReaction(_trigger),
     ];
@@ -145,7 +145,7 @@ class FillInComposingSlackTagCommand implements EditCommand {
     }
 
     // Remove the composing attribution from the text.
-    final removeComposingAttributionCommand = _removeSlackComposingTokenAttribution(document, tagIndex);
+    final removeComposingAttributionCommand = removeSlackComposingTokenAttribution(document, tagIndex);
 
     // Insert the final text and apply a stable tag attribution.
     final tag = tagIndex.composingSlackTag.value!;
@@ -240,7 +240,7 @@ class CancelComposingSlackTagCommand implements EditCommand {
     final document = context.find<MutableDocument>(Editor.documentKey);
 
     // Remove the composing attribution from the text.
-    final removeComposingAttributionCommand = _removeSlackComposingTokenAttribution(document, tagIndex);
+    final removeComposingAttributionCommand = removeSlackComposingTokenAttribution(document, tagIndex);
 
     // Reset the tag index.
     final tag = tagIndex.composingSlackTag.value!;
@@ -269,7 +269,7 @@ class CancelComposingSlackTagCommand implements EditCommand {
   }
 }
 
-EditCommand? _removeSlackComposingTokenAttribution(Document document, SlackTagIndex tagIndex) {
+EditCommand? removeSlackComposingTokenAttribution(Document document, SlackTagIndex tagIndex) {
   print("REMOVING COMPOSING ATTRIBUTION");
   // Remove any composing attribution for the previous state of the tag.
   // It's possible that the previous composing region disappeared, e.g., due to a deletion.
@@ -788,7 +788,7 @@ class SlackTagIndex with ChangeNotifier implements Editable {
   ValueListenable<ComposingSlackTag?> get composingSlackTag => _composingSlackTag;
   final _composingSlackTag = ValueNotifier<ComposingSlackTag?>(null);
 
-  void _onComposingTagFound(ComposingSlackTag? tag) {
+  void setTag(ComposingSlackTag? tag) {
     _composingSlackTag.value = tag;
   }
 
@@ -1097,10 +1097,10 @@ class AdjustSelectionAroundSlackTagReaction implements EditReaction {
       case SelectionChangeType.placeCaret:
       case SelectionChangeType.pushCaret:
       case SelectionChangeType.collapseSelection:
-        throw AssertionError(
-            "An expanded selection reported a SelectionChangeType for a collapsed selection: ${selectionChangeEvent.changeType}\n${selectionChangeEvent.newSelection}");
+      // throw AssertionError(
+      //     "An expanded selection reported a SelectionChangeType for a collapsed selection: ${selectionChangeEvent.changeType}\n${selectionChangeEvent.newSelection}");
       case SelectionChangeType.clearSelection:
-        throw AssertionError("Expected a collapsed selection but there was no selection.");
+      // throw AssertionError("Expected a collapsed selection but there was no selection.");
     }
   }
 


### PR DESCRIPTION
This PR includes minor changes we would like to get shipped with https://github.com/superlistapp/super_editor/pull/2038.

- Enable providing custom edit request handlers by constructor
- Enable providing the trigger tby constuctor (default to '@')
- Make the removeSlackComposingTokenAttribution method public
- Provide a way to set value on the SlackTagIndex
- Replace print() statements with logger.
- Remove 2 AssertionError thrown when running on Android. They lead to the editor stuck in an unusable state. Removed because the situation happen without encountering any edge case. Normal usage.