### PR TITLE
Fix toggling debug info crashing the editor

### DIFF
--- a/super_editor/lib/src/default_editor/debug_visualization.dart
+++ b/super_editor/lib/src/default_editor/debug_visualization.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:super_editor/src/infrastructure/sliver_hybrid_stack.dart';
 
 class SuperEditorDebugVisuals extends InheritedWidget {
   static SuperEditorDebugVisualsConfig of(BuildContext context) {
@@ -120,7 +121,7 @@ class SuperEditorImeDebugVisuals extends StatelessWidget {
                 ? "ATTACHED TO IME"
                 : "DETACHED FROM IME";
 
-        return Stack(
+        return SliverHybridStack(
           children: [
             // Super Editor
             child,

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -111,6 +111,10 @@ class ContentLayersElement extends RenderObjectElement {
   Element? _content;
   List<Element> _overlays = <Element>[];
 
+  // We need to track the children for which framework has called `forgetChild`,
+  // these need to be excluded from the visitChildren method until next update().
+  // ForgetChild is called for elements that will be reparented to avoid unmounting
+  // and remounting them.
   final Set<Element> _forgottenChildren = HashSet<Element>();
 
   @override
@@ -317,10 +321,12 @@ class ContentLayersElement extends RenderObjectElement {
   void _temporarilyForgetLayers() {
     contentLayersLog.finer("ContentLayersElement - temporarily forgetting layers");
     for (final underlay in _underlays) {
+      // Calling super.forgetChild directly to avoid adding it to _forgottenChildren.
       super.forgetChild(underlay);
     }
 
     for (final overlay in _overlays) {
+      // Calling super.forgetChild directly to avoid adding it to _forgottenChildren.
       super.forgetChild(overlay);
     }
   }

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -317,11 +317,11 @@ class ContentLayersElement extends RenderObjectElement {
   void _temporarilyForgetLayers() {
     contentLayersLog.finer("ContentLayersElement - temporarily forgetting layers");
     for (final underlay in _underlays) {
-      forgetChild(underlay);
+      super.forgetChild(underlay);
     }
 
     for (final overlay in _overlays) {
-      forgetChild(overlay);
+      super.forgetChild(overlay);
     }
   }
 

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -345,7 +345,10 @@ class ContentLayersElement extends RenderObjectElement {
     assert(!debugChildrenHaveDuplicateKeys(widget, [newContent]));
 
     _content = updateChild(_content, newContent, _contentSlot);
-    // This is where the framework elements clean up the forgotten children.
+    // super.update() and updateChild() is where the framework reparents 
+    // forgotten children. Therefore, at this point, the framework is 
+    // done with the concept of forgotten children, so we clear our 
+    // local cache of them, too.
     _forgottenChildren.clear();
   }
 

--- a/super_editor/lib/src/infrastructure/content_layers.dart
+++ b/super_editor/lib/src/infrastructure/content_layers.dart
@@ -322,11 +322,15 @@ class ContentLayersElement extends RenderObjectElement {
     contentLayersLog.finer("ContentLayersElement - temporarily forgetting layers");
     for (final underlay in _underlays) {
       // Calling super.forgetChild directly to avoid adding it to _forgottenChildren.
+      // We're doing this to prevent the children from building, but not from
+      // being enumerated in visitChildren, which would happen with this.forgetChild.
       super.forgetChild(underlay);
     }
 
     for (final overlay in _overlays) {
       // Calling super.forgetChild directly to avoid adding it to _forgottenChildren.
+      // We're doing this to prevent the children from building, but not from
+      // being enumerated in visitChildren, which would happen with this.forgetChild.
       super.forgetChild(overlay);
     }
   }
@@ -341,6 +345,7 @@ class ContentLayersElement extends RenderObjectElement {
     assert(!debugChildrenHaveDuplicateKeys(widget, [newContent]));
 
     _content = updateChild(_content, newContent, _contentSlot);
+    // This is where the framework elements clean up the forgotten children.
     _forgottenChildren.clear();
   }
 
@@ -396,6 +401,7 @@ class ContentLayersElement extends RenderObjectElement {
 
   @override
   void visitChildren(ElementVisitor visitor) {
+    // It is the responsibility of `visitChildren` to skip over forgotten children.
     if (_content != null && !_forgottenChildren.contains(_content)) {
       visitor(_content!);
     }


### PR DESCRIPTION
Fixes https://github.com/superlistapp/super_editor/issues/2254

- Changes `Stack` in `SuperEditorImeDebugVisuals` to `SliverHybridStack` because the render object now lives in a sliver
- Implements `forgetChild` inside `ContentLayersElement`. This is necessary because the `content` of `ContentLayersElement` is being reparented using `GlobalKey` so it needs to be excluded from `visitChildren` when unmounting.