### PR TITLE
Extend more types of attributions when typing (Resolves #2280)

### DIFF
--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -205,6 +205,7 @@ final defaultExtendableStyles = Set.unmodifiable({
 });
 
 const defaultExtendableTypes = {
+  FontSizeAttribution,
   ColorAttribution,
   BackgroundColorAttribution,
 };

--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -17,7 +17,8 @@ import 'package:super_editor/src/default_editor/text.dart';
 /// be automatically applied to newly typed text. This reaction identifies these
 /// situations and activates the desired styles in the [DocumentComposer].
 ///
-/// Only the given `stylesToExtend` are automatically activated.
+/// Only the given [styleValuesToExtend], [styleTypesToExtend], [styleSelectorsToExtend]
+/// are automatically activated.
 ///
 /// Styles are activated when placing the caret at the beginning of a paragraph,
 /// and the first character has a style:
@@ -39,10 +40,22 @@ import 'package:super_editor/src/default_editor/text.dart';
 /// styles.
 class UpdateComposerTextStylesReaction extends EditReaction {
   UpdateComposerTextStylesReaction({
+    @Deprecated("Use styleValuesToExtend instead") //
     Set<Attribution>? stylesToExtend,
-  }) : _stylesToExtend = stylesToExtend ?? defaultExtendableStyles;
+    Set<Attribution>? styleValuesToExtend,
+    Set<Type> styleTypesToExtend = defaultExtendableTypes,
+    Set<AttributionExtensionSelector> styleSelectorsToExtend = const {},
+  })  : assert(
+          stylesToExtend == null || styleValuesToExtend == null,
+          "stylesToExtend and styleValuesToExtend are the same thing - you should only provide one",
+        ),
+        _styleValuesToExtend = styleValuesToExtend ?? stylesToExtend ?? defaultExtendableStyles,
+        _styleTypesToExtend = styleTypesToExtend,
+        _styleSelectorsToExtend = styleSelectorsToExtend;
 
-  final Set<Attribution> _stylesToExtend;
+  final Set<Attribution> _styleValuesToExtend;
+  final Set<Type> _styleTypesToExtend;
+  final Set<AttributionExtensionSelector> _styleSelectorsToExtend;
 
   DocumentSelection? _previousSelection;
 
@@ -140,7 +153,19 @@ class UpdateComposerTextStylesReaction extends EditReaction {
     Set<Attribution> allAttributions = node.text.getAllAttributionsAt(offsetWithAttributionsToExtend);
 
     // Add desired expandable styles.
-    final newStyles = allAttributions.where((attribution) => _stylesToExtend.contains(attribution)).toSet();
+    final newStyles = {
+      // Extend any attributions whose value matches a desired value.
+      ...allAttributions.where((attribution) => _styleValuesToExtend.contains(attribution)).toSet(),
+      // Extend any attribution whose class type matches a desired attribution type.
+      if (_styleTypesToExtend.isNotEmpty) //
+        ...allAttributions.where((attribution) => _styleTypesToExtend.contains(attribution.runtimeType)).toSet(),
+      // Extend any attribution that's explicitly selected by a given selector.
+      if (_styleSelectorsToExtend.isNotEmpty) //
+        ...allAttributions
+            .where(
+                (attribution) => _styleSelectorsToExtend.firstWhereOrNull((selector) => selector(attribution)) != null)
+            .toSet(),
+    };
 
     // TODO: we shouldn't have such specific behavior in here. Figure out how to generalize this.
     // Add a link attribution only if the selection sits at the middle of the link.
@@ -160,9 +185,26 @@ class UpdateComposerTextStylesReaction extends EditReaction {
   }
 }
 
+/// A function that returns `true` if the given [attribution] should be automatically
+/// extended when the caret is placed after such an attributed character, and the
+/// user continues to type - or `false` to ignore the [attribution] for future typing.
+///
+/// Example: Typically, when a user places the caret immediately following a bold character,
+/// additional user typing also applies the bold attribution.
+///
+/// Example: Typically, when a user places the caret immediately following a link, the link
+/// doesn't extend to include additional characters.
+typedef AttributionExtensionSelector = bool Function(Attribution attribution);
+
 final defaultExtendableStyles = Set.unmodifiable({
   boldAttribution,
   italicsAttribution,
   underlineAttribution,
   strikethroughAttribution,
+  codeAttribution,
 });
