### PR TITLE
[SuperEditor][SuperTextField][Android] Trigger light haptic feedback when dragging collapsed or expanded handles (Resolves #2113)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1101,6 +1101,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     final fingerDocumentPosition = _docLayout.getDocumentPositionNearestToOffset(
       _startDragPositionOffset! + fingerDragDelta - Offset(0, scrollDelta),
     )!;
+    if (fingerDocumentPosition != widget.selection.value!.extent) {
+      HapticFeedback.lightImpact();
+    }
     _selectPosition(fingerDocumentPosition);
   }
 
@@ -1470,6 +1473,7 @@ class SuperEditorAndroidControlsOverlayManagerState extends State<SuperEditorAnd
   void _updateDragHandleSelection(DocumentSelection newSelection) {
     if (newSelection != widget.selection.value) {
       widget.setSelection(newSelection);
+      HapticFeedback.lightImpact();
     }
   }
 

--- a/super_editor/lib/src/super_textfield/android/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/android/_editing_controls.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/multi_listenable_builder.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -341,6 +342,7 @@ class _AndroidEditingOverlayControlsState extends State<AndroidEditingOverlayCon
   void _updateDragHandleSelection(TextSelection selection) {
     if (selection != widget.editingController.textController.selection) {
       widget.editingController.textController.selection = selection;
+      HapticFeedback.lightImpact();
     }
   }
 

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
@@ -316,9 +317,14 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
       return;
     }
 
-    widget.textController.selection = TextSelection.collapsed(
+    final newSelection = TextSelection.collapsed(
       offset: _globalOffsetToTextPosition(details.globalPosition).offset,
     );
+
+    if (newSelection != widget.textController.selection) {
+      widget.textController.selection = newSelection;
+      HapticFeedback.lightImpact();
+    }
 
     setState(() {
       _globalDragOffset = _globalDragOffset! + details.delta;


### PR DESCRIPTION
[SuperEditor][SuperTextField][Android] Trigger light haptic feedback when dragging collapsed or expanded handles. Resolves #2113

Currently on Android, SuperEditor and SuperTextField doesn't provided any haptic feedback when selection selection is changed as the handle (collapsed or expanded) is dragged.

This PR changes `SuperEditor` and `SuperTextField` on Android to trigger haptic feedback as the user is dragging the handles.

However, on my Samsung M51, calling `HapticFeedback.lightImpact()` doesn't produce any feedback. Only `HapticFeedback.vibrate()` seems to be working on this phone.  I noticed there is a Flutter issue tracking this: https://github.com/flutter/flutter/issues/73987. I tried changing the settings as suggested in the ticket, but it still didn't work.