### PR TITLE
[SuperEditor] - Undo/redo can now be disabled (they are disabled by default) (Resolves #2214)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -56,7 +56,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
     _doc = createInitialDocument()..addListener(_onDocumentChange);
     _composer = MutableDocumentComposer();
     _composer.selectionNotifier.addListener(_hideOrShowToolbar);
-    _docEditor = createDefaultDocumentEditor(document: _doc, composer: _composer);
+    _docEditor = createDefaultDocumentEditor(document: _doc, composer: _composer, isHistoryEnabled: true);
     _docOps = CommonEditorOperations(
       editor: _docEditor,
       document: _doc,

--- a/super_editor/example/lib/main_super_editor.dart
+++ b/super_editor/example/lib/main_super_editor.dart
@@ -64,7 +64,7 @@ class _DemoState extends State<_Demo> {
     super.initState();
     _document = createInitialDocument();
     _composer = MutableDocumentComposer();
-    _docEditor = createDefaultDocumentEditor(document: _document, composer: _composer);
+    _docEditor = createDefaultDocumentEditor(document: _document, composer: _composer, isHistoryEnabled: true);
   }
 
   @override

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -58,6 +58,7 @@ class Editor implements RequestDispatcher {
     this.historyGroupingPolicy = neverMergePolicy,
     List<EditReaction>? reactionPipeline,
     List<EditListener>? listeners,
+    this.isHistoryEnabled = false,
   })  : requestHandlers = requestHandlers ?? [],
         reactionPipeline = reactionPipeline ?? [],
         _changeListeners = listeners ?? [] {
@@ -76,6 +77,12 @@ class Editor implements RequestDispatcher {
   /// Service Locator that provides all resources that are relevant for document editing.
   late final EditContext context;
 
+  /// Whether history tracking (and undo/redo) are enabled.
+  ///
+  /// When [isHistoryEnabled] is `false`, undo/redo is disabled, calling [undo] and [redo]
+  /// will have no effect, and [history] and [future] are always empty.
+  final bool isHistoryEnabled;
+
   /// Policies that determine when a new transaction of changes should be combined with the
   /// previous transaction, impacting what is undone by undo.
   final HistoryGroupingPolicy historyGroupingPolicy;
@@ -83,9 +90,17 @@ class Editor implements RequestDispatcher {
   /// Executes [EditCommand]s and collects a list of changes.
   late final _DocumentEditorCommandExecutor _commandExecutor;
 
+  /// A list of editor transactions that were run previously, leading to the current
+  /// state of the document, and other editables.
   List<CommandTransaction> get history => List.from(_history);
   final _history = <CommandTransaction>[];
 
+  /// A list of editor transactions that were undone since the last time a change was
+  /// made.
+  ///
+  /// As soon as a new change is made through the editor, the [future] list is cleared
+  /// out, because the editor no longer knows if the [future] changes can be applied
+  /// to the document and other editables.
   List<CommandTransaction> get future => List.from(_future);
   final _future = <CommandTransaction>[];
 
@@ -173,7 +188,7 @@ class Editor implements RequestDispatcher {
       return;
     }
 
-    if (_transaction!.commands.isNotEmpty) {
+    if (_transaction!.commands.isNotEmpty && isHistoryEnabled) {
       if (_history.isEmpty) {
         // Add this transaction onto the history stack.
         _history.add(_transaction!);
@@ -342,7 +357,7 @@ class Editor implements RequestDispatcher {
       reaction.react(context, this, _activeChangeList!);
     }
 
-    if (_transaction!.commands.isNotEmpty) {
+    if (_transaction!.commands.isNotEmpty && isHistoryEnabled) {
       _history.add(_transaction!);
     }
 
@@ -354,6 +369,11 @@ class Editor implements RequestDispatcher {
   }
 
   void undo() {
+    if (!isHistoryEnabled) {
+      // History is disabled, therefore undo/redo are disabled.
+      return;
+    }
+
     editorEditsLog.info("Running undo");
     if (_history.isEmpty) {
       return;
@@ -412,6 +432,11 @@ class Editor implements RequestDispatcher {
   }
 
   void redo() {
+    if (!isHistoryEnabled) {
+      // History is disabled, therefore undo/redo are disabled.
+      return;
+    }
+
     editorEditsLog.info("Running redo");
     if (_future.isEmpty) {
       return;

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -15,6 +15,7 @@ Editor createDefaultDocumentEditor({
   required MutableDocument document,
   required MutableDocumentComposer composer,
   HistoryGroupingPolicy historyGroupingPolicy = defaultMergePolicy,
+  bool isHistoryEnabled = false,
 }) {
   final editor = Editor(
     editables: {
@@ -24,6 +25,7 @@ Editor createDefaultDocumentEditor({
     requestHandlers: List.from(defaultRequestHandlers),
     historyGroupingPolicy: historyGroupingPolicy,
     reactionPipeline: List.from(defaultEditorReactions),
+    isHistoryEnabled: isHistoryEnabled,
   );
 
   return editor;

--- a/super_editor/test/super_editor/super_editor_undo_redo_test.dart
+++ b/super_editor/test/super_editor/super_editor_undo_redo_test.dart
@@ -10,11 +10,33 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group("Super Editor > undo redo >", () {
+    testWidgets("can be disabled", (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .enableHistory(false)
+          .pump();
+
+      await tester.placeCaretInParagraph("1", 0);
+
+      // Type some text that we'll attempt to undo.
+      await tester.typeImeText("a");
+
+      // Ensure we entered the "a".
+      expect(SuperEditorInspector.findTextInComponent("1").text, "a");
+
+      // Try to run undo.
+      await tester.pressCmdZ(tester);
+
+      // Ensure that the text was unchanged.
+      expect(SuperEditorInspector.findTextInComponent("1").text, "a");
+    });
+
     group("text insertion >", () {
       testWidgets("insert a word", (tester) async {
         final document = deserializeMarkdownToDocument("Hello  world");
         final composer = MutableDocumentComposer();
-        final editor = createDefaultDocumentEditor(document: document, composer: composer);
+        final editor = createDefaultDocumentEditor(document: document, composer: composer, isHistoryEnabled: true);
         final paragraphId = document.first.id;
 
         editor.execute([
@@ -85,6 +107,7 @@ void main() {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -142,6 +165,7 @@ void main() {
         final editContext = await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -168,6 +192,7 @@ void main() {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -195,6 +220,7 @@ void main() {
         final editContext = await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -221,6 +247,7 @@ void main() {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -254,6 +281,7 @@ void main() {
         final editContext = await tester //
             .createDocument()
             .withSingleEmptyParagraph()
+            .enableHistory(true)
             .pump();
 
         await tester.placeCaretInParagraph("1", 0);
@@ -273,6 +301,7 @@ void main() {
       final editContext = await tester //
           .createDocument()
           .withSingleEmptyParagraph()
+          .enableHistory(true)
           .pump();
 
       await tester.placeCaretInParagraph("1", 0);
@@ -318,6 +347,7 @@ This is paragraph 3''');
           await tester //
               .createDocument()
               .withSingleEmptyParagraph()
+              .enableHistory(true)
               .withHistoryGroupingPolicy(const MergeRapidTextInputPolicy())
               .pump();
 
@@ -341,6 +371,7 @@ This is paragraph 3''');
           await tester //
               .createDocument()
               .withSingleEmptyParagraph()
+              .enableHistory(true)
               .withHistoryGroupingPolicy(const MergeRapidTextInputPolicy())
               .pump();
 
@@ -381,6 +412,7 @@ This is paragraph 3''');
           final testContext = await tester //
               .createDocument()
               .withLongDoc()
+              .enableHistory(true)
               .withHistoryGroupingPolicy(defaultMergePolicy)
               .pump();
 
@@ -405,6 +437,7 @@ This is paragraph 3''');
           final testContext = await tester //
               .createDocument()
               .withLongDoc()
+              .enableHistory(true)
               .withHistoryGroupingPolicy(defaultMergePolicy)
               .pump();
 

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -249,6 +249,11 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  TestSuperEditorConfigurator enableHistory(bool isHistoryEnabled) {
+    _config.isHistoryEnabled = isHistoryEnabled;
+    return this;
+  }
+
   TestSuperEditorConfigurator withHistoryGroupingPolicy(HistoryGroupingPolicy policy) {
     _config.historyGroupPolicy = policy;
     return this;
@@ -431,6 +436,7 @@ class TestSuperEditorConfigurator {
       document: _config.document,
       composer: composer,
       historyGroupingPolicy: _config.historyGroupPolicy ?? neverMergePolicy,
+      isHistoryEnabled: _config.isHistoryEnabled,
     )
       ..requestHandlers.insertAll(0, _config.addedRequestHandlers)
       ..reactionPipeline.insertAll(0, _config.addedReactions);
@@ -678,6 +684,7 @@ class SuperEditorTestConfiguration {
   ScrollController? scrollController;
   bool insideCustomScrollView = false;
   DocumentGestureMode? gestureMode;
+  bool isHistoryEnabled = false;
   HistoryGroupingPolicy? historyGroupPolicy;
   TextInputSource? inputSource;
   SuperEditorSelectionPolicies? selectionPolicies;


### PR DESCRIPTION
[SuperEditor] - Undo/redo can now be disabled (they are disabled by default) (Resolves #2214)

The `Editor` now has a property called `isHistoryEnabled`. That property is respected inside the `Editor` - `undo()` and `redo()` bail if it's `false`. Also, the locations that would otherwise add to the history only do that when the property is `true`.

I made the property a constant on each `Editor` instance because attempting to change that value over time seems more likely to create bugs than to enable desired behavior.

I also updated the test configuration system to take a value for `isHistoryEnabled`.