### PR TITLE
[SuperEditor][macOS] Fix crash after merging paragraphs containing a composing region (Resolves #2218)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1199,6 +1199,9 @@ class CommonEditorOperations {
         SelectionChangeType.deleteContent,
         SelectionReason.userInteraction,
       ),
+      // Since two paragraphs were combined, the composing region might point
+      // to a deleted paragraph. Clear it.
+      ClearComposingRegionRequest(),
     ]);
 
     return true;

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1628,7 +1628,8 @@ Paragraph two
       // Simulate the user pressing BACKSPACE to merge the paragraphs.
       // Now that we are deleting a whitespace, mac reports a deleteBackward: selector
       // instead of a deletion delta.
-      await tester.pressBackspace();
+      await _receiveSelector('deleteBackward:');
+      await tester.pump();
 
       // Ensure the composing region was cleared in the IME.
       expect(composingBase, -1);
@@ -1746,4 +1747,21 @@ Future<void> _typeSpaceAdaptive(WidgetTester tester) async {
   }
 
   await tester.typeImeText(' ');
+}
+
+/// Simulates a `TextInputClient.performSelectors` call from the platform.
+Future<void> _receiveSelector(String selectorName) async {
+  await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    SystemChannels.textInput.name,
+    SystemChannels.textInput.codec.encodeMethodCall(
+      MethodCall(
+        "TextInputClient.performSelectors",
+        [
+          -1,
+          [selectorName],
+        ],
+      ),
+    ),
+    null,
+  );
 }

--- a/super_editor/test/super_editor/supereditor_input_ime_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_ime_test.dart
@@ -1548,6 +1548,98 @@ Paragraph two
       // Ensure SuperEditor composing region was cleared.
       expect(testContext.composer.composingRegion.value, isNull);
     });
+
+    testWidgetsOnMac('clears composing region after merging paragraphs', (tester) async {
+      final testContext = await tester
+          .createDocument() //
+          .withTwoEmptyParagraphs()
+          .withInputSource(TextInputSource.ime)
+          .pump();
+
+      // Place the caret at the beginning of the second paragraph.
+      await tester.placeCaretInParagraph('2', 0);
+
+      // Ensure we don't have a composing region.
+      expect(testContext.composer.composingRegion.value, isNull);
+
+      // Simulate an insertion containing a composing region.
+      await tester.ime.sendDeltas(
+        [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. ',
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: 2, end: 2),
+          ),
+          const TextEditingDeltaInsertion(
+            oldText: '. ',
+            textInserted: 'あ',
+            insertionOffset: 2,
+            selection: TextSelection.collapsed(offset: 3),
+            composing: TextRange(start: 2, end: 3),
+          ),
+        ],
+        getter: imeClientGetter,
+      );
+
+      // Ensure the editor applied the composing region.
+      expect(
+        testContext.composer.composingRegion.value,
+        isNotNull,
+      );
+
+      // Intercept the setEditingState message sent to the platform to check if we
+      // cleared the IME composing region when merging paragraphs.
+      int? composingBase;
+      int? composingExtent;
+      tester
+          .interceptChannel(SystemChannels.textInput.name) //
+          .interceptMethod(
+        'TextInput.setEditingState',
+        (methodCall) {
+          final params = methodCall.arguments as Map;
+          composingBase = params['composingBase'];
+          composingExtent = params['composingExtent'];
+
+          return null;
+        },
+      );
+
+      // Simulate the user pressing BACKSPACE to delete the first character.
+      // Even though the selection sits after a whitespace in the IME, mac still reports
+      // a composing region starting after the space.
+      await tester.ime.sendDeltas(
+        [
+          const TextEditingDeltaDeletion(
+            oldText: '. あ',
+            deletedRange: TextRange(start: 2, end: 3),
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: 2, end: 2),
+          ),
+        ],
+        getter: imeClientGetter,
+      );
+
+      // Ensure we still have a composing region in the editor.
+      expect(
+        testContext.composer.composingRegion.value,
+        isNotNull,
+      );
+
+      // Simulate the user pressing BACKSPACE to merge the paragraphs.
+      // Now that we are deleting a whitespace, mac reports a deleteBackward: selector
+      // instead of a deletion delta.
+      await tester.pressBackspace();
+
+      // Ensure the composing region was cleared in the IME.
+      expect(composingBase, -1);
+      expect(composingExtent, -1);
+
+      // Ensure SuperEditor composing region was cleared.
+      expect(testContext.composer.composingRegion.value, isNull);
+
+      // Ensure the paragraphs were merged.
+      expect(testContext.document.nodeCount, equals(1));
+    });
   });
 }
 


