### PR TITLE
[SuperEditor][SuperTextField][iOS] Allow animating caret blink (Resolves #2099)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -618,7 +618,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   bool get isCaretDisplayed => layoutData?.caret != null;
 
   @visibleForTesting
-  bool get isCaretVisible => _caretBlinkController.opacity == 1.0 && isCaretDisplayed;
+  bool get isCaretVisible => _caretBlinkController.isVisible && isCaretDisplayed;
 
   @visibleForTesting
   Duration get caretFlashPeriod => _caretBlinkController.flashPeriod;


### PR DESCRIPTION
[SuperEditor][SuperTextField][iOS] Allow animating caret blink. Resolves #2099 

Currently, our blinking caret has an on/off visibility, it doesn't animates the visibility changes. 

This PR adds a fade in/out transition when the caret switches from visible to invisible. 

Some problems that I found:

- Although we have an option to use a `Ticker` to drive the visibility change, we are setting the `_ticker` to `null` when `stopBlinking` is called. It means that once the user types or places the caret somewhere, which causes `stopBlinking` to be called to momentary stop blinking, we are switching to the timer mode:

https://github.com/superlistapp/super_editor/blob/4c7472b0e43460f27b7a2809ba704286dcec7b21/super_text_layout/lib/src/infrastructure/blink_controller.dart#L90-L96

https://github.com/superlistapp/super_editor/blob/4c7472b0e43460f27b7a2809ba704286dcec7b21/super_text_layout/lib/src/infrastructure/blink_controller.dart#L68-L88

- Fixing the previous issue creates an issue in some tests that check if the caret is blinking. Such tests were working before because we were always using the timer mode. When switching to ticker mode, there are some tests failing due to `pumpAndSettleTimeout`. The timeout happens because two methods used in those tests (`tester.ime.backspace` and `tester.doubleTapInParagraph`) internally call `pumpAndSettle`.

### Open questions:

- How should we expose the configuration to animate the caret blink? Via `SuperEditorIosControlsController` ?
- Should we add parameters to `tester.ime.backspace` and `tester.doubleTapInParagraph` to avoid calling `pumpAndSettle`?