+
+const defaultExtendableTypes = {
+  ColorAttribution,
+  BackgroundColorAttribution,
+};

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -73,10 +73,10 @@ void main() {
             // Place the caret at "Color|".
             await tester.placeCaretInParagraph(document.first.id, 5);
 
-            // Type text that should expand the bold attribution.
+            // Type text that should expand the color attribution.
             await tester.typeImeText("s");
 
-            // Ensure the bold attribution was applied to the inserted text.
+            // Ensure the color attribution was applied to the inserted text.
             final text = SuperEditorInspector.findTextInComponent(document.first.id);
             expect(text.text, "Colors text");
             expect(
@@ -171,10 +171,10 @@ void main() {
             await tester.pressBackspace();
             await tester.pressBackspace();
 
-            // Type at a character that should expand the bold attribution.
+            // Type at a character that should expand the color attribution.
             await tester.typeImeText("s");
 
-            // Ensure the bold attribution was applied to the inserted text.
+            // Ensure the color attribution was applied to the inserted text.
             final text = SuperEditorInspector.findTextInComponent(document.first.id);
             expect(text.text, "Colors");
             expect(

--- a/super_editor/test/super_editor/supereditor_attributions_test.dart
+++ b/super_editor/test/super_editor/supereditor_attributions_test.dart
@@ -12,6 +12,190 @@ import 'test_documents.dart';
 void main() {
   group("SuperEditor", () {
     group("applies attributions", () {
+      group("when continuing existing attributions >", () {
+        group("by placing caret >", () {
+          // Bold is a stand-in for any value-based attribution extension, e.g.,
+          // italics, underline, strikethrough.
+          testWidgetsOnAllPlatforms("bold", (tester) async {
+            await tester //
+                .createDocument()
+                .fromMarkdown("A **bold** text")
+                .withInputSource(TextInputSource.ime)
+                .pump();
+
+            final doc = SuperEditorInspector.findDocument()!;
+
+            // Place the caret at "bold|".
+            await tester.placeCaretInParagraph(doc.first.id, 6);
+
+            // Type at an offset that should expand the bold attribution.
+            await tester.typeImeText("er");
+
+            // Ensure the bold attribution was applied to the inserted text.
+            expect(doc, equalsMarkdown("A **bolder** text"));
+          });
+
+          // Text color is a stand-in for any type-based attribution, e.g.,
+          // background color.
+          testWidgetsOnAllPlatforms("text color", (tester) async {
+            final testContext = await tester //
+                .createDocument()
+                .withCustomContent(
+                  MutableDocument(
+                    nodes: [
+                      ParagraphNode(
+                        id: '1',
+                        text: AttributedText(
+                          'Color text',
+                          AttributedSpans(
+                            attributions: [
+                              const SpanMarker(
+                                attribution: ColorAttribution(Colors.orange),
+                                offset: 0,
+                                markerType: SpanMarkerType.start,
+                              ),
+                              const SpanMarker(
+                                attribution: ColorAttribution(Colors.orange),
+                                offset: 4,
+                                markerType: SpanMarkerType.end,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+                .pump();
+
+            final document = testContext.document;
+
+            // Place the caret at "Color|".
+            await tester.placeCaretInParagraph(document.first.id, 5);
+
+            // Type text that should expand the bold attribution.
+            await tester.typeImeText("s");
+
+            // Ensure the bold attribution was applied to the inserted text.
+            final text = SuperEditorInspector.findTextInComponent(document.first.id);
+            expect(text.text, "Colors text");
+            expect(
+              text.spans,
+              AttributedSpans(attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 5,
+                  markerType: SpanMarkerType.end,
+                ),
+              ]),
+            );
+          });
+        });
+
+        group("by deleting characters and typing again >", () {
+          // Bold is a stand-in for any value-based attribution extension, e.g.,
+          // italics, underline, strikethrough.
+          testWidgetsOnAllPlatforms("bold", (tester) async {
+            await tester //
+                .createDocument()
+                .fromMarkdown("A **bold** text")
+                .withInputSource(TextInputSource.ime)
+                .pump();
+
+            final doc = SuperEditorInspector.findDocument()!;
+
+            // Place the caret at " text|".
+            await tester.placeCaretInParagraph(doc.first.id, 11);
+
+            // Delete all the back to "bold|".
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+
+            // Type text that should expand the bold attribution.
+            await tester.typeImeText("er");
+
+            // Ensure the bold attribution was applied to the inserted text.
+            expect(doc, equalsMarkdown("A **bolder**"));
+          });
+
+          // Text color is a stand-in for any type-based attribution, e.g.,
+          // background color.
+          testWidgetsOnAllPlatforms("text color", (tester) async {
+            final testContext = await tester //
+                .createDocument()
+                .withCustomContent(
+                  MutableDocument(
+                    nodes: [
+                      ParagraphNode(
+                        id: '1',
+                        text: AttributedText(
+                          'Color text',
+                          AttributedSpans(
+                            attributions: [
+                              const SpanMarker(
+                                attribution: ColorAttribution(Colors.orange),
+                                offset: 0,
+                                markerType: SpanMarkerType.start,
+                              ),
+                              const SpanMarker(
+                                attribution: ColorAttribution(Colors.orange),
+                                offset: 4,
+                                markerType: SpanMarkerType.end,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+                .pump();
+
+            final document = testContext.document;
+
+            // Place the caret at " text|".
+            await tester.placeCaretInParagraph(document.first.id, 10);
+
+            // Delete all the back to "Color|".
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+            await tester.pressBackspace();
+
+            // Type at a character that should expand the bold attribution.
+            await tester.typeImeText("s");
+
+            // Ensure the bold attribution was applied to the inserted text.
+            final text = SuperEditorInspector.findTextInComponent(document.first.id);
+            expect(text.text, "Colors");
+            expect(
+              text.spans,
+              AttributedSpans(attributions: [
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 0,
+                  markerType: SpanMarkerType.start,
+                ),
+                const SpanMarker(
+                  attribution: ColorAttribution(Colors.orange),
+                  offset: 5,
+                  markerType: SpanMarkerType.end,
+                ),
+              ]),
+            );
+          });
+        });
+      });
+
       group("when selecting by tapping", () {
         testWidgetsOnAllPlatforms("and typing at the end of the attributed text", (tester) async {
           await tester //


### PR DESCRIPTION
Extend more types of attributions when typing (Resolves #2280)

Auto-extend `codeAttribution`s. Also auto-extend any attribution of type `ColorAttribution` or `BackgroundColorAttribution`.

I wanted to find a way to configure these extensions without needing to use a custom configuration for `Editor`, but I wasn't able to think of anything compelling.