### PR TITLE
[Quill] - Added tests to lock down regular text followed by block styles (Resolves #2303)

### DIFF
--- a/super_editor_quill/lib/src/parsing/parser.dart
+++ b/super_editor_quill/lib/src/parsing/parser.dart
@@ -35,6 +35,7 @@ MutableDocument parseQuillDeltaDocument(
   return parseQuillDeltaOps(
     deltaDocument["ops"],
     customEditor: customEditor,
+    blockFormats: blockFormats,
     inlineFormats: inlineFormats,
     inlineEmbedFormats: inlineEmbedFormats,
   );

--- a/super_editor_quill/lib/src/testing/quill_delta_comparison.dart
+++ b/super_editor_quill/lib/src/testing/quill_delta_comparison.dart
@@ -20,18 +20,18 @@ class EquivalentQuillDocumentMatcher extends Matcher {
   }
 
   @override
-  bool matches(covariant Object target, Map<dynamic, dynamic> matchState) {
-    return _calculateMismatchReason(target, matchState) == null;
+  bool matches(covariant Object item, Map<dynamic, dynamic> matchState) {
+    return _calculateMismatchReason(item, matchState) == null;
   }
 
   @override
   Description describeMismatch(
-    covariant Object target,
+    covariant Object item,
     Description mismatchDescription,
     Map matchState,
     bool verbose,
   ) {
-    final mismatchReason = _calculateMismatchReason(target, matchState);
+    final mismatchReason = _calculateMismatchReason(item, matchState);
     if (mismatchReason != null) {
       mismatchDescription.add(mismatchReason);
     }


### PR DESCRIPTION
[Quill] - Added tests to lock down regular text followed by block styles (Resolves #2303)

Also, forward `blockFormats` to `parseQuillDeltaOps()`, which was previously missing.