### PR TITLE
[SuperEditor] Fix composer attributions when collapsing the selection (Resolves #2257)

### DIFF
--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -94,12 +94,12 @@ class UpdateComposerTextStylesReaction extends EditReaction {
       final selectedNodePosition = selectionExtent.nodePosition as TextNodePosition;
       final previousSelectedNodePosition = previousSelectionExtent.nodePosition as TextNodePosition;
 
+      // Ignore the attributions at the caret only if the previous selection
+      // was already collapsed. If the selection was expanded and the user
+      // placed the caret at the extent of the selection, we should update
+      // the composer attributions.
       if (selectionExtent.nodeId == previousSelectionExtent.nodeId &&
           selectedNodePosition.offset == previousSelectedNodePosition.offset &&
-          // Ignore the attributions at the caret only if the previous selection
-          // was already collapsed. If the selection was expanded and the user
-          // placed the caret at the extent of the selection, we should update
-          // the composer attributions.
           _previousSelection?.isCollapsed == true) {
         // The text selection changed, but only the affinity is different. An affinity change doesn't alter
         // the selection from the user's perspective, so don't alter any preferences. Return.

--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -2,8 +2,8 @@ import 'dart:ui';
 
 import 'package:attributed_text/attributed_text.dart';
 import 'package:collection/collection.dart';
-import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/text.dart';
@@ -44,7 +44,7 @@ class UpdateComposerTextStylesReaction extends EditReaction {
 
   final Set<Attribution> _stylesToExtend;
 
-  DocumentPosition? _previousSelectionExtent;
+  DocumentSelection? _previousSelection;
 
   @override
   void react(EditContext editContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {
@@ -67,36 +67,47 @@ class UpdateComposerTextStylesReaction extends EditReaction {
 
     // Update our internal accounting.
     final composer = editContext.find<MutableDocumentComposer>(Editor.composerKey);
-    _previousSelectionExtent = composer.selection?.extent;
+    _previousSelection = composer.selection;
   }
 
   void _updateComposerStylesAtCaret(EditContext editContext) {
     final document = editContext.document;
     final composer = editContext.find<MutableDocumentComposer>(Editor.composerKey);
 
-    if (composer.selection?.extent == _previousSelectionExtent) {
+    if (composer.selection?.extent == _previousSelection?.extent && //
+        // Ignore the attributions at the caret only if the previous selection
+        // was already collapsed. If the selection was expanded and the user
+        // placed the caret at the extent of the selection, we should update
+        // the composer attributions.
+        _previousSelection?.isCollapsed == true) {
       return;
     }
 
+    final previousSelectionExtent = _previousSelection?.extent;
     final selectionExtent = composer.selection?.extent;
     if (selectionExtent != null &&
         selectionExtent.nodePosition is TextNodePosition &&
-        _previousSelectionExtent != null &&
-        _previousSelectionExtent!.nodePosition is TextNodePosition) {
+        previousSelectionExtent != null &&
+        previousSelectionExtent.nodePosition is TextNodePosition) {
       // The current and previous selections are text positions. Check for the situation where the two
       // selections are functionally equivalent, but the affinity changed.
       final selectedNodePosition = selectionExtent.nodePosition as TextNodePosition;
-      final previousSelectedNodePosition = _previousSelectionExtent!.nodePosition as TextNodePosition;
+      final previousSelectedNodePosition = previousSelectionExtent.nodePosition as TextNodePosition;
 
-      if (selectionExtent.nodeId == _previousSelectionExtent!.nodeId &&
-          selectedNodePosition.offset == previousSelectedNodePosition.offset) {
+      if (selectionExtent.nodeId == previousSelectionExtent.nodeId &&
+          selectedNodePosition.offset == previousSelectedNodePosition.offset &&
+          // Ignore the attributions at the caret only if the previous selection
+          // was already collapsed. If the selection was expanded and the user
+          // placed the caret at the extent of the selection, we should update
+          // the composer attributions.
+          _previousSelection?.isCollapsed == true) {
         // The text selection changed, but only the affinity is different. An affinity change doesn't alter
         // the selection from the user's perspective, so don't alter any preferences. Return.
         return;
       }
     }
 
-    _previousSelectionExtent = composer.selection?.extent;
+    _previousSelection = composer.selection;
 
     composer.preferences.clearStyles();
 

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -180,6 +180,56 @@ void main() {
         });
       });
 
+      group("when collapsing the selection", () {
+        testWidgetsOnMac("by keyboard and typing at the end of the attributed text", (tester) async {
+          await tester //
+              .createDocument()
+              .fromMarkdown("A bold text")
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Double tap to select the word "bold".
+          await tester.doubleTapInParagraph(doc.first.id, 4);
+
+          // Press command + b to apply bold attribution to the selected text.
+          await tester.pressCmdB();
+
+          // Press right arrow to place the caret at the end of the word "bold".
+          await tester.pressRightArrow();
+
+          // Type "er" so "bold" becomes "bolder".
+          await tester.typeImeText("er");
+
+          // Ensure the bold attribution was applied to the inserted text.
+          expect(doc, equalsMarkdown("A **bolder** text"));
+        });
+
+        testWidgetsOnMac("by tapping and typing at the end of the attributed text", (tester) async {
+          await tester //
+              .createDocument()
+              .fromMarkdown("A bold text")
+              .pump();
+
+          final doc = SuperEditorInspector.findDocument()!;
+
+          // Double tap to select the word "bold".
+          await tester.doubleTapInParagraph(doc.first.id, 4);
+
+          // Press command + b to apply bold attribution to the selected text.
+          await tester.pressCmdB();
+
+          // Place the caret at "bold|".
+          await tester.placeCaretInParagraph(doc.first.id, 6);
+
+          // Type "er" so "bold" becomes "bolder".
+          await tester.typeImeText("er");
+
+          // Ensure the bold attribution was applied to the inserted text.
+          expect(doc, equalsMarkdown("A **bolder** text"));
+        });
+      });
+
       group("when a single node is selected", () {
         testWidgetsOnAllPlatforms("toggles attribution throughout a node", (tester) async {
           final TestDocumentContext context = await tester //


### PR DESCRIPTION
[SuperEditor] Fix composer attributions when collapsing the selection. Resolves #2257

After applying an attribution to an expanded selection and collapsing the selection to the extent, the applied attribution isn't applied to the composer preferences. This causes the issue that the attribution isn't applied if the user types after placing the selection:

https://github.com/user-attachments/assets/5f79f688-d752-4d0d-82e8-31d8070274e5

The issue is that the reaction that applies attributions to the composer preferences does nothing if the previous selection extent is equal to the new selection extent, which is the case when the user places the caret at the end of an expanded selection, since the base changed but the extent don't.

This PR fixes the issue by also checking if the previous selection was collapsed. If it isn't, we still update the composer preferences.

