### PR TITLE
[Quill] - Now supports custom block-level embed parsers (Resolves #2305)

### DIFF
--- a/super_editor_quill/lib/src/parsing/block_formats.dart
+++ b/super_editor_quill/lib/src/parsing/block_formats.dart
@@ -2,6 +2,7 @@ import 'package:dart_quill_delta/dart_quill_delta.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_quill/src/content/multimedia.dart';
 
 /// A [BlockDeltaFormat] that applies a header block type to a paragraph.
 class HeaderDeltaFormat extends FilterByNameBlockDeltaFormat {
@@ -218,6 +219,153 @@ abstract class FilterByNameBlockDeltaFormat implements BlockDeltaFormat {
 
   @protected
   List<EditRequest>? doApplyFormat(Editor editor, Object value);
+}
+
+class ImageEmbedBlockDeltaFormat extends StandardEmbedBlockDeltaFormat {
+  const ImageEmbedBlockDeltaFormat();
+
+  @override
+  DocumentNode? createNodeForEmbed(Operation operation, String nodeId) {
+    final data = operation.data;
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final imageUrl = data['image'];
+    if (imageUrl is! String) {
+      return null;
+    }
+
+    return ImageNode(
+      id: nodeId,
+      imageUrl: imageUrl,
+    );
+  }
+}
+
+class AudioEmbedBlockDeltaFormat extends StandardEmbedBlockDeltaFormat {
+  const AudioEmbedBlockDeltaFormat();
+
+  @override
+  DocumentNode? createNodeForEmbed(Operation operation, String nodeId) {
+    final data = operation.data;
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final audioUrl = data['audio'];
+    if (audioUrl is! String) {
+      return null;
+    }
+
+    return AudioNode(
+      id: nodeId,
+      url: audioUrl,
+    );
+  }
+}
+
+class VideoEmbedBlockDeltaFormat extends StandardEmbedBlockDeltaFormat {
+  const VideoEmbedBlockDeltaFormat();
+
+  @override
+  DocumentNode? createNodeForEmbed(Operation operation, String nodeId) {
+    final data = operation.data;
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final videoUrl = data['video'];
+    if (videoUrl is! String) {
+      return null;
+    }
+
+    return VideoNode(
+      id: nodeId,
+      url: videoUrl,
+    );
+  }
+}
+
+class FileEmbedBlockDeltaFormat extends StandardEmbedBlockDeltaFormat {
+  const FileEmbedBlockDeltaFormat();
+
+  @override
+  DocumentNode? createNodeForEmbed(Operation operation, String nodeId) {
+    final data = operation.data;
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final fileUrl = data['file'];
+    if (fileUrl is! String) {
+      return null;
+    }
+
+    return FileNode(
+      id: nodeId,
+      url: fileUrl,
+    );
+  }
+}
+
+abstract class StandardEmbedBlockDeltaFormat implements BlockDeltaFormat {
+  const StandardEmbedBlockDeltaFormat();
+
+  @override
+  List<EditRequest>? applyTo(Operation operation, Editor editor) {
+    // Check if the selected node is an empty text node. If it is, we want to replace it
+    // with the media that we're inserting.
+    final document = editor.context.find<MutableDocument>(Editor.documentKey);
+    final selectedNodeId = editor.context.composer.selection!.extent.nodeId;
+    final selectedNode = document.getNodeById(selectedNodeId);
+    final shouldReplaceSelectedNode = selectedNode is TextNode && selectedNode.text.text.isEmpty;
+
+    final newNodeId = Editor.createNodeId();
+    final newNode = createNodeForEmbed(operation, newNodeId);
+    if (newNode == null) {
+      return null;
+    }
+
+    final newParagraphId = Editor.createNodeId();
+    return [
+      shouldReplaceSelectedNode
+          ? ReplaceNodeRequest(
+              existingNodeId: selectedNodeId,
+              newNode: newNode,
+            )
+          : InsertNodeAfterNodeRequest(
+              existingNodeId: editor.context.composer.selection!.extent.nodeId,
+              newNode: newNode,
+            ),
+      // Always insert an empty paragraph after the embed block so that the user
+      // is able to enter text below it.
+      InsertNodeAfterNodeRequest(
+        existingNodeId: newNodeId,
+        newNode: ParagraphNode(
+          id: newParagraphId,
+          text: AttributedText(""),
+        ),
+      ),
+      ChangeSelectionRequest(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: newParagraphId,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+        SelectionChangeType.insertContent,
+        SelectionReason.contentChange,
+      ),
+    ];
+  }
+
+  /// Attempts to parse the given [operation] as a desired block-level embed,
+  /// returning a [DocumentNode] that represents the embed, or `null` if this
+  /// format doesn't apply to the given block-level embed.
+  ///
+  /// The returned [DocumentNode] should use the given [nodeId] as its ID.
+  DocumentNode? createNodeForEmbed(Operation operation, String nodeId);
 }
 
 /// A block-level format for a text block, e.g., header, blockquote, code.


### PR DESCRIPTION
[Quill] - Now supports custom block-level embed parsers (Resolves #2305)