### PR TITLE
Cherry-pick "[SuperEditor] Fix ActionTagComposingReaction looking for composing tag at selection base twice instead of at base and at extent. (#2201)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -316,7 +316,7 @@ class ActionTagComposingReaction extends EditReaction {
         tagRule: _tagRule,
         nodeId: textNode.id,
         text: textNode.text,
-        expansionPosition: base.nodePosition as TextNodePosition,
+        expansionPosition: extent.nodePosition as TextNodePosition,
         isTokenCandidate: (attributions) => !attributions.contains(actionTagCancelledAttribution),
       );
     }

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -633,6 +633,38 @@ void main() {
       });
     });
   });
+
+  group("selections >", () {
+    testWidgetsOnAllPlatforms("can find tag that surrounds the extent position when the selection is expanded",
+        (tester) async {
+      await _pumpTestEditor(
+        tester,
+        paragraphThenHrDoc(),
+      );
+
+      // Create cancelled action tag
+      await tester.placeCaretInParagraph("1", 0);
+      await tester.typeImeText("/header ");
+
+      // Place cursor at the end of the horizontal rule/block node
+      await tester.pressDownArrow();
+      await tester.pressRightArrow();
+
+      // Select upstream towards the cancelled action tag
+      await expectLater(
+        () async {
+          await tester.pressShiftLeftArrow();
+          await tester.pressShiftUpArrow();
+        },
+        returnsNormally,
+      );
+
+      // If we reach the end without exception, then ActionTagComposingReaction did not blow up due to the base or extent
+      // position, and type of content at those positions.
+      //
+      // Original bug: https://github.com/superlistapp/super_editor/pull/2201
+    });
+  });
 }
 
 Future<TestDocumentContext> _pumpTestEditor(


### PR DESCRIPTION
This PR cherry-picks "[SuperEditor] Fix ActionTagComposingReaction looking for composing tag at selection base twice instead of at base and at extent. (#2201)" to stable.