### PR TITLE
[SuperTextField][iOS] Increase drag handle interaction area (Resolves #1926)

### DIFF
--- a/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
+++ b/super_editor/lib/src/super_textfield/ios/_editing_controls.dart
@@ -515,7 +515,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls>
       offset: followerOffset,
       child: Transform.translate(
         offset: Offset(
-          -12,
+          -24,
           -selectionHighlightBoxVerticalExpansion +
               (isUpstreamHandle
                   // For the upstream handle, the ball is displayed above the text, partially
@@ -533,7 +533,7 @@ class _IOSEditingControlsState extends State<IOSEditingControls>
             onPanEnd: _onPanEnd,
             onPanCancel: _onPanCancel,
             child: Container(
-              width: 24,
+              width: 48,
               color: widget.showDebugPaint ? Colors.green : Colors.transparent,
               child: showHandle
                   ? isUpstreamHandle


### PR DESCRIPTION
[SuperTextField][iOS] Increase drag handle interaction area. Resolves #1926 

Our iOS text field has a small interaction area (24px wide). Looking at the SuperEditor implementation, it looks like we are already using 48px wide. Also, the textfield caret already seems to have a 48px wide interaction area.

The expanded handle ball radius was already increased in a previous PR.

This PR only changes the width of the interaction area of the expanded handles to 48px, as it was mentioned that this was the width Flutter textfield uses.


