### PR TITLE
[DemoApp] Fix build Android failure (Resolves #2281)

### DIFF
--- a/super_editor/example/android/build.gradle
+++ b/super_editor/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/super_editor/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/super_editor/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip

--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   cupertino_icons: ^1.0.1
 
   charcode: ^1.1.3
-  flutter_keyboard_visibility: ^5.0.3
+  flutter_keyboard_visibility: ^6.0.0
   google_fonts: ^2.0.0
   http: ^0.13.1
   linkify: ^5.0.0


### PR DESCRIPTION
[DemoApp] Fix build Android failure. Resolves #2281

Trying to run the example app on Android fails with the following build exception:

```console
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
   > Android resource linking failed
     aapt2 E 08-27 19:43:04 11507 82156 LoadedArsc.cpp:94] RES_TABLE_TYPE_TYPE entry offsets overlap actual entry data.
     aapt2 E 08-27 19:43:04 11507 82156 ApkAssets.cpp:149] Failed to load resources table in APK '/Users/angelosilvestre/Library/Android/sdk/platforms/android-35/android.jar'.
     error: failed to load include path /Users/angelosilvestre/Library/Android/sdk/platforms/android-35/android.jar.
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────────┐
│ [!] Using compileSdk 35 requires Android Gradle Plugin (AGP) 8.1.0 or higher.                    │
│  Please upgrade to a newer AGP version. The version of AGP that your project uses is likely      │
│  defined in:                                                                                     │
│ /Users/angelosilvestre/dev/super_editor/super_editor/example/android/settings.gradle,            │
│ in the 'plugins' closure.                                                                        │
│  Alternatively, if your project was created with an older version of the templates, it is likely │
│ in the buildscript.dependencies closure of the top-level build.gradle:                           │
│ /Users/angelosilvestre/dev/super_editor/super_editor/example/android/build.gradle.               │
│                                                                                                  │
│  Finally, if you have a strong reason to avoid upgrading AGP, you can temporarily lower the      │
│  compileSdk version in the following file:                                                       │
│ /Users/angelosilvestre/dev/super_editor/super_editor/example/android/app/build.gradle            │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
Error: Gradle task assembleDebug failed with exit code 1
Exited (1)

```

It seems this an issue with the Android Gradle Plugin. Sources:

https://stackoverflow.com/questions/78678063/this-happens-when-i-try-to-build-an-android-project-or-to-run-the-emulator

https://issuetracker.google.com/issues/342522139

This PR updates the Android Gradle Plugin version. I also bumped the `flutter_keyboard_visibility` dependency because it seems it is incompatible with this version.