### PR TITLE
[Quill] - Fix exceptions when parsing ambiguous custom block formats (Resolves #2286)

### DIFF
--- a/super_editor_quill/lib/src/parsing/block_formats.dart
+++ b/super_editor_quill/lib/src/parsing/block_formats.dart
@@ -11,8 +11,12 @@ class HeaderDeltaFormat extends FilterByNameBlockDeltaFormat {
 
   @override
   List<EditRequest>? doApplyFormat(Editor editor, Object value) {
+    if (value is! int) {
+      return null;
+    }
+
     final composer = editor.context.find<MutableDocumentComposer>(Editor.composerKey);
-    final level = value as int;
+    final level = value;
 
     return [
       ChangeParagraphBlockTypeRequest(
@@ -91,9 +95,13 @@ class ListDeltaFormat extends FilterByNameBlockDeltaFormat {
 
   @override
   List<EditRequest>? doApplyFormat(Editor editor, Object value) {
+    if (value is! String) {
+      return null;
+    }
+
     final composer = editor.context.find<MutableDocumentComposer>(Editor.composerKey);
 
-    if (_isTask(value as String)) {
+    if (_isTask(value)) {
       return [
         ConvertParagraphToTaskRequest(
           nodeId: composer.selection!.extent.nodeId,
@@ -143,12 +151,16 @@ class AlignDeltaFormat extends FilterByNameBlockDeltaFormat {
 
   @override
   List<EditRequest>? doApplyFormat(Editor editor, Object value) {
+    if (value is! String) {
+      return null;
+    }
+
     final composer = editor.context.find<MutableDocumentComposer>(Editor.composerKey);
 
     return [
       ChangeParagraphAlignmentRequest(
         nodeId: composer.selection!.extent.nodeId,
-        alignment: _getTextAlignment(value as String),
+        alignment: _getTextAlignment(value),
       ),
     ];
   }

--- a/super_editor_quill/lib/src/parsing/parser.dart
+++ b/super_editor_quill/lib/src/parsing/parser.dart
@@ -224,6 +224,13 @@ extension OperationParser on Operation {
       final blockChanges = blockFormat.applyTo(this, editor);
       if (blockChanges != null) {
         changeRequests.addAll(blockChanges);
+
+        // We found a format that handled this delta. Ignore the remaining
+        // formats.
+        //
+        // If a situation is found where multiple formats need to act on the same
+        // delta, please file an issue with an explanation.
+        break;
       }
     }
 


### PR DESCRIPTION
[Quill] - Fix exceptions when parsing ambiguous custom block formats (Resolves #2286)

When implementing a custom Delta format that happens to have the same key as a standard format, e.g., "list", we were blowing up with an exception because the standard format assumed the wrong value type for the given key.