### PR TITLE
Publish extension methods to access MutableDocument and MutableComposer from Editor for convenience. (Resolves #2157)

### DIFF
--- a/super_editor/clones/quill/lib/deltas/deltas_display.dart
+++ b/super_editor/clones/quill/lib/deltas/deltas_display.dart
@@ -1,5 +1,4 @@
 import 'package:dart_quill_delta/dart_quill_delta.dart';
-import 'package:feather/infrastructure/super_editor_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
 import 'package:super_editor/super_editor.dart';

--- a/super_editor/clones/quill/lib/editor/toolbar.dart
+++ b/super_editor/clones/quill/lib/editor/toolbar.dart
@@ -4,7 +4,6 @@ import 'package:feather/infrastructure/popovers/color_selector.dart';
 import 'package:feather/editor/editor.dart';
 import 'package:feather/infrastructure/popovers/icon_selector.dart';
 import 'package:feather/infrastructure/popovers/text_item_selector.dart';
-import 'package:feather/infrastructure/super_editor_extensions.dart';
 import 'package:feather/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';

--- a/super_editor/clones/quill/lib/infrastructure/super_editor_extensions.dart
+++ b/super_editor/clones/quill/lib/infrastructure/super_editor_extensions.dart
@@ -1,7 +1,0 @@
-import 'package:super_editor/super_editor.dart';
-
-extension Editables on Editor {
-  MutableDocument get document => context.find<MutableDocument>(Editor.documentKey);
-
-  MutableDocumentComposer get composer => context.find<MutableDocumentComposer>(Editor.composerKey);
-}

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -988,6 +988,34 @@ class FunctionalEditListener implements EditListener {
   void onEdit(List<EditEvent> changeList) => _onEdit(changeList);
 }
 
+/// Extensions that provide direct, type-safe access to [Editable]s that are
+/// expected to exist in all [Editor]s.
+///
+/// This extension is similar to [StandardEditablesInContext], except this extension
+/// operates on an [Editor] and the other operates on [EditContext]s. Both exist
+/// for convenience.
+extension StandardEditables on Editor {
+  /// Finds and returns the [MutableDocument] within the [Editor].
+  MutableDocument get document => context.find<MutableDocument>(Editor.documentKey);
+
+  /// Finds and returns the [MutableDocumentComposer] within the [Editor].
+  MutableDocumentComposer get composer => context.find<MutableDocumentComposer>(Editor.composerKey);
+}
+
+/// Extensions that provide direct, type-safe access to [Editable]s that are
+/// expected to exist in all [EditContext]s.
+///
+/// This extension is similar to [StandardEditables], except this extension
+/// operates on an [EditContext] and the other operates on [Editor]s. Both exist
+/// for convenience.
+extension StandardEditablesInContext on EditContext {
+  /// Finds and returns the [MutableDocument] within the [EditContext].
+  MutableDocument get document => find<MutableDocument>(Editor.documentKey);
+
+  /// Finds and returns the [MutableDocumentComposer] within the [EditContext].
+  MutableDocumentComposer get composer => find<MutableDocumentComposer>(Editor.composerKey);
+}
+
 /// An in-memory, mutable [Document].
 class MutableDocument with Iterable<DocumentNode> implements Document, Editable {
   /// Creates an in-memory, mutable version of a [Document].

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -250,7 +250,7 @@ class ConvertBlockquoteToParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final blockquote = node as ParagraphNode;
     final newParagraphNode = ParagraphNode(
@@ -343,7 +343,7 @@ class SplitBlockquoteCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final blockquote = node as ParagraphNode;
     final text = blockquote.text;

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -320,7 +320,7 @@ class DeleteUpstreamAtBeginningOfBlockNodeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final documentLayoutEditable = context.find<DocumentLayoutEditable>(Editor.layoutKey);
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2267,7 +2267,7 @@ class PasteEditorCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final currentNodeWithSelection = document.getNodeById(_pastePosition.nodeId);
     if (currentNodeWithSelection is! TextNode) {
@@ -2447,7 +2447,7 @@ class DeleteUpstreamCharacterCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final selection = composer.selection;
 
@@ -2501,7 +2501,7 @@ class DeleteDownstreamCharacterCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final selection = composer.selection;
 

--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -71,7 +71,7 @@ class UpdateComposerTextStylesReaction extends EditReaction {
   }
 
   void _updateComposerStylesAtCaret(EditContext editContext) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final composer = editContext.find<MutableDocumentComposer>(Editor.composerKey);
 
     if (composer.selection?.extent == _previousSelectionExtent) {

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -189,7 +189,7 @@ class OrderedListItemConversionReaction extends ParagraphPrefixConversionReactio
       // ordered list item. For example, the list has the items 1, 2, 3 and 4,
       // and the user types " 5. ".
 
-      final document = editContext.find<MutableDocument>(Editor.documentKey);
+      final document = editContext.document;
 
       final upstreamNode = document.getNodeBefore(paragraph);
       if (upstreamNode == null || upstreamNode is! ListItemNode || upstreamNode.type != ListItemType.ordered) {
@@ -298,7 +298,7 @@ class HorizontalRuleConversionReaction extends EditReaction {
       return;
     }
 
-    final document = editorContext.find<MutableDocument>(Editor.documentKey);
+    final document = editorContext.document;
 
     final didTypeSpace = EditInspector.didTypeSpace(document, changeList);
     if (!didTypeSpace) {
@@ -372,7 +372,7 @@ abstract class ParagraphPrefixConversionReaction extends EditReaction {
 
   @override
   void react(EditContext editContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final typedText = EditInspector.findLastTextUserTyped(document, changeList);
     if (typedText == null) {
       return;
@@ -435,7 +435,7 @@ class ImageUrlConversionReaction extends EditReaction {
       return;
     }
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final previousNode = document.getNodeById(selectionChange.oldSelection!.extent.nodeId);
     if (previousNode is! ParagraphNode) {
       // The intention indicated that the user pressed "enter" from a paragraph
@@ -563,7 +563,7 @@ class LinkifyReaction extends EditReaction {
 
   @override
   void react(EditContext editContext, RequestDispatcher requestDispatcher, List<EditEvent> edits) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final composer = editContext.find<MutableDocumentComposer>(Editor.composerKey);
     final selection = composer.selection;
 
@@ -923,7 +923,7 @@ class DashConversionReaction extends EditReaction {
 
   @override
   void react(EditContext editorContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
-    final document = editorContext.find<MutableDocument>(Editor.documentKey);
+    final document = editorContext.document;
     final composer = editorContext.find<MutableDocumentComposer>(Editor.composerKey);
 
     if (changeList.length < 2) {

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -837,7 +837,7 @@ class IndentListItemCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final listItem = node as ListItemNode;
     if (listItem.indent >= 6) {
@@ -875,7 +875,7 @@ class UnIndentListItemCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final listItem = node as ListItemNode;
     if (listItem.indent > 0) {
@@ -922,7 +922,7 @@ class ConvertListItemToParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final listItem = node as ListItemNode;
     final newMetadata = Map<String, dynamic>.from(paragraphMetadata ?? {});
@@ -969,7 +969,7 @@ class ConvertParagraphToListItemCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final paragraphNode = node as ParagraphNode;
 
@@ -1012,7 +1012,7 @@ class ChangeListItemTypeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final existingListItem = document.getNodeById(nodeId) as ListItemNode;
 
     final newListItemNode = ListItemNode(
@@ -1058,7 +1058,7 @@ class SplitListItemCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     final node = document.getNodeById(nodeId);

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -48,7 +48,7 @@ class PasteStructuredContentEditorCommand extends EditCommand {
       return;
     }
 
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final currentNodeWithSelection = document.getNodeById(_pastePosition.nodeId);
     if (currentNodeWithSelection is! TextNode) {
@@ -292,7 +292,7 @@ class InsertNodeAtIndexCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     document.insertNodeAt(nodeIndex, newNode);
     executor.logChanges([
       DocumentEdit(
@@ -323,7 +323,7 @@ class InsertNodeBeforeNodeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final existingNode = document.getNodeById(existingNodeId)!;
     document.insertNodeBefore(existingNode: existingNode, newNode: newNode);
 
@@ -356,7 +356,7 @@ class InsertNodeAfterNodeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final existingNode = document.getNodeById(existingNodeId)!;
     document.insertNodeAfter(existingNode: existingNode, newNode: newNode);
 
@@ -385,7 +385,7 @@ class InsertNodeAtCaretCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     if (composer.selection == null) {
@@ -518,7 +518,7 @@ class MoveNodeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     // Log all the move changes that will happen when we move the target node
     // elsewhere in the document.
@@ -586,7 +586,7 @@ class ReplaceNodeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final oldNode = document.getNodeById(existingNodeId)!;
     document.replaceNode(oldNode: oldNode, newNode: newNode);
 
@@ -631,7 +631,7 @@ class ReplaceNodeWithEmptyParagraphWithCaretCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final oldNode = document.getNodeById(nodeId);
     if (oldNode == null) {
@@ -691,7 +691,7 @@ class DeleteContentCommand extends EditCommand {
   @override
   void execute(EditContext context, CommandExecutor executor) {
     _log.log('DeleteSelectionCommand', 'DocumentEditor: deleting selection: $documentRange');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final nodes = document.getNodesInside(documentRange.start, documentRange.end);
     final normalizedRange = documentRange.normalize(document);
 
@@ -1072,7 +1072,7 @@ class DeleteNodeCommand extends EditCommand {
   void execute(EditContext context, CommandExecutor executor) {
     _log.log('DeleteNodeCommand', 'DocumentEditor: deleting node: $nodeId');
 
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     if (node == null) {
       _log.log('DeleteNodeCommand', 'No such node. Returning.');

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -340,7 +340,7 @@ class ChangeParagraphAlignmentCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final existingNode = document.getNodeById(nodeId)! as ParagraphNode;
 
@@ -406,7 +406,7 @@ class ChangeParagraphBlockTypeCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final existingNode = document.getNodeById(nodeId)! as ParagraphNode;
     existingNode.putMetadataValue('blockType', blockType);
@@ -454,7 +454,7 @@ class CombineParagraphsCommand extends EditCommand {
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing CombineParagraphsCommand');
     editorDocLog.info(' - merging "$firstNodeId" <- "$secondNodeId"');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final secondNode = document.getNodeById(secondNodeId);
     if (secondNode is! TextNode) {
       editorDocLog.info('WARNING: Cannot merge node of type: $secondNode into node above.');
@@ -567,7 +567,7 @@ class SplitParagraphCommand extends EditCommand {
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing SplitParagraphCommand');
 
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     if (node is! ParagraphNode) {
       editorDocLog.info('WARNING: Cannot split paragraph for node of type: $node.');
@@ -695,7 +695,7 @@ class DeleteUpstreamAtBeginningOfParagraphCommand extends EditCommand {
       return;
     }
 
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     final documentLayoutEditable = context.find<DocumentLayoutEditable>(Editor.layoutKey);
 
@@ -899,7 +899,7 @@ class DeleteParagraphCommand extends EditCommand {
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing DeleteParagraphCommand');
     editorDocLog.info(' - deleting "$nodeId"');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     if (node is! TextNode) {
       editorDocLog.shout('WARNING: Cannot delete node of type: $node.');
@@ -1078,7 +1078,7 @@ class SetParagraphIndentCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final paragraph = document.getNodeById(nodeId);
     if (paragraph is! ParagraphNode) {
@@ -1111,7 +1111,7 @@ class IndentParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final paragraph = document.getNodeById(nodeId);
     if (paragraph is! ParagraphNode) {
@@ -1186,7 +1186,7 @@ class UnIndentParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final paragraph = document.getNodeById(nodeId);
     if (paragraph is! ParagraphNode) {

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -608,7 +608,7 @@ class ChangeTaskCompletionCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final taskNode = context.find<MutableDocument>(Editor.documentKey).getNodeById(nodeId);
+    final taskNode = context.document.getNodeById(nodeId);
     if (taskNode is! TaskNode) {
       return;
     }
@@ -658,7 +658,7 @@ class ConvertParagraphToTaskCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final existingNode = document.getNodeById(nodeId);
     if (existingNode is! ParagraphNode) {
       editorOpsLog.warning(
@@ -713,7 +713,7 @@ class ConvertTaskToParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId);
     final taskNode = node as TaskNode;
     final newMetadata = Map<String, dynamic>.from(paragraphMetadata ?? {});
@@ -762,7 +762,7 @@ class SplitExistingTaskCommand extends EditCommand {
 
   @override
   void execute(EditContext editContext, CommandExecutor executor) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final composer = editContext.find<MutableDocumentComposer>(Editor.composerKey);
     final selection = composer.selection;
 
@@ -849,7 +849,7 @@ class IndentTaskCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final task = document.getNodeById(nodeId);
     if (task is! TaskNode) {
@@ -898,7 +898,7 @@ class UnIndentTaskCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final task = document.getNodeById(nodeId);
     if (task is! TaskNode) {
@@ -971,7 +971,7 @@ class SetTaskIndentCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final task = document.getNodeById(nodeId);
     if (task is! TaskNode) {
@@ -1003,7 +1003,7 @@ class UpdateSubTaskIndentAfterTaskDeletionReaction extends EditReaction {
     // At least one task was deleted. We're not sure where in the document the
     // tasks were before being deleted. Therefore, we check and fix every task
     // indentation in the document.
-    final document = editorContext.find<MutableDocument>(Editor.documentKey);
+    final document = editorContext.document;
     final changeIndentationRequests = <EditRequest>[];
     int maxIndentation = 0;
     for (int i = 0; i < document.nodeCount; i += 1) {

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1209,7 +1209,7 @@ class AddTextAttributionsCommand extends EditCommand {
   @override
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing AddTextAttributionsCommand');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final nodes = document.getNodesInside(documentRange.start, documentRange.end);
     if (nodes.isEmpty) {
       editorDocLog.shout(' - Bad DocumentSelection. Could not get range of nodes. Selection: $documentRange');
@@ -1329,7 +1329,7 @@ class RemoveTextAttributionsCommand extends EditCommand {
   @override
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing RemoveTextAttributionsCommand');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final nodes = document.getNodesInside(documentRange.start, documentRange.end);
     if (nodes.isEmpty) {
       editorDocLog.shout(' - Bad DocumentSelection. Could not get range of nodes. Selection: $documentRange');
@@ -1455,7 +1455,7 @@ class ToggleTextAttributionsCommand extends EditCommand {
   @override
   void execute(EditContext context, CommandExecutor executor) {
     editorDocLog.info('Executing ToggleTextAttributionsCommand');
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final nodes = document.getNodesInside(documentRange.start, documentRange.end);
     if (nodes.isEmpty) {
       editorDocLog.shout(' - Bad DocumentSelection. Could not get range of nodes. Selection: $documentRange');
@@ -1658,7 +1658,7 @@ class ChangeSingleColumnLayoutComponentStylesCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final node = document.getNodeById(nodeId)!;
 
     styles.applyTo(node);
@@ -1703,7 +1703,7 @@ class InsertTextCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final textNode = document.getNodeById(documentPosition.nodeId);
     if (textNode is! TextNode) {
@@ -1827,7 +1827,7 @@ class ConvertTextNodeToParagraphCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
 
     final extentNode = document.getNodeById(nodeId) as TextNode;
     if (extentNode is ParagraphNode) {
@@ -1871,7 +1871,7 @@ class InsertAttributedTextCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final textNode = document.getNodeById(documentPosition.nodeId);
     if (textNode is! TextNode) {
       editorDocLog.shout('ERROR: can\'t insert text in a node that isn\'t a TextNode: $textNode');
@@ -1969,7 +1969,7 @@ class InsertCharacterAtCaretCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     if (composer.selection == null) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -118,7 +118,7 @@ class SubmitComposingActionTagCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
     if (composer.selection == null) {
       return;
@@ -196,7 +196,7 @@ class CancelComposingActionTagCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     final selection = composer.selection;
@@ -278,7 +278,7 @@ class ActionTagComposingReaction extends EditReaction {
 
   @override
   void react(EditContext editorContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
-    final document = editorContext.find<MutableDocument>(Editor.documentKey);
+    final document = editorContext.document;
     final composer = editorContext.find<MutableDocumentComposer>(Editor.composerKey);
 
     _composingTag = editorContext.composingActionTag.value;

--- a/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/pattern_tags.dart
@@ -69,7 +69,7 @@ class PatternTagPlugin extends SuperEditorPlugin {
   }
 
   void _initializePatternTagIndex(Editor editor) {
-    final document = editor.context.find<MutableDocument>(Editor.documentKey);
+    final document = editor.context.document;
 
     for (final node in document) {
       if (node is! TextNode) {
@@ -244,7 +244,7 @@ class PatternTagReaction extends EditReaction {
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
   ) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
 
     final tag = _findTagAtCaret(editContext, (attributions) => attributions.contains(const PatternTagAttribution()));
     if (tag == null) {
@@ -287,7 +287,7 @@ class PatternTagReaction extends EditReaction {
       return null;
     }
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final selectedNode = document.getNodeById(selectionPosition.nodeId);
     if (selectedNode is! TextNode) {
       // Tagging only happens in the middle of text. The selected content isn't text. Return.
@@ -325,7 +325,7 @@ class PatternTagReaction extends EditReaction {
       return;
     }
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final selectedNode = document.getNodeById(selectionPosition.nodeId);
     if (selectedNode is! TextNode) {
       // Tagging only happens in the middle of text. The selected content isn't text. Return.
@@ -398,7 +398,7 @@ class PatternTagReaction extends EditReaction {
   ///     [#flutter][#dart]
   ///
   void _splitBackToBackTags(EditContext editContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
 
     final textEdits = changeList
         .whereType<DocumentEdit>()
@@ -533,7 +533,7 @@ class PatternTagReaction extends EditReaction {
 
     // Inspect every TextNode where a text deletion impacted a tag. If a tag no longer contains
     // a trigger, or only contains a trigger, remove the attribution.
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final removeTagRequests = <EditRequest>{};
     for (final nodeId in nodesToInspect) {
       final textNode = document.getNodeById(nodeId) as TextNode;
@@ -566,7 +566,7 @@ class PatternTagReaction extends EditReaction {
   }
 
   void _updateTagIndex(EditContext editContext, List<EditEvent> changeList) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final index = editContext.patternTagIndex;
     for (final event in changeList) {
       if (event is! DocumentEdit) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/stable_tags.dart
@@ -176,7 +176,7 @@ class FillInComposingUserTagCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     final selection = composer.selection;
@@ -291,7 +291,7 @@ class CancelComposingStableTagCommand extends EditCommand {
 
   @override
   void execute(EditContext context, CommandExecutor executor) {
-    final document = context.find<MutableDocument>(Editor.documentKey);
+    final document = context.document;
     final composer = context.find<MutableDocumentComposer>(Editor.composerKey);
 
     final selection = composer.selection;
@@ -387,7 +387,7 @@ class TagUserReaction extends EditReaction {
     editorStableTagsLog.info(
         "Caret position: ${editContext.find<MutableDocumentComposer>(Editor.composerKey).selection?.extent.nodePosition}");
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     _healCancelledTags(requestDispatcher, document, changeList);
 
     _adjustTagAttributionsAroundAlteredTags(editContext, requestDispatcher, changeList);
@@ -486,7 +486,7 @@ class TagUserReaction extends EditReaction {
     RequestDispatcher requestDispatcher,
     List<EditEvent> changeList,
   ) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
 
     final composingToken = _findComposingTagAtCaret(editContext);
     if (composingToken != null) {
@@ -526,7 +526,7 @@ class TagUserReaction extends EditReaction {
     List<EditEvent> changeList,
   ) {
     editorStableTagsLog.info("Removing invalid tags.");
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final nodesToInspect = <String>{};
     for (final edit in changeList) {
       // We only care about deleted text, in case the deletion made an existing tag invalid.
@@ -699,7 +699,7 @@ class TagUserReaction extends EditReaction {
       return;
     }
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final selectedNode = document.getNodeById(selectionPosition.nodeId);
     if (selectedNode is! TextNode) {
       // Tagging only happens in the middle of text. The selected content isn't text. Return.
@@ -780,7 +780,7 @@ class TagUserReaction extends EditReaction {
     List<EditEvent> changeList,
   ) {
     editorStableTagsLog.fine("Looking for completed tags to commit.");
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final composingTagNodeCandidates = <String>{};
     for (final edit in changeList) {
       if (edit is DocumentEdit && (edit.change is TextInsertionEvent || edit.change is TextDeletedEvent)) {
@@ -897,7 +897,7 @@ class TagUserReaction extends EditReaction {
       return null;
     }
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final selectedNode = document.getNodeById(selectionPosition.nodeId);
     if (selectedNode is! TextNode) {
       // Tagging only happens in the middle of text. The selected content isn't text. Return.
@@ -914,7 +914,7 @@ class TagUserReaction extends EditReaction {
   }
 
   void _updateTagIndex(EditContext editContext, List<EditEvent> changeList) {
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final index = editContext.stableTagIndex;
     for (final event in changeList) {
       if (event is! DocumentEdit) {
@@ -1144,7 +1144,7 @@ class AdjustSelectionAroundTagReaction extends EditReaction {
 
     editorStableTagsLog.info(" - we received just one selection change event. Checking for user tag.");
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
 
     final newCaret = selectionChangeEvent.newSelection?.extent;
     if (newCaret == null) {
@@ -1236,7 +1236,7 @@ class AdjustSelectionAroundTagReaction extends EditReaction {
   }) {
     editorStableTagsLog.fine("Adjusting an expanded selection to avoid a partial stable tag selection.");
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final extentNode = document.getNodeById(newCaret.nodeId);
     if (extentNode is! TextNode) {
       // The caret isn't sitting in text. Fizzle.
@@ -1394,7 +1394,7 @@ class AdjustSelectionAroundTagReaction extends EditReaction {
     bool expand = false,
   }) {
     editorStableTagsLog.info("Pushing caret to other side of token - tag around caret: $tagAroundCaret");
-    final Document document = editContext.find<MutableDocument>(Editor.documentKey);
+    final Document document = editContext.document;
 
     final pushDirection = document.getAffinityBetween(
       base: selectionChangeEvent.oldSelection!.extent,
@@ -1450,7 +1450,7 @@ class AdjustSelectionAroundTagReaction extends EditReaction {
   }) {
     editorStableTagsLog.info("Pushing expanded selection to other side(s) of token(s)");
 
-    final document = editContext.find<MutableDocument>(Editor.documentKey);
+    final document = editContext.document;
     final selection = selectionChangeEvent.newSelection!;
     final selectionAffinity = document.getAffinityForSelection(selection);
 


### PR DESCRIPTION
Publish extension methods to access MutableDocument and MutableComposer from Editor for convenience. (Resolves #2157)

This PR doesn't contain any behavior changes - it just adds extension APIs to make it easier to access the `MutableDocument` and `MutableComposer` in the `EditContext`. The standard access lets developers query for any possible `Editable`, and there's no obvious place to learn about the existence of document or composer. So these methods now appear in intellisense.