### PR TITLE
[SuperEditor][Android] Honor handle builders (Resolves #1934)

### DIFF
--- a/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
@@ -137,10 +137,12 @@ class AndroidTextFieldDragHandleSelectionStrategy {
     final didFocalPointStayInSameNode = nearestPositionNodeIndex == previousNearestPositionNodeIndex;
 
     final didFocalPointMoveDownstream = didFocalPointMoveToDownstreamNode ||
-        (didFocalPointStayInSameNode && nearestPositionTextOffset > previousNearestPositionTextOffset);
+        (didFocalPointStayInSameNode && nearestPositionTextOffset > previousNearestPositionTextOffset) ||
+        (didFocalPointStayInSameNode && details.delta.dx > 0);
 
     final didFocalPointMoveUpstream = didFocalPointMoveToUpstreamNode ||
-        (didFocalPointStayInSameNode && nearestPositionTextOffset < previousNearestPositionTextOffset);
+        (didFocalPointStayInSameNode && nearestPositionTextOffset < previousNearestPositionTextOffset) ||
+        (didFocalPointStayInSameNode && details.delta.dx < 0);
 
     _lastFocalPosition = nearestPosition;
 

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -20,20 +20,11 @@ class DocumentKeys {
 /// Builds a full-screen collapsed drag handle display, with the handle positioned near the [focalPoint],
 /// and with the handle attached to the given [handleKey].
 ///
-/// The [handleKey] is used to find the handle in the widget tree for various purposes,
-/// e.g., within tests to verify the presence or absence of the handle.
-///
-/// The [gestureDelegate] defines handlers for gesture events that occur on a given handle. Implementers
-/// should set each of the [gestureDelegate]'s properties to the corresponding properties on the handle's
-/// gesture detector. For example, [gestureDelegate.onTap] must be set to the handle's `onTap` event.
-///
-/// When the handle is not desired, instead of not calling this builder at all, it's called with
-/// [shouldShow] set to `false`. This allows implementers to fade in/out the handle entrance/exit. If an
-/// animation isn't desired, simply return a [SizedBox] when [shouldShow] is `false`.
-///
-/// The [handleKey] must be attached to the handle, not the top-level widget returned
-/// from this builder, because the [handleKey] might be used to verify the size and location
-/// of the handle. For example:
+/// Implementers of this builder have the following responsibilities:
+/// * Attach the [handleKey] to the widget that renders the handle.
+/// * Wrap the handle widget with a `Follower` and attach the `focalPoint` to the `Follower`.
+/// * Wrap the handle widget with a `GestureDetector` and attach the provided [gestureDelegate] callbacks to the `GestureDetector`.
+/// * When [shouldShow] is `false`, hide the handle and ensure that no gestures are handled.
 ///
 /// ```dart
 /// Widget buildCollapsedHandle(BuildContext context, {
@@ -42,10 +33,21 @@ class DocumentKeys {
 ///   required Key handleKey,
 ///   required bool shouldShow,
 /// }) {
-///   return Follower(
+///   if (!shouldShow) {
+///     return const SizedBox();
+///   }
+///   return Follower.withOffset(
+///     offset: Offset.zero,
 ///     link: focalPoint,
-///     child: CollapsedHandle(
-///       key: handleKey,
+///     child: GestureDetector(
+///       onTap: gestureDelegate.onTap,
+///       onPanStart: gestureDelegate.onPanStart,
+///       onPanUpdate: gestureDelegate.onPanUpdate,
+///       onPanEnd: gestureDelegate.onPanEnd,
+///       onPanCancel: gestureDelegate.onPanCancel,
+///       child: CollapsedHandle(
+///         key: handleKey,
+///       ),
 ///     ),
 ///   );
 /// }
@@ -65,15 +67,15 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
 /// The [upstreamHandleKey] and [downstreamHandleKey] are used to find the handles in the widget tree for
 /// various purposes, e.g., within tests to verify the presence or absence of the handles.
 ///
-/// The [downstreamGestureDelegate] and [upstreamGestureDelegate] define handlers for gesture events
-/// that occur on a given handle. Implementers should set each of the [downstreamGestureDelegate]'s properties to
-/// the corresponding properties on the downstream handle's gesture detector and each of the [upstreamGestureDelegate]'s
-/// properties to the corresponding properties on the upstream handle's gesture detector. For example,
-/// [downstreamGestureDelegate.onTap] must be set to the downstream handle's `onTap` event.
-///
-/// When the handle is not desired, instead of not calling this builder at all, it's called with
-/// [shouldShow] set to `false`. This allows implementers to fade in/out the handle entrance/exit. If an
-/// animation isn't desired, simply return a [SizedBox] when [shouldShow] is `false`.
+/// Implementers of this builder have the following responsibilities:
+/// * Attach the [upstreamHandleKey] to the widget that renders the upstream handle and [downstreamHandleKey]
+///   to the downstream handle.
+/// * Wrap each handle widget with a `Follower`, attaching the [downstreamFocalPoint] to the downstream handle `Follower`
+///   and [upstreamFocalPoint] to the upstream handle `Follower`.
+/// * Wrap each handle widget with a `GestureDetector`, attaching the provided [upstreamGestureDelegate] callbacks to
+///   the upstream handle `GestureDetector` and the [downstreamGestureDelegate] callbacks to the downstream
+///   handle `GestureDetector`.
+/// * When [shouldShow] is `false`, hide the handle and ensure that no gestures are handled.
 ///
 /// The handle keys must be attached to the handles, not the top-level widget returned
 /// from this builder, because the handle keys might be used to verify the size and location
@@ -89,15 +91,34 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
 ///   required Key upstreamHandleKey,
 ///   required bool shouldShow,
 ///  }) {
+///   if (!shouldShow) {
+///     return const SizedBox();
+///   }
 ///   return Stack(
 ///     children: [
-///       Follower(
-///        link: upstreamFocalPoint,
-///        child: UpstreamHandle(key: upstreamHandleKey),
+///       Follower.withOffset(
+///         offset: Offset.zero,
+///         link: upstreamFocalPoint,
+///         child: GestureDetector(
+///           onTapDown: upstreamGestureDelegate.onTapDown,
+///           onPanStart: upstreamGestureDelegate.onPanStart,
+///           onPanUpdate: upstreamGestureDelegate.onPanUpdate,
+///           onPanEnd: upstreamGestureDelegate.onPanEnd,
+///           onPanCancel: upstreamGestureDelegate.onPanCancel,
+///           child: UpstreamHandle(key: upstreamHandleKey),
+///         ),
 ///       ),
-///       Follower(
-///        link: downstreamFocalPoint,
-///        child: DownstreamHandle(key: downstreamHandleKey),
+///       Follower.withOffset(
+///         offset: Offset.zero,
+///         link: downstreamFocalPoint,
+///         child: GestureDetector(
+///           onTapDown: downstreamGestureDelegate.onTapDown,
+///           onPanStart: downstreamGestureDelegate.onPanStart,
+///           onPanUpdate: downstreamGestureDelegate.onPanUpdate,
+///           onPanEnd: downstreamGestureDelegate.onPanEnd,
+///           onPanCancel: downstreamGestureDelegate.onPanCancel,
+///           child: DownstreamHandle(key: downstreamHandleKey),
+///         ),
 ///       ),
 ///     ],
 ///   );

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -23,12 +23,13 @@ class DocumentKeys {
 /// The [handleKey] is used to find the handle in the widget tree for various purposes,
 /// e.g., within tests to verify the presence or absence of the handle.
 ///
-/// The [gestureDelegate] hold event handles that should be attached to the gesture recognizer
-/// attached to the handle. For example, set [gestureDelegate.onTap] to the handle's `onTap` event.
+/// The [gestureDelegate] defines handlers for gesture events that occur on a given handle. Implementers
+/// should set each of the [gestureDelegate]'s properties to the corresponding properties on the handle's
+/// gesture detector. For example, [gestureDelegate.onTap] must be set to the handle's `onTap` event.
 ///
-/// Use [shouldShow] to fade in/out the handle entrance/exit, for example, using an [AnimatedOpacity]
-/// to switch between `0.0` and `1.0`. If an animation isn't desired, return a [SizedBox] when [shouldShow]
-/// is `false`.
+/// When the handle is not desired, instead of not calling this builder at all, it's called with
+/// [shouldShow] set to `false`. This allows implementers to fade in/out the handle entrance/exit. If an
+/// animation isn't desired, simply return a [SizedBox] when [shouldShow] is `false`.
 ///
 /// The [handleKey] must be attached to the handle, not the top-level widget returned
 /// from this builder, because the [handleKey] might be used to verify the size and location
@@ -64,20 +65,22 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
 /// The [upstreamHandleKey] and [downstreamHandleKey] are used to find the handles in the widget tree for
 /// various purposes, e.g., within tests to verify the presence or absence of the handles.
 ///
-/// The [downstreamGestureDelegate] and [upstreamGestureDelegate] hold event handles that should be attached
-/// to the gesture recognizers attached to the handles. For example, set [downstreamGestureDelegate.onTap] to
-/// the downstream handle recognizer's `onTap` event.
+/// The [downstreamGestureDelegate] and [upstreamGestureDelegate] define handlers for gesture events
+/// that occur on a given handle. Implementers should set each of the [downstreamGestureDelegate]'s properties to
+/// the corresponding properties on the downstream handle's gesture detector and each of the [upstreamGestureDelegate]'s
+/// properties to the corresponding properties on the upstream handle's gesture detector. For example,
+/// [downstreamGestureDelegate.onTap] must be set to the downstream handle's `onTap` event.
 ///
-/// Use [shouldShow] to fade in/out the handles entrance/exit, for example, using an [AnimatedOpacity]
-/// to switch between `0.0` and `1.0`. If an animation isn't desired, return a [SizedBox] when [shouldShow]
-/// is `false`.
+/// When the handle is not desired, instead of not calling this builder at all, it's called with
+/// [shouldShow] set to `false`. This allows implementers to fade in/out the handle entrance/exit. If an
+/// animation isn't desired, simply return a [SizedBox] when [shouldShow] is `false`.
 ///
 /// The handle keys must be attached to the handles, not the top-level widget returned
 /// from this builder, because the handle keys might be used to verify the size and location
 /// of the handles. For example:
 ///
 /// ```dart
-/// Widget buildCollapsedHandle(BuildContext context, {
+/// Widget buildExpandedHandles(BuildContext context, {
 ///   required LeaderLink downstreamFocalPoint,
 ///   required DocumentHandleGestureDelegate downstreamGestureDelegate,
 ///   required Key downstreamHandleKey,
@@ -114,10 +117,31 @@ typedef DocumentExpandedHandlesBuilder = Widget Function(
 /// Delegate for handling gestures on a document handle.
 ///
 /// These callbacks are intended to make it easier for developers to customize
-/// the drag handles, without having to re-implement the gesture logic.
+/// the drag handles, without having to re-implement the gesture logic. For
+/// example, implementers can wrap the handle in a `GestureDetector`:
 ///
-/// To use it, for example, wrap the handle in a `GestureDetector` and pass
-/// these callbacks to the corresponding gesture events.
+/// ```dart
+/// Widget buildCollapsedHandle(BuildContext context, {
+///   required LeaderLink focalPoint,
+///   required DocumentHandleGestureDelegate gestureDelegate,
+///   required Key handleKey,
+///   required bool shouldShow,
+/// }) {
+///   return Follower(
+///     link: focalPoint,
+///     child: GestureDetector(
+///       onTap: gestureDelegate.onTap,
+///       onPanStart: gestureDelegate.onPanStart,
+///       onPanUpdate: gestureDelegate.onPanUpdate,
+///       onPanEnd: gestureDelegate.onPanEnd,
+///       onPanCancel: gestureDelegate.onPanCancel,
+///       child: CollapsedHandle(
+///         key: handleKey,
+///       ),
+///     ),
+///   );
+/// }
+/// ```
 class DocumentHandleGestureDelegate {
   DocumentHandleGestureDelegate({
     this.onTapDown,

--- a/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
+++ b/super_editor/lib/src/infrastructure/platforms/mobile_documents.dart
@@ -23,8 +23,8 @@ class DocumentKeys {
 /// The [handleKey] is used to find the handle in the widget tree for various purposes,
 /// e.g., within tests to verify the presence or absence of the handle.
 ///
-/// The [gestureCallbacks] hold event handles that should be attached to the gesture recognizer
-/// attached to the handle. For example, set [gestureCallbacks.onTap] to the handle's `onTap` event.
+/// The [gestureDelegate] hold event handles that should be attached to the gesture recognizer
+/// attached to the handle. For example, set [gestureDelegate.onTap] to the handle's `onTap` event.
 ///
 /// Use [shouldShow] to fade in/out the handle entrance/exit, for example, using an [AnimatedOpacity]
 /// to switch between `0.0` and `1.0`. If an animation isn't desired, return a [SizedBox] when [shouldShow]
@@ -37,7 +37,7 @@ class DocumentKeys {
 /// ```dart
 /// Widget buildCollapsedHandle(BuildContext context, {
 ///   required LeaderLink focalPoint,
-///   required DocumentHandleGestureCallbacks gestureCallbacks,
+///   required DocumentHandleGestureDelegate gestureDelegate,
 ///   required Key handleKey,
 ///   required bool shouldShow,
 /// }) {
@@ -53,7 +53,7 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
   BuildContext, {
   required Key handleKey,
   required LeaderLink focalPoint,
-  required DocumentHandleGestureCallbacks gestureCallbacks,
+  required DocumentHandleGestureDelegate gestureDelegate,
   required bool shouldShow,
 });
 
@@ -64,8 +64,8 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
 /// The [upstreamHandleKey] and [downstreamHandleKey] are used to find the handles in the widget tree for
 /// various purposes, e.g., within tests to verify the presence or absence of the handles.
 ///
-/// The [downstreamGestureCallbacks] and [upstreamGestureCallbacks] hold event handles that should be attached
-/// to the gesture recognizers attached to the handles. For example, set [downstreamGestureCallbacks.onTap] to
+/// The [downstreamGestureDelegate] and [upstreamGestureDelegate] hold event handles that should be attached
+/// to the gesture recognizers attached to the handles. For example, set [downstreamGestureDelegate.onTap] to
 /// the downstream handle recognizer's `onTap` event.
 ///
 /// Use [shouldShow] to fade in/out the handles entrance/exit, for example, using an [AnimatedOpacity]
@@ -79,10 +79,10 @@ typedef DocumentCollapsedHandleBuilder = Widget Function(
 /// ```dart
 /// Widget buildCollapsedHandle(BuildContext context, {
 ///   required LeaderLink downstreamFocalPoint,
-///   required DocumentHandleGestureCallbacks downstreamGestureCallbacks,
+///   required DocumentHandleGestureDelegate downstreamGestureDelegate,
 ///   required Key downstreamHandleKey,
 ///   required LeaderLink upstreamFocalPoint,
-///   required DocumentHandleGestureCallbacks upstreamGestureCallbacks,
+///   required DocumentHandleGestureDelegate upstreamGestureDelegate,
 ///   required Key upstreamHandleKey,
 ///   required bool shouldShow,
 ///  }) {
@@ -104,22 +104,22 @@ typedef DocumentExpandedHandlesBuilder = Widget Function(
   BuildContext, {
   required Key upstreamHandleKey,
   required LeaderLink upstreamFocalPoint,
-  required DocumentHandleGestureCallbacks upstreamGestureCallbacks,
+  required DocumentHandleGestureDelegate upstreamGestureDelegate,
   required Key downstreamHandleKey,
   required LeaderLink downstreamFocalPoint,
-  required DocumentHandleGestureCallbacks downstreamGestureCallbacks,
+  required DocumentHandleGestureDelegate downstreamGestureDelegate,
   required bool shouldShow,
 });
 
-/// Callbacks for handling gestures on a document handle.
+/// Delegate for handling gestures on a document handle.
 ///
 /// These callbacks are intended to make it easier for developers to customize
 /// the drag handles, without having to re-implement the gesture logic.
 ///
-/// For example, wrap the handle in a `GestureDetector` and pass these callbacks
-/// to the corresponding gesture events.
-class DocumentHandleGestureCallbacks {
-  DocumentHandleGestureCallbacks({
+/// To use it, for example, wrap the handle in a `GestureDetector` and pass
+/// these callbacks to the corresponding gesture events.
+class DocumentHandleGestureDelegate {
+  DocumentHandleGestureDelegate({
     this.onTapDown,
     this.onTap,
     this.onPanStart,

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -318,7 +318,7 @@ void main() {
           BuildContext context, {
           required Key handleKey,
           required LeaderLink focalPoint,
-          required DocumentHandleGestureCallbacks gestureCallbacks,
+          required DocumentHandleGestureDelegate gestureDelegate,
           required bool shouldShow,
         }) {
           return SizedBox(
@@ -353,10 +353,10 @@ void main() {
           BuildContext context, {
           required Key upstreamHandleKey,
           required LeaderLink upstreamFocalPoint,
-          required DocumentHandleGestureCallbacks upstreamGestureCallbacks,
+          required DocumentHandleGestureDelegate upstreamGestureDelegate,
           required Key downstreamHandleKey,
           required LeaderLink downstreamFocalPoint,
-          required DocumentHandleGestureCallbacks downstreamGestureCallbacks,
+          required DocumentHandleGestureDelegate downstreamGestureDelegate,
           required bool shouldShow,
         }) {
           return Stack(

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
@@ -302,6 +303,91 @@ void main() {
 
       // Ensure caret is visible.
       expect(SuperEditorInspector.isCaretVisible(), true);
+    });
+
+    testWidgetsOnAndroid("allows customizing the collapsed handle", (tester) async {
+      // Use a key different from the provided by the builder to make sure our handle
+      // is used instead of the default one.
+      final collapsedFinderKey = GlobalKey();
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withAndroidCollapsedHandleBuilder(
+        (
+          BuildContext context, {
+          required Key handleKey,
+          required LeaderLink focalPoint,
+          required DocumentHandleGestureCallbacks gestureCallbacks,
+          required bool shouldShow,
+        }) {
+          return SizedBox(
+            key: collapsedFinderKey,
+            width: 20,
+            height: 20,
+            child: Container(
+              key: handleKey,
+            ),
+          );
+        },
+      ).pump();
+
+      // Place the caret at the beginning of the document to show the collapsed handle.
+      await tester.placeCaretInParagraph('1', 0);
+
+      // Ensure the custom handle is used.
+      expect(find.byKey(collapsedFinderKey), findsOneWidget);
+    });
+
+    testWidgetsOnAndroid("allows customizing the expanded handles", (tester) async {
+      // Use keys different from the provided by the builder to make sure our handles
+      // are used instead of the default ones.
+      final upstreamFinderKey = GlobalKey();
+      final downstreamFinderKey = GlobalKey();
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .withAndroidExpandedHandlesBuilder(
+        (
+          BuildContext context, {
+          required Key upstreamHandleKey,
+          required LeaderLink upstreamFocalPoint,
+          required DocumentHandleGestureCallbacks upstreamGestureCallbacks,
+          required Key downstreamHandleKey,
+          required LeaderLink downstreamFocalPoint,
+          required DocumentHandleGestureCallbacks downstreamGestureCallbacks,
+          required bool shouldShow,
+        }) {
+          return Stack(
+            children: [
+              SizedBox(
+                key: upstreamFinderKey,
+                width: 20,
+                height: 20,
+                child: Container(
+                  key: upstreamHandleKey,
+                ),
+              ),
+              SizedBox(
+                key: downstreamFinderKey,
+                width: 20,
+                height: 20,
+                child: Container(
+                  key: downstreamHandleKey,
+                ),
+              ),
+            ],
+          );
+        },
+      ).pump();
+
+      // Double tap to select the first word and show the expanded handles.
+      await tester.doubleTapInParagraph('1', 0);
+
+      // Ensure the custom handles are used.
+      expect(find.byKey(upstreamFinderKey), findsOneWidget);
+      expect(find.byKey(downstreamFinderKey), findsOneWidget);
     });
 
     group('shows magnifier above the caret when dragging the collapsed handle', () {

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -309,6 +309,18 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  /// Configures the [SuperEditor] to use the given [builder] as its android collapsed handle builder.
+  TestSuperEditorConfigurator withAndroidCollapsedHandleBuilder(DocumentCollapsedHandleBuilder? builder) {
+    _config.androidCollapsedHandleBuilder = builder;
+    return this;
+  }
+
+  /// Configures the [SuperEditor] to use the given [builder] as its android expanded handles builder.
+  TestSuperEditorConfigurator withAndroidExpandedHandlesBuilder(DocumentExpandedHandlesBuilder? builder) {
+    _config.androidExpandedHandlesBuilder = builder;
+    return this;
+  }
+
   /// Configures the [SuperEditor] to use the given [builder] as its iOS toolbar builder.
   TestSuperEditorConfigurator withiOSToolbarBuilder(DocumentFloatingToolbarBuilder? builder) {
     _config.iOSToolbarBuilder = builder;
@@ -550,6 +562,8 @@ class _TestSuperEditorState extends State<_TestSuperEditor> {
 
     _androidControlsController = SuperEditorAndroidControlsController(
       toolbarBuilder: widget.testConfiguration.androidToolbarBuilder,
+      collapsedHandleBuilder: widget.testConfiguration.androidCollapsedHandleBuilder,
+      expandedHandlesBuilder: widget.testConfiguration.androidExpandedHandlesBuilder,
     );
   }
 
@@ -708,7 +722,11 @@ class SuperEditorTestConfiguration {
   final prependedKeyboardActions = <DocumentKeyboardAction>[];
   final appendedKeyboardActions = <DocumentKeyboardAction>[];
   final addedComponents = <ComponentBuilder>[];
+
   DocumentFloatingToolbarBuilder? androidToolbarBuilder;
+  DocumentCollapsedHandleBuilder? androidCollapsedHandleBuilder;
+  DocumentExpandedHandlesBuilder? androidExpandedHandlesBuilder;
+
   DocumentFloatingToolbarBuilder? iOSToolbarBuilder;
 
   DocumentSelection? selection;


### PR DESCRIPTION
[SuperEditor][Android] Honor handle builders. Resolves #1934

`SuperEditorAndroidControlsController` exposes `collapsedHandleBuilder` and `expandedHandlesBuilder`, but neither of them are being used anywhere.

This PR changes the android touch interactor to honor the provided builders.

The drag handles involve various gesture callbacks to place/expand/collapse the selection, start/stop the blinking caret, show/hide the toolbar, among other things. It would be very difficult for developers to do that on their own.

Because of that, this PR introduces an object called `DocumentHandleGestureCallbacks`, which holds the gesture callbacks that should be attached to the drag handle. Developers would wrap the handle with a `GestureDetector` and set each property to its corresponding `GestureDetector` callback.

I needed to modify the expanded handles selection logic, because after these changes, when the user starts dragging  the expanded handle, the pan update event is trigger before the user moves the drag handle to another character, so we couldn't determine if the user is dragging upstream or downstream. This breaks our logic of selecting by word or character.

The original ticket also mentions that we use `magnifierBuilder` and `toolbarBuilder` in different ways. For `magnifierBuilder`, we expect that developers will include the `Follower` in the returned widget, while in `toolbarBuilder` we wrap the returned widget with a `Follower`. Letting the developers attach the `Follower` to the tree seems more logical to me, because it would be able to customize the offset and anchors. But changing that now seems like a big breaking change. Should we do that?  