### PR TITLE
[Infrastructure] Fix demo site compilation issues (Resolves #2200)

### DIFF
--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -52,8 +52,8 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
     _composer = MutableDocumentComposer(
       initialSelection: DocumentSelection.collapsed(
         position: DocumentPosition(
-          nodeId: _doc.nodes.last.id, // Place caret at end of document
-          nodePosition: (_doc.nodes.last as TextNode).endPosition,
+          nodeId: _doc.last.id, // Place caret at end of document
+          nodePosition: (_doc.last as TextNode).endPosition,
         ),
       ),
     );

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   super_text_layout: ^0.1.0
   url_launcher:
 
+dependency_overrides:
+  super_text_layout:
+    path: ../super_text_layout
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
[Infrastructure] Fix demo site compilation issues. Resolves #2200

The demo website was using the removed `nodes` property from `Document`. Additionally, we need to release a new version of `super_text_layout`, because there is a new constant exposed.

This PR replaces the `nodes` usage with the new API and override the `super_text_layout` dependency. After releasing a new `super_text_layout` we can remove the dependency override.