### PR TITLE
Expose floating cursor geometry in document coordinates

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1826,6 +1826,14 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
       FloatingCursorPolicies.defaultFloatingCursorWidth,
       _floatingCursorHeight,
     );
+
+    _controlsContext!.floatingCursorController.cursorGeometryInDocument.value = Rect.fromLTWH(
+      _floatingCursorFocalPointInDocument!.dx,
+      _floatingCursorFocalPointInDocument!.dy - (_floatingCursorHeight / 2),
+      FloatingCursorPolicies.defaultFloatingCursorWidth,
+      _floatingCursorHeight,
+    );
+
     editorIosFloatingCursorLog.finer(
         "Set floating cursor geometry to: ${_controlsContext!.floatingCursorController.cursorGeometryInViewport.value}");
   }
@@ -1864,6 +1872,7 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
     editorIosFloatingCursorLog.fine("Floating cursor stopped.");
     _controlsContext!.floatingCursorController.isNearText.value = false;
     _controlsContext!.floatingCursorController.cursorGeometryInViewport.value = null;
+    _controlsContext!.floatingCursorController.cursorGeometryInDocument.value = null;
 
     _floatingCursorFocalPointInDocument = null;
     _floatingCursorFocalPointInViewport = null;
@@ -1886,7 +1895,7 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
 
   Widget _buildFloatingCursor() {
     return ValueListenableBuilder<Rect?>(
-      valueListenable: _controlsContext!.floatingCursorController.cursorGeometryInViewport,
+      valueListenable: _controlsContext!.floatingCursorController.cursorGeometryInDocument,
       builder: (context, floatingCursorRect, child) {
         if (floatingCursorRect == null) {
           return const SizedBox();

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -288,8 +288,11 @@ class FloatingCursorController {
   /// or not a standard gray caret should be displayed.
   final isNearText = ValueNotifier<bool>(false);
 
-  /// The offset, width, and height of the active floating cursor.
+  /// The offset, width, and height of the active floating cursor in viewport coordinates.
   final cursorGeometryInViewport = ValueNotifier<Rect?>(null);
+
+  /// The offset, width, and height of the active floating cursor in document coordinates.
+  final cursorGeometryInDocument = ValueNotifier<Rect?>(null);
 
   /// Report that the user has activated the floating cursor.
   void onStart() {


### PR DESCRIPTION
Fixes https://github.com/superlistapp/super_editor/issues/2258

The cursor geometry is currently exposed in viewport coordinates, which works correctly for autoscroll, but for correct positioning document coordinates are needed.