### PR TITLE
Fix: switch super_editor_quill to local super_editor and add missing interface APIs

### DIFF
--- a/super_editor_quill/lib/src/content/multimedia.dart
+++ b/super_editor_quill/lib/src/content/multimedia.dart
@@ -11,6 +11,11 @@ class VideoNode extends UrlMediaNode {
     super.altText = '',
     super.blockAttribution = videoAttribution,
   });
+
+  @override
+  DocumentNode copy() {
+    return VideoNode(id: id, url: url, altText: altText, blockAttribution: blockquoteAttribution);
+  }
 }
 
 /// [DocumentNode] that represents an audio source at a URL.
@@ -23,6 +28,11 @@ class AudioNode extends UrlMediaNode {
     super.altText = '',
     super.blockAttribution = audioAttribution,
   });
+
+  @override
+  DocumentNode copy() {
+    return AudioNode(id: id, url: url, altText: altText, blockAttribution: blockquoteAttribution);
+  }
 }
 
 /// [DocumentNode] that represents a file at a URL.
@@ -35,6 +45,11 @@ class FileNode extends UrlMediaNode {
     super.altText = '',
     super.blockAttribution = fileAttribution,
   });
+
+  @override
+  DocumentNode copy() {
+    return FileNode(id: id, url: url, altText: altText, blockAttribution: blockquoteAttribution);
+  }
 }
 
 /// [DocumentNode] that represents a media source that exists a given [url].
@@ -84,6 +99,17 @@ class UrlMediaNode extends BlockNode with ChangeNotifier {
   @override
   bool hasEquivalentContent(DocumentNode other) {
     return other is UrlMediaNode && url == other.url && altText == other.altText;
+  }
+
+  @override
+  DocumentNode copy() {
+    return UrlMediaNode(
+      id: id,
+      url: url,
+      altText: altText,
+      blockAttribution: getMetadataValue("blockType"),
+      metadata: metadata,
+    );
   }
 
   @override

--- a/super_editor_quill/pubspec.yaml
+++ b/super_editor_quill/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   dart_quill_delta: ^9.4.1
   collection: ^1.18.0
 
-#dependency_overrides:
-#  super_editor:
-#    path: ../super_editor
+dependency_overrides:
+  super_editor:
+    path: ../super_editor
 #  attributed_text:
 #    path: ../attributed_text
 

--- a/super_editor_quill/pubspec.yaml
+++ b/super_editor_quill/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
 dependency_overrides:
   super_editor:
     path: ../super_editor
+  super_text_layout:
+    path: ../super_text_layout
 #  attributed_text:
 #    path: ../attributed_text
 


### PR DESCRIPTION
Fix: switch super_editor_quill to local super_editor and add missing interface APIs

This PR should fix CI failures for super_editor_quill on `stable`.