### PR TITLE
[SuperEditor][SuperTextField][iOS] Allow caret to slide over characters (Resolves #2103)

### DIFF
--- a/super_editor/lib/src/infrastructure/documents/selection_leader_document_layer.dart
+++ b/super_editor/lib/src/infrastructure/documents/selection_leader_document_layer.dart
@@ -194,12 +194,14 @@ class _SelectionLeadersDocumentLayerState
 class DocumentSelectionLayout {
   DocumentSelectionLayout({
     this.caret,
+    this.ghostCaret,
     this.upstream,
     this.downstream,
     this.expandedSelectionBounds,
   });
 
   final Rect? caret;
+  final Rect? ghostCaret;
   final Rect? upstream;
   final Rect? downstream;
   final Rect? expandedSelectionBounds;


### PR DESCRIPTION
[SuperEditor][SuperTextField][iOS] Allow caret to slide over characters. Resolves #2103

Currently, as the user drags the caret on iOS, SuperEditor and SuperTextField snap the caret to the nearest legal caret position. 

On native iOS, dragging the caret moves the caret by the exact drag amount in the current line of text, regardless of whether that x-offset is a legal caret position or not. When the user releases, the caret animates to the nearest legal position. Also, when the user is dragging the caret far from the text, a gray caret is displayed at the nearest legal position.

This PR implements this behavior.

https://github.com/user-attachments/assets/4454a140-91bb-4c89-b278-cddd8f9d2536

Implementation details: 

- Our iOS caret is displayed in `IosHandlesDocumentLayer`. Currently, this widget doesn't have access to the position where the caret is being dragged. I added a `ValueListenable` so the widget can listen be notified when the user drags the caret.

- I added a `ghostCaret` (for the lack of a better name) in `DocumentSelectionLayout` to hold the position for the gray caret. `DocumentSelectionLayout` isn't specific to iOS, so this isn't ideal.


