### PR TITLE
Cherry-pick "[AttributedText] - Replace clear() with methods that explicitly state what they clear (Resolves #2094) (#2125)" to stable

### DIFF
--- a/super_editor/example/lib/demos/example_editor/_toolbar.dart
+++ b/super_editor/example/lib/demos/example_editor/_toolbar.dart
@@ -423,7 +423,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
     ]);
 
     // Clear the field and hide the URL bar
-    _urlController!.clear();
+    _urlController!.clearTextAndSelection();
     setState(() {
       _showUrlField = false;
       _urlFocusNode.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
@@ -733,7 +733,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
                 setState(() {
                   _urlFocusNode.unfocus();
                   _showUrlField = false;
-                  _urlController!.clear();
+                  _urlController!.clearTextAndSelection();
                 });
               },
             ),

--- a/super_editor/example_docs/lib/toolbar.dart
+++ b/super_editor/example_docs/lib/toolbar.dart
@@ -282,7 +282,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
     ]);
 
     // Clear the field and hide the URL bar
-    _urlController!.clear();
+    _urlController!.clearTextAndSelection();
     _urlFocusNode.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
     _linkPopoverController.close();
     setState(() {});
@@ -1188,7 +1188,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
               onPressed: () {
                 setState(() {
                   _urlFocusNode.unfocus();
-                  _urlController!.clear();
+                  _urlController!.clearTextAndSelection();
                 });
               },
             ),

--- a/super_editor/lib/src/super_textfield/infrastructure/attributed_text_editing_controller.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/attributed_text_editing_controller.dart
@@ -659,13 +659,31 @@ class AttributedTextEditingController with ChangeNotifier {
     return text.computeTextSpan(styleBuilder);
   }
 
-  void clear() {
+  /// Clears the text, composing attributions, composing region, and moves
+  /// the collapsed selection to the start of the now empty text controller.
+  void clearText() {
+    _text = AttributedText();
+    _selection = const TextSelection.collapsed(offset: 0);
+    _composingAttributions.clear();
+    _composingRegion = TextRange.empty;
+
+    notifyListeners();
+  }
+
+  /// Clears the text, selection, composing attributions, and composing region.
+  void clearTextAndSelection() {
     _text = AttributedText();
     _selection = const TextSelection.collapsed(offset: -1);
     _composingAttributions.clear();
     _composingRegion = TextRange.empty;
 
     notifyListeners();
+  }
+
+  /// Clears the text, selection, composing attributions, and composing region.
+  @Deprecated('This will be removed in a future release. Use clearText or clearTextAndSelection instead')
+  void clear() {
+    clearTextAndSelection();
   }
 
   //------ START: Methods moved here from extension methods ---------

--- a/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
+++ b/super_editor/lib/src/super_textfield/input_method_engine/_ime_text_editing_controller.dart
@@ -636,7 +636,19 @@ class ImeAttributedTextEditingController extends AttributedTextEditingController
   }
 
   @override
+  void clearText() {
+    _realController.clearText();
+  }
+
+  @override
+  void clearTextAndSelection() {
+    _realController.clearTextAndSelection();
+  }
+
+  @override
+  @Deprecated('This will be removed in a future release. Use clearText or clearTextAndSelection instead')
   void clear() {
+    // ignore: deprecated_member_use_from_same_package
     _realController.clear();
   }
 

--- a/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
+++ b/super_editor/test/super_textfield/attributed_text_editing_controller_test.dart
@@ -803,18 +803,81 @@ void main() {
       });
     });
 
-    group("clear", () {
-      test('notifies listeners', () {
+    group("clearing text and selection", () {
+      test("can remove the text, selection, and composing region at the same time", () {
         int listenerNotifyCount = 0;
-
         final controller = AttributedTextEditingController(
           text: AttributedText('my text'),
-        )..addListener(() {
+          selection: TextSelection.collapsed(offset: 7),
+          composingRegion: TextRange(start: 3, end: 7),
+        )
+          ..composingAttributions = {
+            boldAttribution,
+          }
+          ..addListener(() {
             listenerNotifyCount += 1;
           });
 
+        controller.clearTextAndSelection();
+
+        expect(controller.text.text, isEmpty);
+        expect(
+          controller.selection,
+          const TextSelection.collapsed(offset: -1),
+        );
+        expect(controller.composingAttributions, isEmpty);
+        expect(controller.composingRegion, TextRange.empty);
+        expect(listenerNotifyCount, 1);
+
+        // Below here we want to validate that the old deprecated method
+        // .clear() does exactly the same thing as its replacement method
+        // .clearTextAndSelection().
+        //
+        // As soon as the deprecated method is removed, the below code will
+        // throw a compile error, at which time it will be safe to remove it.
+        controller
+          ..text = AttributedText('my text')
+          ..selection = TextSelection.collapsed(offset: 7)
+          ..composingRegion = TextRange(start: 3, end: 7)
+          ..composingAttributions = {boldAttribution};
+        listenerNotifyCount = 0;
+
+        // ignore: deprecated_member_use_from_same_package
         controller.clear();
 
+        expect(controller.text.text, isEmpty);
+        expect(
+          controller.selection,
+          const TextSelection.collapsed(offset: -1),
+        );
+        expect(controller.composingAttributions, isEmpty);
+        expect(controller.composingRegion, TextRange.empty);
+        expect(listenerNotifyCount, 1);
+      });
+
+      test("can remove the text and composing region, and place the caret at the start, at the same time", () {
+        int listenerNotifyCount = 0;
+        final controller = AttributedTextEditingController(
+          text: AttributedText('my text'),
+          selection: TextSelection.collapsed(offset: 7),
+          composingRegion: TextRange(start: 3, end: 7),
+        )
+          ..composingAttributions = {
+            boldAttribution,
+          }
+          ..addListener(() {
+            listenerNotifyCount += 1;
+          });
+
+        controller.clearText();
+
+        expect(controller.text.text, isEmpty);
+        expect(
+          controller.selection,
+          const TextSelection.collapsed(offset: 0),
+        );
+        expect(controller.composingAttributions, isEmpty);
+        expect(controller.composingRegion, TextRange.empty);
         expect(listenerNotifyCount, 1);
       });
     });

--- a/website/lib/homepage/editor_toolbar.dart
+++ b/website/lib/homepage/editor_toolbar.dart
@@ -401,7 +401,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
     ]);
 
     // Clear the field and hide the URL bar
-    _urlController!.clear();
+    _urlController!.clearTextAndSelection();
     setState(() {
       _showUrlField = false;
       _urlFocusNode.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
@@ -695,7 +695,7 @@ class _EditorToolbarState extends State<EditorToolbar> {
                 setState(() {
                   _urlFocusNode.unfocus();
                   _showUrlField = false;
-                  _urlController!.clear();
+                  _urlController!.clearTextAndSelection();
                 });
               },
             ),


### PR DESCRIPTION
This PR cherry-picks "[AttributedText] - Replace clear() with methods that explicitly state what they clear (Resolves #2094) (#2125)" to stable.