### PR DESCRIPTION
[SuperEditor][macOS] Fix crash after merging paragraphs containing a composing region. Resolves #2218

When using a Japanese language, typing in a paragraph and then pressing delete until the paragraph is merged with the upstream paragraph crashes the editor with the following exception:

```console
════════ Exception caught by foundation library ════════════════════════════════
The following _Exception was thrown while dispatching notifications for PausableValueNotifier<DocumentSelection?>:
Exception: No such document position in the IME content: [DocumentPosition] - node: "9ca894f5-0b79-4a3a-b0bf-842011f2d2d8", position: (TextPosition(offset: 0, affinity: TextAffinity.downstream))

When the exception was thrown, this was the stack:
#0      DocumentImeSerializer._documentToImePosition (package:super_editor/src/default_editor/document_ime/document_serialization.dart:351:7)
document_serialization.dart:351
#1      DocumentImeSerializer.documentToImeRange (package:super_editor/src/default_editor/document_ime/document_serialization.dart:335:30)
document_serialization.dart:335
#2      DocumentImeSerializer.toTextEditingValue (package:super_editor/src/default_editor/document_ime/document_serialization.dart:382:32)
document_serialization.dart:382
#3      DocumentImeInputClient._sendDocumentToIme (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:273:58)
document_ime_communication.dart:273
#4      DocumentImeInputClient._onContentChange (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:87:5)
document_ime_communication.dart:87
#5      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:437:24)
change_notifier.dart:437
#6      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:559:5)
change_notifier.dart:559
#7      PausableValueNotifier.resumeNotifications (package:super_editor/src/infrastructure/pausable_value_notifier.dart:49:11)
pausable_value_notifier.dart:49
#8      MutableDocumentComposer.onTransactionEnd (package:super_editor/src/core/document_composer.dart:155:24)
document_composer.dart:155
#9      Editor._onTransactionEnd (package:super_editor/src/core/editor.dart:331:16)
editor.dart:331
#10     Editor.endTransaction (package:super_editor/src/core/editor.dart:231:5)
editor.dart:231
#11     Editor.execute (package:super_editor/src/core/editor.dart:283:7)
editor.dart:283
#12     CommonEditorOperations.mergeTextNodeWithUpstreamTextNode (package:super_editor/src/default_editor/common_editor_operations.dart:1187:12)
common_editor_operations.dart:1187
#13     CommonEditorOperations.deleteUpstream (package:super_editor/src/default_editor/common_editor_operations.dart:1109:18)
common_editor_operations.dart:1109
#14     deleteBackward (package:super_editor/src/default_editor/document_ime/supereditor_ime_interactor.dart:709:21)
supereditor_ime_interactor.dart:709
#15     SuperEditorImeInteractorState._onPerformSelector (package:super_editor/src/default_editor/document_ime/supereditor_ime_interactor.dart:472:12)
supereditor_ime_interactor.dart:472
#16     DocumentImeInputClient.performSelector (package:super_editor/src/default_editor/document_ime/document_ime_communication.dart:305:22)
document_ime_communication.dart:305
#17     DeltaTextInputClientDecorator.performSelector (package:super_editor/src/default_editor/document_ime/ime_decoration.dart:104:14)
ime_decoration.dart:104
#18     ListBase.forEach (dart:collection/list.dart:51:13)
list.dart:51
#19     TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1922:19)
text_input.dart:1922
#20     TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1803:20)
text_input.dart:1803
#21     MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:571:55)
platform_channel.dart:571
#22     MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:564:34)
platform_channel.dart:564
#23     _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:618:35)
binding.dart:618
#24     _invoke2 (dart:ui/hooks.dart:344:13)
hooks.dart:344
#25     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
channel_buffers.dart:45
#26     _Channel.push (dart:ui/channel_buffers.dart:135:31)
channel_buffers.dart:135
#27     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
channel_buffers.dart:343
#28     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:750:22)
platform_dispatcher.dart:750
#29     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)
hooks.dart:257
```

The cause of the crash is that we are maintaining the previous composing region, which after the paragraph merging, points to a deleted paragraph.

This PR fixed the issue by making a request to clear the composing region when a paragraph merge is requested.