### PR TITLE
Removed document and composer from SuperEditor widget property list (Resolves #2160)

### DIFF
--- a/super_editor/clones/quill/lib/editor/editor.dart
+++ b/super_editor/clones/quill/lib/editor/editor.dart
@@ -28,27 +28,6 @@ class FeatherEditor extends StatefulWidget {
 class _FeatherEditorState extends State<FeatherEditor> {
   final _editorFocusNode = FocusNode();
 
-  late MutableDocument _document;
-  late MutableDocumentComposer _composer;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _document = widget.editor.context.find<MutableDocument>(Editor.documentKey);
-    _composer = widget.editor.context.find<MutableDocumentComposer>(Editor.composerKey);
-  }
-
-  @override
-  void didUpdateWidget(FeatherEditor oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    if (widget.editor != oldWidget.editor) {
-      _document = widget.editor.context.find<MutableDocument>(Editor.documentKey);
-      _composer = widget.editor.context.find<MutableDocumentComposer>(Editor.composerKey);
-    }
-  }
-
   @override
   void dispose() {
     _editorFocusNode.dispose();
@@ -90,8 +69,6 @@ class _FeatherEditorState extends State<FeatherEditor> {
       child: SuperEditor(
         focusNode: _editorFocusNode,
         editor: widget.editor,
-        document: _document,
-        composer: _composer,
         stylesheet: featherStylesheet,
         componentBuilders: const [
           FeatherBlockquoteComponentBuilder(),

--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -71,8 +71,6 @@ class _TextWithHintDemoState extends State<TextWithHintDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: Stylesheet(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
         rules: defaultStylesheet.rules,

--- a/super_editor/example/lib/demos/components/demo_unselectable_hr.dart
+++ b/super_editor/example/lib/demos/components/demo_unselectable_hr.dart
@@ -52,8 +52,6 @@ class _UnselectableHrDemoState extends State<UnselectableHrDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
       ),

--- a/super_editor/example/lib/demos/demo_animated_task_height.dart
+++ b/super_editor/example/lib/demos/demo_animated_task_height.dart
@@ -52,8 +52,6 @@ class _AnimatedTaskHeightDemoState extends State<AnimatedTaskHeightDemo> {
     print("Building the entire demo");
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
       ),

--- a/super_editor/example/lib/demos/demo_app_shortcuts.dart
+++ b/super_editor/example/lib/demos/demo_app_shortcuts.dart
@@ -52,11 +52,7 @@ class _AppShortcutsDemoState extends State<AppShortcutsDemo> {
             child: Column(
               children: [
                 Expanded(
-                  child: SuperEditor(
-                    editor: _editor,
-                    document: _doc,
-                    composer: _composer,
-                  ),
+                  child: SuperEditor(editor: _editor),
                 ),
                 const TextField(
                   decoration: InputDecoration(

--- a/super_editor/example/lib/demos/demo_document_loses_focus.dart
+++ b/super_editor/example/lib/demos/demo_document_loses_focus.dart
@@ -41,8 +41,6 @@ class _LoseFocusDemoState extends State<LoseFocusDemo> {
               ),
               child: SuperEditor(
                 editor: _docEditor,
-                document: _doc,
-                composer: _composer,
                 inputSource: TextInputSource.ime,
                 stylesheet: defaultStylesheet.copyWith(
                   documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),

--- a/super_editor/example/lib/demos/demo_empty_document.dart
+++ b/super_editor/example/lib/demos/demo_empty_document.dart
@@ -37,8 +37,6 @@ class _EmptyDocumentDemoState extends State<EmptyDocumentDemo> {
     return SafeArea(
       child: SuperEditor(
         editor: _docEditor,
-        document: _doc,
-        composer: _composer,
         gestureMode: DocumentGestureMode.mouse,
       ),
     );

--- a/super_editor/example/lib/demos/demo_markdown_serialization.dart
+++ b/super_editor/example/lib/demos/demo_markdown_serialization.dart
@@ -66,8 +66,6 @@ class _MarkdownSerializationDemoState extends State<MarkdownSerializationDemo> {
             child: SuperEditor(
               key: _docKey,
               editor: _docEditor,
-              document: _doc,
-              composer: _composer,
               componentBuilders: [
                 TaskComponentBuilder(_docEditor),
                 ...defaultComponentBuilders,

--- a/super_editor/example/lib/demos/demo_paragraphs.dart
+++ b/super_editor/example/lib/demos/demo_paragraphs.dart
@@ -30,8 +30,6 @@ class _ParagraphsDemoState extends State<ParagraphsDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
       ),

--- a/super_editor/example/lib/demos/demo_rtl.dart
+++ b/super_editor/example/lib/demos/demo_rtl.dart
@@ -33,8 +33,6 @@ class _RTLDemoState extends State<RTLDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
       ),

--- a/super_editor/example/lib/demos/demo_switch_document_content.dart
+++ b/super_editor/example/lib/demos/demo_switch_document_content.dart
@@ -53,8 +53,6 @@ class _SwitchDocumentDemoState extends State<SwitchDocumentDemo> {
           Expanded(
             child: SuperEditor(
               editor: _activeDocumentEditor,
-              document: _activeDocument,
-              composer: _activeComposer,
               stylesheet: defaultStylesheet.copyWith(
                 documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
               ),

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
@@ -105,8 +105,6 @@ class _MobileEditingAndroidDemoState extends State<MobileEditingAndroidDemo> {
               focusNode: _editorFocusNode,
               documentLayoutKey: _docLayoutKey,
               editor: _docEditor,
-              document: _doc,
-              composer: _composer,
               overlayController: _overlayController,
               gestureMode: DocumentGestureMode.android,
               inputSource: TextInputSource.ime,

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -98,8 +98,6 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> with Single
                 focusNode: _editorFocusNode,
                 documentLayoutKey: _docLayoutKey,
                 editor: _docEditor,
-                document: _doc,
-                composer: _composer,
                 gestureMode: DocumentGestureMode.iOS,
                 inputSource: TextInputSource.ime,
                 selectionLayerLinks: _selectionLayerLinks,

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -377,8 +377,6 @@ class _ExampleEditorState extends State<ExampleEditor> {
             controller: _iosControlsController,
             child: SuperEditor(
               editor: _docEditor,
-              document: _doc,
-              composer: _composer,
               focusNode: _editorFocusNode,
               scrollController: _scrollController,
               documentLayoutKey: _docLayoutKey,

--- a/super_editor/example/lib/demos/experiments/demo_panel_behind_keyboard.dart
+++ b/super_editor/example/lib/demos/experiments/demo_panel_behind_keyboard.dart
@@ -177,8 +177,6 @@ class _PanelBehindKeyboardDemoState extends State<PanelBehindKeyboardDemo> {
               child: SuperEditor(
                 focusNode: _focusNode,
                 editor: _editor,
-                document: _doc,
-                composer: _composer,
                 softwareKeyboardController: _keyboardController,
                 selectionPolicies: const SuperEditorSelectionPolicies(
                   clearSelectionWhenEditorLosesFocus: false,

--- a/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_action_tags.dart
@@ -109,8 +109,6 @@ class _ActionTagsFeatureDemoState extends State<ActionTagsFeatureDemo> {
     return IntrinsicHeight(
       child: SuperEditor(
         editor: _editor,
-        document: _document,
-        composer: _composer,
         focusNode: _editorFocusNode,
         componentBuilders: [
           TaskComponentBuilder(_editor),

--- a/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_pattern_tags.dart
@@ -64,8 +64,6 @@ class _HashTagsFeatureDemoState extends State<HashTagsFeatureDemo> {
     return IntrinsicHeight(
       child: SuperEditor(
         editor: _editor,
-        document: _document,
-        composer: _composer,
         stylesheet: defaultStylesheet.copyWith(
           inlineTextStyler: (attributions, existingStyle) {
             TextStyle style = defaultInlineTextStyler(attributions, existingStyle);

--- a/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_stable_tags.dart
@@ -110,8 +110,6 @@ class _UserTagsFeatureDemoState extends State<UserTagsFeatureDemo> {
     return IntrinsicHeight(
       child: SuperEditor(
         editor: _editor,
-        document: _document,
-        composer: _composer,
         focusNode: _editorFocusNode,
         stylesheet: defaultStylesheet.copyWith(
           inlineTextStyler: (attributions, existingStyle) {

--- a/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
+++ b/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
@@ -72,8 +72,6 @@ class _SelectedTextColorsDemoState extends State<SelectedTextColorsDemo> {
   Widget _buildEditor() {
     return SuperEditor(
       editor: _editor,
-      document: _document,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         selectedTextColorStrategy: _selectedTextColorStrategy,
         addRulesAfter: [

--- a/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
+++ b/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
@@ -65,8 +65,6 @@ class _TaskAndChatWithCustomScrollViewDemoState extends State<TaskAndChatWithCus
                 SliverToBoxAdapter(
                   child: SuperEditor(
                     editor: _editor,
-                    document: _doc,
-                    composer: _composer,
                     stylesheet: defaultStylesheet.copyWith(
                       documentPadding: const EdgeInsets.all(48),
                     ),

--- a/super_editor/example/lib/demos/sliver_example_editor.dart
+++ b/super_editor/example/lib/demos/sliver_example_editor.dart
@@ -78,8 +78,6 @@ class _SliverExampleEditorState extends State<SliverExampleEditor> {
                 SliverToBoxAdapter(
                   child: SuperEditor(
                     editor: _docEditor,
-                    document: _doc,
-                    composer: _composer,
                     stylesheet: defaultStylesheet.copyWith(
                       documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
                     ),

--- a/super_editor/example/lib/demos/styles/demo_doc_styles.dart
+++ b/super_editor/example/lib/demos/styles/demo_doc_styles.dart
@@ -137,8 +137,6 @@ class _DocumentStylesDemoState extends State<DocumentStylesDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: _createStyles(),
     );
   }

--- a/super_editor/example/lib/main_super_editor.dart
+++ b/super_editor/example/lib/main_super_editor.dart
@@ -235,8 +235,6 @@ class _StandardEditorState extends State<_StandardEditor> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: widget.editor,
-      document: widget.document,
-      composer: widget.composer,
       focusNode: _editorFocusNode,
       scrollController: _scrollController,
       documentLayoutKey: _docLayoutKey,

--- a/super_editor/example/lib/marketing_video/main_marketing_video.dart
+++ b/super_editor/example/lib/marketing_video/main_marketing_video.dart
@@ -193,8 +193,6 @@ class _MarketingVideoState extends State<MarketingVideo> {
         child: SuperEditor(
           documentLayoutKey: _docLayoutKey,
           editor: _editor,
-          document: _document,
-          composer: _composer,
           stylesheet: defaultStylesheet.copyWith(
             documentPadding: const EdgeInsets.all(16),
             addRulesAfter: [

--- a/super_editor/example_docs/lib/editor.dart
+++ b/super_editor/example_docs/lib/editor.dart
@@ -63,8 +63,6 @@ class _DocsEditorState extends State<DocsEditor> {
         return SuperEditor(
           focusNode: _editorFocusNode,
           editor: widget.editor,
-          document: widget.document,
-          composer: widget.composer,
           stylesheet: defaultStylesheet.copyWith(
             addRulesAfter: docsStylesheet,
             inlineTextStyler: _applyFontFamily,

--- a/super_editor/example_perf/lib/demos/long_doc_demo.dart
+++ b/super_editor/example_perf/lib/demos/long_doc_demo.dart
@@ -26,11 +26,7 @@ class _LongDocDemoState extends State<LongDocDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SuperEditor(
-        document: _doc,
-        composer: _composer,
-        editor: _docEditor,
-      ),
+      body: SuperEditor(editor: _docEditor),
     );
   }
 }

--- a/super_editor/example_perf/lib/demos/rebuild_demo.dart
+++ b/super_editor/example_perf/lib/demos/rebuild_demo.dart
@@ -54,8 +54,6 @@ class _RebuildCountDemoState extends State<RebuildCountDemo> {
   Widget build(BuildContext context) {
     return SuperEditor(
       editor: _docEditor,
-      document: _doc,
-      composer: _composer,
       stylesheet: defaultStylesheet.copyWith(
         documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
       ),

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -998,8 +998,16 @@ extension StandardEditables on Editor {
   /// Finds and returns the [MutableDocument] within the [Editor].
   MutableDocument get document => context.find<MutableDocument>(Editor.documentKey);
 
+  /// Finds and returns the [MutableDocument] within the [Editor], or `null` if no [MutableDocument]
+  /// is in the [Editor].
+  MutableDocument? get maybeDocument => context.findMaybe<MutableDocument>(Editor.documentKey);
+
   /// Finds and returns the [MutableDocumentComposer] within the [Editor].
   MutableDocumentComposer get composer => context.find<MutableDocumentComposer>(Editor.composerKey);
+
+  /// Finds and returns the [MutableDocumentComposer] within the [Editor], or `null` if no
+  /// [MutableDocumentComposer] is in the [Editor].
+  MutableDocumentComposer? get maybeComposer => context.findMaybe<MutableDocumentComposer>(Editor.composerKey);
 }
 
 /// Extensions that provide direct, type-safe access to [Editable]s that are
@@ -1012,8 +1020,16 @@ extension StandardEditablesInContext on EditContext {
   /// Finds and returns the [MutableDocument] within the [EditContext].
   MutableDocument get document => find<MutableDocument>(Editor.documentKey);
 
+  /// Finds and returns the [MutableDocument] within the [EditContext], or `null` if no [MutableDocument]
+  /// is in the [EditContext].
+  MutableDocument? get maybeDocument => findMaybe<MutableDocument>(Editor.documentKey);
+
   /// Finds and returns the [MutableDocumentComposer] within the [EditContext].
   MutableDocumentComposer get composer => find<MutableDocumentComposer>(Editor.composerKey);
+
+  /// Finds and returns the [MutableDocumentComposer] within the [EditContext], or `null` if no
+  /// [MutableDocumentComposer] is in the [EditContext].
+  MutableDocumentComposer? get maybeComposer => findMaybe<MutableDocumentComposer>(Editor.composerKey);
 }
 
 /// An in-memory, mutable [Document].

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -53,48 +53,46 @@ import 'unknown_component.dart';
 
 /// A rich text editor that displays a document in a single-column layout.
 ///
-/// A [SuperEditor] brings together the key pieces needed
-/// to display a user-editable document:
-///  * document model
-///  * document editor
-///  * document layout
-///  * document interaction (tapping, dragging, typing, scrolling)
-///  * document composer (current selection, and styles to apply to next character)
+/// A [SuperEditor] brings together the key pieces needed to display a user-editable document:
+///  * An editor, which includes a document and a composer (which holds the user selection and styles).
+///  * A document layout, which positions components for every piece of content in the document.
+///  * User interactions with the document layout (tapping, dragging, typing, scrolling)
 ///
-/// A [SuperEditor] determines the visual styling by way of:
+/// A [SuperEditor] applies visual styles based on:
 ///  * [stylesheet], which applies styles throughout the document layout,
 ///    including text styles and block padding.
-///  * [componentStyles], which applies targeted styles to specific components
-///    in the document layout.
-///  * [componentBuilders], which produce every visual component within the document layout.
 ///  * [selectionStyles], which dictates the color of the caret and the color of
 ///    selected text and components
+///  * [componentStyles], which applies targeted styles to specific components
+///    in the document layout.
+///  * [componentBuilders], which produce every visual component [Widget] within the document layout.
 ///
-/// A [SuperEditor] determines how a physical keyboard interacts with the document
-/// by way of [keyboardActions].
+/// [keyboardActions] decides how physical keyboard key presses alter the document within
+/// a [SuperEditor].
 ///
-/// A [SuperEditor] works with software keyboards through the platform's Input Method
-/// Engine (IME). To customize how [SuperEditor] works with the IME, see [imePolicies],
-/// [imeConfiguration], and [softwareKeyboardController].
+/// [imePolicies], [imeConfiguration], and [softwareKeyboardController] decide how user interactions
+/// with the operating system's Input Method Editor (IME) alters the document within a
+/// [SuperEditor].
 ///
 /// ## Deeper explanation of core artifacts:
 ///
-/// The document model is responsible for holding the content of a
-/// document in a structured and query-able manner.
+/// A [Document] is responsible for holding the content of a document in a structured
+/// and query-able manner.
 ///
-/// The document editor is responsible for mutating the document
-/// structure.
+/// A [DocumentComposer] is responsible for holding the user's selection, as well as any inline
+/// text styles that should be applied as the user types.
 ///
-/// Document layout is responsible for positioning and rendering the
-/// various visual components in the document. It's also responsible
-/// for linking logical document nodes to visual document components
-/// to facilitate user interactions like tapping and dragging.
+/// An [Editor] is responsible for executing every request that alters a [Document] or
+/// [DocumentComposer]. The [Editor] provides hooks for reactions, which can further alter
+/// content after a command, such as parsing inline Markdown, or creating hash tags. The
+/// [Editor] implements undo/redo control.
 ///
-/// Document interaction is responsible for taking appropriate actions
-/// in response to user taps, drags, and key presses.
+/// A [DocumentLayout] is responsible for positioning and rendering the various visual
+/// components in the document. It's also responsible for linking logical document nodes
+/// to visual document components to facilitate user interactions like tapping and dragging.
 ///
-/// Document composer is responsible for owning document selection and
-/// the current text entry mode.
+/// Document interaction is responsible for taking appropriate actions in response to user
+/// taps, drags, and key presses.
 class SuperEditor extends StatefulWidget {
   /// Creates a `Super Editor` with common (but configurable) defaults for
   /// visual components, text styles, and user interaction.
@@ -104,8 +102,12 @@ class SuperEditor extends StatefulWidget {
     this.autofocus = false,
     this.tapRegionGroupId,
     required this.editor,
-    required this.document,
-    required this.composer,
+    @Deprecated(
+        "The document is now retrieved from the Editor. You should remove this property from your SuperEditor widget.")
+    this.document,
+    @Deprecated(
+        "The composer is now retrieved from the Editor. You should remove this property from your SuperEditor widget.")
+    this.composer,
     this.scrollController,
     this.documentLayoutKey,
     Stylesheet? stylesheet,
@@ -143,7 +145,7 @@ class SuperEditor extends StatefulWidget {
   /// [FocusNode] for the entire `SuperEditor`.
   final FocusNode? focusNode;
 
-  /// Whether or not the [SuperEditor] should autofocus
+  /// Whether or not the [SuperEditor] should autofocus upon initial display.
   final bool autofocus;
 
   /// {@template super_editor_tap_region_group_id}
@@ -162,6 +164,33 @@ class SuperEditor extends StatefulWidget {
   /// `scrollController` is not used if this `SuperEditor` has an ancestor
   /// `Scrollable`.
   final ScrollController? scrollController;
+
+  /// An editing pipeline, which is responsible for all changes made to a document from
+  /// this [SuperEditor].
+  ///
+  /// All [SuperEditor] interactions apply changes to a document by submitting requests to
+  /// this [editor]. The [editor] takes requests, runs corresponding commands, runs reactions
+  /// to those commands (e.g., parsing Markdown), and then notifies listeners about what
+  /// changed.
+  ///
+  /// The editing pipeline within the [editor] applies to a set of [Editable]s. These are the
+  /// things that can be changed through editing. For example, every [editor] is expected to
+  /// contain a [MutableDocument] and a [MutableDocumentComposer] within the set of [Editable]s.
+  /// That way, edit commands can alter the document and the composer.
+  ///
+  /// See [Editor] for more details.
+  final Editor editor;
+
+  /// The [Document] that's edited by the [editor].
+  @Deprecated(
+      "The Document is now retrieved from the Editor. You should remove this property from your SuperEditor widget.")
+  final Document? document;
+
+  /// Owns the editor's current selection, the current attributions for
+  /// text input, and other transitive editor configurations.
+  @Deprecated(
+      "The DocumentComposer is now retrieved from the Editor. You should remove this property from your SuperEditor widget.")
+  final DocumentComposer? composer;
 
   /// [GlobalKey] that's bound to the [DocumentLayout] within
   /// this `SuperEditor`.
@@ -248,12 +277,6 @@ class SuperEditor extends StatefulWidget {
   /// user's selection.
   final SelectionLayerLinks? selectionLayerLinks;
 
-  /// Alters the [document] and other artifacts.
-  final Editor editor;
-
-  /// The [Document] that's edited by the [editor].
-  final Document document;
-
   /// Layers that are displayed under the document layout, aligned
   /// with the location and size of the document layout.
   final List<SuperEditorLayerBuilder> documentUnderlayBuilders;
@@ -261,10 +284,6 @@ class SuperEditor extends StatefulWidget {
   /// Layers that are displayed on top of the document layout, aligned
   /// with the location and size of the document layout.
   final List<SuperEditorLayerBuilder> documentOverlayBuilders;
-
-  /// Owns the editor's current selection, the current attributions for
-  /// text input, and other transitive editor configurations.
-  final DocumentComposer composer;
 
   /// Priority list of widget factories that create instances of
   /// each visual component displayed in the document layout, e.g.,
@@ -386,9 +405,18 @@ class SuperEditorState extends State<SuperEditor> {
   void initState() {
     super.initState();
 
+    if (widget.editor.maybeDocument == null) {
+      throw Exception(
+          "No Document is available to SuperEditor. The Editor given to SuperEditor must contain a MutableDocument in the set of Editables.");
+    }
+    if (widget.editor.maybeComposer == null) {
+      throw Exception(
+          "No DocumentComposer is available to SuperEditor. The Editor given to SuperEditor must contain a MutableDocumentComposer in the set of Editables.");
+    }
+
     _focusNode = (widget.focusNode ?? FocusNode())..addListener(_onFocusChange);
 
-    _composer = widget.composer;
+    _composer = widget.editor.composer;
 
     _scrollController = widget.scrollController ?? ScrollController();
     _autoScrollController = AutoScrollController();
@@ -424,8 +452,13 @@ class SuperEditorState extends State<SuperEditor> {
       _selectionLinks = widget.selectionLayerLinks ?? SelectionLayerLinks();
     }
 
-    if (widget.composer != oldWidget.composer) {
-      _composer = widget.composer;
+    if (widget.editor.maybeComposer != oldWidget.editor.composer) {
+      if (widget.editor.maybeComposer == null) {
+        throw Exception(
+            "No DocumentComposer is available to SuperEditor. The Editor given to SuperEditor must contain a MutableDocumentComposer in the set of Editables.");
+      }
+
+      _composer = widget.editor.composer;
     }
 
     if (widget.editor != oldWidget.editor) {
@@ -487,13 +520,13 @@ class SuperEditorState extends State<SuperEditor> {
 
     editContext = SuperEditorContext(
       editor: widget.editor,
-      document: widget.document,
+      document: widget.editor.document,
       composer: _composer,
       getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
       scroller: _scroller!,
       commonOps: CommonEditorOperations(
         editor: widget.editor,
-        document: widget.document,
+        document: widget.editor.document,
         composer: _composer,
         documentLayoutResolver: () => _docLayoutKey.currentState as DocumentLayout,
       ),
@@ -609,7 +642,7 @@ class SuperEditorState extends State<SuperEditor> {
           child: EditorSelectionAndFocusPolicy(
             focusNode: _focusNode,
             editor: widget.editor,
-            document: widget.document,
+            document: widget.editor.document,
             selection: _composer.selectionNotifier,
             isDocumentLayoutAvailable: () =>
                 (_docLayoutKey.currentContext?.findRenderObject() as RenderBox?)?.hasSize == true,
@@ -751,9 +784,9 @@ class SuperEditorState extends State<SuperEditor> {
           child: SuperEditorIosMagnifierOverlayManager(
             child: EditorFloatingCursor(
               editor: widget.editor,
-              document: widget.document,
+              document: widget.editor.document,
               getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
-              selection: widget.composer.selectionNotifier,
+              selection: widget.editor.composer.selectionNotifier,
               scrollChangeSignal: _scrollChangeSignal,
               child: child,
             ),

--- a/super_editor/test/infrastructure/content_layers_test.dart
+++ b/super_editor/test/infrastructure/content_layers_test.dart
@@ -424,8 +424,6 @@ void main() {
               rebuildSignal: rebuildSignal,
               builder: (context) => SuperEditor(
                 editor: editorContext.context.editor,
-                document: editorContext.context.document,
-                composer: editorContext.context.composer,
                 inputSource: TextInputSource.keyboard,
               ),
             ),

--- a/super_editor/test/super_editor/bug_fix_test.dart
+++ b/super_editor/test/super_editor/bug_fix_test.dart
@@ -24,8 +24,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 gestureMode: DocumentGestureMode.mouse,
                 inputSource: TextInputSource.keyboard,
               ),
@@ -96,8 +94,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 gestureMode: DocumentGestureMode.mouse,
                 inputSource: TextInputSource.keyboard,
               ),

--- a/super_editor/test/super_editor/components/block_node_test.dart
+++ b/super_editor/test/super_editor/components/block_node_test.dart
@@ -627,8 +627,6 @@ Widget _buildHardwareKeyboardEditor(MutableDocument document, MutableDocumentCom
     home: Scaffold(
       body: SuperEditor(
         editor: editor,
-        document: document,
-        composer: composer,
         // Make the text small so that the test paragraphs fit on a single
         // line, so that we can place the caret on the left/right halves
         // of lines, as needed.

--- a/super_editor/test/super_editor/components/task_test.dart
+++ b/super_editor/test/super_editor/components/task_test.dart
@@ -677,8 +677,6 @@ Future<Editor> _pumpScaffold(WidgetTester tester, {MutableDocument? document}) a
       home: Scaffold(
         body: SuperEditor(
           editor: editor,
-          document: document,
-          composer: composer,
         ),
       ),
     ),

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -2557,8 +2557,6 @@ Future<void> _pumpEditorWithTaskComponent(
       home: Scaffold(
         body: SuperEditor(
           editor: editor,
-          document: document,
-          composer: composer,
           componentBuilders: [
             TaskComponentBuilder(editor),
             ...defaultComponentBuilders,

--- a/super_editor/test/super_editor/supereditor_multi_editor_test.dart
+++ b/super_editor/test/super_editor/supereditor_multi_editor_test.dart
@@ -294,8 +294,6 @@ class _SwitchEditorsDemoState extends State<_SwitchEditorsDemo> {
             Expanded(
               child: SuperEditor(
                 editor: _activeDocumentEditor,
-                document: _activeDocument,
-                composer: _activeComposer,
                 stylesheet: defaultStylesheet.copyWith(
                   documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
                 ),

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -1527,8 +1527,6 @@ class _SliverTestEditorState extends State<_SliverTestEditor> {
               SliverToBoxAdapter(
                 child: SuperEditor(
                   editor: _docEditor,
-                  document: _doc,
-                  composer: _composer,
                   stylesheet: defaultStylesheet.copyWith(
                     documentPadding: const EdgeInsets.symmetric(vertical: 56, horizontal: 24),
                   ),

--- a/super_editor/test/super_editor/supereditor_shortcuts_test.dart
+++ b/super_editor/test/super_editor/supereditor_shortcuts_test.dart
@@ -83,8 +83,6 @@ Future<void> _pumpShortcutsAndSuperEditor(
             },
             child: SuperEditor(
               editor: editor,
-              document: document,
-              composer: composer,
               keyboardActions: keyboardActions,
             ),
           ),

--- a/super_editor/test/super_editor/supereditor_switching_test.dart
+++ b/super_editor/test/super_editor/supereditor_switching_test.dart
@@ -117,8 +117,6 @@ class _EditorReaderSwitchDemoState extends State<_EditorReaderSwitchDemo> {
   Widget _buildEditorOrReader() {
     if (widget.isEditable.value) {
       return SuperEditor(
-        document: widget.document,
-        composer: _composer,
         editor: _docEditor,
       );
     } else {

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -585,8 +585,6 @@ class _TestSuperEditorState extends State<_TestSuperEditor> {
       autofocus: widget.testConfiguration.autoFocus,
       tapRegionGroupId: widget.testConfiguration.tapRegionGroupId,
       editor: widget.testDocumentContext.editor,
-      document: widget.testDocumentContext.document,
-      composer: widget.testDocumentContext.composer,
       documentLayoutKey: widget.testDocumentContext.layoutKey,
       inputSource: widget.testConfiguration.inputSource,
       selectionPolicies: widget.testConfiguration.selectionPolicies ?? const SuperEditorSelectionPolicies(),

--- a/super_editor/test/super_editor/supereditor_text_layout_test.dart
+++ b/super_editor/test/super_editor/supereditor_text_layout_test.dart
@@ -64,8 +64,6 @@ void main() {
               trackBuilds: true,
               child: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,

--- a/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
+++ b/super_editor/test/super_editor/text_entry/dash_conversion_test.dart
@@ -343,8 +343,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -396,8 +394,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -454,8 +450,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -512,8 +506,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -688,8 +688,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -754,8 +752,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -822,8 +818,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -891,8 +885,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -959,8 +951,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,
@@ -1028,8 +1018,6 @@ void main() {
             home: Scaffold(
               body: SuperEditor(
                 editor: editor,
-                document: document,
-                composer: composer,
                 componentBuilders: [
                   TaskComponentBuilder(editor),
                   ...defaultComponentBuilders,

--- a/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
+++ b/super_editor/test_goldens/editor/text_entry/super_editor_composing_region_underline_test.dart
@@ -123,8 +123,6 @@ Future<(Editor, Document)> _pumpScaffold(WidgetTester tester, String contentMark
       body: Center(
         child: SuperEditor(
           editor: editor,
-          document: document,
-          composer: composer,
           componentBuilders: [
             TaskComponentBuilder(editor),
             ...defaultComponentBuilders,

--- a/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
+++ b/super_editor_markdown/test/markdown_inline_upstream_plugin_test.dart
@@ -551,8 +551,6 @@ Future<(Document, Editor)> _pumpScaffold(WidgetTester tester, [String initialMar
       home: Scaffold(
         body: SuperEditor(
           editor: editor,
-          document: document,
-          composer: composer,
           plugins: {
             MarkdownInlineUpstreamSyntaxPlugin(),
           },

--- a/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_pasting_test.dart
@@ -37,8 +37,6 @@ void main() {
           home: Scaffold(
             body: SuperEditor(
               editor: editor,
-              document: document,
-              composer: composer,
               keyboardActions: [
                 pasteMarkdownOnCmdAndCtrlV,
                 ...defaultKeyboardActions,
@@ -401,8 +399,6 @@ Future<(Editor, MutableDocument, MutableDocumentComposer)> _pumpSuperEditor(
       home: Scaffold(
         body: SuperEditor(
           editor: editor,
-          document: document,
-          composer: composer,
           keyboardActions: [
             pasteMarkdownOnCmdAndCtrlV,
             ...defaultKeyboardActions,


### PR DESCRIPTION
Removed document and composer from SuperEditor widget property list (Resolves #2160)

It's been confusing for a while that `SuperEditor` requires an `Editor`, `Document`, and `DocumentComposer`, despite the fact that the `Document` and `DocumentComposer` both exist within the `Editor`. This PR deprecates the `document` and `composer` properties on `SuperEditor` in favor of just an `Editor`.