### PR TITLE
Support configurable underlines in TextWithHintComponent

### DIFF
--- a/super_editor/example/lib/demos/components/demo_text_with_hint.dart
+++ b/super_editor/example/lib/demos/components/demo_text_with_hint.dart
@@ -191,8 +191,7 @@ class HeaderWithHintComponentBuilder implements ComponentBuilder {
       ),
       textSelection: textSelection,
       selectionColor: componentViewModel.selectionColor,
-      composingRegion: componentViewModel.composingRegion,
-      showComposingUnderline: componentViewModel.showComposingRegionUnderline,
+      underlines: componentViewModel.createUnderlines(),
     );
   }
 }

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -565,10 +565,7 @@ class TextWithHintComponent extends StatefulWidget {
     this.textSelection,
     this.selectionColor = Colors.lightBlueAccent,
     this.highlightWhenEmpty = false,
-    this.composingRegion,
-    this.showComposingUnderline = false,
-    this.spellingErrorUnderlineStyle,
-    this.spellingErrors = const [],
+    this.underlines = const [],
     this.showDebugPaint = false,
   }) : super(key: key);
 
@@ -582,12 +579,7 @@ class TextWithHintComponent extends StatefulWidget {
   final TextSelection? textSelection;
   final Color selectionColor;
   final bool highlightWhenEmpty;
-
-  final TextRange? composingRegion;
-  final bool showComposingUnderline;
-
-  final UnderlineStyle? spellingErrorUnderlineStyle;
-  final List<TextRange> spellingErrors;
+  final List<Underlines> underlines;
 
   final bool showDebugPaint;
 
@@ -637,13 +629,7 @@ class _TextWithHintComponentState extends State<TextWithHintComponent>
           textSelection: widget.textSelection,
           selectionColor: widget.selectionColor,
           highlightWhenEmpty: widget.highlightWhenEmpty,
-          underlines: [
-            if (widget.spellingErrors.isNotEmpty)
-              Underlines(
-                style: widget.spellingErrorUnderlineStyle ?? const SquiggleUnderlineStyle(),
-                underlines: widget.spellingErrors,
-              ),
-          ],
+          underlines: widget.underlines,
           showDebugPaint: widget.showDebugPaint,
         ),
       ],

--- a/super_editor/test/super_editor/supereditor_components_test.dart
+++ b/super_editor/test/super_editor/supereditor_components_test.dart
@@ -140,8 +140,7 @@ class HintTextComponentBuilder implements ComponentBuilder {
       ),
       textSelection: textSelection,
       selectionColor: componentViewModel.selectionColor,
-      composingRegion: componentViewModel.composingRegion,
-      showComposingUnderline: componentViewModel.showComposingRegionUnderline,
+      underlines: componentViewModel.createUnderlines(),
     );
   }
 }


### PR DESCRIPTION
Fixes #2267 

Currently `TextWithHintComponent` does not support underline for composing region.
With this PR it changes the widget so that it resembles with other components, i.e., it receives a list underlines instead of determining these based on other variables (e.g. `composingRegion` and `showComposingUnderline` for composing region underlines or `spellingErrorUnderlineStyle` and `spellingErrors` for spelling errors underlines). 

The component builders that create a `TextWithHintComponent` will then rely on the view model to create the underlines.