### PR TITLE
[SuperEditor] expose canUndo and canRedo

### DIFF
--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -353,6 +353,10 @@ class Editor implements RequestDispatcher {
     _isReacting = false;
   }
 
+  bool canUndo() => _history.isNotEmpty;
+
+  bool canRedo() => _future.isNotEmpty;
+
   void undo() {
     editorEditsLog.info("Running undo");
     if (_history.isEmpty) {


### PR DESCRIPTION
In order to build a toolbar with undo/redo buttons on mobile, it would be nice to expose the state of the history lists.
This way we can build button with enabled/disabled UI state.
