### PR TITLE
[SuperEditor][Mobile] Fix crash on long press over non-text node (Resolves #2126)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/android/long_press_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/long_press_selection.dart
@@ -222,10 +222,12 @@ class AndroidDocumentLongPressSelectionStrategy {
 
     final isOverNonTextNode = fingerDocumentPosition.nodePosition is! TextNodePosition;
     if (isOverNonTextNode) {
-      // The user is dragging over content that isn't text, therefore it doesn't have
-      // a concept of "words". Select the whole node.
-      longPressSelectionLog.finer("Dragging over non-text node. Selecting the whole node.");
-      _select(_longPressInitialSelection!.expandTo(fingerDocumentPosition));
+      if (fingerDocumentPosition.nodeId != _longPressInitialSelection!.base.nodeId) {
+        // The user is dragging over content that isn't text, therefore it doesn't have
+        // a concept of "words". Select the whole node.
+        longPressSelectionLog.finer("Dragging over non-text node. Selecting the whole node.");
+        _select(_longPressInitialSelection!.expandTo(fingerDocumentPosition));
+      }
       return;
     }
 

--- a/super_editor/lib/src/infrastructure/platforms/android/long_press_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/long_press_selection.dart
@@ -222,6 +222,9 @@ class AndroidDocumentLongPressSelectionStrategy {
 
     final isOverNonTextNode = fingerDocumentPosition.nodePosition is! TextNodePosition;
     if (isOverNonTextNode) {
+      // Don't change selection if the user long-presses over a non-text node and then
+      // moves the finger over the same node. This prevents the selection from collapsing
+      // when the user moves the finger towards the starting edge of the node.
       if (fingerDocumentPosition.nodeId != _longPressInitialSelection!.base.nodeId) {
         // The user is dragging over content that isn't text, therefore it doesn't have
         // a concept of "words". Select the whole node.

--- a/super_editor/lib/src/infrastructure/platforms/ios/long_press_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/long_press_selection.dart
@@ -85,6 +85,9 @@ class IosLongPressSelectionStrategy {
 
     final isOverNonTextNode = fingerDocumentPosition.nodePosition is! TextNodePosition;
     if (isOverNonTextNode) {
+      // Don't change selection if the user long-presses over a non-text node and then
+      // moves the finger over the same node. This prevents the selection from collapsing
+      // when the user moves the finger towards the starting edge of the node.
       if (fingerDocumentPosition.nodeId != _longPressInitialSelection!.base.nodeId) {
         // The user is dragging over content that isn't text, therefore it doesn't have
         // a concept of "words". Select the whole node.

--- a/super_editor/lib/src/infrastructure/platforms/ios/long_press_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/long_press_selection.dart
@@ -2,6 +2,7 @@ import 'package:flutter/rendering.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -44,7 +45,22 @@ class IosLongPressSelectionStrategy {
       return false;
     }
 
-    _longPressInitialSelection = getWordSelection(docPosition: docPosition, docLayout: _docLayout);
+    if (docPosition.nodePosition is! TextNodePosition) {
+      // Select the whole node.
+      _longPressInitialSelection = DocumentSelection(
+        base: DocumentPosition(
+          nodeId: docPosition.nodeId,
+          nodePosition: UpstreamDownstreamNodePosition.upstream(),
+        ),
+        extent: DocumentPosition(
+          nodeId: docPosition.nodeId,
+          nodePosition: UpstreamDownstreamNodePosition.downstream(),
+        ),
+      );
+    } else {
+      _longPressInitialSelection = getWordSelection(docPosition: docPosition, docLayout: _docLayout);
+    }
+
     _select(_longPressInitialSelection!);
     return true;
   }
@@ -69,9 +85,11 @@ class IosLongPressSelectionStrategy {
 
     final isOverNonTextNode = fingerDocumentPosition.nodePosition is! TextNodePosition;
     if (isOverNonTextNode) {
-      // The user is dragging over content that isn't text, therefore it doesn't have
-      // a concept of "words". Select the whole node.
-      _select(_longPressInitialSelection!.expandTo(fingerDocumentPosition));
+      if (fingerDocumentPosition.nodeId != _longPressInitialSelection!.base.nodeId) {
+        // The user is dragging over content that isn't text, therefore it doesn't have
+        // a concept of "words". Select the whole node.
+        _select(_longPressInitialSelection!.expandTo(fingerDocumentPosition));
+      }
       return;
     }
 

--- a/super_editor/test/super_editor/mobile/super_editor_android_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_selection_test.dart
@@ -1,3 +1,6 @@
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/magnifier.dart';
@@ -421,6 +424,130 @@ void main() {
               extent: DocumentPosition(
                 nodeId: "1",
                 nodePosition: TextNodePosition(offset: _wordIncididuntEnd),
+              ),
+            ),
+          );
+
+          // Release the gesture so the test system doesn't complain.
+          await gesture.up();
+          await tester.pump();
+        });
+
+        testWidgetsOnAndroid("selects an image and then by word when jumping down", (tester) async {
+          await tester
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ImageNode(id: '1', imageUrl: ''),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('Lorem ipsum dolor'),
+                    )
+                  ],
+                ),
+              )
+              .withAddedComponents(
+            [
+              const FakeImageComponentBuilder(
+                size: Size(100, 100),
+              ),
+            ],
+          ).pump();
+
+          // Long press near the top of the image.
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final gesture = await tester.startGesture(tapDownOffset);
+          await tester.pump(kLongPressTimeout + kPressTimeout);
+
+          // Ensure the image was selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection(
+              base: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.upstream()),
+              extent: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.downstream()),
+            ),
+          );
+
+          // Drag down from the image to the begining of the paragraph.
+          const dragIncrementCount = 10;
+          final verticalDragDistance =
+              Offset(0, (tester.getTopLeft(find.byType(TextComponent)).dy - tapDownOffset.dy) / dragIncrementCount);
+          for (int i = 0; i < dragIncrementCount; i += 1) {
+            await gesture.moveBy(verticalDragDistance);
+            await tester.pump();
+          }
+
+          // Ensure the selection begins at the image and goes to the end of "Lorem".
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.upstream()),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 5),
+              ),
+            ),
+          );
+
+          // Release the gesture so the test system doesn't complain.
+          await gesture.up();
+          await tester.pump();
+        });
+
+        testWidgetsOnAndroid("selects an image and then by word when jumping up", (tester) async {
+          await tester
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('Lorem ipsum dolor'),
+                    ),
+                    ImageNode(id: '2', imageUrl: ''),
+                  ],
+                ),
+              )
+              .withAddedComponents(
+            [
+              const FakeImageComponentBuilder(
+                size: Size(100, 100),
+              ),
+            ],
+          ).pump();
+
+          // Long press near the top of the image.
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final gesture = await tester.startGesture(tapDownOffset);
+          await tester.pump(kLongPressTimeout + kPressTimeout);
+
+          // Ensure the image was selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection(
+              base: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.upstream()),
+              extent: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.downstream()),
+            ),
+          );
+
+          // Drag up from the image to the begining of the paragraph.
+          const dragIncrementCount = 10;
+          final verticalDragDistance =
+              Offset(0, (tester.getTopLeft(find.byType(TextComponent)).dy - tapDownOffset.dy) / dragIncrementCount);
+          for (int i = 0; i < dragIncrementCount; i += 1) {
+            await gesture.moveBy(verticalDragDistance);
+            await tester.pump();
+          }
+
+          // Ensure the selection begins at the image and goes to the beginning of the paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.downstream()),
+              extent: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 0),
               ),
             ),
           );


### PR DESCRIPTION
[SuperEditor][Mobile] Fix crash on long press over non-text node. Resolves #2126.

Long-pressing on a non-text node, such as an image or a horizontal rule causes the editor to crash, and prevents the selection with the following exception:

```console
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Null check operator used on a null value
#0      IosLongPressSelectionStrategy.onLongPressStart (package:super_editor/src/infrastructure/platforms/ios/long_press_selection.dart:48:39)
#1      _IosDocumentTouchInteractorState._onLongPressDown (package:super_editor/src/default_editor/document_gestures_touch_ios.dart:610:60)
#2      Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
#3      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398:19)
#4      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429:5)
#5      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
```

A similar crash also happens on Android.

The issue is that we are assuming that the long-press selection always starts at a text node, which isn't the case.

This PR changes the long-press selection strategy to handle the case where the selection starts at a non-text node.

[android_long_press.webm](https://github.com/superlistapp/super_editor/assets/7597082/c23f1113-7bfe-4612-9de6-33a5aec3b7a7)


