### PR TITLE
[SuperEditor] Fix ActionTagComposingReaction looking for composing tag at selection base twice instead of at base and at extent.

### DIFF
--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -316,7 +316,7 @@ class ActionTagComposingReaction extends EditReaction {
         tagRule: _tagRule,
         nodeId: textNode.id,
         text: textNode.text,
-        expansionPosition: base.nodePosition as TextNodePosition,
+        expansionPosition: extent.nodePosition as TextNodePosition,
         isTokenCandidate: (attributions) => !attributions.contains(actionTagCancelledAttribution),
       );
     }

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -668,8 +668,15 @@ void main() {
       await tester.pressRightArrow();
 
       // Select upstream towards the cancelled action tag
-      await tester.pressShiftLeftArrow();
-      await tester.pressShiftUpArrow();
+      await expectLater(
+        () async {
+          await tester.pressShiftLeftArrow();
+          await tester.pressShiftUpArrow();
+        },
+        returnsNormally,
+      );
+
+      // If we reach the end without exception, then ActionTagComposingReaction did not fail due to selection.base.nodePosition not being a TextNodePosition.
     });
   });
 }

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -679,6 +679,7 @@ void main() {
       );
 
       // If we reach the end without exception, then ActionTagComposingReaction did not fail due to selection.base.nodePosition not being a TextNodePosition.
+      // See also: https://github.com/superlistapp/super_editor/pull/2201
     });
   });
 }

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -653,7 +653,9 @@ void main() {
   });
 
   group("selections >", () {
-    testWidgetsOnAllPlatforms("upstream cancelled action tag from block node", (tester) async {
+    testWidgetsOnAllPlatforms(
+        "exception in ActionTagComposingReaction when selecting upstream from BlockNode while cancelled action tag exists",
+        (tester) async {
       await _pumpTestEditor(
         tester,
         paragraphThenHrDoc(),

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -651,6 +651,27 @@ void main() {
       });
     });
   });
+
+  group("selections >", () {
+    testWidgetsOnAllPlatforms("upstream cancelled action tag from block node", (tester) async {
+      await _pumpTestEditor(
+        tester,
+        paragraphThenHrDoc(),
+      );
+
+      // Create cancelled action tag
+      await tester.placeCaretInParagraph("1", 0);
+      await tester.typeImeText("/header ");
+
+      // Place cursor at the end of the horizontal rule/block node
+      await tester.pressDownArrow();
+      await tester.pressRightArrow();
+
+      // Select upstream towards the cancelled action tag
+      await tester.pressShiftLeftArrow();
+      await tester.pressShiftUpArrow();
+    });
+  });
 }
 
 Future<TestDocumentContext> _pumpTestEditor(

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -653,8 +653,7 @@ void main() {
   });
 
   group("selections >", () {
-    testWidgetsOnAllPlatforms(
-        "exception in ActionTagComposingReaction when selecting upstream from BlockNode while cancelled action tag exists",
+    testWidgetsOnAllPlatforms("can find tag that surrounds the extent position when the selection is expanded",
         (tester) async {
       await _pumpTestEditor(
         tester,
@@ -678,8 +677,10 @@ void main() {
         returnsNormally,
       );
 
-      // If we reach the end without exception, then ActionTagComposingReaction did not fail due to selection.base.nodePosition not being a TextNodePosition.
-      // See also: https://github.com/superlistapp/super_editor/pull/2201
+      // If we reach the end without exception, then ActionTagComposingReaction did not blow up due to the base or extent
+      // position, and type of content at those positions.
+      //
+      // Original bug: https://github.com/superlistapp/super_editor/pull/2201
     });
   });
 }


### PR DESCRIPTION
Without this fix, this could cause an exception, as the condition checks if `extent.nodePosition` is a `TextNodePosition` and then assumes that `base.nodePosition` is a `TextNodePosition`.