### PR TITLE
[SuperEditor] - Fix: Document.firstOrNull was actually returning lastOrNull (Resolves #2187)

### DIFF
--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -1087,7 +1087,7 @@ class MutableDocument with Iterable<DocumentNode> implements Document, Editable 
   Iterator<DocumentNode> get iterator => _nodes.iterator;
 
   @override
-  DocumentNode? get firstOrNull => _nodes.lastOrNull;
+  DocumentNode? get firstOrNull => _nodes.firstOrNull;
 
   @override
   DocumentNode? get lastOrNull => _nodes.lastOrNull;


### PR DESCRIPTION
[SuperEditor] - Fix: Document.firstOrNull was actually returning lastOrNull (Resolves #2187)