### PR TITLE
Remove nodes list from Document to make Document immutable at API level (Resolves #2156)

### DIFF
--- a/super_editor/clones/quill/lib/app.dart
+++ b/super_editor/clones/quill/lib/app.dart
@@ -126,7 +126,7 @@ class _AlwaysTrailingParagraphReaction extends EditReaction {
   @override
   void modifyContent(EditContext editorContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
     final document = editorContext.find<MutableDocument>(Editor.documentKey);
-    final lastNode = document.nodes.lastOrNull;
+    final lastNode = document.lastOrNull;
 
     if (lastNode != null &&
         lastNode is ParagraphNode &&
@@ -140,7 +140,7 @@ class _AlwaysTrailingParagraphReaction extends EditReaction {
     // We need to insert a trailing empty paragraph.
     requestDispatcher.execute([
       InsertNodeAtIndexRequest(
-        nodeIndex: document.nodes.length,
+        nodeIndex: document.nodeCount,
         newNode: ParagraphNode(
           id: Editor.createNodeId(),
           text: AttributedText(""),

--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -63,7 +63,7 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
     setState(() {
       _actions.clear();
 
-      for (final node in _document.nodes) {
+      for (final node in _document) {
         if (node is! TextNode) {
           continue;
         }

--- a/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
@@ -64,7 +64,7 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
     setState(() {
       _users.clear();
 
-      for (final node in _document.nodes) {
+      for (final node in _document) {
         if (node is! TextNode) {
           continue;
         }

--- a/super_editor/example/lib/demos/super_reader/demo_super_reader.dart
+++ b/super_editor/example/lib/demos/super_reader/demo_super_reader.dart
@@ -109,19 +109,18 @@ class _SuperReaderDemoState extends State<SuperReaderDemo> {
   }
 
   void _selectAll() {
-    final nodes = _document.nodes;
-    if (nodes.isEmpty) {
+    if (_document.isEmpty) {
       return;
     }
 
     _selection.value = DocumentSelection(
       base: DocumentPosition(
-        nodeId: nodes.first.id,
-        nodePosition: nodes.first.beginningPosition,
+        nodeId: _document.first.id,
+        nodePosition: _document.first.beginningPosition,
       ),
       extent: DocumentPosition(
-        nodeId: nodes.last.id,
-        nodePosition: nodes.last.endPosition,
+        nodeId: _document.last.id,
+        nodePosition: _document.last.endPosition,
       ),
     );
   }

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -31,8 +31,8 @@ class _MarketingVideoState extends State<MarketingVideo> {
     _composer = MutableDocumentComposer(
       initialSelection: DocumentSelection.collapsed(
         position: DocumentPosition(
-          nodeId: _document.nodes.first.id,
-          nodePosition: _document.nodes.first.endPosition,
+          nodeId: _document.first.id,
+          nodePosition: _document.first.endPosition,
         ),
       ),
     );
@@ -309,12 +309,12 @@ class DocumentEditingRobot {
             ChangeSelectionRequest(
               DocumentSelection(
                 base: DocumentPosition(
-                  nodeId: _document.nodes.first.id,
-                  nodePosition: _document.nodes.first.beginningPosition,
+                  nodeId: _document.first.id,
+                  nodePosition: _document.first.beginningPosition,
                 ),
                 extent: DocumentPosition(
-                  nodeId: _document.nodes.last.id,
-                  nodePosition: _document.nodes.last.endPosition,
+                  nodeId: _document.last.id,
+                  nodePosition: _document.last.endPosition,
                 ),
               ),
               SelectionChangeType.expandSelection,

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -28,11 +28,11 @@ abstract class Document implements Iterable<DocumentNode> {
 
   /// Returns the first [DocumentNode] in this [Document], or `null` if this
   /// [Document] is empty.
-  DocumentNode? get firstNodeOrNull;
+  DocumentNode? get firstOrNull;
 
   /// Returns the last [DocumentNode] in this [Document], or `null` if this
   /// [Document] is empty.
-  DocumentNode? get lastNodeOrNull;
+  DocumentNode? get lastOrNull;
 
   /// Returns the [DocumentNode] with the given [nodeId], or [null]
   /// if no such node exists.

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -17,10 +17,22 @@ import 'package:flutter/widgets.dart';
 /// content.
 ///
 /// To edit the content of a document, see [DocumentEditor].
-abstract class Document {
-  /// Returns all of the content within the document as a list
-  /// of [DocumentNode]s.
-  List<DocumentNode> get nodes;
+abstract class Document implements Iterable<DocumentNode> {
+  /// The number of [DocumentNode]s in this [Document].
+  int get nodeCount;
+
+  /// Returns `true` if this [Document] has zero nodes, or `false` if it
+  /// has `1+ nodes.
+  @override
+  bool get isEmpty;
+
+  /// Returns the first [DocumentNode] in this [Document], or `null` if this
+  /// [Document] is empty.
+  DocumentNode? get firstNodeOrNull;
+
+  /// Returns the last [DocumentNode] in this [Document], or `null` if this
+  /// [Document] is empty.
+  DocumentNode? get lastNodeOrNull;
 
   /// Returns the [DocumentNode] with the given [nodeId], or [null]
   /// if no such node exists.
@@ -240,7 +252,7 @@ class DocumentPosition {
   ///
   /// ```dart
   /// final documentPosition = DocumentPosition(
-  ///   nodeId: documentEditor.document.nodes.first.id,
+  ///   nodeId: documentEditor.document.first.id,
   ///   nodePosition: TextNodePosition(offset: 1),
   /// );
   /// ```

--- a/super_editor/lib/src/core/document_selection.dart
+++ b/super_editor/lib/src/core/document_selection.dart
@@ -376,11 +376,9 @@ extension InspectDocumentSelection on Document {
   /// from upstream to downstream.
   List<DocumentNode> getNodesInContentOrder(DocumentSelection selection) {
     final upstreamPosition = selectUpstreamPosition(selection.base, selection.extent);
-    final upstreamIndex = getNodeIndexById(upstreamPosition.nodeId);
     final downstreamPosition = selectDownstreamPosition(selection.base, selection.extent);
-    final downstreamIndex = getNodeIndexById(downstreamPosition.nodeId);
 
-    return nodes.sublist(upstreamIndex, downstreamIndex + 1);
+    return getNodesInside(upstreamPosition, downstreamPosition);
   }
 
   /// Given [docPosition1] and [docPosition2], returns the `DocumentPosition` that

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -1043,10 +1043,10 @@ class MutableDocument with Iterable<DocumentNode> implements Document, Editable 
   Iterator<DocumentNode> get iterator => _nodes.iterator;
 
   @override
-  DocumentNode? get firstNodeOrNull => _nodes.lastOrNull;
+  DocumentNode? get firstOrNull => _nodes.lastOrNull;
 
   @override
-  DocumentNode? get lastNodeOrNull => _nodes.lastOrNull;
+  DocumentNode? get lastOrNull => _nodes.lastOrNull;
 
   @override
   DocumentNode? getNodeById(String nodeId) {

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -631,7 +631,7 @@ class MergeRapidTextInputPolicy implements HistoryGroupingPolicy {
       return TransactionMerge.noOpinion;
     }
 
-    if (newTransaction.firstChangeTime.difference(previousTransaction.lastChangeTime!) > _maxMergeTime) {
+    if (newTransaction.firstChangeTime.difference(previousTransaction.lastChangeTime) > _maxMergeTime) {
       // The text insertions were far enough apart in time that we don't want to merge them.
       return TransactionMerge.noOpinion;
     }
@@ -989,7 +989,7 @@ class FunctionalEditListener implements EditListener {
 }
 
 /// An in-memory, mutable [Document].
-class MutableDocument implements Document, Editable {
+class MutableDocument with Iterable<DocumentNode> implements Document, Editable {
   /// Creates an in-memory, mutable version of a [Document].
   ///
   /// Initializes the content of this [MutableDocument] with the given [nodes],
@@ -1026,7 +1026,10 @@ class MutableDocument implements Document, Editable {
   final List<DocumentNode> _nodes;
 
   @override
-  List<DocumentNode> get nodes => UnmodifiableListView(_nodes);
+  int get nodeCount => _nodes.length;
+
+  @override
+  bool get isEmpty => _nodes.isEmpty;
 
   /// Maps a node id to its index in the node list.
   final Map<String, int> _nodeIndicesById = {};
@@ -1035,6 +1038,15 @@ class MutableDocument implements Document, Editable {
   final Map<String, DocumentNode> _nodesById = {};
 
   final _listeners = <DocumentChangeListener>[];
+
+  @override
+  Iterator<DocumentNode> get iterator => _nodes.iterator;
+
+  @override
+  DocumentNode? get firstNodeOrNull => _nodes.lastOrNull;
+
+  @override
+  DocumentNode? get lastNodeOrNull => _nodes.lastOrNull;
 
   @override
   DocumentNode? getNodeById(String nodeId) {
@@ -1206,13 +1218,12 @@ class MutableDocument implements Document, Editable {
   /// ignores the runtime type of the [Document], itself.
   @override
   bool hasEquivalentContent(Document other) {
-    final otherNodes = other.nodes;
-    if (_nodes.length != otherNodes.length) {
+    if (_nodes.length != other.nodeCount) {
       return false;
     }
 
     for (int i = 0; i < _nodes.length; ++i) {
-      if (!_nodes[i].hasEquivalentContent(otherNodes[i])) {
+      if (!_nodes[i].hasEquivalentContent(other.getNodeAt(i)!)) {
         return false;
       }
     }
@@ -1277,7 +1288,7 @@ class MutableDocument implements Document, Editable {
       identical(this, other) ||
       other is MutableDocument &&
           runtimeType == other.runtimeType &&
-          const DeepCollectionEquality().equals(_nodes, other.nodes);
+          const DeepCollectionEquality().equals(_nodes, other._nodes);
 
   @override
   int get hashCode => _nodes.hashCode;

--- a/super_editor/lib/src/core/styles.dart
+++ b/super_editor/lib/src/core/styles.dart
@@ -216,7 +216,7 @@ class _LastBlockMatcher implements _BlockMatcher {
 
   @override
   bool matches(Document document, DocumentNode node) {
-    return document.getNodeIndexById(node.id) == document.nodes.length - 1;
+    return document.getNodeIndexById(node.id) == document.nodeCount - 1;
   }
 }
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -209,8 +209,7 @@ class CommonEditorOperations {
   ///
   /// Always returns [true].
   bool selectAll() {
-    final nodes = document.nodes;
-    if (nodes.isEmpty) {
+    if (document.isEmpty) {
       return false;
     }
 
@@ -218,12 +217,12 @@ class CommonEditorOperations {
       ChangeSelectionRequest(
         DocumentSelection(
           base: DocumentPosition(
-            nodeId: nodes.first.id,
-            nodePosition: nodes.first.beginningPosition,
+            nodeId: document.first.id,
+            nodePosition: document.first.beginningPosition,
           ),
           extent: DocumentPosition(
-            nodeId: nodes.last.id,
-            nodePosition: nodes.last.endPosition,
+            nodeId: document.last.id,
+            nodePosition: document.last.endPosition,
           ),
         ),
         SelectionChangeType.expandSelection,
@@ -665,11 +664,11 @@ class CommonEditorOperations {
       return false;
     }
 
-    if (document.nodes.isEmpty) {
+    if (document.isEmpty) {
       return false;
     }
 
-    final firstNode = document.nodes.first;
+    final firstNode = document.first;
 
     if (expand) {
       final currentExtentNode = document.getNodeById(composer.selection!.extent.nodeId);
@@ -729,11 +728,11 @@ class CommonEditorOperations {
       return false;
     }
 
-    if (document.nodes.isEmpty) {
+    if (document.isEmpty) {
       return false;
     }
 
-    final lastNode = document.nodes.last;
+    final lastNode = document.last;
 
     if (expand) {
       final currentExtentNode = document.getNodeById(composer.selection!.extent.nodeId);

--- a/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
@@ -164,17 +164,17 @@ class SingleColumnLayoutPresenter {
       // The document changed. All view models were invalidated. Create a
       // new base document view model.
       final viewModels = <SingleColumnLayoutComponentViewModel>[];
-      for (int i = 0; i < _document.nodes.length; i += 1) {
+      for (int i = 0; i < _document.nodeCount; i += 1) {
         SingleColumnLayoutComponentViewModel? viewModel;
         for (final builder in _componentBuilders) {
-          viewModel = builder.createViewModel(_document, _document.nodes[i]);
+          viewModel = builder.createViewModel(_document, _document.getNodeAt(i)!);
           if (viewModel != null) {
             break;
           }
         }
         if (viewModel == null) {
           throw Exception(
-              "Couldn't find styler to create component for document node: ${_document.nodes[i].runtimeType}");
+              "Couldn't find styler to create component for document node: ${_document.getNodeAt(i)!.runtimeType}");
         }
         viewModels.add(viewModel);
       }

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -22,7 +22,7 @@ class PasteStructuredContentEditorRequest implements EditRequest {
     required this.pastePosition,
   });
 
-  final List<DocumentNode> content;
+  final Document content;
   final DocumentPosition pastePosition;
 }
 
@@ -30,12 +30,12 @@ class PasteStructuredContentEditorRequest implements EditRequest {
 /// given paste position within the document.
 class PasteStructuredContentEditorCommand extends EditCommand {
   PasteStructuredContentEditorCommand({
-    required List<DocumentNode> content,
+    required Document content,
     required DocumentPosition pastePosition,
   })  : _content = content,
         _pastePosition = pastePosition;
 
-  final List<DocumentNode> _content;
+  final Document _content;
   final DocumentPosition _pastePosition;
 
   @override
@@ -127,7 +127,7 @@ class PasteStructuredContentEditorCommand extends EditCommand {
   void _pasteMultipleNodes(
     CommandExecutor executor,
     MutableDocument document,
-    List<DocumentNode> pastedNodes,
+    Document pastedNodes,
     TextNode currentNodeWithSelection,
   ) {
     final textNode = document.getNode(_pastePosition) as TextNode;
@@ -865,7 +865,7 @@ class DeleteContentCommand extends EditCommand {
 
     _log.log('_deleteNodesBetweenFirstAndLast', ' - start node index: $startIndex');
     _log.log('_deleteNodesBetweenFirstAndLast', ' - end node index: $endIndex');
-    _log.log('_deleteNodesBetweenFirstAndLast', ' - initially ${document.nodes.length} nodes');
+    _log.log('_deleteNodesBetweenFirstAndLast', ' - initially ${document.nodeCount} nodes');
 
     // Remove nodes from last to first so that indices don't get
     // screwed up during removal.

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -913,7 +913,7 @@ class UnIndentTaskCommand extends EditCommand {
 
     final subTasks = <TaskNode>[];
     int index = document.getNodeIndexById(task.id) + 1;
-    while (index < document.nodes.length) {
+    while (index < document.nodeCount) {
       final subTask = document.getNodeAt(index);
       if (subTask is! TaskNode) {
         break;
@@ -1006,7 +1006,7 @@ class UpdateSubTaskIndentAfterTaskDeletionReaction extends EditReaction {
     final document = editorContext.find<MutableDocument>(Editor.documentKey);
     final changeIndentationRequests = <EditRequest>[];
     int maxIndentation = 0;
-    for (int i = 0; i < document.nodes.length; i += 1) {
+    for (int i = 0; i < document.nodeCount; i += 1) {
       final node = document.getNodeAt(i);
       if (node is! TaskNode) {
         // This node isn't a task. The first task in a list of tasks

--- a/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
@@ -71,7 +71,7 @@ class PatternTagPlugin extends SuperEditorPlugin {
   void _initializePatternTagIndex(Editor editor) {
     final document = editor.context.find<MutableDocument>(Editor.documentKey);
 
-    for (final node in document.nodes) {
+    for (final node in document) {
       if (node is! TextNode) {
         continue;
       }

--- a/super_editor/lib/src/document_operations/selection_operations.dart
+++ b/super_editor/lib/src/document_operations/selection_operations.dart
@@ -602,19 +602,18 @@ bool moveCaretDown({
 /// Returns `true` if any content was selected, or `false` if the document
 /// is empty.
 bool selectAll(Document document, ValueNotifier<DocumentSelection?> selection) {
-  final nodes = document.nodes;
-  if (nodes.isEmpty) {
+  if (document.isEmpty) {
     return false;
   }
 
   selection.value = DocumentSelection(
     base: DocumentPosition(
-      nodeId: nodes.first.id,
-      nodePosition: nodes.first.beginningPosition,
+      nodeId: document.first.id,
+      nodePosition: document.first.beginningPosition,
     ),
     extent: DocumentPosition(
-      nodeId: nodes.last.id,
-      nodePosition: nodes.last.endPosition,
+      nodeId: document.last.id,
+      nodePosition: document.last.endPosition,
     ),
   );
 

--- a/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
+++ b/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
@@ -58,7 +58,7 @@ class _AttributionBoundsState extends ContentLayerState<AttributionBounds, List<
   List<AttributionBoundsLayout>? computeLayoutData(Element? contentElement, RenderObject? contentLayout) {
     final bounds = <AttributionBoundsLayout>[];
 
-    for (final node in widget.document.nodes) {
+    for (final node in widget.document) {
       if (node is! TextNode) {
         continue;
       }

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -284,11 +284,11 @@ class SuperEditorInspector {
       throw Exception('SuperEditor not found');
     }
 
-    if (index >= doc.nodes.length) {
-      throw Exception('Tried to access index $index in a document where the max index is ${doc.nodes.length - 1}');
+    if (index >= doc.nodeCount) {
+      throw Exception('Tried to access index $index in a document where the max index is ${doc.nodeCount - 1}');
     }
 
-    final node = doc.nodes[index];
+    final node = doc.getNodeAt(index);
     if (node is! NodeType) {
       throw Exception('Tried to access a ${node.runtimeType} as $NodeType');
     }

--- a/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
+++ b/super_editor/lib/src/test/super_reader_test/super_reader_inspector.dart
@@ -145,11 +145,11 @@ class SuperReaderInspector {
       throw Exception('SuperReader not found');
     }
 
-    if (index >= doc.nodes.length) {
-      throw Exception('Tried to access index $index in a document where the max index is ${doc.nodes.length - 1}');
+    if (index >= doc.nodeCount) {
+      throw Exception('Tried to access index $index in a document where the max index is ${doc.nodeCount - 1}');
     }
 
-    final node = doc.nodes[index];
+    final node = doc.getNodeAt(index);
     if (node is! NodeType) {
       throw Exception('Tried to access a ${node.runtimeType} as $NodeType');
     }

--- a/super_editor/test/super_editor/bug_fix_test.dart
+++ b/super_editor/test/super_editor/bug_fix_test.dart
@@ -41,19 +41,19 @@ void main() {
         await tester.pressEnter();
 
         // Ensure we created the new nodes.
-        expect(document.nodes.length, 3);
+        expect(document.nodeCount, 3);
 
         // Select the new nodes.
         editor.execute([
           ChangeSelectionRequest(
             DocumentSelection(
               base: DocumentPosition(
-                nodeId: document.nodes[2].id,
-                nodePosition: document.nodes[2].endPosition,
+                nodeId: document.getNodeAt(2)!.id,
+                nodePosition: document.getNodeAt(2)!.endPosition,
               ),
               extent: DocumentPosition(
-                nodeId: document.nodes[1].id,
-                nodePosition: document.nodes[1].beginningPosition,
+                nodeId: document.getNodeAt(1)!.id,
+                nodePosition: document.getNodeAt(1)!.beginningPosition,
               ),
             ),
             SelectionChangeType.expandSelection,
@@ -68,12 +68,12 @@ void main() {
 
         // Bug #429 - the deletion threw an error due to a selection
         // type mismatch.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.isCollapsed, true);
         expect(
           composer.selection!.extent,
           DocumentPosition(
-            nodeId: document.nodes.last.id,
+            nodeId: document.last.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         );
@@ -117,12 +117,12 @@ void main() {
           ChangeSelectionRequest(
             DocumentSelection(
               base: DocumentPosition(
-                nodeId: document.nodes[1].id,
-                nodePosition: document.nodes[1].beginningPosition,
+                nodeId: document.getNodeAt(1)!.id,
+                nodePosition: document.getNodeAt(1)!.beginningPosition,
               ),
               extent: DocumentPosition(
-                nodeId: document.nodes[2].id,
-                nodePosition: document.nodes[2].endPosition,
+                nodeId: document.getNodeAt(2)!.id,
+                nodePosition: document.getNodeAt(2)!.endPosition,
               ),
             ),
             SelectionChangeType.expandSelection,
@@ -138,12 +138,12 @@ void main() {
         // The bug was a problem with an expanded upstream selection.
         // Here we make sure that deleting an expanded downstream
         // selection works, too.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.isCollapsed, true);
         expect(
           composer.selection!.extent,
           DocumentPosition(
-            nodeId: document.nodes.last.id,
+            nodeId: document.last.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         );

--- a/super_editor/test/super_editor/components/block_node_test.dart
+++ b/super_editor/test/super_editor/components/block_node_test.dart
@@ -437,7 +437,7 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.extent.nodeId, "1");
         expect((composer.selection!.extent.nodePosition as TextNodePosition).offset, 20);
       });
@@ -456,7 +456,7 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.extent.nodeId, "3");
         expect((composer.selection!.extent.nodePosition as TextNodePosition).offset, 0);
       });
@@ -475,7 +475,7 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 1);
+        expect(document.nodeCount, 1);
         expect(composer.selection!.extent.nodeId, "1");
         expect((composer.selection!.extent.nodePosition as TextNodePosition).offset, 20);
       });
@@ -529,7 +529,7 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.extent.nodePosition, isA<TextNodePosition>());
         expect((composer.selection!.extent.nodePosition as TextNodePosition).offset, 0);
         expect(document.getNodeAt(0)!.id, composer.selection!.extent.nodeId);
@@ -548,7 +548,7 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(composer.selection!.extent.nodePosition, isA<TextNodePosition>());
         expect((composer.selection!.extent.nodePosition as TextNodePosition).offset, 0);
         expect(document.getNodeAt(1)!.id, composer.selection!.extent.nodeId);
@@ -569,9 +569,9 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
-        expect(document.nodes[0], isA<ParagraphNode>());
-        expect(document.nodes[1], isA<HorizontalRuleNode>());
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(0)!, isA<ParagraphNode>());
+        expect(document.getNodeAt(1)!, isA<HorizontalRuleNode>());
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 1));
       });
 
@@ -588,9 +588,9 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 2);
-        expect(document.nodes[0], isA<HorizontalRuleNode>());
-        expect(document.nodes[1], isA<ParagraphNode>());
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(0)!, isA<HorizontalRuleNode>());
+        expect(document.getNodeAt(1)!, isA<ParagraphNode>());
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 1));
       });
 
@@ -612,8 +612,8 @@ void main() {
         await tester.pump();
 
         expect(composer.selection!.isCollapsed, true);
-        expect(document.nodes.length, 1);
-        expect(document.nodes[0], isA<HorizontalRuleNode>());
+        expect(document.nodeCount, 1);
+        expect(document.getNodeAt(0)!, isA<HorizontalRuleNode>());
         expect(composer.selection!.extent.nodePosition, const UpstreamDownstreamNodePosition.upstream());
       });
     });

--- a/super_editor/test/super_editor/components/horizontal_rule_test.dart
+++ b/super_editor/test/super_editor/components/horizontal_rule_test.dart
@@ -26,15 +26,15 @@ Paragraph 2
 
       // Place the caret at the end of the horizontal rule, by first placing the caret in the paragraph after the
       // horizontal rule, and then pressing the left arrow to move it up.
-      await tester.placeCaretInParagraph(document.nodes.last.id, 0);
+      await tester.placeCaretInParagraph(document.last.id, 0);
       await tester.pressLeftArrow();
 
       // Type at the end of the horizontal rule
       await tester.typeImeText('new paragraph');
 
       // Ensure that the new text was inserted in a new paragraph after the horizontal rule.
-      expect(document.nodes.length, 4);
-      final insertedNode = document.nodes[2];
+      expect(document.nodeCount, 4);
+      final insertedNode = document.getNodeAt(2)!;
       expect(insertedNode, isA<ParagraphNode>());
       expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
       expect(
@@ -65,15 +65,15 @@ Paragraph 2
 
       // Place the caret at the beginning of the horizontal rule, by first placing the caret in the paragraph before the
       // horizontal rule, and then pressing the right arrow to move it down.
-      await tester.placeCaretInParagraph(document.nodes.first.id, 11);
+      await tester.placeCaretInParagraph(document.first.id, 11);
       await tester.pressRightArrow();
 
       // Type at the beginning of the horizontal rule
       await tester.typeImeText('new paragraph');
 
       // Ensure that the new text was inserted in a new paragraph before the horizontal rule.
-      expect(document.nodes.length, 4);
-      final insertedNode = document.nodes[1];
+      expect(document.nodeCount, 4);
+      final insertedNode = document.getNodeAt(1)!;
       expect(insertedNode, isA<ParagraphNode>());
       expect((insertedNode as ParagraphNode).text.text, 'new paragraph');
       expect(

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -28,7 +28,7 @@ void main() {
         expect(richText.text.style!.color, Colors.blue);
 
         // Tap to place caret.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Convert the list item to a paragraph.
         testContext.findEditContext().commonOps.convertToParagraph(
@@ -46,7 +46,7 @@ void main() {
         // Convert the paragraph back to an unordered list item.
         testContext.findEditContext().commonOps.convertToListItem(
               ListItemType.unordered,
-              (doc.nodes.first as ParagraphNode).text,
+              (doc.first as ParagraphNode).text,
             );
         await tester.pumpAndSettle();
 
@@ -72,7 +72,7 @@ void main() {
         expect(richText.text.style!.color, Colors.blue);
 
         // Tap to place caret.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Convert the list item to a paragraph.
         testContext.findEditContext().commonOps.convertToParagraph(
@@ -90,7 +90,7 @@ void main() {
         // Convert the paragraph back to an ordered list item.
         testContext.findEditContext().commonOps.convertToListItem(
               ListItemType.ordered,
-              (doc.nodes.first as ParagraphNode).text,
+              (doc.first as ParagraphNode).text,
             );
         await tester.pumpAndSettle();
 
@@ -106,7 +106,7 @@ void main() {
         await _pumpOrderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.first as ListItemNode;
+        final listItemNode = doc.first as ListItemNode;
 
         // Place caret at the first list item, which has one level of indentation.
         await tester.placeCaretInParagraph(listItemNode.id, 0);
@@ -149,7 +149,7 @@ void main() {
         await _pumpUnorderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.last as ListItemNode;
+        final listItemNode = doc.last as ListItemNode;
 
         // Place caret at the last list item, which has two levels of indentation.
         // For some reason, taping at the first character isn't displaying any caret,
@@ -195,7 +195,7 @@ void main() {
         await _pumpUnorderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.last as ListItemNode;
+        final listItemNode = doc.last as ListItemNode;
 
         // Place caret at the last list item, which has two levels of indentation.
         // For some reason, taping at the first character isn't displaying any caret,
@@ -222,7 +222,7 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.last.id, 6);
+        await tester.placeCaretInParagraph(document.last.id, 6);
 
         // Type at the end of the list item to generate a composing region,
         // simulating the Samsung keyboard.
@@ -239,22 +239,22 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -270,7 +270,7 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.first.id, 6);
 
         // Type at the end of the list item to generate a composing region,
         // simulating the Samsung keyboard.
@@ -287,22 +287,22 @@ void main() {
         await tester.typeImeText("\n");
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -318,7 +318,7 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.first.id, 6);
 
         // Type at the end of the list item to generate a composing region,
         // simulating the Samsung keyboard.
@@ -335,22 +335,22 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 12");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 12");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -366,24 +366,24 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // Press enter to split the existing item into two.
         await tester.pressEnter();
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -400,24 +400,24 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -434,24 +434,24 @@ void main() {
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // On iOS, pressing ENTER generates a newline action.
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -473,31 +473,31 @@ void main() {
    - Second unoredered item""") //
             .pump();
 
-        expect(context.document.nodes.length, 6);
+        expect(context.document.nodeCount, 6);
 
         // Ensure the nodes have the correct type.
-        expect(context.document.nodes[0], isA<ListItemNode>());
-        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(0), isA<ListItemNode>());
+        expect((context.document.getNodeAt(0) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[1], isA<ListItemNode>());
-        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(1), isA<ListItemNode>());
+        expect((context.document.getNodeAt(1) as ListItemNode).type, ListItemType.unordered);
 
-        expect(context.document.nodes[2], isA<ListItemNode>());
-        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(2), isA<ListItemNode>());
+        expect((context.document.getNodeAt(2) as ListItemNode).type, ListItemType.unordered);
 
-        expect(context.document.nodes[3], isA<ListItemNode>());
-        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(3), isA<ListItemNode>());
+        expect((context.document.getNodeAt(3) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[4], isA<ListItemNode>());
-        expect((context.document.nodes[4] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(4), isA<ListItemNode>());
+        expect((context.document.getNodeAt(4) as ListItemNode).type, ListItemType.unordered);
 
-        expect(context.document.nodes[5], isA<ListItemNode>());
-        expect((context.document.nodes[5] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(5), isA<ListItemNode>());
+        expect((context.document.getNodeAt(5) as ListItemNode).type, ListItemType.unordered);
 
         // Ensure the sequence was kept.
         final firstOrderedItem = tester.widget<OrderedListItemComponent>(
           find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[0].id)),
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.getNodeAt(0)!.id)),
             matching: find.byType(OrderedListItemComponent),
           ),
         );
@@ -505,7 +505,7 @@ void main() {
 
         final secondOrderedItem = tester.widget<OrderedListItemComponent>(
           find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[3].id)),
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.getNodeAt(3)!.id)),
             matching: find.byType(OrderedListItemComponent),
           ),
         );
@@ -526,21 +526,21 @@ void main() {
 """) //
             .pump();
 
-        expect(context.document.nodes.length, 6);
+        expect(context.document.nodeCount, 6);
 
         // Ensure the nodes have the correct type.
         for (int i = 0; i < 6; i++) {
-          expect(context.document.nodes[i], isA<ListItemNode>());
-          expect((context.document.nodes[i] as ListItemNode).type, ListItemType.ordered);
+          expect(context.document.getNodeAt(i), isA<ListItemNode>());
+          expect((context.document.getNodeAt(i) as ListItemNode).type, ListItemType.ordered);
         }
 
         // Ensure the sequence was kept.
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[0].id), 1);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[1].id), 2);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[2].id), 1);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[3].id), 2);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[4].id), 3);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[5].id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(0)!.id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(1)!.id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(2)!.id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(3)!.id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(4)!.id), 3);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(5)!.id), 1);
       });
 
       testWidgetsOnArbitraryDesktop('restarts item order when separated by an unordered item', (tester) async {
@@ -555,32 +555,32 @@ void main() {
 2. Second ordered item""") //
             .pump();
 
-        expect(context.document.nodes.length, 6);
+        expect(context.document.nodeCount, 6);
 
         // Ensure the nodes have the correct type.
-        expect(context.document.nodes[0], isA<ListItemNode>());
-        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(0), isA<ListItemNode>());
+        expect((context.document.getNodeAt(0) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[1], isA<ListItemNode>());
-        expect((context.document.nodes[1] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(1), isA<ListItemNode>());
+        expect((context.document.getNodeAt(1) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[2], isA<ListItemNode>());
-        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(2), isA<ListItemNode>());
+        expect((context.document.getNodeAt(2) as ListItemNode).type, ListItemType.unordered);
 
-        expect(context.document.nodes[3], isA<ListItemNode>());
-        expect((context.document.nodes[3] as ListItemNode).type, ListItemType.unordered);
+        expect(context.document.getNodeAt(3), isA<ListItemNode>());
+        expect((context.document.getNodeAt(3) as ListItemNode).type, ListItemType.unordered);
 
-        expect(context.document.nodes[4], isA<ListItemNode>());
-        expect((context.document.nodes[4] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(4), isA<ListItemNode>());
+        expect((context.document.getNodeAt(4) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[5], isA<ListItemNode>());
-        expect((context.document.nodes[5] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(5), isA<ListItemNode>());
+        expect((context.document.getNodeAt(5) as ListItemNode).type, ListItemType.ordered);
 
         // Ensure the sequence restarted after the unordered items.
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[0].id), 1);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[1].id), 2);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[4].id), 1);
-        expect(SuperEditorInspector.findListItemOrdinal(context.document.nodes[5].id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(0)!.id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(1)!.id), 2);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(4)!.id), 1);
+        expect(SuperEditorInspector.findListItemOrdinal(context.document.getNodeAt(5)!.id), 2);
       });
 
       testWidgetsOnArbitraryDesktop('does not keep sequence for items split by paragraphs', (tester) async {
@@ -594,21 +594,21 @@ A paragraph
 2. Second ordered item""") //
             .pump();
 
-        expect(context.document.nodes.length, 3);
+        expect(context.document.nodeCount, 3);
 
         // Ensure the nodes have the correct type.
-        expect(context.document.nodes[0], isA<ListItemNode>());
-        expect((context.document.nodes[0] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(0), isA<ListItemNode>());
+        expect((context.document.getNodeAt(0) as ListItemNode).type, ListItemType.ordered);
 
-        expect(context.document.nodes[1], isA<ParagraphNode>());
+        expect(context.document.getNodeAt(1), isA<ParagraphNode>());
 
-        expect(context.document.nodes[2], isA<ListItemNode>());
-        expect((context.document.nodes[2] as ListItemNode).type, ListItemType.ordered);
+        expect(context.document.getNodeAt(2), isA<ListItemNode>());
+        expect((context.document.getNodeAt(2) as ListItemNode).type, ListItemType.ordered);
 
         // Ensure the sequence reset when reaching the second list item.
         final firstOrderedItem = tester.widget<OrderedListItemComponent>(
           find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[0].id)),
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.getNodeAt(0)!.id)),
             matching: find.byType(OrderedListItemComponent),
           ),
         );
@@ -616,7 +616,7 @@ A paragraph
 
         final secondOrderedItem = tester.widget<OrderedListItemComponent>(
           find.ancestor(
-            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.nodes[2].id)),
+            of: find.byWidget(SuperEditorInspector.findWidgetForComponent(context.document.getNodeAt(2)!.id)),
             matching: find.byType(OrderedListItemComponent),
           ),
         );
@@ -627,7 +627,7 @@ A paragraph
         await _pumpOrderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.first as ListItemNode;
+        final listItemNode = doc.first as ListItemNode;
 
         // Place caret at the first list item, which has one level of indentation.
         await tester.placeCaretInParagraph(listItemNode.id, 0);
@@ -670,7 +670,7 @@ A paragraph
         await _pumpOrderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.last as ListItemNode;
+        final listItemNode = doc.last as ListItemNode;
 
         // Place caret at the last list item, which has two levels of indentation.
         // For some reason, taping at the first character isn't displaying any caret,
@@ -716,7 +716,7 @@ A paragraph
         await _pumpOrderedListWithTextField(tester);
 
         final doc = SuperEditorInspector.findDocument()!;
-        final listItemNode = doc.nodes.last as ListItemNode;
+        final listItemNode = doc.last as ListItemNode;
 
         // Place caret at the last list item, which has two levels of indentation.
         // For some reason, taping at the first character isn't displaying any caret,
@@ -743,28 +743,28 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.first.id, 6);
 
         // Press enter to create a new list item.
         await tester.pressEnter();
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 1");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -780,28 +780,28 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.first.id, 6);
 
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 1");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -817,28 +817,28 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at the end of the list item.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 6);
+        await tester.placeCaretInParagraph(document.first.id, 6);
 
         // On iOS, pressing ENTER generates a newline action.
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new, empty list item was created.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
         // Ensure the existing item remains the same.
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "Item 1");
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "Item 1");
 
         // Ensure the new item has the correct list item type and indentation.
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -854,24 +854,24 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // Press enter to split the existing item into two.
         await tester.pressEnter();
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -888,24 +888,24 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -922,24 +922,24 @@ A paragraph
         final document = context.findEditContext().document;
 
         // Place the caret at "List |Item"
-        await tester.placeCaretInParagraph(document.nodes.first.id, 5);
+        await tester.placeCaretInParagraph(document.first.id, 5);
 
         // On iOS, pressing ENTER generates a newline action.
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new item was created with part of the previous item.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).text.text, "List ");
-        expect(document.nodes.last, isA<ListItemNode>());
-        expect((document.nodes.last as ListItemNode).text.text, "Item");
-        expect((document.nodes.last as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.last as ListItemNode).indent, 0);
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.text, "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.text, "Item");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),

--- a/super_editor/test/super_editor/components/paragraph_test.dart
+++ b/super_editor/test/super_editor/components/paragraph_test.dart
@@ -146,14 +146,14 @@ void main() {
         await tester.pressEnter();
 
         // Ensure the new paragraph is indented.
-        var newParagraph = SuperEditorInspector.findDocument()!.nodes[1] as ParagraphNode;
+        var newParagraph = SuperEditorInspector.findDocument()!.getNodeAt(1) as ParagraphNode;
         expect(newParagraph.indent, 1);
 
         // Press Enter again to reset the indent.
         await tester.pressEnter();
 
         // Ensure the new paragraph is no longer indented.
-        newParagraph = SuperEditorInspector.findDocument()!.nodes[1] as ParagraphNode;
+        newParagraph = SuperEditorInspector.findDocument()!.getNodeAt(1) as ParagraphNode;
         expect(newParagraph.indent, 0);
       });
 

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -22,21 +22,21 @@ void main() {
       await _pumpScaffold(tester, document: document);
 
       // Ensure the task isn't checked.
-      expect((document.nodes.first as TaskNode).isComplete, false);
+      expect((document.first as TaskNode).isComplete, false);
       expect(TaskInspector.isChecked("1"), false);
 
       // Tap to check the box.
       await tester.tapOnCheckbox("1");
 
       // Ensure the task is checked.
-      expect((document.nodes.first as TaskNode).isComplete, true);
+      expect((document.first as TaskNode).isComplete, true);
       expect(TaskInspector.isChecked("1"), true);
 
       // Tap to uncheck the box.
       await tester.tapOnCheckbox("1");
 
       // Ensure the task isn't checked.
-      expect((document.nodes.first as TaskNode).isComplete, false);
+      expect((document.first as TaskNode).isComplete, false);
       expect(TaskInspector.isChecked("1"), false);
     });
 
@@ -52,9 +52,9 @@ void main() {
       editor.execute([const ConvertParagraphToTaskRequest(nodeId: "1")]);
 
       // Ensure the node is now a task.
-      expect(document.nodes.length, 1);
-      expect(document.nodes.first, isA<TaskNode>());
-      expect((document.nodes.first as TaskNode).text.text, "This will be a task");
+      expect(document.nodeCount, 1);
+      expect(document.first, isA<TaskNode>());
+      expect((document.first as TaskNode).text.text, "This will be a task");
     });
 
     group("inserts", () {
@@ -74,16 +74,16 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that a new, empty task was created.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is a task");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is a task");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -109,16 +109,16 @@ void main() {
         await tester.pump();
 
         // Ensure that a new, empty task was created.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is a task");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is a task");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -141,16 +141,16 @@ void main() {
         await tester.typeImeText("\n");
 
         // Ensure that a new, empty task was created.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is a task");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is a task");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -173,16 +173,16 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new, empty task was created.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is a task");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is a task");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -206,16 +206,16 @@ void main() {
         await tester.pressEnter();
 
         // Ensure that a new task was created with part of the previous task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is ");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "a task");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is ");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "a task");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -237,16 +237,16 @@ void main() {
         await tester.typeImeText("\n");
 
         // Ensure that a new task was created with part of the previous task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is ");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "a task");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is ");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "a task");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -268,16 +268,16 @@ void main() {
         await tester.testTextInput.receiveAction(TextInputAction.newline);
 
         // Ensure that a new task was created with part of the previous task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).text.text, "This is ");
-        expect(document.nodes.last, isA<TaskNode>());
-        expect((document.nodes.last as TaskNode).text.text, "a task");
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).text.text, "This is ");
+        expect(document.last, isA<TaskNode>());
+        expect((document.last as TaskNode).text.text, "a task");
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: document.nodes.last.id,
+              nodeId: document.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -301,9 +301,9 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the task converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "This is a task");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "This is a task");
       });
 
       testWidgetsOnAllPlatforms(
@@ -334,9 +334,9 @@ void main() {
         ], getter: imeClientGetter);
 
         // Ensure the task converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "This is a task");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "This is a task");
       });
 
       testWidgetsOnAllPlatforms("task to paragraph when the user presses ENTER on an empty task", (tester) async {
@@ -351,9 +351,9 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
 
         // Ensure the task was converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnAndroid("task to paragraph upon new line insertion on an empty task", (tester) async {
@@ -369,9 +369,9 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
 
         // Ensure the task was converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnIos("task to paragraph new line input action on an empty task", (tester) async {
@@ -387,9 +387,9 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
 
         // Ensure the task was converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnWebDesktop("task to paragraph when the user presses ENTER on an empty task", (tester) async {
@@ -407,9 +407,9 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
 
         // Ensure the task was converted to a paragraph.
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect((document.nodes.first as ParagraphNode).text.text, "");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect((document.first as ParagraphNode).text.text, "");
       });
 
       testWidgets("paragraph to task for incomplete task", (tester) async {
@@ -426,8 +426,8 @@ void main() {
         ]);
 
         // Ensure the paragraph is a task, and it's not checked.
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).isComplete, isFalse);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).isComplete, isFalse);
       });
 
       testWidgets("paragraph to task for complete task", (tester) async {
@@ -444,8 +444,8 @@ void main() {
         ]);
 
         // Ensure the paragraph is a task, and it IS checked.
-        expect(document.nodes.first, isA<TaskNode>());
-        expect((document.nodes.first as TaskNode).isComplete, isTrue);
+        expect(document.first, isA<TaskNode>());
+        expect((document.first as TaskNode).isComplete, isTrue);
       });
     });
 

--- a/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
+++ b/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
@@ -44,8 +44,8 @@ void main() {
 
         commonOps.deleteSelection();
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first.id, "2");
+        expect(document.nodeCount, 1);
+        expect(document.first.id, "2");
         expect(composer.selection!.extent.nodeId, "2");
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 0));
       });
@@ -82,8 +82,8 @@ void main() {
 
         commonOps.deleteSelection();
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first.id, "2");
+        expect(document.nodeCount, 1);
+        expect(document.first.id, "2");
         expect(composer.selection!.extent.nodeId, "2");
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 0));
       });
@@ -120,8 +120,8 @@ void main() {
 
         commonOps.deleteSelection();
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first.id, "1");
+        expect(document.nodeCount, 1);
+        expect(document.first.id, "1");
         expect(composer.selection!.extent.nodeId, "1");
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 50));
       });
@@ -153,9 +153,9 @@ void main() {
 
         commonOps.deleteSelection();
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
-        expect(document.nodes.first.id, "1");
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
+        expect(document.first.id, "1");
         expect(composer.selection!.extent.nodePosition, const TextNodePosition(offset: 0));
       });
     });

--- a/super_editor/test/super_editor/infrastructure/document_editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/document_editor_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
 
+import '../../super_reader/reader_test_tools.dart';
+
 void main() {
   group('MutableDocument', () {
     group('.moveNode()', () {
@@ -73,32 +75,44 @@ void main() {
 
         document.moveNode(nodeId: 'move-me', targetIndex: 0);
         expect(
-          document.nodes,
-          [
-            node, // Node exists at index 0
-            HorizontalRuleNode(id: '0'),
-            HorizontalRuleNode(id: '2'),
-          ],
+          document,
+          documentEquivalentTo(
+            MutableDocument(
+              nodes: [
+                node, // Node exists at index 0
+                HorizontalRuleNode(id: '0'),
+                HorizontalRuleNode(id: '2'),
+              ],
+            ),
+          ),
         );
 
         document.moveNode(nodeId: 'move-me', targetIndex: 2);
         expect(
-          document.nodes,
-          [
-            HorizontalRuleNode(id: '0'),
-            HorizontalRuleNode(id: '2'),
-            node, // Node exists at index 2
-          ],
+          document,
+          documentEquivalentTo(
+            MutableDocument(
+              nodes: [
+                HorizontalRuleNode(id: '0'),
+                HorizontalRuleNode(id: '2'),
+                node, // Node exists at index 2
+              ],
+            ),
+          ),
         );
 
         document.moveNode(nodeId: 'move-me', targetIndex: 1);
         expect(
-          document.nodes,
-          [
-            HorizontalRuleNode(id: '0'),
-            node, // Node exists at index 1
-            HorizontalRuleNode(id: '2'),
-          ],
+          document,
+          documentEquivalentTo(
+            MutableDocument(
+              nodes: [
+                HorizontalRuleNode(id: '0'),
+                node, // Node exists at index 1
+                HorizontalRuleNode(id: '2'),
+              ],
+            ),
+          ),
         );
       });
     });
@@ -117,9 +131,9 @@ void main() {
       document.replaceNode(oldNode: oldNode, newNode: newNode);
 
       // oldNode does not exist
-      expect(document.nodes.contains(oldNode), false);
+      expect(document.contains(oldNode), false);
       // newNode exists at index 1
-      expect(document.nodes.indexOf(newNode), 1);
+      expect(document.getNodeIndexById(newNode.id), 1);
     });
 
     test('it is equal to another document when both documents are empty', () {

--- a/super_editor/test/super_editor/infrastructure/editor_test.dart
+++ b/super_editor/test/super_editor/infrastructure/editor_test.dart
@@ -269,7 +269,7 @@ void main() {
           ]);
 
         // Ensure that our reaction ran in the middle of the requests.
-        expect((document.nodes.first as TextNode).text.text, "Hello");
+        expect((document.first as TextNode).text.text, "Hello");
       });
 
       test('reactions receive a change list with events from earlier reactions', () {
@@ -497,7 +497,7 @@ void main() {
         ]);
 
         // Verify content changes.
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
         expect(document.getNodeAt(0)!.id, "1");
         expect(document.getNodeAt(1)!.id, "2");
 

--- a/super_editor/test/super_editor/infrastructure/mutable_document_test.dart
+++ b/super_editor/test/super_editor/infrastructure/mutable_document_test.dart
@@ -72,9 +72,9 @@ void main() {
     group("getNodeIndexById returns the correct index", () {
       test("when creating a document", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         // Ensure the indices are correct when creating the document.
         expect(document.getNodeIndexById(firstNode.id), 0);
@@ -84,8 +84,8 @@ void main() {
 
       test("when inserting a node at the beginning by index", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node at the beginning.
         final thirdNode = ParagraphNode(
@@ -102,8 +102,8 @@ void main() {
 
       test("when inserting a node at the middle by index", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node between firstNode and secondNode.
         final thirdNode = ParagraphNode(
@@ -120,8 +120,8 @@ void main() {
 
       test("when inserting a node at the end by index", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node at the end.
         final thirdNode = ParagraphNode(
@@ -138,8 +138,8 @@ void main() {
 
       test("when inserting a node before the first node", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node at the beginning.
         final thirdNode = ParagraphNode(
@@ -159,8 +159,8 @@ void main() {
 
       test("when inserting a node before the last node", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node between the two nodes.
         final thirdNode = ParagraphNode(
@@ -180,8 +180,8 @@ void main() {
 
       test("when inserting a node after the first node", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node between the two nodes.
         final thirdNode = ParagraphNode(
@@ -201,8 +201,8 @@ void main() {
 
       test("when inserting a node after the last node", () {
         final document = _createTwoParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
 
         // Insert a new node at the end.
         final thirdNode = ParagraphNode(
@@ -222,9 +222,9 @@ void main() {
 
       test("when moving a node from the beginning to the middle", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.moveNode(
           nodeId: firstNode.id,
@@ -239,9 +239,9 @@ void main() {
 
       test("when moving a node from the middle to the end", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.moveNode(
           nodeId: secondNode.id,
@@ -256,9 +256,9 @@ void main() {
 
       test("when moving a node from the end to the middle", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.moveNode(
           nodeId: thirdNode.id,
@@ -273,9 +273,9 @@ void main() {
 
       test("when moving a node from the middle to the beginning", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.moveNode(
           nodeId: secondNode.id,
@@ -290,9 +290,9 @@ void main() {
 
       test("when deleting a node at the beginning", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.deleteNode(firstNode);
 
@@ -304,9 +304,9 @@ void main() {
 
       test("when deleting a node at the middle", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.deleteNode(secondNode);
 
@@ -318,9 +318,9 @@ void main() {
 
       test("when deleting a node at the end", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         document.deleteNode(thirdNode);
 
@@ -332,9 +332,9 @@ void main() {
 
       test("when replacing a node at the beginning", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         final fourthNode = ParagraphNode(
           id: "4",
@@ -355,9 +355,9 @@ void main() {
 
       test("when replacing a node at the middle", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         final fourthNode = ParagraphNode(
           id: "4",
@@ -378,9 +378,9 @@ void main() {
 
       test("when replacing a node at the end", () {
         final document = _createThreeParagraphDoc();
-        final firstNode = document.nodes[0];
-        final secondNode = document.nodes[1];
-        final thirdNode = document.nodes[2];
+        final firstNode = document.getNodeAt(0)!;
+        final secondNode = document.getNodeAt(1)!;
+        final thirdNode = document.getNodeAt(2)!;
 
         final fourthNode = ParagraphNode(
           id: "4",

--- a/super_editor/test/super_editor/mobile/super_editor_android_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_selection_test.dart
@@ -456,14 +456,14 @@ void main() {
           ).pump();
 
           // Long press near the top of the image.
-          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + const Offset(0, 10);
           final gesture = await tester.startGesture(tapDownOffset);
           await tester.pump(kLongPressTimeout + kPressTimeout);
 
           // Ensure the image was selected.
           expect(
             SuperEditorInspector.findDocumentSelection(),
-            DocumentSelection(
+            const DocumentSelection(
               base: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.upstream()),
               extent: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.downstream()),
             ),
@@ -518,14 +518,14 @@ void main() {
           ).pump();
 
           // Long press near the top of the image.
-          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + const Offset(0, 10);
           final gesture = await tester.startGesture(tapDownOffset);
           await tester.pump(kLongPressTimeout + kPressTimeout);
 
           // Ensure the image was selected.
           expect(
             SuperEditorInspector.findDocumentSelection(),
-            DocumentSelection(
+            const DocumentSelection(
               base: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.upstream()),
               extent: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.downstream()),
             ),

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -323,14 +323,14 @@ void main() {
           ).pump();
 
           // Long press near the top of the image.
-          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + const Offset(0, 10);
           final gesture = await tester.startGesture(tapDownOffset);
           await tester.pump(kLongPressTimeout + kPressTimeout);
 
           // Ensure the image was selected.
           expect(
             SuperEditorInspector.findDocumentSelection(),
-            DocumentSelection(
+            const DocumentSelection(
               base: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.upstream()),
               extent: DocumentPosition(nodeId: '1', nodePosition: UpstreamDownstreamNodePosition.downstream()),
             ),
@@ -385,14 +385,14 @@ void main() {
           ).pump();
 
           // Long press near the top of the image.
-          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + Offset(0, 10);
+          final tapDownOffset = tester.getTopLeft(find.byType(ImageComponent)) + const Offset(0, 10);
           final gesture = await tester.startGesture(tapDownOffset);
           await tester.pump(kLongPressTimeout + kPressTimeout);
 
           // Ensure the image was selected.
           expect(
             SuperEditorInspector.findDocumentSelection(),
-            DocumentSelection(
+            const DocumentSelection(
               base: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.upstream()),
               extent: DocumentPosition(nodeId: '2', nodePosition: UpstreamDownstreamNodePosition.downstream()),
             ),
@@ -443,7 +443,7 @@ multiple lines.''',
             .insideCustomScrollView()
             .pump();
 
-        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.document.first as ParagraphNode;
 
         // Double tap to select "SuperEditor".
         await tester.doubleTapInParagraph(paragraphNode.id, 0);
@@ -487,7 +487,7 @@ multiple lines.''',
             .insideCustomScrollView()
             .pump();
 
-        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.document.first as ParagraphNode;
 
         // Double tap to select "SuperEditor".
         await tester.doubleTapInParagraph(paragraphNode.id, 0);

--- a/super_editor/test/super_editor/super_editor_undo_redo_test.dart
+++ b/super_editor/test/super_editor/super_editor_undo_redo_test.dart
@@ -15,7 +15,7 @@ void main() {
         final document = deserializeMarkdownToDocument("Hello  world");
         final composer = MutableDocumentComposer();
         final editor = createDefaultDocumentEditor(document: document, composer: composer);
-        final paragraphId = document.nodes.first.id;
+        final paragraphId = document.first.id;
 
         editor.execute([
           ChangeSelectionRequest(
@@ -151,17 +151,17 @@ void main() {
 
         // Ensure that the paragraph is now a header.
         final document = editContext.document;
-        var paragraph = document.nodes.first as ParagraphNode;
+        var paragraph = document.first as ParagraphNode;
         expect(paragraph.metadata['blockType'], header1Attribution);
-        expect(SuperEditorInspector.findTextInComponent(document.nodes.first.id).text, "");
+        expect(SuperEditorInspector.findTextInComponent(document.first.id).text, "");
 
         await tester.pressCmdZ(tester);
         await tester.pump();
 
         // Ensure that the header attribution is gone.
-        paragraph = document.nodes.first as ParagraphNode;
+        paragraph = document.first as ParagraphNode;
         expect(paragraph.metadata['blockType'], paragraphAttribution);
-        expect(SuperEditorInspector.findTextInComponent(document.nodes.first.id).text, "# ");
+        expect(SuperEditorInspector.findTextInComponent(document.first.id).text, "# ");
       });
 
       testWidgetsOnMac("dashes to em dash", (tester) async {
@@ -204,17 +204,17 @@ void main() {
 
         // Ensure that the paragraph is now a list item.
         final document = editContext.document;
-        var node = document.nodes.first as TextNode;
+        var node = document.first as TextNode;
         expect(node, isA<ListItemNode>());
-        expect(SuperEditorInspector.findTextInComponent(document.nodes.first.id).text, "");
+        expect(SuperEditorInspector.findTextInComponent(document.first.id).text, "");
 
         await tester.pressCmdZ(tester);
         await tester.pump();
 
         // Ensure that the node is back to a paragraph.
-        node = document.nodes.first as TextNode;
+        node = document.first as TextNode;
         expect(node, isA<ParagraphNode>());
-        expect(SuperEditorInspector.findTextInComponent(document.nodes.first.id).text, "1. ");
+        expect(SuperEditorInspector.findTextInComponent(document.first.id).text, "1. ");
       });
 
       testWidgetsOnMac("url to a link", (tester) async {
@@ -259,13 +259,13 @@ void main() {
         await tester.placeCaretInParagraph("1", 0);
 
         await tester.typeImeText("--- ");
-        expect(editContext.document.nodes.first, isA<HorizontalRuleNode>());
+        expect(editContext.document.first, isA<HorizontalRuleNode>());
 
         await tester.pressCmdZ(tester);
         await tester.pump();
 
-        expect(editContext.document.nodes.first, isA<ParagraphNode>());
-        expect(SuperEditorInspector.findTextInComponent(editContext.document.nodes.first.id).text, "—- ");
+        expect(editContext.document.first, isA<ParagraphNode>());
+        expect(SuperEditorInspector.findTextInComponent(editContext.document.first.id).text, "—- ");
       });
     });
 
@@ -287,18 +287,18 @@ This is paragraph 3''');
 
       // Ensure the pasted content was applied as expected.
       final document = editContext.document;
-      expect(document.nodes.length, 3);
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[0].id).text, "This is paragraph 1");
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[1].id).text, "This is paragraph 2");
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[2].id).text, "This is paragraph 3");
+      expect(document.nodeCount, 3);
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(0)!.id).text, "This is paragraph 1");
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(1)!.id).text, "This is paragraph 2");
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(2)!.id).text, "This is paragraph 3");
 
       // Undo the paste.
       await tester.pressCmdZ(tester);
       await tester.pump();
 
       // Ensure we're back to a single empty paragraph.
-      expect(document.nodes.length, 1);
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[0].id).text, "");
+      expect(document.nodeCount, 1);
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(0)!.id).text, "");
 
       // Redo the paste
       // TODO: remove WidgetTester as required argument to this robot method
@@ -306,10 +306,10 @@ This is paragraph 3''');
       await tester.pump();
 
       // Ensure the pasted content was applied as expected.
-      expect(document.nodes.length, 3);
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[0].id).text, "This is paragraph 1");
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[1].id).text, "This is paragraph 2");
-      expect(SuperEditorInspector.findTextInComponent(document.nodes[2].id).text, "This is paragraph 3");
+      expect(document.nodeCount, 3);
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(0)!.id).text, "This is paragraph 1");
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(1)!.id).text, "This is paragraph 2");
+      expect(SuperEditorInspector.findTextInComponent(document.getNodeAt(2)!.id).text, "This is paragraph 3");
     });
 
     group("transaction grouping >", () {

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -23,13 +23,13 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at "bold|".
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 6);
+          await tester.placeCaretInParagraph(doc.first.id, 6);
 
           // Type at an offset that should expand the bold attribution.
           await tester.typeImeText("er");
 
           // Place the caret at "text|".
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 13);
+          await tester.placeCaretInParagraph(doc.first.id, 13);
 
           // Type at an offset that shouldn't expand any attributions.
           await tester.typeImeText(".");
@@ -48,13 +48,13 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at b|ld.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 3);
+          await tester.placeCaretInParagraph(doc.first.id, 3);
 
           // Type at an offset that should expand the bold attribution.
           await tester.typeImeText("o");
 
           // Place the caret at A|.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 1);
+          await tester.placeCaretInParagraph(doc.first.id, 1);
 
           // Type at an offset that shouldn't expand any attributions.
           await tester.typeImeText("nother");
@@ -73,13 +73,13 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at This is a|.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 9);
+          await tester.placeCaretInParagraph(doc.first.id, 9);
 
           // Type at an offset that should expand the link attribution.
           await tester.typeImeText("nother");
 
           // Place the caret at google|.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 30);
+          await tester.placeCaretInParagraph(doc.first.id, 30);
 
           // Type at an offset that shouldn't expand any attributions.
           await tester.typeImeText(".");
@@ -100,7 +100,7 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at |text.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 7);
+          await tester.placeCaretInParagraph(doc.first.id, 7);
 
           // Press left arrow to place the caret at bold|.
           await tester.pressLeftArrow();
@@ -128,7 +128,7 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at A|.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 1);
+          await tester.placeCaretInParagraph(doc.first.id, 1);
 
           // Press right arrow twice to place the caret at b|ld.
           await tester.pressRightArrow();
@@ -159,7 +159,7 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at |to google.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 15);
+          await tester.placeCaretInParagraph(doc.first.id, 15);
 
           // Press left arrow twice to place caret at lin|k.
           await tester.pressLeftArrow();
@@ -598,8 +598,8 @@ void main() {
           final editor = context.editor;
           final document = context.document;
 
-          final firstNode = document.nodes[0] as ParagraphNode;
-          final secondNode = document.nodes[1] as ParagraphNode;
+          final firstNode = document.getNodeAt(0) as ParagraphNode;
+          final secondNode = document.getNodeAt(1) as ParagraphNode;
 
           // Apply the bold attribution, starting after the last character of the first node.
           editor.toggleAttributionsForDocumentSelection(
@@ -646,8 +646,8 @@ void main() {
           final editor = context.editor;
           final document = context.document;
 
-          final firstNode = document.nodes[0] as ParagraphNode;
-          final secondNode = document.nodes[1] as ParagraphNode;
+          final firstNode = document.getNodeAt(0) as ParagraphNode;
+          final secondNode = document.getNodeAt(1) as ParagraphNode;
 
           // Apply the bold attribution, with a selection that start at the beginning of the first node and ends
           // before the first character of the second node.
@@ -1138,7 +1138,7 @@ void main() {
           final doc = SuperEditorInspector.findDocument()!;
 
           // Place the caret at |bold.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 2);
+          await tester.placeCaretInParagraph(doc.first.id, 2);
 
           // Type some letters.
           await tester.typeImeText("very ");
@@ -1160,7 +1160,7 @@ void main() {
           final composer = context.findEditContext().composer;
 
           // Place the caret at the end of the paragraph.
-          await tester.placeCaretInParagraph(doc.nodes.first.id, 19);
+          await tester.placeCaretInParagraph(doc.first.id, 19);
 
           // Toggle the bold attribution.
           composer.preferences.toggleStyle(boldAttribution);

--- a/super_editor/test/super_editor/supereditor_components_test.dart
+++ b/super_editor/test/super_editor/supereditor_components_test.dart
@@ -164,7 +164,7 @@ Future<void> _pumpImageTestApp(
                 width: double.infinity,
               ).toMetadata(),
             ),
-            ...longTextDoc().nodes,
+            ...longTextDoc(),
           ],
         ),
       )

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -22,7 +22,7 @@ void main() {
         ).pump();
 
         // Place caret at the beginning of the paragraph.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 0);
 
         // Insert the image at the current selection.
         context.findEditContext().commonOps.insertImage('http://image.fake');
@@ -31,21 +31,21 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that one node was inserted.
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
         // Ensure that the image was added.
-        expect(doc.nodes[0], isA<ImageNode>());
+        expect(doc.getNodeAt(0)!, isA<ImageNode>());
 
         // Ensure that the paragraph node content remains unchanged, but is moved down.
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure the selection was placed at the beginning of the paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[1].id,
+              nodeId: doc.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -61,7 +61,7 @@ void main() {
         ).pump();
 
         // Place caret at "Before the image| after the image".
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 16);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 16);
 
         // Insert the image at the current selection.
         context.findEditContext().commonOps.insertImage('http://image.fake');
@@ -70,25 +70,25 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 3);
+        expect(doc.nodeCount, 3);
 
         // Ensure that the first node has the text from before the caret.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'Before the image');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Before the image');
 
         // Ensure that the image was added.
-        expect(doc.nodes[1], isA<ImageNode>());
+        expect(doc.getNodeAt(1)!, isA<ImageNode>());
 
         // Ensure that the last node has the text from after the caret.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, ' after the image');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, ' after the image');
 
         // Ensure the selection was placed at the beginning of the last paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes.last.id,
+              nodeId: doc.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -105,7 +105,7 @@ void main() {
         ).pump();
 
         // Place caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 15);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 15);
 
         // Insert the image at the current selection.
         context.findEditContext().commonOps.insertImage('http://image.fake');
@@ -114,25 +114,25 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 3);
+        expect(doc.nodeCount, 3);
 
         // Ensure that the first node remains unchanged.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure that the image was added.
-        expect(doc.nodes[1], isA<ImageNode>());
+        expect(doc.getNodeAt(1)!, isA<ImageNode>());
 
         // Ensure that an empty node was added after the image.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, '');
 
         // Ensure the selection was placed at the beginning of the last paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes.last.id,
+              nodeId: doc.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -153,7 +153,7 @@ Second paragraph"""). //
         // Place caret at the end of the first paragraph by selecting the second paragraph and pressing left.
         //
         // This results in an upstream text affinity.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.last.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.last.id, 0);
         await tester.pressLeftArrow();
 
         // Insert the image at the current selection.
@@ -163,25 +163,25 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 4);
+        expect(doc.nodeCount, 4);
 
         // Ensure that the first node remains unchanged.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure that the image was added.
-        expect(doc.nodes[1], isA<ImageNode>());
+        expect(doc.getNodeAt(1)!, isA<ImageNode>());
 
         // Ensure that an empty node was added after the image.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, '');
 
         // Ensure the selection was placed at the beginning of the newly created paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[2].id,
+              nodeId: doc.getNodeAt(2)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -207,21 +207,21 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that one node was inserted.
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
         // Ensure that the paragraph was converted to an image.
-        expect(doc.nodes.first, isA<ImageNode>());
+        expect(doc.first, isA<ImageNode>());
 
         // Ensure that an empty node was added after the image.
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
 
         // Ensure the selection was placed at the empty paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[1].id,
+              nodeId: doc.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -237,7 +237,7 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at the beginning of the paragraph.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 0);
 
         // Insert the horizontal rule at the current selection.
         context.findEditContext().commonOps.insertHorizontalRule();
@@ -246,21 +246,21 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that one node was inserted.
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
         // Ensure that the horizontal rule was added.
-        expect(doc.nodes[0], isA<HorizontalRuleNode>());
+        expect(doc.getNodeAt(0)!, isA<HorizontalRuleNode>());
 
         // Ensure that the paragraph node content remains unchanged, but is moved down.
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure the selection was placed at the beginning of the paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[1].id,
+              nodeId: doc.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -273,7 +273,7 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at "Before the hr| after the hr".
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 13);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 13);
 
         // Insert the horizontal rule at the current selection.
         context.findEditContext().commonOps.insertHorizontalRule();
@@ -282,25 +282,25 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 3);
+        expect(doc.nodeCount, 3);
 
         // Ensure that the first node has the text from before the caret.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'Before the hr');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Before the hr');
 
         // Ensure that the horizontal rule was added.
-        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+        expect(doc.getNodeAt(1)!, isA<HorizontalRuleNode>());
 
         // Ensure that the last node has the text from after the caret.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, ' after the hr');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, ' after the hr');
 
         // Ensure the selection was placed at the beginning of the last paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes.last.id,
+              nodeId: doc.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -314,7 +314,7 @@ Second paragraph"""). //
             .pump();
 
         // Place caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.first.id, 15);
+        await tester.placeCaretInParagraph(context.findEditContext().document.first.id, 15);
 
         // Insert the horizontal rule at the current selection.
         context.findEditContext().commonOps.insertHorizontalRule();
@@ -323,25 +323,25 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 3);
+        expect(doc.nodeCount, 3);
 
         // Ensure that the first node remains unchanged.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure that the horizontal rule was added.
-        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+        expect(doc.getNodeAt(1)!, isA<HorizontalRuleNode>());
 
         // Ensure that an empty node was added at the end.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, '');
 
         // Ensure the selection was placed at the beginning of the last paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes.last.id,
+              nodeId: doc.last.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -359,7 +359,7 @@ Second paragraph"""). //
         // Place caret at the end of the first paragraph by selecting the second paragraph and pressing left.
         //
         // This results in an upstream text affinity.
-        await tester.placeCaretInParagraph(context.findEditContext().document.nodes.last.id, 0);
+        await tester.placeCaretInParagraph(context.findEditContext().document.last.id, 0);
         await tester.pressLeftArrow();
 
         // Insert the horizontal rule at the current selection.
@@ -369,25 +369,25 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that two nodes were inserted.
-        expect(doc.nodes.length, 4);
+        expect(doc.nodeCount, 4);
 
         // Ensure that the first node remains unchanged.
-        expect(doc.nodes[0], isA<ParagraphNode>());
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'First paragraph');
+        expect(doc.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'First paragraph');
 
         // Ensure that the horizontal rule was added.
-        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+        expect(doc.getNodeAt(1)!, isA<HorizontalRuleNode>());
 
         // Ensure that an empty node was added at the end.
-        expect(doc.nodes[2], isA<ParagraphNode>());
-        expect((doc.nodes[2] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, '');
 
         // Ensure the selection was placed at the beginning of the newly created paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[2].id,
+              nodeId: doc.getNodeAt(2)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -410,21 +410,21 @@ Second paragraph"""). //
         final doc = SuperEditorInspector.findDocument()!;
 
         // Ensure that one node was inserted.
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
         // Ensure the paragraph was converted to a horizontal rule.
-        expect(doc.nodes.first, isA<HorizontalRuleNode>());
+        expect(doc.first, isA<HorizontalRuleNode>());
 
         // Ensure that an empty node was added after the horizontal rule.
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
 
         // Ensure that the selection was placed at the empty paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[1].id,
+              nodeId: doc.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -477,14 +477,14 @@ Second paragraph"""). //
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
         final doc = testContext.findEditContext().document;
-        expect(doc.nodes.length, 3);
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect(doc.nodeCount, 3);
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.findEditContext().document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -536,14 +536,14 @@ Second paragraph"""). //
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
         final doc = testContext.findEditContext().document;
-        expect(doc.nodes.length, 3);
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect(doc.nodeCount, 3);
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.findEditContext().document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -595,14 +595,14 @@ Second paragraph"""). //
 
         // Ensure an empty paragraph was inserted and the selection was placed on its beginning.
         final doc = testContext.findEditContext().document;
-        expect(doc.nodes.length, 3);
-        expect(doc.nodes[1], isA<ParagraphNode>());
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
+        expect(doc.nodeCount, 3);
+        expect(doc.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
         expect(
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.findEditContext().document.nodes[1].id,
+              nodeId: testContext.findEditContext().document.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
+++ b/super_editor/test/super_editor/supereditor_copy_and_paste_test.dart
@@ -20,7 +20,7 @@ void main() {
 
       // Place the caret at the beginning of the empty document and
       // add some text to give us a non-empty paragraph.
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(doc.first.id, 0);
       await tester.typeImeText("Pasted text: ");
 
       // Paste text into the paragraph.
@@ -30,7 +30,7 @@ void main() {
       await tester.pressCmdV();
 
       // Ensure that the text was pasted into the paragraph.
-      final nodeId = doc.nodes.first.id;
+      final nodeId = doc.first.id;
       expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Pasted text: This was pasted here");
     });
 
@@ -44,7 +44,7 @@ void main() {
       final doc = SuperEditorInspector.findDocument()!;
 
       // Place the caret at the end of the list item.
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 12);
+      await tester.placeCaretInParagraph(doc.first.id, 12);
       await tester.typeImeText(" "); // <- manually add a space because Markdown strips it
 
       // Paste text into the paragraph.
@@ -54,7 +54,7 @@ void main() {
       await tester.pressCmdV();
 
       // Ensure that the text was pasted into the paragraph.
-      final nodeId = doc.nodes.first.id;
+      final nodeId = doc.first.id;
       expect(SuperEditorInspector.findTextInComponent(nodeId).text, "Pasted text: This was pasted here");
     });
 
@@ -85,10 +85,10 @@ This is the third paragraph''');
 
       // Ensure three paragraphs were created.
       final doc = testContext.document;
-      expect(doc.nodes.length, 3);
-      expect((doc.nodes[0] as ParagraphNode).text.text, 'This is a paragraph');
-      expect((doc.nodes[1] as ParagraphNode).text.text, 'This is a second paragraph');
-      expect((doc.nodes[2] as ParagraphNode).text.text, 'This is the third paragraph');
+      expect(doc.nodeCount, 3);
+      expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'This is a paragraph');
+      expect((doc.getNodeAt(1)! as ParagraphNode).text.text, 'This is a second paragraph');
+      expect((doc.getNodeAt(2)! as ParagraphNode).text.text, 'This is the third paragraph');
     });
   });
 }

--- a/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
+++ b/super_editor/test/super_editor/supereditor_floating_cursor_test.dart
@@ -25,7 +25,7 @@ void main() {
             .pump();
 
         // Place caret at "|This is a paragraph".
-        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 0);
 
         // Ensure the caret is displayed.
         expect(_caretFinder(), findsOneWidget);
@@ -75,7 +75,7 @@ void main() {
             .pump();
 
         // Place caret at the end of the text.
-        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 19);
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 19);
 
         // Ensure the caret is displayed.
         expect(_caretFinder(), findsOneWidget);
@@ -108,7 +108,7 @@ void main() {
             .pump();
 
         // Place caret at the end of the text.
-        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 19);
+        await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 19);
 
         // Show the floating cursor.
         await tester.startFloatingCursorGesture();
@@ -148,7 +148,7 @@ void main() {
             .fromMarkdown('This is a paragraph')
             .pump();
 
-        final nodeId = testContext.document.nodes.first.id;
+        final nodeId = testContext.document.first.id;
 
         // Double tap to select the word "This"
         await tester.doubleTapInParagraph(nodeId, 0);
@@ -194,7 +194,7 @@ Second paragraph''') //
             .pump();
 
         // Place the caret at the end of the first paragraph.
-        await tester.placeCaretInParagraph(testContext.document.nodes.first.id, 27);
+        await tester.placeCaretInParagraph(testContext.document.first.id, 27);
 
         // Show the floating cursor.
         await tester.startFloatingCursorGesture();
@@ -221,7 +221,7 @@ Second paragraph''') //
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: testContext.document.nodes.last.id,
+              nodeId: testContext.document.last.id,
               nodePosition: const TextNodePosition(offset: 16, affinity: TextAffinity.upstream),
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -37,7 +37,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -66,7 +66,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -95,7 +95,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -124,7 +124,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -153,7 +153,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -178,7 +178,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.last.id,
+            nodeId: testContext.findEditContext().document.last.id,
             nodePosition: const TextNodePosition(offset: 14),
           ),
         ),
@@ -202,7 +202,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: testContext.findEditContext().document.nodes.first.id,
+            nodeId: testContext.findEditContext().document.first.id,
             nodePosition: const TextNodePosition(offset: 0),
           ),
         ),
@@ -229,7 +229,7 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final paragraphNode = document.nodes.first as ParagraphNode;
+      final paragraphNode = document.first as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -275,7 +275,7 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final paragraphNode = document.nodes.first as ParagraphNode;
+      final paragraphNode = document.first as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -323,8 +323,8 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final titleNode = document.nodes.first as ParagraphNode;
-      final paragraphNode = document.nodes[1] as ParagraphNode;
+      final titleNode = document.first as ParagraphNode;
+      final paragraphNode = document.getNodeAt(1)! as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -372,8 +372,8 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final titleNode = document.nodes.first as ParagraphNode;
-      final paragraphNode = document.nodes[1] as ParagraphNode;
+      final titleNode = document.first as ParagraphNode;
+      final paragraphNode = document.getNodeAt(1)! as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -465,7 +465,7 @@ spans multiple lines.''',
           .pump();
 
       // Tap to place caret.
-      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 0);
 
       // Ensure the drag handle is displayed.
       expect(find.byType(AndroidSelectionHandle), findsOneWidget);
@@ -478,7 +478,7 @@ spans multiple lines.''',
           .pump();
 
       // Tap to place caret.
-      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 0);
 
       // Ensure the drag handle is displayed.
       expect(find.byType(IosFloatingToolbarOverlay), findsOneWidget);
@@ -490,7 +490,7 @@ spans multiple lines.''',
           .withSingleParagraph()
           .pump();
 
-      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.first.id, 0);
 
       // Ensure no drag handle is displayed.
       expect(find.byType(AndroidSelectionHandle), findsNothing);
@@ -693,7 +693,7 @@ spans multiple lines.''',
           expect(context.findEditContext().composer.isInInteractionMode.value, isTrue);
 
           // Tap on the first link.
-          final textNode = context.document.nodes.first;
+          final textNode = context.document.first;
           await tester.tapInParagraph(textNode.id, 3);
 
           // Ensure that we tried to launch the first URL.

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -35,7 +35,7 @@ void main() {
         await tester.typeImeText("Hello");
 
         // Ensure the text was typed.
-        expect((document.nodes.first as ParagraphNode).text.text, "Hello<- text here");
+        expect((document.first as ParagraphNode).text.text, "Hello<- text here");
       });
 
       testWidgetsOnAllPlatforms('in the middle of existing text', (tester) async {
@@ -58,7 +58,7 @@ void main() {
         await tester.typeImeText("Hello");
 
         // Ensure the text was typed.
-        expect((document.nodes.first as ParagraphNode).text.text, "text here ->Hello<---");
+        expect((document.first as ParagraphNode).text.text, "text here ->Hello<---");
       });
 
       testWidgetsOnAllPlatforms('at the end of existing text', (tester) async {
@@ -81,7 +81,7 @@ void main() {
         await tester.typeImeText("Hello");
 
         // Ensure the text was typed.
-        expect((document.nodes.first as ParagraphNode).text.text, "text here ->Hello");
+        expect((document.first as ParagraphNode).text.text, "text here ->Hello");
       });
     });
 
@@ -125,7 +125,7 @@ void main() {
 
       // Ensure that the editor didn't receive the performAction call, and didn't
       // insert a new node.
-      expect(document.nodes.length, 1);
+      expect(document.nodeCount, 1);
     });
 
     testWidgetsOnAndroid('allows app to handle newline action', (tester) async {
@@ -165,7 +165,7 @@ void main() {
 
       // Ensure that the editor didn't receive the performAction call, and didn't
       // insert a new node.
-      expect(document.nodes.length, 1);
+      expect(document.nodeCount, 1);
     });
 
     testWidgetsOnMac('allows apps to handle selectors in their own way', (tester) async {
@@ -353,7 +353,7 @@ void main() {
           ),
         ]);
 
-        expect((document.nodes.first as ParagraphNode).text.text, "This is a sentence. ");
+        expect((document.first as ParagraphNode).text.text, "This is a sentence. ");
       });
 
       testWidgets('can type compound character in an empty paragraph', (tester) async {
@@ -395,7 +395,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Ensure that the empty paragraph now reads "¨".
-        expect((editContext.document.nodes[1] as ParagraphNode).text.text, "¨");
+        expect((editContext.document.getNodeAt(1)! as ParagraphNode).text.text, "¨");
 
         // Ensure that the IME still has the invisible characters.
         expect(deltaClient.currentTextEditingValue!.text, ". ¨");
@@ -420,7 +420,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // Ensure that the empty paragraph now reads "ü".
-        expect((editContext.document.nodes[1] as ParagraphNode).text.text, "ü");
+        expect((editContext.document.getNodeAt(1)! as ParagraphNode).text.text, "ü");
       });
     });
 
@@ -494,13 +494,13 @@ void main() {
 
         // Ensure the paragraph was split.
         expect(
-          (doc.nodes[0] as ParagraphNode).text.text,
+          (doc.getNodeAt(0)! as ParagraphNode).text.text,
           'Before the line break ',
         );
 
         // Ensure the paragraph was split.
         expect(
-          (doc.nodes[1] as ParagraphNode).text.text,
+          (doc.getNodeAt(1)! as ParagraphNode).text.text,
           'new line',
         );
 
@@ -509,7 +509,7 @@ void main() {
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[1].id,
+              nodeId: doc.getNodeAt(1)!.id,
               nodePosition: const TextNodePosition(offset: 0),
             ),
           ),
@@ -530,7 +530,7 @@ Paragraph two
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place caret at the start of the second paragraph.
-        await tester.placeCaretInParagraph(doc.nodes[1].id, 0);
+        await tester.placeCaretInParagraph(doc.getNodeAt(1)!.id, 0);
 
         // Sends the deletion delta followed by non-text deltas.
         //
@@ -559,7 +559,7 @@ Paragraph two
 
         // Ensure the paragraph was merged.
         expect(
-          (doc.nodes[0] as ParagraphNode).text.text,
+          (doc.getNodeAt(0)! as ParagraphNode).text.text,
           'Paragraph oneParagraph two',
         );
 
@@ -568,7 +568,7 @@ Paragraph two
           SuperEditorInspector.findDocumentSelection(),
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes[0].id,
+              nodeId: doc.getNodeAt(0)!.id,
               nodePosition: const TextNodePosition(offset: 13),
             ),
           ),
@@ -793,7 +793,7 @@ Paragraph two
             .pump();
 
         // Place the caret at the end of the paragraph.
-        await tester.placeCaretInParagraph(testContext.document.nodes.first.id, 3);
+        await tester.placeCaretInParagraph(testContext.document.first.id, 3);
 
         // Type a letter simulating a typo. The current text results in "Fixs".
         await tester.typeImeText('s');
@@ -952,9 +952,9 @@ Paragraph two
         final document = testContext.document;
 
         // Ensure the replacement was ignored and a new empty node was added.
-        expect(document.nodes.length, 2);
-        expect((document.nodes[0] as TextNode).text.text, 'run tom');
-        expect((document.nodes[1] as TextNode).text.text, '');
+        expect(document.nodeCount, 2);
+        expect((document.getNodeAt(0)! as TextNode).text.text, 'run tom');
+        expect((document.getNodeAt(1)! as TextNode).text.text, '');
       });
     });
 
@@ -1021,7 +1021,7 @@ Paragraph two
           .withInputSource(TextInputSource.ime)
           .pump();
 
-      final nodeId = testContext.document.nodes.first.id;
+      final nodeId = testContext.document.first.id;
 
       // Place the caret at the beginning of the paragraph.
       await tester.placeCaretInParagraph(nodeId, 0);
@@ -1040,7 +1040,7 @@ Paragraph two
           .withInputSource(TextInputSource.ime)
           .pump();
 
-      final nodeId = testContext.document.nodes.first.id;
+      final nodeId = testContext.document.first.id;
 
       // Place the caret at the end of the paragraph.
       await tester.placeCaretInParagraph(nodeId, 19);
@@ -1079,7 +1079,7 @@ Paragraph two
       final doc = SuperEditorInspector.findDocument()!;
 
       // Place caret at the start of the second paragraph.
-      await tester.placeCaretInParagraph(doc.nodes[1].id, 0);
+      await tester.placeCaretInParagraph(doc.getNodeAt(1)!.id, 0);
 
       // Simulates the user pressing BACKSPACE, which generates a deletion delta.
       // This deletion will cause the two paragraphs to be merged.
@@ -1102,7 +1102,7 @@ Paragraph two
 
       // Ensure the paragraph was merged.
       expect(
-        (doc.nodes[0] as ParagraphNode).text.text,
+        (doc.getNodeAt(0)! as ParagraphNode).text.text,
         'Paragraph oneParagraph two',
       );
     });

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -316,7 +316,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem  dolor sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -345,7 +345,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem dolor sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -374,7 +374,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text, startsWith("Lorem ipsum  sit amet"));
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -403,7 +403,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem ipsum sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -430,7 +430,7 @@ void main() {
           await tester.pressCtlBackspace();
 
           // Ensure that a character was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text, startsWith("Lorem ipsu dolor sit amet"));
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -459,7 +459,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
           // Ensure that a character was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem ipsumdolor sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -618,7 +618,7 @@ void main() {
           await tester.pressCtlBackspace();
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem  dolor sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -645,7 +645,7 @@ void main() {
           await tester.pressCtlBackspace();
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem dolor sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -674,7 +674,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text, startsWith("Lorem ipsum  sit amet"));
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -703,7 +703,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
 
           // Ensure that the whole word was deleted.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text.startsWith("Lorem ipsum sit amet"), isTrue);
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -730,7 +730,7 @@ void main() {
           await tester.pressAltBackspace();
 
           // Ensure that nothing changed.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text, startsWith("Lorem ipsu dolor sit amet"));
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -759,7 +759,7 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
 
           // Ensure that nothing changed.
-          final paragraphNode = testContext.findEditContext().document.nodes.first as ParagraphNode;
+          final paragraphNode = testContext.findEditContext().document.first as ParagraphNode;
           expect(paragraphNode.text.text, startsWith("Lorem ipsumdolor sit amet"));
           expect(
             SuperEditorInspector.findDocumentSelection(),
@@ -782,7 +782,7 @@ void main() {
               .withInputSource(inputSourceVariant.currentValue!)
               .pump();
 
-          final node = testContext.findEditContext().document.nodes.first;
+          final node = testContext.findEditContext().document.first;
 
           // Place caret at "A| header"
           await tester.placeCaretInParagraph(node.id, 1);
@@ -808,7 +808,7 @@ void main() {
               .withInputSource(inputSourceVariant.currentValue!)
               .pump();
 
-          final node = testContext.findEditContext().document.nodes.first;
+          final node = testContext.findEditContext().document.first;
 
           // Place caret at the start of the header.
           await tester.placeCaretInParagraph(node.id, 0);
@@ -836,7 +836,7 @@ Second paragraph''') //
               .pump();
 
           // Place caret at "First para|graph".
-          await tester.placeCaretInParagraph(context.document.nodes.first.id, 10);
+          await tester.placeCaretInParagraph(context.document.first.id, 10);
 
           // Press DOWN arrow to move the caret to the downstream paragraph.
           await tester.pressDownArrow();
@@ -847,7 +847,7 @@ Second paragraph''') //
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.last.id,
+                  nodeId: context.document.last.id,
                   nodePosition: const TextNodePosition(offset: 10),
                 ),
               ),
@@ -904,7 +904,7 @@ This is a paragraph
               .pump();
 
           // Place the caret at "This is a |paragraph".
-          await tester.placeCaretInParagraph(context.document.nodes.first.id, 10);
+          await tester.placeCaretInParagraph(context.document.first.id, 10);
 
           // Press DOWN arrow to move the caret to the downstream node.
           //
@@ -923,7 +923,7 @@ This is a paragraph
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.last.id,
+                  nodeId: context.document.last.id,
                   nodePosition: const TextNodePosition(offset: 8),
                 ),
               ),
@@ -1058,7 +1058,7 @@ This is a paragraph''') //
               .pump();
 
           // Place caret at "This is |a list item".
-          await tester.placeCaretInParagraph(context.document.nodes.first.id, 8);
+          await tester.placeCaretInParagraph(context.document.first.id, 8);
 
           // Press DOWN arrow to move the caret to the downstream node.
           //
@@ -1077,7 +1077,7 @@ This is a paragraph''') //
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.last.id,
+                  nodeId: context.document.last.id,
                   nodePosition: const TextNodePosition(offset: 10),
                 ),
               ),
@@ -1134,7 +1134,7 @@ This is a paragraph''') //
               .pump();
 
           // Place the caret at "This is a|nother list item".
-          await tester.placeCaretInParagraph(context.document.nodes.first.id, 9);
+          await tester.placeCaretInParagraph(context.document.first.id, 9);
 
           // Press down arrow to move the caret to the downstream node.
           //
@@ -1153,7 +1153,7 @@ This is a paragraph''') //
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.last.id,
+                  nodeId: context.document.last.id,
                   nodePosition: const TextNodePosition(offset: 9),
                 ),
               ),
@@ -1173,7 +1173,7 @@ Second paragraph''') //
               .pump();
 
           // Place caret at "Second p|aragraph".
-          await tester.placeCaretInParagraph(context.document.nodes.last.id, 8);
+          await tester.placeCaretInParagraph(context.document.last.id, 8);
 
           // Press UP arrow to move the caret to the upstream paragraph.
           await tester.pressUpArrow();
@@ -1184,7 +1184,7 @@ Second paragraph''') //
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.first.id,
+                  nodeId: context.document.first.id,
                   nodePosition: const TextNodePosition(offset: 10),
                 ),
               ),
@@ -1241,7 +1241,7 @@ This is a paragraph''') //
               .pump();
 
           // Place the caret at "This is a |paragraph".
-          await tester.placeCaretInParagraph(context.document.nodes.last.id, 10);
+          await tester.placeCaretInParagraph(context.document.last.id, 10);
 
           // Press UP arrow to move the caret to the upstream node.
           //
@@ -1260,7 +1260,7 @@ This is a paragraph''') //
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.first.id,
+                  nodeId: context.document.first.id,
                   nodePosition: const TextNodePosition(offset: 8),
                 ),
               ),
@@ -1395,7 +1395,7 @@ This is a paragraph
               .pump();
 
           // Place caret at "This is |a list item".
-          await tester.placeCaretInParagraph(context.document.nodes.last.id, 8);
+          await tester.placeCaretInParagraph(context.document.last.id, 8);
 
           // Press UP arrow to move the caret to the upstream node.
           //
@@ -1414,7 +1414,7 @@ This is a paragraph
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.first.id,
+                  nodeId: context.document.first.id,
                   nodePosition: const TextNodePosition(offset: 10),
                 ),
               ),
@@ -1471,7 +1471,7 @@ This is a paragraph
               .pump();
 
           // Place the caret at "This is a|nother list item".
-          await tester.placeCaretInParagraph(context.document.nodes.last.id, 9);
+          await tester.placeCaretInParagraph(context.document.last.id, 9);
 
           // Press UP arrow to move the caret to the upstream node.
           //
@@ -1490,7 +1490,7 @@ This is a paragraph
             selectionEquivalentTo(
               DocumentSelection.collapsed(
                 position: DocumentPosition(
-                  nodeId: context.document.nodes.first.id,
+                  nodeId: context.document.first.id,
                   nodePosition: const TextNodePosition(offset: 9),
                 ),
               ),

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -394,7 +394,7 @@ void main() {
       // Ensure the document doesn't change.
       expect(
         SuperEditorInspector.findTextInComponent('1').text,
-        (singleParagraphDoc().nodes.first as TextNode).text.text,
+        (singleParagraphDoc().first as TextNode).text.text,
       );
       expect(
         SuperEditorInspector.findDocumentSelection(),
@@ -444,7 +444,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor to open the IME.
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -494,7 +494,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -569,7 +569,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor to open the IME.
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -624,7 +624,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -693,7 +693,7 @@ void main() {
             .pump();
 
         // Place the caret in Super Editor.
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -780,7 +780,7 @@ void main() {
         expect(find.byKey(firstPageKey), findsNothing);
 
         // Place the caret in Super Editor.
-        final nodeId = superEditorAndContext.context.findEditContext().document.nodes.first.id;
+        final nodeId = superEditorAndContext.context.findEditContext().document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Ensure that the document has a selection
@@ -852,10 +852,10 @@ void main() {
       final document = SuperEditorInspector.findDocument()!;
 
       // Ensure the document was created with one node.
-      expect(document.nodes.length, 1);
+      expect(document.nodeCount, 1);
 
       // Tap to give focus to the editor.
-      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(document.first.id, 0);
 
       // Ensure that IME input is enabled. To check IME input, we arbitrarily simulate a newline action from
       // the IME. If the editor responds to the newline, it means IME input is enabled.
@@ -864,7 +864,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Ensure a new node was added.
-      expect(document.nodes.length, 2);
+      expect(document.nodeCount, 2);
     });
   });
 }
@@ -880,7 +880,7 @@ Future<String> _pumpSingleLineWithCaret(
       .withInputSource(inputSource)
       .pump();
 
-  final nodeId = testContext.findEditContext().document.nodes.first.id;
+  final nodeId = testContext.findEditContext().document.first.id;
 
   await tester.placeCaretInParagraph(nodeId, offset);
 
@@ -898,7 +898,7 @@ Future<String> _pumpDoubleLineWithCaret(WidgetTester tester,
       .fromMarkdown("This is the first paragraph.\nThis is the second paragraph.")
       .pump();
 
-  final nodeId = testContext.findEditContext().document.nodes.first.id;
+  final nodeId = testContext.findEditContext().document.first.id;
 
   await tester.placeCaretInParagraph(nodeId, offset);
 

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -254,7 +254,7 @@ void main() {
           .withInputSource(TextInputSource.keyboard)
           .pump();
 
-      final nodeId = testContext.document.nodes.first.id;
+      final nodeId = testContext.document.first.id;
 
       // Tap to place the caret in the first paragraph.
       await tester.placeCaretInParagraph(nodeId, 0);
@@ -276,7 +276,7 @@ void main() {
           .withInputSource(TextInputSource.ime)
           .pump();
 
-      final nodeId = testContext.document.nodes.first.id;
+      final nodeId = testContext.document.first.id;
 
       // Tap to place the caret in the first paragraph.
       await tester.placeCaretInParagraph(nodeId, 0);

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -25,7 +25,7 @@ void main() {
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
 
       final dragGesture = await tester.startDocumentDragFromPosition(
         from: DocumentPosition(
@@ -60,7 +60,7 @@ void main() {
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Jump to the end of the document
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
@@ -99,8 +99,8 @@ void main() {
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       final dragGesture = await tester.startDocumentDragFromPosition(
         from: DocumentPosition(
@@ -144,8 +144,8 @@ void main() {
           .pump();
 
       final document = SuperEditorInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Place the caret at the end of the document, which causes the editor to
       // scroll to the bottom.
@@ -259,7 +259,7 @@ void main() {
           .forDesktop() //
           .pump();
       final document = SuperEditorInspector.findDocument()!;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Place the caret at the end of the document, which should cause the
       // editor to scroll to the bottom.

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -143,7 +143,7 @@ void main() {
           .createDocument() //
           .fromMarkdown("This is paragraph one.\nThis is paragraph two.") //
           .pump();
-      final nodeId = testContext.findEditContext().document.nodes.first.id;
+      final nodeId = testContext.findEditContext().document.first.id;
 
       /// Triple tap on the first line in the paragraph node.
       await tester.tripleTapInParagraph(nodeId, 10);
@@ -174,7 +174,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
+      final firstParagraphId = testContext.findEditContext().document.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -201,7 +201,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
+      final secondParagraphId = testContext.findEditContext().document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -233,7 +233,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
+      final secondParagraphId = testContext.findEditContext().document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -265,7 +265,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
+      final firstParagraphId = testContext.findEditContext().document.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -292,8 +292,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
-      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
+      final firstParagraphId = testContext.findEditContext().document.first.id;
+      final secondParagraphId = testContext.findEditContext().document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -323,8 +323,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.findEditContext().document.nodes.first.id;
-      final secondParagraphId = testContext.findEditContext().document.nodes.last.id;
+      final firstParagraphId = testContext.findEditContext().document.first.id;
+      final secondParagraphId = testContext.findEditContext().document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -495,7 +495,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: doc!.nodes.last.id,
+            nodeId: doc!.last.id,
             nodePosition: const TextNodePosition(offset: 477),
           ),
         ),
@@ -539,7 +539,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: doc!.nodes.last.id,
+            nodeId: doc!.last.id,
             nodePosition: const TextNodePosition(offset: 477),
           ),
         ),
@@ -573,7 +573,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: doc!.nodes.last.id,
+            nodeId: doc!.last.id,
             nodePosition: const TextNodePosition(offset: 477),
           ),
         ),
@@ -599,7 +599,7 @@ void main() {
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: doc!.nodes.last.id,
+            nodeId: doc!.last.id,
             nodePosition: const TextNodePosition(offset: 477),
           ),
         ),
@@ -642,7 +642,7 @@ Second Paragraph
       await tester.pumpAndSettle();
 
       final doc = SuperEditorInspector.findDocument();
-      final secondParagraphNodeId = doc!.nodes[1].id;
+      final secondParagraphNodeId = doc!.getNodeAt(1)!.id;
 
       // Ensure selection is at the last character of the second paragraph.
       expect(
@@ -1179,7 +1179,7 @@ Second Paragraph
         SuperEditorInspector.findDocumentSelection(),
         DocumentSelection.collapsed(
           position: DocumentPosition(
-            nodeId: doc.nodes.last.id,
+            nodeId: doc.last.id,
             nodePosition: const TextNodePosition(offset: 477),
           ),
         ),
@@ -1190,7 +1190,7 @@ Second Paragraph
         ChangeSelectionRequest(
           DocumentSelection.collapsed(
             position: DocumentPosition(
-              nodeId: doc.nodes.last.id,
+              nodeId: doc.last.id,
               nodePosition: const TextNodePosition(offset: 477),
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_software_keyboard_toolbar_test.dart
+++ b/super_editor/test/super_editor/supereditor_software_keyboard_toolbar_test.dart
@@ -21,7 +21,7 @@ void main() {
       final document = SuperEditorInspector.findDocument()!;
 
       // Place the caret at the beginning of the empty document.
-      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(document.first.id, 0);
 
       // Convert the empty paragraph into a horizontal rule.
       final toolbarOps = KeyboardEditingToolbarOperations(
@@ -35,10 +35,10 @@ void main() {
 
       // Ensure the first node is now a horizontal rule node, and there's a
       // a second node, which is a paragraph node.
-      final firstNode = document.nodes.first;
+      final firstNode = document.first;
       expect(firstNode, isA<HorizontalRuleNode>());
 
-      final secondNode = document.nodes[1];
+      final secondNode = document.getNodeAt(1)!;
       expect(secondNode, isA<ParagraphNode>());
       expect((secondNode as ParagraphNode).text.text, isEmpty);
 

--- a/super_editor/test/super_editor/supereditor_style_test.dart
+++ b/super_editor/test/super_editor/supereditor_style_test.dart
@@ -60,8 +60,8 @@ void main() {
 
       final doc = testContext.findEditContext().document;
 
-      final firstParagraphId = doc.nodes[0].id;
-      final secondParagraphId = doc.nodes[1].id;
+      final firstParagraphId = doc.getNodeAt(0)!.id;
+      final secondParagraphId = doc.getNodeAt(1)!.id;
 
       // Ensure the rule for paragraph is applied.
       expect(SuperEditorInspector.findParagraphStyle(firstParagraphId)!.color, Colors.red);
@@ -157,7 +157,7 @@ A paragraph
           .withLongTextContent()
           .pump();
 
-      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.nodes.last.id, 0);
+      await tester.placeCaretInParagraph(SuperEditorInspector.findDocument()!.last.id, 0);
 
       final presenter = tester.state<SuperEditorState>(find.byType(SuperEditor)).presenter;
       presenter.addChangeListener(SingleColumnLayoutPresenterChangeListener(

--- a/super_editor/test/super_editor/supereditor_tapregion_test.dart
+++ b/super_editor/test/super_editor/supereditor_tapregion_test.dart
@@ -40,7 +40,7 @@ void main() {
           )
           .pump();
 
-      final nodeId = context.document.nodes.first.id;
+      final nodeId = context.document.first.id;
 
       // Place the caret at the start of the document to show the drag handle.
       await tester.placeCaretInParagraph(nodeId, 0);
@@ -92,7 +92,7 @@ void main() {
           )
           .pump();
 
-      final nodeId = context.document.nodes.first.id;
+      final nodeId = context.document.first.id;
 
       // Double tap to show the expanded handle.
       await tester.doubleTapInParagraph(nodeId, 0);

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -869,35 +869,34 @@ class EquivalentDocumentMatcher extends Matcher {
     bool nodeCountMismatch = false;
     bool nodeTypeOrContentMismatch = false;
 
-    if (_expectedDocument.nodes.length != actualDocument.nodes.length) {
-      messages
-          .add("expected ${_expectedDocument.nodes.length} document nodes but found ${actualDocument.nodes.length}");
+    if (_expectedDocument.nodeCount != actualDocument.nodeCount) {
+      messages.add("expected ${_expectedDocument.nodeCount} document nodes but found ${actualDocument.nodeCount}");
       nodeCountMismatch = true;
     } else {
       messages.add("document have the same number of nodes");
     }
 
-    final maxNodeCount = max(_expectedDocument.nodes.length, actualDocument.nodes.length);
+    final maxNodeCount = max(_expectedDocument.nodeCount, actualDocument.nodeCount);
     final nodeComparisons = List.generate(maxNodeCount, (index) => ["", "", " "]);
     for (int i = 0; i < maxNodeCount; i += 1) {
-      if (i < _expectedDocument.nodes.length && i < actualDocument.nodes.length) {
-        nodeComparisons[i][0] = _expectedDocument.nodes[i].runtimeType.toString();
-        nodeComparisons[i][1] = actualDocument.nodes[i].runtimeType.toString();
+      if (i < _expectedDocument.nodeCount && i < actualDocument.nodeCount) {
+        nodeComparisons[i][0] = _expectedDocument.getNodeAt(i)!.runtimeType.toString();
+        nodeComparisons[i][1] = actualDocument.getNodeAt(i)!.runtimeType.toString();
 
-        if (_expectedDocument.nodes[i].runtimeType != actualDocument.nodes[i].runtimeType) {
+        if (_expectedDocument.getNodeAt(i)!.runtimeType != actualDocument.getNodeAt(i)!.runtimeType) {
           nodeComparisons[i][2] = "Wrong Type";
           nodeTypeOrContentMismatch = true;
-        } else if (!_expectedDocument.nodes[i].hasEquivalentContent(actualDocument.nodes[i])) {
+        } else if (!_expectedDocument.getNodeAt(i)!.hasEquivalentContent(actualDocument.getNodeAt(i)!)) {
           nodeComparisons[i][2] = "Different Content";
           nodeTypeOrContentMismatch = true;
         }
-      } else if (i < _expectedDocument.nodes.length) {
-        nodeComparisons[i][0] = _expectedDocument.nodes[i].runtimeType.toString();
+      } else if (i < _expectedDocument.nodeCount) {
+        nodeComparisons[i][0] = _expectedDocument.getNodeAt(i)!.runtimeType.toString();
         nodeComparisons[i][1] = "NA";
         nodeComparisons[i][2] = "Missing Node";
-      } else if (i < actualDocument.nodes.length) {
+      } else if (i < actualDocument.nodeCount) {
         nodeComparisons[i][0] = "NA";
-        nodeComparisons[i][1] = actualDocument.nodes[i].runtimeType.toString();
+        nodeComparisons[i][1] = actualDocument.getNodeAt(i)!.runtimeType.toString();
         nodeComparisons[i][2] = "Missing Node";
       }
     }

--- a/super_editor/test/super_editor/supereditor_text_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_text_layout_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       // Keeps track of the build count for each node.
       Map<String, int> buildCountPerNode = {
-        for (var node in document.nodes) //
+        for (final node in document) //
           node.id: 0,
       };
 
@@ -151,7 +151,7 @@ void main() {
 /// Only works for nodes that include a `SuperText` in its tree.
 Map<String, int> _findRebuildCountPerNode(Document document) {
   final rebuildCountPerNode = <String, int>{};
-  for (final node in document.nodes) {
+  for (final node in document) {
     final widget = SuperEditorInspector.findWidgetForComponent<Widget>(node.id);
 
     final superTextState = (find

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -40,7 +40,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent('1').text, SpecialCharacters.emDash);
 
         // Type some arbitrary text.
@@ -60,7 +60,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at the beginning of a paragraph.
         await tester.placeCaretInParagraph(nodeId, 0);
@@ -75,7 +75,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—was inserted');
 
         // Type some arbitrary text.
@@ -95,7 +95,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at "|with".
         await tester.placeCaretInParagraph(nodeId, 10);
@@ -110,7 +110,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —with a reaction');
 
         // Type some arbitrary text.
@@ -139,7 +139,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at the end of the paragraph and add a space
         // just to separate the first word from the dash.
@@ -157,7 +157,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —');
 
         // Type some arbitrary text.
@@ -177,7 +177,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at the beginning of the document.
         await tester.placeCaretInParagraph(nodeId, 0);
@@ -192,7 +192,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—');
 
         // Type some arbitrary text.
@@ -212,7 +212,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at the beginning of the document.
         await tester.placeCaretInParagraph(nodeId, 0);
@@ -227,7 +227,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—was inserted');
 
         // Type a third dash.
@@ -235,7 +235,7 @@ void main() {
 
         // Ensure a dash was inserted and no other nodes were added.
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, '—-was inserted');
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive('(em-dash) ');
@@ -254,7 +254,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at "|with".
         await tester.placeCaretInParagraph(nodeId, 10);
@@ -269,7 +269,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —with a reaction');
 
         // Type some arbitrary text.
@@ -298,7 +298,7 @@ void main() {
             .withInputSource(inputSource)
             .pump();
 
-        final nodeId = context.document.nodes.first.id;
+        final nodeId = context.document.first.id;
 
         // Place the caret at the end of the list item and add a space
         // just to separate the first word from the dash.
@@ -316,7 +316,7 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(context.document.nodes.length, 1);
+        expect(context.document.nodeCount, 1);
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, 'Inserting —');
 
         // Type some arbitrary text.
@@ -354,7 +354,7 @@ void main() {
           ),
         );
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
 
         // Place the caret at the beginning of the document.
         await tester.placeCaretInParagraph(nodeId, 0);
@@ -363,20 +363,20 @@ void main() {
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect((document.nodes.first as TaskNode).text.text, '-');
+        expect((document.first as TaskNode).text.text, '-');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(document.nodes.length, 1);
-        expect((document.nodes.first as TaskNode).text.text, '—');
+        expect(document.nodeCount, 1);
+        expect((document.first as TaskNode).text.text, '—');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' is an em-dash');
 
         // Ensure the text was inserted.
-        expect((document.nodes.first as TaskNode).text.text, '— is an em-dash');
+        expect((document.first as TaskNode).text.text, '— is an em-dash');
       });
 
       testAllInputsOnAllPlatforms('at the beginning of a non-empty task', (
@@ -408,33 +408,33 @@ void main() {
         );
 
         // Place the caret at the beginning of the document.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(document.first.id, 0);
 
         // Type the first dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect((document.nodes.first as TaskNode).text.text, '-was inserted');
+        expect((document.first as TaskNode).text.text, '-was inserted');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(document.nodes.length, 1);
-        expect((document.nodes.first as TaskNode).text.text, '—was inserted');
+        expect(document.nodeCount, 1);
+        expect((document.first as TaskNode).text.text, '—was inserted');
 
         // Type a third dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure a dash was inserted and no other nodes were added.
-        expect((document.nodes.first as TaskNode).text.text, '—-was inserted');
-        expect(document.nodes.length, 1);
+        expect((document.first as TaskNode).text.text, '—-was inserted');
+        expect(document.nodeCount, 1);
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive('(em-dash) ');
 
         // Ensure the text was inserted.
-        expect((document.nodes.first as TaskNode).text.text, '—-(em-dash) was inserted');
+        expect((document.first as TaskNode).text.text, '—-(em-dash) was inserted');
       });
 
       testAllInputsOnAllPlatforms('at the middle of a task', (
@@ -466,20 +466,20 @@ void main() {
         );
 
         // Place the caret at "|with".
-        await tester.placeCaretInParagraph(document.nodes.first.id, 10);
+        await tester.placeCaretInParagraph(document.first.id, 10);
 
         // Type the first dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting -with a reaction');
+        expect((document.first as TaskNode).text.text, 'Inserting -with a reaction');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(document.nodes.length, 1);
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting —with a reaction');
+        expect(document.nodeCount, 1);
+        expect((document.first as TaskNode).text.text, 'Inserting —with a reaction');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' typing two dashes ');
@@ -487,12 +487,12 @@ void main() {
         // Type three dashes. The first two should be converted to an em-dash
         // and the second should be inserted as is.
         await tester.typeTextAdaptive('---');
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting — typing two dashes —-with a reaction');
+        expect((document.first as TaskNode).text.text, 'Inserting — typing two dashes —-with a reaction');
 
         // Type another dash. The previously inserted dash and the current one
         // should be converted to an em-dash.
         await tester.typeTextAdaptive('-');
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting — typing two dashes ——with a reaction');
+        expect((document.first as TaskNode).text.text, 'Inserting — typing two dashes ——with a reaction');
       });
 
       testAllInputsOnAllPlatforms('at the end of a task', (
@@ -526,27 +526,27 @@ void main() {
         // Place the caret at the end of the task and add a space
         // just to separate the first word from the dash.
         // Converting from markdown removes the trailing spaces.
-        await tester.placeCaretInParagraph(document.nodes.first.id, 9);
+        await tester.placeCaretInParagraph(document.first.id, 9);
         await tester.typeTextAdaptive(' ');
 
         // Type the first dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion happened.
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting -');
+        expect((document.first as TaskNode).text.text, 'Inserting -');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect(document.nodes.length, 1);
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting —');
+        expect(document.nodeCount, 1);
+        expect((document.first as TaskNode).text.text, 'Inserting —');
 
         // Type some arbitrary text.
         await tester.typeTextAdaptive(' by typing two dashes');
 
         // Ensure the text was inserted.
-        expect((document.nodes.first as TaskNode).text.text, 'Inserting — by typing two dashes');
+        expect((document.first as TaskNode).text.text, 'Inserting — by typing two dashes');
       });
     });
   });

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -97,9 +97,9 @@ void main() {
         );
 
         // Ensure we added a new empty paragraph.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a paragraph', (tester) async {
@@ -109,7 +109,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -147,9 +147,9 @@ void main() {
         );
 
         // Ensure we split the paragraph.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "after link");
       });
 
       testWidgetsOnAndroid(
@@ -198,9 +198,9 @@ void main() {
         );
 
         // Ensure we added a new empty paragraph.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnAndroid(
@@ -212,7 +212,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -251,9 +251,9 @@ void main() {
         );
 
         // Ensure we split the paragraph.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "after link");
       });
 
       testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a paragraph (on iOS)',
@@ -302,9 +302,9 @@ void main() {
         );
 
         // Ensure we added a new empty line.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "");
       });
 
       testWidgetsOnIos(
@@ -316,7 +316,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -356,9 +356,9 @@ void main() {
         );
 
         // Ensure we split the paragraph.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ParagraphNode>());
-        expect((textContext.document.nodes[1] as ParagraphNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.text, "after link");
       });
 
       testWidgetsOnAllPlatforms('when pressing ENTER at the end of a list item', (tester) async {
@@ -368,7 +368,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(nodeId, 4);
@@ -406,9 +406,9 @@ void main() {
         );
 
         // Ensure we added a new empty list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "");
       });
 
       testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a list item', (tester) async {
@@ -418,7 +418,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -456,9 +456,9 @@ void main() {
         );
 
         // Ensure we split the list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "after link");
       });
 
       testWidgetsOnAndroid(
@@ -470,7 +470,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(nodeId, 4);
@@ -509,9 +509,9 @@ void main() {
         );
 
         // Ensure we added a new empty list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "");
       });
 
       testWidgetsOnAndroid(
@@ -523,7 +523,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -562,9 +562,9 @@ void main() {
         );
 
         // Ensure we split the list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "after link");
       });
 
       testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a list item (on iOS)',
@@ -575,7 +575,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at the end of the list item.
         await tester.placeCaretInParagraph(nodeId, 4);
@@ -615,9 +615,9 @@ void main() {
         );
 
         // Ensure we added a new empty list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "");
       });
 
       testWidgetsOnIos(
@@ -629,7 +629,7 @@ void main() {
             .withInputSource(TextInputSource.ime)
             .pump();
 
-        final nodeId = textContext.document.nodes.first.id;
+        final nodeId = textContext.document.first.id;
 
         // Place the caret at "Before link |after link".
         await tester.placeCaretInParagraph(nodeId, 12);
@@ -669,9 +669,9 @@ void main() {
         );
 
         // Ensure we split the list item.
-        expect(textContext.document.nodes.length, 2);
-        expect(textContext.document.nodes[1], isA<ListItemNode>());
-        expect((textContext.document.nodes[1] as ListItemNode).text.text, "after link");
+        expect(textContext.document.nodeCount, 2);
+        expect(textContext.document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((textContext.document.getNodeAt(1)! as ListItemNode).text.text, "after link");
       });
 
       testWidgetsOnAllPlatforms('when pressing ENTER at the end of a task', (tester) async {
@@ -735,9 +735,9 @@ void main() {
         );
 
         // Ensure we added a new empty task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "");
       });
 
       testWidgetsOnAllPlatforms('when pressing ENTER at the middle of a task', (tester) async {
@@ -801,9 +801,9 @@ void main() {
         );
 
         // Ensure we split the task
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "after link");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "after link");
       });
 
       testWidgetsOnAndroid(
@@ -870,9 +870,9 @@ void main() {
         );
 
         // Ensure we added a new empty task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "");
       });
 
       testWidgetsOnAndroid(
@@ -939,9 +939,9 @@ void main() {
         );
 
         // Ensure we split the task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "after link");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "after link");
       });
 
       testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a task (on iOS)',
@@ -1008,9 +1008,9 @@ void main() {
         );
 
         // Ensure we added a new empty task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "");
       });
 
       testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a task (on iOS)',
@@ -1077,9 +1077,9 @@ void main() {
         );
 
         // Ensure we split the task.
-        expect(document.nodes.length, 2);
-        expect(document.nodes[1], isA<TaskNode>());
-        expect((document.nodes[1] as TaskNode).text.text, "after link");
+        expect(document.nodeCount, 2);
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1)! as TaskNode).text.text, "after link");
       });
     });
 
@@ -1312,7 +1312,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText('Go to ');
@@ -1335,7 +1335,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText('Go to ');
@@ -1358,7 +1358,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText('Go to ');
@@ -1382,7 +1382,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText(' to learn anything');
@@ -1405,7 +1405,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText(' to learn anything');
@@ -1428,7 +1428,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret in the first paragraph at the start of the link.
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Type some text by simulating hardware keyboard key presses.
         await tester.typeKeyboardText(' to learn anything');
@@ -1452,13 +1452,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.goog|le.com"
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+        await tester.placeCaretInParagraph(doc.first.id, 8);
 
         // Add characters.
         await tester.typeImeText("oooo");
 
         // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
+        final nodeId = doc.first.id;
         var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.googoooole.com");
@@ -1484,13 +1484,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.goog|le.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+        await tester.placeCaretInParagraph(doc.first.id, 8);
 
         // Add characters.
         await tester.typeImeText("oooo");
 
         // Ensure the characters were inserted and the link was updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.googoooole.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1514,13 +1514,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.goog|le.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 8);
+        await tester.placeCaretInParagraph(doc.first.id, 8);
 
         // Add characters.
         await tester.typeImeText("oooo");
 
         // Ensure the characters were inserted and the attribution was removed.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.googoooole.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1537,7 +1537,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "|www.google.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Delete downstream characters.
         await tester.pressDelete();
@@ -1546,7 +1546,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
+        final nodeId = doc.first.id;
         var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "google.com");
@@ -1572,7 +1572,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "|www.google.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Delete downstream characters.
         await tester.pressDelete();
@@ -1581,7 +1581,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the characters were delete and link attribution was updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "google.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1605,7 +1605,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the attribution was updated.
-        final textAfter = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final textAfter = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(textAfter.text, "m");
         expect(
           (textAfter.getAllAttributionsAt(0).first as LinkAttribution).url.toString(),
@@ -1616,7 +1616,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the text was deleted.
-        expect(SuperEditorInspector.findTextInComponent(doc.nodes.first.id).text, isEmpty);
+        expect(SuperEditorInspector.findTextInComponent(doc.first.id).text, isEmpty);
       });
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
@@ -1630,7 +1630,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "|www.google.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(doc.first.id, 0);
 
         // Delete downstream characters.
         await tester.pressDelete();
@@ -1639,7 +1639,7 @@ void main() {
         await tester.pressDelete();
 
         // Ensure the characters were delete and link attribution was removed.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "google.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1656,7 +1656,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google.com|".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+        await tester.placeCaretInParagraph(doc.first.id, 10);
 
         // Delete upstream characters.
         await tester.pressBackspace();
@@ -1666,7 +1666,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the characters were deleted and the whole link is still attributed.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.g.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1690,7 +1690,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google|.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+        await tester.placeCaretInParagraph(doc.first.id, 10);
 
         // Remove characters.
         await tester.pressBackspace();
@@ -1704,7 +1704,7 @@ void main() {
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        var text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        var text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1728,13 +1728,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google|.com".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 10);
+        await tester.placeCaretInParagraph(doc.first.id, 10);
 
         // Remove a single character.
         await tester.pressBackspace();
 
         // Ensure the text was updated and the attribution was removed.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.googl.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1751,7 +1751,7 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google.com|".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Delete upstream characters.
         await tester.pressBackspace();
@@ -1760,7 +1760,7 @@ void main() {
         await tester.pressBackspace();
 
         // Ensure the characters were inserted, the whole link is still attributed.
-        final nodeId = doc.nodes.first.id;
+        final nodeId = doc.first.id;
         var text = SuperEditorInspector.findTextInComponent(nodeId);
 
         expect(text.text, "www.google");
@@ -1786,14 +1786,14 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google.com|".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Delete upstream characters.
         await tester.pressBackspace();
         await tester.pressBackspace();
 
         // Ensure the characters were deleted and the link was updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.google.c");
         expect(
           text.hasAttributionsThroughout(
@@ -1817,13 +1817,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Place the caret at "www.google.com|".
-        await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+        await tester.placeCaretInParagraph(doc.first.id, 14);
 
         // Delete an upstream characters.
         await tester.pressBackspace();
 
         // Ensure the character was deleted and the link was removed.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.google.co");
         expect(text.spans.markers, isEmpty);
       });
@@ -1840,13 +1840,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Double tap to select "google".
-        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+        await tester.doubleTapInParagraph(doc.first.id, 5);
 
         // Replace "google" with "duckduckgo".
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1870,13 +1870,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Double tap to select "google".
-        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+        await tester.doubleTapInParagraph(doc.first.id, 5);
 
         // Replace "google" with "duckduckgo".
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(
           text.hasAttributionsThroughout(
@@ -1900,13 +1900,13 @@ void main() {
         final doc = SuperEditorInspector.findDocument()!;
 
         // Double tap to select "google".
-        await tester.doubleTapInParagraph(doc.nodes.first.id, 5);
+        await tester.doubleTapInParagraph(doc.first.id, 5);
 
         // Replace "google" with "duckduckgo".
         await tester.typeImeText('duckduckgo');
 
         // Ensure the text and the link were updated.
-        final text = SuperEditorInspector.findTextInComponent(doc.nodes.first.id);
+        final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.text, "www.duckduckgo.com");
         expect(text.spans.markers, isEmpty);
       });
@@ -1922,7 +1922,7 @@ void main() {
       final doc = SuperEditorInspector.findDocument()!;
 
       // Place the caret at "www.google.com|".
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+      await tester.placeCaretInParagraph(doc.first.id, 14);
 
       // Delete a character at the end of the link.
       await tester.pressBackspace();
@@ -1931,7 +1931,7 @@ void main() {
       await tester.typeImeText(" hello");
 
       // Ensure the text were inserted, and only the URL is linkified.
-      final nodeId = doc.nodes.first.id;
+      final nodeId = doc.first.id;
       var text = SuperEditorInspector.findTextInComponent(nodeId);
 
       expect(text.text, "www.google.co hello");
@@ -1965,7 +1965,7 @@ void main() {
       final doc = SuperEditorInspector.findDocument()!;
 
       // Place the caret at "www.google.com|".
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+      await tester.placeCaretInParagraph(doc.first.id, 14);
 
       // Create a new paragraph.
       await tester.pressEnter();
@@ -1973,8 +1973,8 @@ void main() {
       // We had an issue where link attributions were extended to the beginning of
       // an empty paragraph, but were removed after the user started typing. So, first,
       // ensure that no link markers were added to the empty paragraph.
-      expect(doc.nodes.length, 2);
-      final newParagraphId = doc.nodes[1].id;
+      expect(doc.nodeCount, 2);
+      final newParagraphId = doc.getNodeAt(1)!.id;
       AttributedText newParagraphText = SuperEditorInspector.findTextInComponent(newParagraphId);
       expect(newParagraphText.spans.markers, isEmpty);
 
@@ -2003,10 +2003,10 @@ void main() {
       final doc = SuperEditorInspector.findDocument()!;
 
       // Ensure the Markdown correctly created a list item.
-      expect(doc.nodes.first, isA<ListItemNode>());
+      expect(doc.first, isA<ListItemNode>());
 
       // Place the caret at "www.google.com|".
-      await tester.placeCaretInParagraph(doc.nodes.first.id, 14);
+      await tester.placeCaretInParagraph(doc.first.id, 14);
 
       // Create a new list item.
       await tester.pressEnter();
@@ -2014,9 +2014,9 @@ void main() {
       // We had an issue where link attributions were extended to the beginning of
       // an empty list item, but were removed after the user started typing. So, first,
       // ensure that no link markers were added to the empty list item.
-      expect(doc.nodes.length, 2);
-      expect(doc.nodes[1], isA<ListItemNode>());
-      final newListItemId = doc.nodes[1].id;
+      expect(doc.nodeCount, 2);
+      expect(doc.getNodeAt(1)!, isA<ListItemNode>());
+      final newListItemId = doc.getNodeAt(1)!.id;
       AttributedText newListItemText = SuperEditorInspector.findTextInComponent(newListItemId);
       expect(newListItemText.spans.markers, isEmpty);
 

--- a/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
+++ b/super_editor/test/super_editor/text_entry/paragraph_conversions_test.dart
@@ -28,7 +28,7 @@ void main() {
 
           // Ensure that the paragraph is now a header, and it's content is empty.
           final document = context.findEditContext().document;
-          final paragraph = document.nodes.first as ParagraphNode;
+          final paragraph = document.first as ParagraphNode;
 
           expect(paragraph.metadata['blockType'], headerVariant.$2);
           expect(paragraph.text.text.isEmpty, isTrue);
@@ -49,7 +49,7 @@ void main() {
 
         // Ensure that the paragraph hasn't changed.
         final document = context.findEditContext().document;
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
 
         expect(paragraph.metadata['blockType'], paragraphAttribution);
         expect(paragraph.text.text, "####### ");
@@ -68,7 +68,7 @@ void main() {
         final unorderedListItemPattern = _unorderedListVariant.currentValue!;
         await tester.typeImeText(unorderedListItemPattern);
 
-        final listItemNode = context.findEditContext().document.nodes.first;
+        final listItemNode = context.findEditContext().document.first;
         expect(listItemNode, isA<ListItemNode>());
         expect((listItemNode as ListItemNode).type, ListItemType.unordered);
         expect(listItemNode.text.text.isEmpty, isTrue);
@@ -84,7 +84,7 @@ void main() {
 
         await tester.typeImeText("1 ");
 
-        final paragraphNode = context.findEditContext().document.nodes.first;
+        final paragraphNode = context.findEditContext().document.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, "1 ");
       });
@@ -99,7 +99,7 @@ void main() {
 
         await tester.typeImeText(" 1 ");
 
-        final paragraphNode = context.findEditContext().document.nodes.first;
+        final paragraphNode = context.findEditContext().document.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, " 1 ");
       });
@@ -117,7 +117,7 @@ void main() {
         final orderedListItemPattern = _orderedListVariant.currentValue!;
         await tester.typeImeText(orderedListItemPattern);
 
-        final listItemNode = context.findEditContext().document.nodes.first;
+        final listItemNode = context.findEditContext().document.first;
         expect(listItemNode, isA<ListItemNode>());
         expect((listItemNode as ListItemNode).type, ListItemType.ordered);
         expect(listItemNode.text.text.isEmpty, isTrue);
@@ -138,13 +138,13 @@ void main() {
             .pump();
 
         final document = context.document;
-        await tester.placeCaretInParagraph(document.nodes[3].id, 0);
+        await tester.placeCaretInParagraph(document.getNodeAt(3)!.id, 0);
 
         // Type a list pattern with the number 4.
         await tester.typeImeText(_orderedListNumberVariant.currentValue!.replaceAll('n', '4'));
 
         // Ensure the paragraph was converted.
-        final listItemNode = context.findEditContext().document.nodes[3];
+        final listItemNode = context.findEditContext().document.getNodeAt(3)!;
         expect(listItemNode, isA<ListItemNode>());
         expect((listItemNode as ListItemNode).type, ListItemType.ordered);
         expect(listItemNode.text.text.isEmpty, isTrue);
@@ -165,14 +165,14 @@ void main() {
             .pump();
 
         final document = context.document;
-        await tester.placeCaretInParagraph(document.nodes[3].id, 0);
+        await tester.placeCaretInParagraph(document.getNodeAt(3)!.id, 0);
 
         // Type a list pattern with the number 5.
         final orderedListItemPattern = _orderedListNumberVariant.currentValue!.replaceAll('n', '5');
         await tester.typeImeText(orderedListItemPattern);
 
         // Ensure the paragraph was not converted and the typed text was kept.
-        final editingNode = context.findEditContext().document.nodes[3];
+        final editingNode = context.findEditContext().document.getNodeAt(3)!;
         expect(editingNode, isA<ParagraphNode>());
         expect((editingNode as ParagraphNode).text.text, orderedListItemPattern);
       }, variant: _orderedListNumberVariant);
@@ -193,7 +193,7 @@ void main() {
         await tester.typeImeText(orderedListItemPattern);
 
         // Ensure the paragraph was not converted and the typed text was kept.
-        final editingNode = document.nodes.first;
+        final editingNode = document.first;
         expect(editingNode, isA<ParagraphNode>());
         expect((editingNode as ParagraphNode).text.text, orderedListItemPattern);
       }, variant: _orderedListNumberVariant);
@@ -208,7 +208,7 @@ void main() {
 
         await tester.typeImeText("1 ");
 
-        final paragraphNode = context.findEditContext().document.nodes.first;
+        final paragraphNode = context.findEditContext().document.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, "1 ");
       });
@@ -223,7 +223,7 @@ void main() {
 
         await tester.typeImeText(" 1 ");
 
-        final paragraphNode = context.findEditContext().document.nodes.first;
+        final paragraphNode = context.findEditContext().document.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, " 1 ");
       });
@@ -245,11 +245,11 @@ void main() {
 
         // Ensure that we now have two nodes, and the first one is an HR.
         final document = context.findEditContext().document;
-        expect(document.nodes.length, 2);
+        expect(document.nodeCount, 2);
 
-        expect(document.nodes.first, isA<HorizontalRuleNode>());
-        expect(document.nodes.last, isA<ParagraphNode>());
-        expect((document.nodes.last as ParagraphNode).text.text.isEmpty, isTrue);
+        expect(document.first, isA<HorizontalRuleNode>());
+        expect(document.last, isA<ParagraphNode>());
+        expect((document.last as ParagraphNode).text.text.isEmpty, isTrue);
       });
 
       testAllInputsOnAllPlatforms('with --- at the beginning of an non-empty paragraph', (
@@ -263,28 +263,28 @@ void main() {
             .pump();
 
         // Place the caret at the beginning of the document.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 0);
+        await tester.placeCaretInParagraph(context.document.first.id, 0);
 
         // Type the first dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure no conversion was performed.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '-Existing paragraph');
+        expect((context.document.first as ParagraphNode).text.text, '-Existing paragraph');
 
         // Type the second dash.
         await tester.typeTextAdaptive('-');
 
         // Ensure the two dashes were converted to an em-dash.
-        expect((context.document.nodes.first as ParagraphNode).text.text, '—Existing paragraph');
+        expect((context.document.first as ParagraphNode).text.text, '—Existing paragraph');
 
         // Type the third dash.
         await tester.typeTextAdaptive('- ');
 
         // Ensure a horizontal rule was inserted before the existing paragraph.
-        expect(context.document.nodes.length, 2);
-        expect(context.document.nodes.first, isA<HorizontalRuleNode>());
-        expect(context.document.nodes.last, isA<ParagraphNode>());
-        expect((context.document.nodes.last as ParagraphNode).text.text, 'Existing paragraph');
+        expect(context.document.nodeCount, 2);
+        expect(context.document.first, isA<HorizontalRuleNode>());
+        expect(context.document.last, isA<ParagraphNode>());
+        expect((context.document.last as ParagraphNode).text.text, 'Existing paragraph');
       });
 
       testWidgetsOnAllPlatforms('does not convert non-HR dashes', (tester) async {
@@ -301,7 +301,7 @@ void main() {
 
         await tester.typeImeText(input);
 
-        final paragraphNode = context.findEditContext().document.nodes.first;
+        final paragraphNode = context.findEditContext().document.first;
         expect(paragraphNode, isA<ParagraphNode>());
         expect((paragraphNode as ParagraphNode).text.text, expectedResult);
       }, variant: _nonHrVariant);
@@ -320,7 +320,7 @@ void main() {
 
         // Ensure that the paragraph is now a blockquote, and it's content is empty.
         final document = context.findEditContext().document;
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
 
         expect(paragraph.metadata['blockType'], blockquoteAttribution);
         expect(paragraph.text.text.isEmpty, isTrue);
@@ -334,7 +334,7 @@ void main() {
             .fromMarkdown("# My Header")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final headerNode = context.findEditContext().document.nodes.first;
+        final headerNode = context.findEditContext().document.first;
 
         await tester.placeCaretInParagraph(headerNode.id, 0);
 
@@ -370,7 +370,7 @@ void main() {
             .fromMarkdown("> My Blockquote")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final blockquoteNode = context.findEditContext().document.nodes.first;
+        final blockquoteNode = context.findEditContext().document.first;
 
         await tester.placeCaretInParagraph(blockquoteNode.id, 0);
 
@@ -406,7 +406,7 @@ void main() {
             .fromMarkdown("1. My list item")
             .withInputSource(TextInputSource.ime)
             .pump();
-        final listItemNode = context.findEditContext().document.nodes.first;
+        final listItemNode = context.findEditContext().document.first;
 
         await tester.placeCaretInParagraph(listItemNode.id, 0);
 
@@ -432,7 +432,7 @@ void main() {
         );
 
         // Ensure that the list item became a paragraph.
-        final newNode = context.findEditContext().document.nodes.first;
+        final newNode = context.findEditContext().document.first;
         expect(newNode, isA<ParagraphNode>());
         expect(newNode.metadata["blockType"], paragraphAttribution);
         expect(SuperEditorInspector.findTextInComponent(listItemNode.id).text, "My list item");

--- a/super_editor/test/super_editor/text_entry/text_test.dart
+++ b/super_editor/test/super_editor/text_entry/text_test.dart
@@ -48,7 +48,7 @@ Future<void> main() async {
 
         editor.execute([request]);
 
-        final boldedText = (document.nodes.first as ParagraphNode).text;
+        final boldedText = (document.first as ParagraphNode).text;
         expect(boldedText.getAllAttributionsAt(0), <dynamic>{});
         expect(boldedText.getAllAttributionsAt(1), {boldAttribution});
         expect(boldedText.getAllAttributionsAt(12), {boldAttribution});
@@ -288,7 +288,7 @@ Future<void> main() async {
         // The handler should insert a character
         expect(result, ExecutionInstruction.haltExecution);
         expect(
-          (editContext.document.nodes.first as TextNode).text.text,
+          (editContext.document.first as TextNode).text.text,
           'aThis is some text',
         );
       });
@@ -332,7 +332,7 @@ Future<void> main() async {
         // The handler should insert a character
         expect(result, ExecutionInstruction.haltExecution);
         expect(
-          (editContext.document.nodes.first as TextNode).text.text,
+          (editContext.document.first as TextNode).text.text,
           'ßThis is some text',
         );
       });

--- a/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
+++ b/super_editor/test/super_reader/mobile/super_reader_ios_selection_test.dart
@@ -262,7 +262,7 @@ multiple lines.''',
             .insideCustomScrollView()
             .pump();
 
-        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.document.first as ParagraphNode;
 
         // Double tap to select "SuperEditor".
         await SuperReaderRobot(tester).doubleTapInParagraph(paragraphNode.id, 0);
@@ -306,7 +306,7 @@ multiple lines.''',
             .insideCustomScrollView()
             .pump();
 
-        final paragraphNode = testContext.document.nodes.first as ParagraphNode;
+        final paragraphNode = testContext.document.first as ParagraphNode;
 
         // Double tap to select "SuperEditor".
         await SuperReaderRobot(tester).doubleTapInParagraph(paragraphNode.id, 0);

--- a/super_editor/test/super_reader/reader_test_tools.dart
+++ b/super_editor/test/super_reader/reader_test_tools.dart
@@ -486,35 +486,34 @@ class EquivalentDocumentMatcher extends Matcher {
     bool nodeCountMismatch = false;
     bool nodeTypeOrContentMismatch = false;
 
-    if (_expectedDocument.nodes.length != actualDocument.nodes.length) {
-      messages
-          .add("expected ${_expectedDocument.nodes.length} document nodes but found ${actualDocument.nodes.length}");
+    if (_expectedDocument.nodeCount != actualDocument.nodeCount) {
+      messages.add("expected ${_expectedDocument.nodeCount} document nodes but found ${actualDocument.nodeCount}");
       nodeCountMismatch = true;
     } else {
       messages.add("document have the same number of nodes");
     }
 
-    final maxNodeCount = max(_expectedDocument.nodes.length, actualDocument.nodes.length);
+    final maxNodeCount = max(_expectedDocument.nodeCount, actualDocument.nodeCount);
     final nodeComparisons = List.generate(maxNodeCount, (index) => ["", "", " "]);
     for (int i = 0; i < maxNodeCount; i += 1) {
-      if (i < _expectedDocument.nodes.length && i < actualDocument.nodes.length) {
-        nodeComparisons[i][0] = _expectedDocument.nodes[i].runtimeType.toString();
-        nodeComparisons[i][1] = actualDocument.nodes[i].runtimeType.toString();
+      if (i < _expectedDocument.nodeCount && i < actualDocument.nodeCount) {
+        nodeComparisons[i][0] = _expectedDocument.getNodeAt(i)!.runtimeType.toString();
+        nodeComparisons[i][1] = actualDocument.getNodeAt(i)!.runtimeType.toString();
 
-        if (_expectedDocument.nodes[i].runtimeType != actualDocument.nodes[i].runtimeType) {
+        if (_expectedDocument.getNodeAt(i)!.runtimeType != actualDocument.getNodeAt(i)!.runtimeType) {
           nodeComparisons[i][2] = "Wrong Type";
           nodeTypeOrContentMismatch = true;
-        } else if (!_expectedDocument.nodes[i].hasEquivalentContent(actualDocument.nodes[i])) {
+        } else if (!_expectedDocument.getNodeAt(i)!.hasEquivalentContent(actualDocument.getNodeAt(i)!)) {
           nodeComparisons[i][2] = "Different Content";
           nodeTypeOrContentMismatch = true;
         }
-      } else if (i < _expectedDocument.nodes.length) {
-        nodeComparisons[i][0] = _expectedDocument.nodes[i].runtimeType.toString();
+      } else if (i < _expectedDocument.nodeCount) {
+        nodeComparisons[i][0] = _expectedDocument.getNodeAt(i)!.runtimeType.toString();
         nodeComparisons[i][1] = "NA";
         nodeComparisons[i][2] = "Missing Node";
-      } else if (i < actualDocument.nodes.length) {
+      } else if (i < actualDocument.nodeCount) {
         nodeComparisons[i][0] = "NA";
-        nodeComparisons[i][1] = actualDocument.nodes[i].runtimeType.toString();
+        nodeComparisons[i][1] = actualDocument.getNodeAt(i)!.runtimeType.toString();
         nodeComparisons[i][2] = "Missing Node";
       }
     }

--- a/super_editor/test/super_reader/super_reader_keyboard_test.dart
+++ b/super_editor/test/super_reader/super_reader_keyboard_test.dart
@@ -277,7 +277,7 @@ Future<String> _pumpSingleLineAndSelectAWord(
       .autoFocus(true)
       .pump();
 
-  final nodeId = testContext.documentContext.document.nodes.first.id;
+  final nodeId = testContext.documentContext.document.first.id;
 
   await tester.doubleTapInParagraph(nodeId, offset);
 
@@ -299,7 +299,7 @@ Future<String> _pumpDoubleLine(
       .autoFocus(true)
       .pump();
 
-  final nodeId = testContext.documentContext.document.nodes.first.id;
+  final nodeId = testContext.documentContext.document.first.id;
 
   await tester.doubleTapInParagraph(nodeId, offset);
 

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -21,7 +21,7 @@ void main() {
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
 
       final dragGesture = await tester.startDocumentDragFromPosition(
         from: DocumentPosition(
@@ -56,7 +56,7 @@ void main() {
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Jump to the end of the document
       scrollController.jumpTo(scrollController.position.maxScrollExtent);
@@ -95,8 +95,8 @@ void main() {
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       final dragGesture = await tester.startDocumentDragFromPosition(
         from: DocumentPosition(
@@ -140,8 +140,8 @@ void main() {
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final firstParagraph = document.nodes.first as ParagraphNode;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final firstParagraph = document.first as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Place the caret at the end of the document, which causes the editor to
       // scroll to the bottom.
@@ -195,7 +195,7 @@ void main() {
           .forDesktop() //
           .pump();
       final document = SuperReaderInspector.findDocument()!;
-      final lastParagraph = document.nodes.last as ParagraphNode;
+      final lastParagraph = document.last as ParagraphNode;
 
       // Place the caret at the end of the document, which should cause the
       // editor to scroll to the bottom.

--- a/super_editor/test/super_reader/super_reader_selection_test.dart
+++ b/super_editor/test/super_reader/super_reader_selection_test.dart
@@ -65,7 +65,7 @@ void main() {
           .createDocument() //
           .fromMarkdown("This is paragraph one.\nThis is paragraph two.") //
           .pump();
-      final nodeId = testContext.documentContext.document.nodes.first.id;
+      final nodeId = testContext.documentContext.document.first.id;
 
       /// Triple tap on the first line in the paragraph node.
       await tester.tripleTapInParagraph(nodeId, 10);
@@ -96,7 +96,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.documentContext.document.nodes.first.id;
+      final firstParagraphId = testContext.documentContext.document.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -123,7 +123,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.documentContext.document.nodes.last.id;
+      final secondParagraphId = testContext.documentContext.document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -156,7 +156,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final secondParagraphId = testContext.documentContext.document.nodes.last.id;
+      final secondParagraphId = testContext.documentContext.document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -189,7 +189,7 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.documentContext.document.nodes.first.id;
+      final firstParagraphId = testContext.documentContext.document.first.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -216,8 +216,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.documentContext.document.nodes.first.id;
-      final secondParagraphId = testContext.documentContext.document.nodes.last.id;
+      final firstParagraphId = testContext.documentContext.document.first.id;
+      final secondParagraphId = testContext.documentContext.document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -250,8 +250,8 @@ void main() {
         (tester) async {
       final testContext = await _pumpUnselectableComponentTestApp(tester);
 
-      final firstParagraphId = testContext.documentContext.document.nodes.first.id;
-      final secondParagraphId = testContext.documentContext.document.nodes.last.id;
+      final firstParagraphId = testContext.documentContext.document.first.id;
+      final secondParagraphId = testContext.documentContext.document.last.id;
 
       // TODO: replace the following direct layout access with a simulated user
       // drag, once we've merged some new dragging tools in #645.
@@ -300,7 +300,7 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final paragraphNode = document.nodes.first as ParagraphNode;
+      final paragraphNode = document.first as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -346,7 +346,7 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final paragraphNode = document.nodes.first as ParagraphNode;
+      final paragraphNode = document.first as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -394,8 +394,8 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final titleNode = document.nodes.first as ParagraphNode;
-      final paragraphNode = document.nodes[1] as ParagraphNode;
+      final titleNode = document.first as ParagraphNode;
+      final paragraphNode = document.getNodeAt(1)! as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(
@@ -443,8 +443,8 @@ spans multiple lines.''',
           .pump();
 
       final document = SuperReaderInspector.findDocument()!;
-      final titleNode = document.nodes.first as ParagraphNode;
-      final paragraphNode = document.nodes[1] as ParagraphNode;
+      final titleNode = document.first as ParagraphNode;
+      final paragraphNode = document.getNodeAt(1)! as ParagraphNode;
 
       await tester.dragSelectDocumentFromPositionByOffset(
         from: DocumentPosition(

--- a/super_editor/test/super_reader/super_reader_tapregion_test.dart
+++ b/super_editor/test/super_reader/super_reader_tapregion_test.dart
@@ -40,7 +40,7 @@ void main() {
           )
           .pump();
 
-      final nodeId = context.document.nodes.first.id;
+      final nodeId = context.document.first.id;
 
       // Double tap to show the expanded handle.
       await SuperReaderRobot(tester).doubleTapInParagraph(nodeId, 0);

--- a/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
+++ b/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
@@ -21,7 +21,7 @@ void main() {
             .withiOSToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .withAndroidToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .pump();
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
 
         await tester.placeCaretInParagraph(nodeId, 15);
 
@@ -40,7 +40,7 @@ void main() {
             .withiOSToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .withAndroidToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .pump();
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
 
         await tester.doubleTapInParagraph(nodeId, 15);
 
@@ -59,7 +59,7 @@ void main() {
             .withiOSToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .withAndroidToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .pump();
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
 
         await tester.placeCaretInParagraph(nodeId, 15);
 
@@ -78,7 +78,7 @@ void main() {
             .withiOSToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .withAndroidToolbarBuilder((context, mobileToolbarKey, focalPoint) => const SizedBox())
             .pump();
-        final nodeId = testContext.findEditContext().document.nodes.first.id;
+        final nodeId = testContext.findEditContext().document.first.id;
 
         await tester.doubleTapInParagraph(nodeId, 15);
 

--- a/super_editor/test_goldens/editor/supereditor_caret_test.dart
+++ b/super_editor/test_goldens/editor/supereditor_caret_test.dart
@@ -166,7 +166,7 @@ void main() {
         // Place caret at "adipiscing elit|.". In portrait mode, this character
         // is displayed on the second line. In landscape mode, it's displayed
         // on the first line.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 54);
+        await tester.placeCaretInParagraph(context.document.first.id, 54);
 
         await screenMatchesGolden(tester, 'super-editor-caret-rotation-portrait-landscape-before-ios');
 
@@ -189,7 +189,7 @@ void main() {
         // Place caret at "adipiscing elit|.". In portrait mode, this character
         // is displayed on the second line. In landscape mode, it's displayed
         // on the first line.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 54);
+        await tester.placeCaretInParagraph(context.document.first.id, 54);
 
         await screenMatchesGolden(tester, 'super-editor-caret-rotation-portrait-landscape-before-android');
 
@@ -212,7 +212,7 @@ void main() {
         // Place caret at "adipiscing elit|.". In portrait mode, this character
         // is displayed on the second line. In landscape mode, it's displayed
         // on the first line.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 54);
+        await tester.placeCaretInParagraph(context.document.first.id, 54);
 
         await screenMatchesGolden(tester, 'super-editor-caret-rotation-landscape-portrait-before-ios');
 
@@ -235,7 +235,7 @@ void main() {
         // Place caret at "adipiscing elit|.". In portrait mode, this character
         // is displayed on the second line. In landscape mode, it's displayed
         // on the first line.
-        await tester.placeCaretInParagraph(context.document.nodes.first.id, 54);
+        await tester.placeCaretInParagraph(context.document.first.id, 54);
 
         await screenMatchesGolden(tester, 'super-editor-caret-rotation-landscape-portrait-before-android');
 

--- a/super_editor/test_goldens/editor/supereditor_text_layout_test.dart
+++ b/super_editor/test_goldens/editor/supereditor_text_layout_test.dart
@@ -179,7 +179,7 @@ Future<void> _placeCaretAtFirstNode(
   final regularEditorFinder = find.byKey(editorKey);
   final regularDoc = SuperEditorInspector.findDocument(regularEditorFinder)!;
   await tester.placeCaretInParagraph(
-    regularDoc.nodes.first.id,
+    regularDoc.first.id,
     offset,
     superEditorFinder: regularEditorFinder,
   );
@@ -194,7 +194,7 @@ Future<void> _doubleTapAtFirstNode(
   final regularEditorFinder = find.byKey(editorKey);
   final regularDoc = SuperEditorInspector.findDocument(regularEditorFinder)!;
   await tester.doubleTapInParagraph(
-    regularDoc.nodes.first.id,
+    regularDoc.first.id,
     offset,
     superEditorFinder: regularEditorFinder,
   );

--- a/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
+++ b/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
@@ -140,7 +140,7 @@ Future<(Editor, Document)> _pumpScaffold(WidgetTester tester, String contentMark
 }
 
 Future<void> _simulateComposingRegion(WidgetTester tester, Editor editor, Document document) async {
-  final nodeId = document.nodes.first.id;
+  final nodeId = document.first.id;
   editor.execute([
     ChangeSelectionRequest(
       DocumentSelection.collapsed(
@@ -169,7 +169,7 @@ Future<void> _simulateComposingRegion(WidgetTester tester, Editor editor, Docume
 }
 
 Future<void> _clearComposingRegion(WidgetTester tester, Editor editor, Document document) async {
-  final nodeId = document.nodes.first.id;
+  final nodeId = document.first.id;
   editor.execute([
     ChangeSelectionRequest(
       DocumentSelection.collapsed(

--- a/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
+++ b/super_editor_markdown/lib/src/document_to_markdown_serializer.dart
@@ -31,14 +31,14 @@ String serializeDocumentToMarkdown(
 
   StringBuffer buffer = StringBuffer();
 
-  for (int i = 0; i < doc.nodes.length; ++i) {
+  for (int i = 0; i < doc.nodeCount; ++i) {
     if (i > 0) {
       // Add a new line before every node, except the first node.
       buffer.writeln("");
     }
 
     // Serialize the current node to markdown.
-    final node = doc.nodes[i];
+    final node = doc.getNodeAt(i)!;
     for (final serializer in nodeSerializers) {
       final serialization = serializer.serialize(doc, node);
       if (serialization != null) {
@@ -139,7 +139,7 @@ class ListItemNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Lis
     buffer.write('$indent$symbol ${node.text.toMarkdown()}');
 
     final nodeIndex = document.getNodeIndexById(node.id);
-    final nodeBelow = nodeIndex < document.nodes.length - 1 ? document.nodes[nodeIndex + 1] : null;
+    final nodeBelow = nodeIndex < document.nodeCount - 1 ? document.getNodeAt(nodeIndex + 1) : null;
     if (nodeBelow != null && (nodeBelow is! ListItemNode || nodeBelow.type != node.type)) {
       // This list item is the last item in the list. Add an extra
       // blank line after it.
@@ -201,7 +201,7 @@ class ParagraphNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Pa
     // paragraph so that we can tell the difference between separate
     // paragraphs vs. newlines within a single paragraph.
     final nodeIndex = document.getNodeIndexById(node.id);
-    if (nodeIndex != document.nodes.length - 1) {
+    if (nodeIndex != document.nodeCount - 1) {
       buffer.writeln();
     }
 
@@ -456,7 +456,7 @@ class HeaderNodeSerializer extends NodeTypedDocumentNodeMarkdownSerializer<Parag
     // paragraph so that we can tell the difference between separate
     // paragraphs vs. newlines within a single paragraph.
     final nodeIndex = document.getNodeIndexById(node.id);
-    if (nodeIndex != document.nodes.length - 1) {
+    if (nodeIndex != document.nodeCount - 1) {
       buffer.writeln();
     }
 

--- a/super_editor_markdown/lib/src/markdown_to_attributed_text_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_attributed_text_parsing.dart
@@ -12,9 +12,9 @@ AttributedText attributedTextFromMarkdown(String markdown) {
   }
 
   final document = deserializeMarkdownToDocument(markdown);
-  assert(document.nodes.length == 1,
-      "Tried to parse Markdown to AttributedText. Expected one paragraph node but ended up with ${document.nodes.length} parsed nodes.");
-  assert(document.nodes.first is ParagraphNode,
-      "Tried to parse Markdown to AttributedText. Expected text but found content type: ${document.nodes.first.runtimeType}");
-  return (document.nodes.first as ParagraphNode).text;
+  assert(document.nodeCount == 1,
+      "Tried to parse Markdown to AttributedText. Expected one paragraph node but ended up with ${document.nodeCount} parsed nodes.");
+  assert(document.first is ParagraphNode,
+      "Tried to parse Markdown to AttributedText. Expected text but found content type: ${document.first.runtimeType}");
+  return (document.first as ParagraphNode).text;
 }

--- a/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
+++ b/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
@@ -66,7 +66,7 @@ Future<void> pasteMarkdown({
   // Paste the structured content into the document.
   editor.execute([
     PasteStructuredContentEditorRequest(
-      content: deserializedMarkdown.nodes,
+      content: deserializedMarkdown,
       pastePosition: pastePosition,
     ),
   ]);

--- a/super_editor_markdown/test/custom_block_parser_test.dart
+++ b/super_editor_markdown/test/custom_block_parser_test.dart
@@ -19,21 +19,21 @@ This is another normal paragraph.''',
         customElementToNodeConverters: [UpsellElementToNodeConverter()],
       );
 
-      expect(document.nodes.length, 4);
+      expect(document.nodeCount, 4);
       expect(
-        document.nodes[0],
+        document.getNodeAt(0)!,
         isA<ParagraphNode>(),
       );
       expect(
-        document.nodes[1],
+        document.getNodeAt(1)!,
         isA<ParagraphNode>(),
       );
       expect(
-        document.nodes[2],
+        document.getNodeAt(2)!,
         isA<UpsellNode>(),
       );
       expect(
-        document.nodes[3],
+        document.getNodeAt(3)!,
         isA<ParagraphNode>(),
       );
     });
@@ -52,25 +52,25 @@ This is another normal paragraph.''',
         customElementToNodeConverters: [CalloutElementToNodeConverter()],
       );
 
-      expect(document.nodes.length, 4);
+      expect(document.nodeCount, 4);
       expect(
-        document.nodes[0],
+        document.getNodeAt(0)!,
         isA<ParagraphNode>(),
       );
       expect(
-        document.nodes[1],
+        document.getNodeAt(1)!,
         isA<ParagraphNode>(),
       );
       expect(
-        document.nodes[2],
+        document.getNodeAt(2)!,
         isA<ParagraphNode>(),
       );
       expect(
-        (document.nodes[2] as ParagraphNode).metadata["blockType"],
+        (document.getNodeAt(2)! as ParagraphNode).metadata["blockType"],
         const NamedAttribution("callout"),
       );
       expect(
-        document.nodes[3],
+        document.getNodeAt(3)!,
         isA<ParagraphNode>(),
       );
     });

--- a/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
+++ b/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
@@ -13,7 +13,7 @@ void main() {
       testWidgets("bold", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
         await tester.typeImeText("**bold**");
 
@@ -27,7 +27,7 @@ void main() {
       testWidgets("italics", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
         await tester.typeImeText("*italics*");
 
@@ -41,7 +41,7 @@ void main() {
       testWidgets("strikethrough", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
         await tester.typeImeText("~strikethrough");
 
@@ -67,7 +67,7 @@ void main() {
       testWidgets("code", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
         await tester.typeImeText("`code");
 
@@ -94,7 +94,7 @@ void main() {
         testWidgets("bold then italics", (tester) async {
           final (document, _) = await _pumpScaffold(tester);
 
-          final nodeId = document.nodes.first.id;
+          final nodeId = document.first.id;
           await tester.placeCaretInParagraph(nodeId, 0);
           await tester.typeImeText("**token*");
 
@@ -105,7 +105,7 @@ void main() {
         testWidgets("italics then bold", (tester) async {
           final (document, _) = await _pumpScaffold(tester);
 
-          final nodeId = document.nodes.first.id;
+          final nodeId = document.first.id;
           await tester.placeCaretInParagraph(nodeId, 0);
           await tester.typeImeText("*token**");
 
@@ -122,7 +122,7 @@ void main() {
       testWidgets("bold", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "Hello");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 5);
 
         await tester.typeImeText(" **bold**");
@@ -137,7 +137,7 @@ void main() {
       testWidgets("italics", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "Hello");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 5);
 
         await tester.typeImeText(" *italics*");
@@ -152,7 +152,7 @@ void main() {
       testWidgets("strikethrough", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "Hello");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 5);
 
         await tester.typeImeText(" ~strikethrough~");
@@ -168,7 +168,7 @@ void main() {
         testWidgets("bold then italics", (tester) async {
           final (document, _) = await _pumpScaffold(tester, "Hello");
 
-          final nodeId = document.nodes.first.id;
+          final nodeId = document.first.id;
           await tester.placeCaretInParagraph(nodeId, 5);
           await tester.typeImeText(" **token*");
 
@@ -179,7 +179,7 @@ void main() {
         testWidgets("italics then bold", (tester) async {
           final (document, _) = await _pumpScaffold(tester, "Hello");
 
-          final nodeId = document.nodes.first.id;
+          final nodeId = document.first.id;
           await tester.placeCaretInParagraph(nodeId, 5);
           await tester.typeImeText(" *token**");
 
@@ -196,20 +196,20 @@ void main() {
       testWidgets("unbalanced italics", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         await tester.typeImeText("**noitalics*");
 
         expect(SuperEditorInspector.findTextInComponent(nodeId).text, "**noitalics*");
-        expect((document.nodes.first as ParagraphNode).text.spans.markers.isEmpty, isTrue);
+        expect((document.first as ParagraphNode).text.spans.markers.isEmpty, isTrue);
       });
     });
 
     testWidgets("multiple styles", (tester) async {
       final (document, _) = await _pumpScaffold(tester, "Hello");
 
-      final nodeId = document.nodes.first.id;
+      final nodeId = document.first.id;
       await tester.placeCaretInParagraph(nodeId, 5);
 
       // Italics
@@ -247,7 +247,7 @@ void main() {
     testWidgets("preserves non-Markdown attributions", (tester) async {
       final (document, editor) = await _pumpScaffold(tester, "Hello *italics");
 
-      final nodeId = document.nodes.first.id;
+      final nodeId = document.first.id;
 
       // Add a non-Markdown attribution to the text.
       const colorAttribution = ColorAttribution(Color(0xFFFF0000));
@@ -288,7 +288,7 @@ void main() {
       // when given a specific ambiguous input.
       final (document, _) = await _pumpScaffold(tester, "Hello");
 
-      final nodeId = document.nodes.first.id;
+      final nodeId = document.first.id;
       await tester.placeCaretInParagraph(nodeId, 5);
 
       // "**this*" should do nothing because the downstream syntax doesn't have a
@@ -334,7 +334,7 @@ void main() {
       testWidgets("italics", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "Hello italics*");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 6);
 
         await tester.typeImeText("*");
@@ -352,7 +352,7 @@ void main() {
       testWidgets("bold", (tester) async {
         final (document, _) = await _pumpScaffold(tester, "Hello bold**");
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 6);
 
         await tester.typeImeText("*");
@@ -381,7 +381,7 @@ void main() {
       testWidgets("bold", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -395,7 +395,7 @@ void main() {
       testWidgets("italics > single trigger > star", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -409,7 +409,7 @@ void main() {
       testWidgets("italics > tripple trigger > star", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -423,7 +423,7 @@ void main() {
       testWidgets("italics > single trigger > underscore", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -437,7 +437,7 @@ void main() {
       testWidgets("italics > tripple trigger > underscore", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -451,7 +451,7 @@ void main() {
       testWidgets("strikethrough", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -465,7 +465,7 @@ void main() {
       testWidgets("code", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Type the trigger characters, without any content between them.
@@ -481,7 +481,7 @@ void main() {
       testWidgets("but only when a space follows the syntax", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         // Enter a link syntax, but no characters after it.
@@ -512,7 +512,7 @@ void main() {
       testWidgets("parses Markdown link syntax and plays nice with built-in linkification reaction", (tester) async {
         final (document, _) = await _pumpScaffold(tester);
 
-        final nodeId = document.nodes.first.id;
+        final nodeId = document.first.id;
         await tester.placeCaretInParagraph(nodeId, 0);
 
         await tester.typeImeText("[google](www.google.com) ");

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -85,7 +85,7 @@ This is the document that exists before Markdown is pasted.
       );
 
       // Place the caret at the beginning of the document.
-      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(document.first.id, 0);
 
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
@@ -129,7 +129,7 @@ This is the document that exists before Markdown is pasted.
       );
 
       // Place the caret at the beginning of the document.
-      await tester.placeCaretInParagraph(document.nodes.first.id, 0);
+      await tester.placeCaretInParagraph(document.first.id, 0);
 
       // Ensure that the document has the caret.
       expect(composer.selection, isNotNull);
@@ -168,7 +168,7 @@ This is the document that exists before Markdown is pasted.''',
       );
 
       // Place the caret between chevrons ">|<"
-      final lastParagraph = document.nodes.last as TextNode;
+      final lastParagraph = document.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, 37);
 
       // Ensure that the document has the caret.
@@ -203,7 +203,7 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continu
       );
 
       // Place the caret between chevrons ">|<".
-      final lastParagraph = document.nodes.last as TextNode;
+      final lastParagraph = document.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, 40);
 
       // Ensure that the document has the caret.
@@ -236,7 +236,7 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.< here and continu
       );
 
       // Place the caret between chevrons ">|<".
-      final lastParagraph = document.nodes.last as TextNode;
+      final lastParagraph = document.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, 42);
 
       // Ensure that the document has the caret.
@@ -274,7 +274,7 @@ This is the document that exists before Markdown is pasted.
       );
 
       // Place the caret at the end of the existing document.
-      final lastParagraph = document.nodes.last as TextNode;
+      final lastParagraph = document.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, lastParagraph.endPosition.offset);
 
       // Ensure that the document has the caret.
@@ -319,7 +319,7 @@ This is the document that exists before Markdown is pasted.
       );
 
       // Place the caret at the end of the existing document.
-      final lastParagraph = document.nodes.last as TextNode;
+      final lastParagraph = document.last as TextNode;
       await tester.placeCaretInParagraph(lastParagraph.id, lastParagraph.endPosition.offset);
 
       // Ensure that the document has the caret.
@@ -359,7 +359,7 @@ Aenean mattis ante justo, quis sollicitudin metus interdum id.''',
       );
 
       // Place the caret in empty paragraph.
-      final paragraph = document.nodes.first as TextNode;
+      final paragraph = document.first as TextNode;
       await tester.placeCaretInParagraph(paragraph.id, 0);
 
       // Simulate the user copying a markdown snippet.

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -13,22 +13,22 @@ void main() {
           ),
         ]);
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header1Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header1Attribution);
         expect(serializeDocumentToMarkdown(doc), '# My Header');
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header2Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header2Attribution);
         expect(serializeDocumentToMarkdown(doc), '## My Header');
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header3Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header3Attribution);
         expect(serializeDocumentToMarkdown(doc), '### My Header');
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header4Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header4Attribution);
         expect(serializeDocumentToMarkdown(doc), '#### My Header');
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header5Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header5Attribution);
         expect(serializeDocumentToMarkdown(doc), '##### My Header');
 
-        (doc.nodes[0] as ParagraphNode).putMetadataValue('blockType', header6Attribution);
+        (doc.getNodeAt(0)! as ParagraphNode).putMetadataValue('blockType', header6Attribution);
         expect(serializeDocumentToMarkdown(doc), '###### My Header');
       });
 
@@ -812,27 +812,27 @@ with multiple lines
     group('deserialization', () {
       test('headers', () {
         final header1Doc = deserializeMarkdownToDocument('# Header 1');
-        expect((header1Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect((header1Doc.first as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
 
         final header2Doc = deserializeMarkdownToDocument('## Header 2');
-        expect((header2Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header2Attribution);
+        expect((header2Doc.first as ParagraphNode).getMetadataValue('blockType'), header2Attribution);
 
         final header3Doc = deserializeMarkdownToDocument('### Header 3');
-        expect((header3Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header3Attribution);
+        expect((header3Doc.first as ParagraphNode).getMetadataValue('blockType'), header3Attribution);
 
         final header4Doc = deserializeMarkdownToDocument('#### Header 4');
-        expect((header4Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header4Attribution);
+        expect((header4Doc.first as ParagraphNode).getMetadataValue('blockType'), header4Attribution);
 
         final header5Doc = deserializeMarkdownToDocument('##### Header 5');
-        expect((header5Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header5Attribution);
+        expect((header5Doc.first as ParagraphNode).getMetadataValue('blockType'), header5Attribution);
 
         final header6Doc = deserializeMarkdownToDocument('###### Header 6');
-        expect((header6Doc.nodes.first as ParagraphNode).getMetadataValue('blockType'), header6Attribution);
+        expect((header6Doc.first as ParagraphNode).getMetadataValue('blockType'), header6Attribution);
       });
 
       test('header with left alignment', () {
         final headerLeftAlignment1 = deserializeMarkdownToDocument(':---\n# Header 1');
-        final header = headerLeftAlignment1.nodes.first as ParagraphNode;
+        final header = headerLeftAlignment1.first as ParagraphNode;
         expect(header.getMetadataValue('blockType'), header1Attribution);
         expect(header.getMetadataValue('textAlign'), 'left');
         expect(header.text.text, 'Header 1');
@@ -840,7 +840,7 @@ with multiple lines
 
       test('header with center alignment', () {
         final headerLeftAlignment1 = deserializeMarkdownToDocument(':---:\n# Header 1');
-        final header = headerLeftAlignment1.nodes.first as ParagraphNode;
+        final header = headerLeftAlignment1.first as ParagraphNode;
         expect(header.getMetadataValue('blockType'), header1Attribution);
         expect(header.getMetadataValue('textAlign'), 'center');
         expect(header.text.text, 'Header 1');
@@ -848,7 +848,7 @@ with multiple lines
 
       test('header with right alignment', () {
         final headerLeftAlignment1 = deserializeMarkdownToDocument('---:\n# Header 1');
-        final header = headerLeftAlignment1.nodes.first as ParagraphNode;
+        final header = headerLeftAlignment1.first as ParagraphNode;
         expect(header.getMetadataValue('blockType'), header1Attribution);
         expect(header.getMetadataValue('textAlign'), 'right');
         expect(header.text.text, 'Header 1');
@@ -856,7 +856,7 @@ with multiple lines
 
       test('header with justify alignment', () {
         final headerLeftAlignment1 = deserializeMarkdownToDocument('-::-\n# Header 1');
-        final header = headerLeftAlignment1.nodes.first as ParagraphNode;
+        final header = headerLeftAlignment1.first as ParagraphNode;
         expect(header.getMetadataValue('blockType'), header1Attribution);
         expect(header.getMetadataValue('textAlign'), 'justify');
         expect(header.text.text, 'Header 1');
@@ -865,7 +865,7 @@ with multiple lines
       test('blockquote', () {
         final blockquoteDoc = deserializeMarkdownToDocument('> This is a blockquote');
 
-        final blockquote = blockquoteDoc.nodes.first as ParagraphNode;
+        final blockquote = blockquoteDoc.first as ParagraphNode;
         expect(blockquote.getMetadataValue('blockType'), blockquoteAttribution);
         expect(blockquote.text.text, 'This is a blockquote');
       });
@@ -876,7 +876,7 @@ with multiple lines
 This is some code
 ```''');
 
-        final code = codeBlockDoc.nodes.first as ParagraphNode;
+        final code = codeBlockDoc.first as ParagraphNode;
         expect(code.getMetadataValue('blockType'), codeAttribution);
         expect(code.text.text, 'This is some code\n');
       });
@@ -884,7 +884,7 @@ This is some code
       test('image', () {
         final codeBlockDoc = deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize, isNull);
@@ -894,7 +894,7 @@ This is some code
         final codeBlockDoc =
             deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =500x200)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, 500.0);
@@ -905,7 +905,7 @@ This is some code
         final codeBlockDoc = deserializeMarkdownToDocument(
             '![Image alt text](https://images.com/some/image.png =500x200 "image title")');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, 500.0);
@@ -916,7 +916,7 @@ This is some code
         final codeBlockDoc =
             deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =500x)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, 500.0);
@@ -927,7 +927,7 @@ This is some code
         final codeBlockDoc =
             deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =x200)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, isNull);
@@ -937,7 +937,7 @@ This is some code
       test('image with size notation without width and height', () {
         final codeBlockDoc = deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =x)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, isNull);
@@ -947,7 +947,7 @@ This is some code
       test('image with incomplete size notation', () {
         final codeBlockDoc = deserializeMarkdownToDocument('![Image alt text](https://images.com/some/image.png =)');
 
-        final image = codeBlockDoc.nodes.first as ImageNode;
+        final image = codeBlockDoc.first as ImageNode;
         expect(image.imageUrl, 'https://images.com/some/image.png');
         expect(image.altText, 'Image alt text');
         expect(image.expectedBitmapSize?.width, isNull);
@@ -959,10 +959,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         expect(paragraph.text.text, 'This is some unstyled text to parse as markdown');
       });
 
@@ -971,10 +971,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'This is some styled text to parse as markdown');
 
@@ -990,10 +990,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'Preserves symbols like &, <, and >, rather than use HTML escape codes.');
       });
@@ -1003,10 +1003,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown, encodeHtml: true);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'Escapes HTML symbols like &amp;, &lt;, and &gt;, when requested.');
       });
@@ -1016,10 +1016,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'This is some styled link text');
 
@@ -1038,10 +1038,10 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'This is a test');
 
@@ -1060,10 +1060,10 @@ This is some code
         const markdown = 'This **is [a** link](https://example.org) test';
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'This **is a** link test');
 
@@ -1077,10 +1077,10 @@ This is some code
         const markdown = 'This is [a link]() test';
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ParagraphNode>());
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ParagraphNode>());
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         final styledText = paragraph.text;
         expect(styledText.text, 'This is a link test');
 
@@ -1097,36 +1097,36 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 5);
-        for (final node in document.nodes) {
+        expect(document.nodeCount, 5);
+        for (final node in document) {
           expect(node, isA<ListItemNode>());
           expect((node as ListItemNode).type, ListItemType.unordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).indent, 0);
-        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+        expect((document.getNodeAt(0)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
 
-        expect((document.nodes[1] as ListItemNode).indent, 0);
-        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
+        expect((document.getNodeAt(1)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'list item 2');
 
-        expect((document.nodes[2] as ListItemNode).indent, 1);
-        expect((document.nodes[2] as ListItemNode).text.text, 'list item 2.1');
+        expect((document.getNodeAt(2)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'list item 2.1');
 
-        expect((document.nodes[3] as ListItemNode).indent, 1);
-        expect((document.nodes[3] as ListItemNode).text.text, 'list item 2.2');
+        expect((document.getNodeAt(3)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(3)! as ListItemNode).text.text, 'list item 2.2');
 
-        expect((document.nodes[4] as ListItemNode).indent, 0);
-        expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
+        expect((document.getNodeAt(4)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(4)! as ListItemNode).text.text, 'list item 3');
       });
 
       test('empty unordered list item', () {
         const markdown = '* ';
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes.first as ListItemNode).text.text, isEmpty);
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).type, ListItemType.unordered);
+        expect((document.first as ListItemNode).text.text, isEmpty);
       });
 
       test('unordered list followd by empty list item', () {
@@ -1135,11 +1135,11 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
+        expect(document.nodeCount, 1);
 
-        expect(document.nodes[0], isA<ListItemNode>());
-        expect((document.nodes[0] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+        expect(document.getNodeAt(0)!, isA<ListItemNode>());
+        expect((document.getNodeAt(0)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
       });
 
       test('parses mixed unordered and ordered items', () {
@@ -1158,37 +1158,37 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 9);
-        for (final node in document.nodes) {
+        expect(document.nodeCount, 9);
+        for (final node in document) {
           expect(node, isA<ListItemNode>());
         }
 
-        expect((document.nodes[0] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[0] as ListItemNode).text.text, 'Ordered 1');
+        expect((document.getNodeAt(0)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'Ordered 1');
 
-        expect((document.nodes[1] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[1] as ListItemNode).text.text, 'Unordered 1');
+        expect((document.getNodeAt(1)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'Unordered 1');
 
-        expect((document.nodes[2] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[2] as ListItemNode).text.text, 'Unordered 2');
+        expect((document.getNodeAt(2)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'Unordered 2');
 
-        expect((document.nodes[3] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[3] as ListItemNode).text.text, 'Ordered 2');
+        expect((document.getNodeAt(3)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(3)! as ListItemNode).text.text, 'Ordered 2');
 
-        expect((document.nodes[4] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[4] as ListItemNode).text.text, 'Unordered 1');
+        expect((document.getNodeAt(4)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(4)! as ListItemNode).text.text, 'Unordered 1');
 
-        expect((document.nodes[5] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[5] as ListItemNode).text.text, 'Unordered 2');
+        expect((document.getNodeAt(5)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(5)! as ListItemNode).text.text, 'Unordered 2');
 
-        expect((document.nodes[6] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[6] as ListItemNode).text.text, 'Ordered 3');
+        expect((document.getNodeAt(6)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(6)! as ListItemNode).text.text, 'Ordered 3');
 
-        expect((document.nodes[7] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[7] as ListItemNode).text.text, 'Unordered 1');
+        expect((document.getNodeAt(7)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(7)! as ListItemNode).text.text, 'Unordered 1');
 
-        expect((document.nodes[8] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[8] as ListItemNode).text.text, 'Unordered 2');
+        expect((document.getNodeAt(8)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(8)! as ListItemNode).text.text, 'Unordered 2');
       });
 
       test('unordered list with empty lines between items', () {
@@ -1201,15 +1201,15 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 3);
-        for (final node in document.nodes) {
+        expect(document.nodeCount, 3);
+        for (final node in document) {
           expect(node, isA<ListItemNode>());
           expect((node as ListItemNode).type, ListItemType.unordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
-        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
-        expect((document.nodes[2] as ListItemNode).text.text, 'list item 3');
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'list item 2');
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'list item 3');
       });
 
       test('ordered list', () {
@@ -1222,36 +1222,36 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 5);
-        for (final node in document.nodes) {
+        expect(document.nodeCount, 5);
+        for (final node in document) {
           expect(node, isA<ListItemNode>());
           expect((node as ListItemNode).type, ListItemType.ordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).indent, 0);
-        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
+        expect((document.getNodeAt(0)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
 
-        expect((document.nodes[1] as ListItemNode).indent, 0);
-        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
+        expect((document.getNodeAt(1)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'list item 2');
 
-        expect((document.nodes[2] as ListItemNode).indent, 1);
-        expect((document.nodes[2] as ListItemNode).text.text, 'list item 2.1');
+        expect((document.getNodeAt(2)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'list item 2.1');
 
-        expect((document.nodes[3] as ListItemNode).indent, 1);
-        expect((document.nodes[3] as ListItemNode).text.text, 'list item 2.2');
+        expect((document.getNodeAt(3)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(3)! as ListItemNode).text.text, 'list item 2.2');
 
-        expect((document.nodes[4] as ListItemNode).indent, 0);
-        expect((document.nodes[4] as ListItemNode).text.text, 'list item 3');
+        expect((document.getNodeAt(4)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(4)! as ListItemNode).text.text, 'list item 3');
       });
 
       test('empty ordered list item', () {
         const markdown = '1. ';
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 1);
-        expect(document.nodes.first, isA<ListItemNode>());
-        expect((document.nodes.first as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes.first as ListItemNode).text.text, isEmpty);
+        expect(document.nodeCount, 1);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).type, ListItemType.ordered);
+        expect((document.first as ListItemNode).text.text, isEmpty);
       });
 
       test('ordered list with empty lines between items', () {
@@ -1264,15 +1264,15 @@ This is some code
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 3);
-        for (final node in document.nodes) {
+        expect(document.nodeCount, 3);
+        for (final node in document) {
           expect(node, isA<ListItemNode>());
           expect((node as ListItemNode).type, ListItemType.ordered);
         }
 
-        expect((document.nodes[0] as ListItemNode).text.text, 'list item 1');
-        expect((document.nodes[1] as ListItemNode).text.text, 'list item 2');
-        expect((document.nodes[2] as ListItemNode).text.text, 'list item 3');
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'list item 2');
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'list item 3');
       });
 
       test('mixing multiple levels of ordered and unordered lists', () {
@@ -1293,59 +1293,59 @@ This is some code
 ''';
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 13);
+        expect(document.nodeCount, 13);
 
-        expect((document.nodes[0] as ListItemNode).indent, 0);
-        expect((document.nodes[0] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[0] as ListItemNode).text.text, 'Level 1');
+        expect((document.getNodeAt(0)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(0)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(0)! as ListItemNode).text.text, 'Level 1');
 
-        expect((document.nodes[1] as ListItemNode).indent, 1);
-        expect((document.nodes[1] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[1] as ListItemNode).text.text, 'Level 2');
+        expect((document.getNodeAt(1)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(1)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, 'Level 2');
 
-        expect((document.nodes[2] as ListItemNode).indent, 2);
-        expect((document.nodes[2] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[2] as ListItemNode).text.text, 'Level 3');
+        expect((document.getNodeAt(2)! as ListItemNode).indent, 2);
+        expect((document.getNodeAt(2)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(2)! as ListItemNode).text.text, 'Level 3');
 
-        expect((document.nodes[3] as ListItemNode).indent, 3);
-        expect((document.nodes[3] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[3] as ListItemNode).text.text, 'Sublevel 1');
+        expect((document.getNodeAt(3)! as ListItemNode).indent, 3);
+        expect((document.getNodeAt(3)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(3)! as ListItemNode).text.text, 'Sublevel 1');
 
-        expect((document.nodes[4] as ListItemNode).indent, 3);
-        expect((document.nodes[4] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[4] as ListItemNode).text.text, 'Sublevel 2');
+        expect((document.getNodeAt(4)! as ListItemNode).indent, 3);
+        expect((document.getNodeAt(4)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(4)! as ListItemNode).text.text, 'Sublevel 2');
 
-        expect((document.nodes[5] as ListItemNode).indent, 2);
-        expect((document.nodes[5] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[5] as ListItemNode).text.text, 'Level 3 again');
+        expect((document.getNodeAt(5)! as ListItemNode).indent, 2);
+        expect((document.getNodeAt(5)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(5)! as ListItemNode).text.text, 'Level 3 again');
 
-        expect((document.nodes[6] as ListItemNode).indent, 1);
-        expect((document.nodes[6] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[6] as ListItemNode).text.text, 'Level 2 returning');
+        expect((document.getNodeAt(6)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(6)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(6)! as ListItemNode).text.text, 'Level 2 returning');
 
-        expect((document.nodes[7] as ListItemNode).indent, 0);
-        expect((document.nodes[7] as ListItemNode).type, ListItemType.ordered);
-        expect((document.nodes[7] as ListItemNode).text.text, 'Level 1 once more');
+        expect((document.getNodeAt(7)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(7)! as ListItemNode).type, ListItemType.ordered);
+        expect((document.getNodeAt(7)! as ListItemNode).text.text, 'Level 1 once more');
 
-        expect((document.nodes[8] as ListItemNode).indent, 1);
-        expect((document.nodes[8] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[8] as ListItemNode).text.text, 'Bullet list');
+        expect((document.getNodeAt(8)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(8)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(8)! as ListItemNode).text.text, 'Bullet list');
 
-        expect((document.nodes[9] as ListItemNode).indent, 2);
-        expect((document.nodes[9] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[9] as ListItemNode).text.text, 'Another bullet');
+        expect((document.getNodeAt(9)! as ListItemNode).indent, 2);
+        expect((document.getNodeAt(9)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(9)! as ListItemNode).text.text, 'Another bullet');
 
-        expect((document.nodes[10] as ListItemNode).indent, 0);
-        expect((document.nodes[10] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[10] as ListItemNode).text.text, 'Main bullet list');
+        expect((document.getNodeAt(10)! as ListItemNode).indent, 0);
+        expect((document.getNodeAt(10)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(10)! as ListItemNode).text.text, 'Main bullet list');
 
-        expect((document.nodes[11] as ListItemNode).indent, 1);
-        expect((document.nodes[11] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[11] as ListItemNode).text.text, 'Sub bullet list');
+        expect((document.getNodeAt(11)! as ListItemNode).indent, 1);
+        expect((document.getNodeAt(11)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(11)! as ListItemNode).text.text, 'Sub bullet list');
 
-        expect((document.nodes[12] as ListItemNode).indent, 2);
-        expect((document.nodes[12] as ListItemNode).type, ListItemType.unordered);
-        expect((document.nodes[12] as ListItemNode).text.text, 'Subsub bullet list');
+        expect((document.getNodeAt(12)! as ListItemNode).indent, 2);
+        expect((document.getNodeAt(12)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(12)! as ListItemNode).text.text, 'Subsub bullet list');
       });
 
       test('tasks', () {
@@ -1358,84 +1358,84 @@ with multiple lines
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodes.length, 4);
+        expect(document.nodeCount, 4);
 
-        expect(document.nodes[0], isA<TaskNode>());
-        expect(document.nodes[1], isA<TaskNode>());
-        expect(document.nodes[2], isA<TaskNode>());
-        expect(document.nodes[3], isA<TaskNode>());
+        expect(document.getNodeAt(0)!, isA<TaskNode>());
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect(document.getNodeAt(2)!, isA<TaskNode>());
+        expect(document.getNodeAt(3)!, isA<TaskNode>());
 
-        expect((document.nodes[0] as TaskNode).text.text, 'Task 1');
-        expect((document.nodes[0] as TaskNode).isComplete, isTrue);
+        expect((document.getNodeAt(0)! as TaskNode).text.text, 'Task 1');
+        expect((document.getNodeAt(0)! as TaskNode).isComplete, isTrue);
 
-        expect((document.nodes[1] as TaskNode).text.text, 'Task 2');
-        expect((document.nodes[1] as TaskNode).isComplete, isFalse);
+        expect((document.getNodeAt(1)! as TaskNode).text.text, 'Task 2');
+        expect((document.getNodeAt(1)! as TaskNode).isComplete, isFalse);
 
-        expect((document.nodes[2] as TaskNode).text.text, 'Task 3\nwith multiple lines');
-        expect((document.nodes[2] as TaskNode).isComplete, isFalse);
+        expect((document.getNodeAt(2)! as TaskNode).text.text, 'Task 3\nwith multiple lines');
+        expect((document.getNodeAt(2)! as TaskNode).isComplete, isFalse);
 
-        expect((document.nodes[3] as TaskNode).text.text, 'Task 4');
-        expect((document.nodes[3] as TaskNode).isComplete, isTrue);
+        expect((document.getNodeAt(3)! as TaskNode).text.text, 'Task 4');
+        expect((document.getNodeAt(3)! as TaskNode).isComplete, isTrue);
       });
 
       test('example doc 1', () {
         final document = deserializeMarkdownToDocument(exampleMarkdownDoc1);
 
-        expect(document.nodes.length, 26);
+        expect(document.nodeCount, 26);
 
-        expect(document.nodes[0], isA<ParagraphNode>());
-        expect((document.nodes[0] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect(document.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(0)! as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
 
-        expect(document.nodes[1], isA<HorizontalRuleNode>());
+        expect(document.getNodeAt(1)!, isA<HorizontalRuleNode>());
 
-        expect(document.nodes[2], isA<ParagraphNode>());
+        expect(document.getNodeAt(2)!, isA<ParagraphNode>());
 
-        expect(document.nodes[3], isA<ParagraphNode>());
+        expect(document.getNodeAt(3)!, isA<ParagraphNode>());
 
         for (int i = 4; i < 9; ++i) {
-          expect(document.nodes[i], isA<ListItemNode>());
+          expect(document.getNodeAt(i)!, isA<ListItemNode>());
         }
 
-        expect(document.nodes[9], isA<HorizontalRuleNode>());
+        expect(document.getNodeAt(9)!, isA<HorizontalRuleNode>());
 
         for (int i = 10; i < 15; ++i) {
-          expect(document.nodes[i], isA<ListItemNode>());
+          expect(document.getNodeAt(i)!, isA<ListItemNode>());
         }
 
-        expect(document.nodes[15], isA<HorizontalRuleNode>());
+        expect(document.getNodeAt(15)!, isA<HorizontalRuleNode>());
 
-        expect(document.nodes[16], isA<ImageNode>());
+        expect(document.getNodeAt(16)!, isA<ImageNode>());
 
-        expect(document.nodes[17], isA<TaskNode>());
+        expect(document.getNodeAt(17)!, isA<TaskNode>());
 
-        expect(document.nodes[18], isA<ParagraphNode>());
+        expect(document.getNodeAt(18)!, isA<ParagraphNode>());
 
-        expect(document.nodes[19], isA<TaskNode>());
+        expect(document.getNodeAt(19)!, isA<TaskNode>());
 
-        expect(document.nodes[20], isA<HorizontalRuleNode>());
+        expect(document.getNodeAt(20)!, isA<HorizontalRuleNode>());
 
-        expect(document.nodes[21], isA<ParagraphNode>());
-        expect((document.nodes[21] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
-        expect((document.nodes[21] as ParagraphNode).getMetadataValue('textAlign'), 'left');
+        expect(document.getNodeAt(21)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(21)! as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect((document.getNodeAt(21)! as ParagraphNode).getMetadataValue('textAlign'), 'left');
 
-        expect(document.nodes[22], isA<ParagraphNode>());
-        expect((document.nodes[22] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
-        expect((document.nodes[22] as ParagraphNode).getMetadataValue('textAlign'), 'center');
+        expect(document.getNodeAt(22)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(22)! as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect((document.getNodeAt(22)! as ParagraphNode).getMetadataValue('textAlign'), 'center');
 
-        expect(document.nodes[23], isA<ParagraphNode>());
-        expect((document.nodes[23] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
-        expect((document.nodes[23] as ParagraphNode).getMetadataValue('textAlign'), 'right');
+        expect(document.getNodeAt(23)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(23)! as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect((document.getNodeAt(23)! as ParagraphNode).getMetadataValue('textAlign'), 'right');
 
-        expect(document.nodes[24], isA<ParagraphNode>());
-        expect((document.nodes[24] as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
-        expect((document.nodes[24] as ParagraphNode).getMetadataValue('textAlign'), 'justify');
+        expect(document.getNodeAt(24)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(24)! as ParagraphNode).getMetadataValue('blockType'), header1Attribution);
+        expect((document.getNodeAt(24)! as ParagraphNode).getMetadataValue('textAlign'), 'justify');
 
-        expect(document.nodes[25], isA<ParagraphNode>());
+        expect(document.getNodeAt(25)!, isA<ParagraphNode>());
       });
 
       test('paragraph with strikethrough', () {
         final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
-        final styledText = (doc.nodes[0] as ParagraphNode).text;
+        final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
 
         // Ensure text within the range is attributed.
         expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), true);
@@ -1447,7 +1447,7 @@ with multiple lines
 
       test('paragraph with underline', () {
         final doc = deserializeMarkdownToDocument('¬This is¬ a paragraph.');
-        final styledText = (doc.nodes[0] as ParagraphNode).text;
+        final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
 
         // Ensure text within the range is attributed.
         expect(styledText.getAllAttributionsAt(0).contains(underlineAttribution), true);
@@ -1460,7 +1460,7 @@ with multiple lines
       test('paragraph with left alignment', () {
         final doc = deserializeMarkdownToDocument(':---\nParagraph1');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'left');
         expect(paragraph.text.text, 'Paragraph1');
       });
@@ -1468,7 +1468,7 @@ with multiple lines
       test('paragraph with center alignment', () {
         final doc = deserializeMarkdownToDocument(':---:\nParagraph1');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'center');
         expect(paragraph.text.text, 'Paragraph1');
       });
@@ -1476,7 +1476,7 @@ with multiple lines
       test('paragraph with right alignment', () {
         final doc = deserializeMarkdownToDocument('---:\nParagraph1');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'right');
         expect(paragraph.text.text, 'Paragraph1');
       });
@@ -1484,7 +1484,7 @@ with multiple lines
       test('paragraph with justify alignment', () {
         final doc = deserializeMarkdownToDocument('-::-\nParagraph1');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), 'justify');
         expect(paragraph.text.text, 'Paragraph1');
       });
@@ -1492,7 +1492,7 @@ with multiple lines
       test('treats alignment token as text at the end of the document', () {
         final doc = deserializeMarkdownToDocument('---:');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), isNull);
         expect(paragraph.text.text, '---:');
       });
@@ -1500,18 +1500,18 @@ with multiple lines
       test('treats alignment token as text when not followed by a paragraph', () {
         final doc = deserializeMarkdownToDocument('---:\n - - -');
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), isNull);
         expect(paragraph.text.text, '---:');
 
         // Ensure the horizontal rule is parsed.
-        expect(doc.nodes[1], isA<HorizontalRuleNode>());
+        expect(doc.getNodeAt(1)!, isA<HorizontalRuleNode>());
       });
 
       test('treats alignment token as text when not using supereditor syntax', () {
         final doc = deserializeMarkdownToDocument(':---\nParagraph1', syntax: MarkdownSyntax.normal);
 
-        final paragraph = doc.nodes.first as ParagraphNode;
+        final paragraph = doc.first as ParagraphNode;
         expect(paragraph.getMetadataValue('textAlign'), isNull);
         expect(paragraph.text.text, ':---\nParagraph1');
       });
@@ -1522,9 +1522,9 @@ with multiple lines
 Paragraph2""";
         final doc = deserializeMarkdownToDocument(input);
 
-        expect(doc.nodes.length, 2);
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'Paragraph1');
-        expect((doc.nodes[1] as ParagraphNode).text.text, 'Paragraph2');
+        expect(doc.nodeCount, 2);
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Paragraph1');
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, 'Paragraph2');
       });
 
       test('empty paragraph between paragraphs', () {
@@ -1535,10 +1535,10 @@ Paragraph2""";
 Paragraph3""";
         final doc = deserializeMarkdownToDocument(input);
 
-        expect(doc.nodes.length, 3);
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'Paragraph1');
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
-        expect((doc.nodes[2] as ParagraphNode).text.text, 'Paragraph3');
+        expect(doc.nodeCount, 3);
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Paragraph1');
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, 'Paragraph3');
       });
 
       test('multiple empty paragraph between paragraphs', () {
@@ -1551,59 +1551,59 @@ Paragraph3""";
 Paragraph4""";
         final doc = deserializeMarkdownToDocument(input);
 
-        expect(doc.nodes.length, 4);
-        expect((doc.nodes[0] as ParagraphNode).text.text, 'Paragraph1');
-        expect((doc.nodes[1] as ParagraphNode).text.text, '');
-        expect((doc.nodes[2] as ParagraphNode).text.text, '');
-        expect((doc.nodes[3] as ParagraphNode).text.text, 'Paragraph4');
+        expect(doc.nodeCount, 4);
+        expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Paragraph1');
+        expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
+        expect((doc.getNodeAt(2)! as ParagraphNode).text.text, '');
+        expect((doc.getNodeAt(3)! as ParagraphNode).text.text, 'Paragraph4');
       });
 
       test('paragraph ending with one blank line', () {
         final doc = deserializeMarkdownToDocument('First Paragraph.  \n\n\nSecond Paragraph');
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, 'First Paragraph.\n');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, 'First Paragraph.\n');
 
-        expect(doc.nodes.last, isA<ParagraphNode>());
-        expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
+        expect(doc.last, isA<ParagraphNode>());
+        expect((doc.last as ParagraphNode).text.text, 'Second Paragraph');
       });
 
       test('paragraph ending with multiple blank lines', () {
         final doc = deserializeMarkdownToDocument('First Paragraph.  \n  \n  \n\n\nSecond Paragraph');
 
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, 'First Paragraph.\n\n\n');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, 'First Paragraph.\n\n\n');
 
-        expect(doc.nodes.last, isA<ParagraphNode>());
-        expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
+        expect(doc.last, isA<ParagraphNode>());
+        expect((doc.last as ParagraphNode).text.text, 'Second Paragraph');
       });
 
       test('paragraph with multiple blank lines at the middle', () {
         final doc =
             deserializeMarkdownToDocument('First Paragraph.  \n  \n  \nStill First Paragraph\n\nSecond Paragraph');
 
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, 'First Paragraph.\n\n\nStill First Paragraph');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, 'First Paragraph.\n\n\nStill First Paragraph');
 
-        expect(doc.nodes.last, isA<ParagraphNode>());
-        expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
+        expect(doc.last, isA<ParagraphNode>());
+        expect((doc.last as ParagraphNode).text.text, 'Second Paragraph');
       });
 
       test('paragraph beginning with multiple blank lines', () {
         final doc = deserializeMarkdownToDocument('  \n  \nFirst Paragraph.\n\nSecond Paragraph');
 
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, '\n\nFirst Paragraph.');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, '\n\nFirst Paragraph.');
 
-        expect(doc.nodes.last, isA<ParagraphNode>());
-        expect((doc.nodes.last as ParagraphNode).text.text, 'Second Paragraph');
+        expect(doc.last, isA<ParagraphNode>());
+        expect((doc.last as ParagraphNode).text.text, 'Second Paragraph');
       });
 
       test('document ending with an empty paragraph', () {
@@ -1613,22 +1613,22 @@ First Paragraph.
 
 """);
 
-        expect(doc.nodes.length, 2);
+        expect(doc.nodeCount, 2);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, 'First Paragraph.');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, 'First Paragraph.');
 
-        expect(doc.nodes.last, isA<ParagraphNode>());
-        expect((doc.nodes.last as ParagraphNode).text.text, '');
+        expect(doc.last, isA<ParagraphNode>());
+        expect((doc.last as ParagraphNode).text.text, '');
       });
 
       test('empty markdown produces an empty paragraph', () {
         final doc = deserializeMarkdownToDocument('');
 
-        expect(doc.nodes.length, 1);
+        expect(doc.nodeCount, 1);
 
-        expect(doc.nodes.first, isA<ParagraphNode>());
-        expect((doc.nodes.first as ParagraphNode).text.text, '');
+        expect(doc.first, isA<ParagraphNode>());
+        expect((doc.first as ParagraphNode).text.text, '');
       });
     });
   });

--- a/super_editor_quill/lib/src/parsing/parser.dart
+++ b/super_editor_quill/lib/src/parsing/parser.dart
@@ -53,7 +53,7 @@ MutableDocument parseQuillDeltaOps(
 
   // Place the caret in the (only) empty paragraph so we can begin applying
   // deltas to the document.
-  final firstParagraph = document.nodes.first as ParagraphNode;
+  final firstParagraph = document.first as ParagraphNode;
   composer.setSelectionWithReason(
     DocumentSelection.collapsed(
       position: DocumentPosition(
@@ -136,14 +136,14 @@ extension OperationParser on Operation {
 
         // Deduplicate all back-to-back code blocks.
         final document = editor.context.find<MutableDocument>(Editor.documentKey);
-        if (document.nodes.length < 3) {
+        if (document.nodeCount < 3) {
           // Minimum of 3 nodes: code, code, newline.
           break;
         }
 
         var codeBlocks = <ParagraphNode>[];
-        for (int i = document.nodes.length - 2; i >= 0; i -= 1) {
-          final node = document.nodes[i];
+        for (int i = document.nodeCount - 2; i >= 0; i -= 1) {
+          final node = document.getNodeAt(i)!;
           if (node is! ParagraphNode) {
             break;
           }

--- a/super_editor_quill/lib/src/serializing/serializing.dart
+++ b/super_editor_quill/lib/src/serializing/serializing.dart
@@ -16,8 +16,8 @@ extension QuillDelta on MutableDocument {
   }) {
     final deltaDocument = Delta();
 
-    for (final node in nodes) {
-      if (node is ParagraphNode && node == nodes.last && node.text.text.isEmpty && nodes.length > 1) {
+    for (final node in this) {
+      if (node is ParagraphNode && node == last && node.text.text.isEmpty && nodeCount > 1) {
         // This final, empty paragraph in the document represents the final
         // newline "\n" in the Delta document. But, due to how we serialize
         // deltas, the node/delta before this one already inserted a newline,

--- a/super_editor_quill/test/parsing_test.dart
+++ b/super_editor_quill/test/parsing_test.dart
@@ -21,13 +21,13 @@ void main() {
           },
         );
 
-        expect((document.nodes[0] as TextNode).text.text, "");
-        expect((document.nodes[1] as TextNode).text.text, "Line one");
-        expect((document.nodes[2] as TextNode).text.text, "Line two");
-        expect((document.nodes[3] as TextNode).text.text, "Line three");
-        expect((document.nodes[4] as TextNode).text.text, "Line four");
-        expect((document.nodes[5] as TextNode).text.text, "");
-        expect((document.nodes[6] as TextNode).text.text, "");
+        expect((document.getNodeAt(0)! as TextNode).text.text, "");
+        expect((document.getNodeAt(1)! as TextNode).text.text, "Line one");
+        expect((document.getNodeAt(2)! as TextNode).text.text, "Line two");
+        expect((document.getNodeAt(3)! as TextNode).text.text, "Line three");
+        expect((document.getNodeAt(4)! as TextNode).text.text, "Line four");
+        expect((document.getNodeAt(5)! as TextNode).text.text, "");
+        expect((document.getNodeAt(6)! as TextNode).text.text, "");
 
         // A note on the length of the document. If this document is placed in a
         // Quill editor, there will only be 6 lines the user can edit. This seems
@@ -37,7 +37,7 @@ void main() {
         // we parse every newline, including the trailing newline, so the length
         // of this document is 7. If that's a problem, we can make the parser
         // more intelligent about this later.
-        expect(document.nodes.length, 7);
+        expect(document.nodeCount, 7);
       });
 
       test("multiline code block", () {
@@ -68,18 +68,18 @@ void main() {
         );
 
         expect(
-          (document.nodes[0] as ParagraphNode).text.text,
+          (document.getNodeAt(0)! as ParagraphNode).text.text,
           "This is a code block\nThis is line two\nThis is line three",
         );
-        expect((document.nodes[0] as ParagraphNode).getMetadataValue("blockType"), codeAttribution);
-        expect((document.nodes[1] as ParagraphNode).text.text, "");
-        expect(document.nodes.length, 2);
+        expect((document.getNodeAt(0)! as ParagraphNode).getMetadataValue("blockType"), codeAttribution);
+        expect((document.getNodeAt(1)! as ParagraphNode).text.text, "");
+        expect(document.nodeCount, 2);
       });
 
       test("all text blocks and styles", () {
         final document = parseQuillDeltaOps(allTextStylesDeltaDocument);
 
-        final nodes = document.nodes.iterator..moveNext();
+        final nodes = document.iterator..moveNext();
         DocumentNode? node = nodes.current;
 
         // Check the header.
@@ -385,7 +385,7 @@ void main() {
           },
         );
 
-        final paragraph = document.nodes.first as ParagraphNode;
+        final paragraph = document.first as ParagraphNode;
         expect(paragraph.text.text, "This paragraph has some overlapping styles.");
         expect(
           paragraph.text.getAttributionSpansByFilter((a) => true),
@@ -408,20 +408,20 @@ void main() {
           {"insert": "\nParagraph two\n"},
         ]);
 
-        expect(document.nodes.length, 3);
+        expect(document.nodeCount, 3);
 
-        expect(document.nodes[0], isA<ParagraphNode>());
-        expect((document.nodes[0] as ParagraphNode).text.text, "Paragraph one");
+        expect(document.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(0)! as ParagraphNode).text.text, "Paragraph one");
         expect(
-          (document.nodes[0] as ParagraphNode).text.getAttributionSpansByFilter((a) => true),
+          (document.getNodeAt(0)! as ParagraphNode).text.getAttributionSpansByFilter((a) => true),
           const <AttributionSpan>{},
         );
 
-        expect(document.nodes[1], isA<ParagraphNode>());
-        expect((document.nodes[1] as ParagraphNode).text.text, "Paragraph two");
+        expect(document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(1)! as ParagraphNode).text.text, "Paragraph two");
 
-        expect(document.nodes[2], isA<ParagraphNode>());
-        expect((document.nodes[2] as ParagraphNode).text.text, "");
+        expect(document.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(2)! as ParagraphNode).text.text, "");
       });
 
       test("gracefully handles unknown text block format", () {
@@ -434,21 +434,21 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        expect(document.nodes.length, 3);
+        expect(document.nodeCount, 3);
 
-        expect(document.nodes[0], isA<ParagraphNode>());
-        expect((document.nodes[0] as ParagraphNode).text.text, "Paragraph one");
-        expect((document.nodes[0] as ParagraphNode).metadata["blockType"], paragraphAttribution);
+        expect(document.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(0)! as ParagraphNode).text.text, "Paragraph one");
+        expect((document.getNodeAt(0)! as ParagraphNode).metadata["blockType"], paragraphAttribution);
         expect(
-          (document.nodes[0] as ParagraphNode).text.getAttributionSpansByFilter((a) => true),
+          (document.getNodeAt(0)! as ParagraphNode).text.getAttributionSpansByFilter((a) => true),
           const <AttributionSpan>{},
         );
 
-        expect(document.nodes[1], isA<ParagraphNode>());
-        expect((document.nodes[1] as ParagraphNode).text.text, "Paragraph two");
+        expect(document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(1)! as ParagraphNode).text.text, "Paragraph two");
 
-        expect(document.nodes[2], isA<ParagraphNode>());
-        expect((document.nodes[2] as ParagraphNode).text.text, "");
+        expect(document.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(2)! as ParagraphNode).text.text, "");
       });
     });
 
@@ -464,7 +464,7 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        final image = document.nodes[1];
+        final image = document.getNodeAt(1)!;
         expect(image, isA<ImageNode>());
         image as ImageNode;
         expect(image.imageUrl, "https://quilljs.com/assets/images/icon.png");
@@ -485,7 +485,7 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        final image = document.nodes[1];
+        final image = document.getNodeAt(1)!;
         expect(image, isA<ImageNode>());
         image as ImageNode;
         expect(image.imageUrl, "https://quilljs.com/assets/images/icon.png");
@@ -502,7 +502,7 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        final video = document.nodes[1];
+        final video = document.getNodeAt(1)!;
         expect(video, isA<VideoNode>());
         video as VideoNode;
         expect(video.url, "https://quilljs.com/assets/media/video.mp4");
@@ -519,7 +519,7 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        final audio = document.nodes[1];
+        final audio = document.getNodeAt(1)!;
         expect(audio, isA<AudioNode>());
         audio as AudioNode;
         expect(audio.url, "https://quilljs.com/assets/media/audio.mp3");
@@ -536,7 +536,7 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        final file = document.nodes[1];
+        final file = document.getNodeAt(1)!;
         expect(file, isA<FileNode>());
         file as FileNode;
         expect(file.url, "https://quilljs.com/assets/media/file.pdf");
@@ -553,16 +553,16 @@ void main() {
           {"insert": "Paragraph two\n"},
         ]);
 
-        expect(document.nodes.length, 3);
+        expect(document.nodeCount, 3);
 
-        expect(document.nodes[0], isA<ParagraphNode>());
-        expect((document.nodes[0] as ParagraphNode).text.text, "Paragraph one");
+        expect(document.getNodeAt(0)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(0)! as ParagraphNode).text.text, "Paragraph one");
 
-        expect(document.nodes[1], isA<ParagraphNode>());
-        expect((document.nodes[1] as ParagraphNode).text.text, "Paragraph two");
+        expect(document.getNodeAt(1)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(1)! as ParagraphNode).text.text, "Paragraph two");
 
-        expect(document.nodes[2], isA<ParagraphNode>());
-        expect((document.nodes[2] as ParagraphNode).text.text, "");
+        expect(document.getNodeAt(2)!, isA<ParagraphNode>());
+        expect((document.getNodeAt(2)! as ParagraphNode).text.text, "");
       });
     });
   });


### PR DESCRIPTION
Remove nodes list from Document to make Document immutable at API level (Resolves #2156)

This PR has a large change list, but it all boils down to removing the `nodes` property on `Document` in favor of accessing nodes with methods and properties, so that clients can't mutate a `Document`.

`Document` now implements `Iterable<DocumentNode>` so that it's still easy to iterate through the nodes in a document. `Iterable` also introduces a `first` and `last` property, which is honored. I also created `firstOrNull` and `lastOrNull` to access those properties in a possibly empty `Document`.