### PR TITLE
Ignore unused_element_parameter for unused parameters

### DIFF
--- a/super_editor/example/lib/demos/demo_animated_task_height.dart
+++ b/super_editor/example/lib/demos/demo_animated_task_height.dart
@@ -96,7 +96,10 @@ class _AnimatedTaskComponent extends StatefulWidget {
   const _AnimatedTaskComponent({
     Key? key,
     required this.viewModel,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugPaint = false,
   }) : super(key: key);
 

--- a/super_editor/example_perf/lib/demos/rebuild_demo.dart
+++ b/super_editor/example_perf/lib/demos/rebuild_demo.dart
@@ -98,7 +98,10 @@ class _AnimatedTaskComponent extends StatefulWidget {
   const _AnimatedTaskComponent({
     super.key,
     required this.viewModel,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugPaint = false,
   });
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -326,7 +326,10 @@ class SuperEditorAndroidControlsController {
 /// floating toolbar.
 class SuperEditorAndroidToolbarFocalPointDocumentLayerBuilder implements SuperEditorLayerBuilder {
   const SuperEditorAndroidToolbarFocalPointDocumentLayerBuilder({
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugLeaderBounds = false,
   });
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1919,7 +1919,10 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
 /// iOS floating toolbar.
 class SuperEditorIosToolbarFocalPointDocumentLayerBuilder implements SuperEditorLayerBuilder {
   const SuperEditorIosToolbarFocalPointDocumentLayerBuilder({
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugLeaderBounds = false,
   });
 

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1008,7 +1008,10 @@ class DefaultAndroidEditorToolbar extends StatelessWidget {
 class _SelectionLeadersDocumentLayerBuilder implements SuperEditorLayerBuilder {
   const _SelectionLeadersDocumentLayerBuilder({
     required this.links,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugLeaderBounds = false,
   });
 

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -639,7 +639,10 @@ class _SelectionLeadersDocumentLayerBuilder implements SuperReaderDocumentLayerB
 /// iOS floating toolbar.
 class SuperReaderIosToolbarFocalPointDocumentLayerBuilder implements SuperReaderDocumentLayerBuilder {
   const SuperReaderIosToolbarFocalPointDocumentLayerBuilder({
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.showDebugLeaderBounds = false,
   });
 

--- a/super_editor/test/infrastructure/content_layers_test.dart
+++ b/super_editor/test/infrastructure/content_layers_test.dart
@@ -574,10 +574,16 @@ class _RebuildableWidget extends StatefulWidget {
     Key? key,
     this.rebuildSignal,
     this.buildTracker,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.elementTracker,
     this.onBuildScheduled,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.onBuild,
     this.builder,
     this.child,
@@ -672,7 +678,10 @@ class _RebuildableContentLayerWidget extends ContentLayerStatefulWidget {
     this.rebuildSignal,
     this.buildTracker,
     this.elementTracker,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.onBuildScheduled,
     this.onBuild,
     this.builder,

--- a/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_auto_scroll_test.dart
@@ -224,7 +224,10 @@ class _KeyboardToggle {
     required this.tester,
     required this.sizeWithoutKeyboard,
     required this.sizeWithKeyboard,
-    // ignore: unused_element
+    // TODO(srawlins): `unused_element`, when reporting a parameter, is being
+    // renamed to `unused_element_parameter`. For now, ignore each; when the SDK
+    // constraint is >= 3.6.0, just ignore `unused_element_parameter`.
+    // ignore: unused_element, unused_element_parameter
     this.frameCount = 60,
   });
 


### PR DESCRIPTION
In dart-lang/sdk#49025, we are splitting the `unused_element` code, so that the warning reported is `unused_element_parameter`.

In this change, I change each ignored case to ignore each warning name, to make the code forwards-compatible.