### PR TITLE
[SuperEditor] - Don't clip iOS drag handles, add start of chat example app

### DIFF
--- a/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
+++ b/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class MobileChatDemo extends StatefulWidget {
+  const MobileChatDemo({super.key});
+
+  @override
+  State<MobileChatDemo> createState() => _MobileChatDemoState();
+}
+
+class _MobileChatDemoState extends State<MobileChatDemo> {
+  late final Editor _editor;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final document = MutableDocument.empty();
+    final composer = MutableDocumentComposer();
+    _editor = createDefaultDocumentEditor(document: document, composer: composer);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: ColoredBox(color: Colors.white),
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: _buildCommentEditor(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCommentEditor() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          height: 48,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(24),
+              topRight: Radius.circular(24),
+            ),
+            border: Border(
+              top: BorderSide(width: 1, color: Colors.grey),
+            ),
+          ),
+        ),
+        Divider(height: 1),
+        CustomScrollView(
+          shrinkWrap: true,
+          slivers: [
+            SuperEditor(
+              editor: _editor,
+              shrinkWrap: true,
+              stylesheet: _chatStylesheet,
+            ),
+          ],
+        ),
+        Divider(height: 1),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+final _chatStylesheet = defaultStylesheet.copyWith(
+  addRulesAfter: [
+    StyleRule(
+      BlockSelector.all.first(),
+      (doc, docNode) {
+        return {
+          Styles.padding: const CascadingPadding.only(top: 0),
+        };
+      },
+    ),
+    StyleRule(
+      BlockSelector.all.last(),
+      (doc, docNode) {
+        return {
+          Styles.padding: const CascadingPadding.only(bottom: 0),
+        };
+      },
+    ),
+  ],
+);

--- a/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
+++ b/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
@@ -43,30 +43,37 @@ class _MobileChatDemoState extends State<MobileChatDemo> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Container(
-          height: 48,
           decoration: BoxDecoration(
+            color: Colors.white,
             borderRadius: BorderRadius.only(
               topLeft: Radius.circular(24),
               topRight: Radius.circular(24),
             ),
             border: Border(
               top: BorderSide(width: 1, color: Colors.grey),
+              left: BorderSide(width: 1, color: Colors.grey),
+              right: BorderSide(width: 1, color: Colors.grey),
             ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.075),
+                blurRadius: 8,
+                spreadRadius: 4,
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.only(top: 16, bottom: 24),
+          child: CustomScrollView(
+            shrinkWrap: true,
+            slivers: [
+              SuperEditor(
+                editor: _editor,
+                shrinkWrap: true,
+                stylesheet: _chatStylesheet,
+              ),
+            ],
           ),
         ),
-        Divider(height: 1),
-        CustomScrollView(
-          shrinkWrap: true,
-          slivers: [
-            SuperEditor(
-              editor: _editor,
-              shrinkWrap: true,
-              stylesheet: _chatStylesheet,
-            ),
-          ],
-        ),
-        Divider(height: 1),
-        const SizedBox(height: 24),
       ],
     );
   }
@@ -75,10 +82,19 @@ class _MobileChatDemoState extends State<MobileChatDemo> {
 final _chatStylesheet = defaultStylesheet.copyWith(
   addRulesAfter: [
     StyleRule(
+      BlockSelector.all,
+      (doc, docNode) {
+        return {
+          Styles.maxWidth: null,
+          Styles.padding: const CascadingPadding.symmetric(horizontal: 24),
+        };
+      },
+    ),
+    StyleRule(
       BlockSelector.all.first(),
       (doc, docNode) {
         return {
-          Styles.padding: const CascadingPadding.only(top: 0),
+          Styles.padding: const CascadingPadding.only(top: 12),
         };
       },
     ),
@@ -86,7 +102,7 @@ final _chatStylesheet = defaultStylesheet.copyWith(
       BlockSelector.all.last(),
       (doc, docNode) {
         return {
-          Styles.padding: const CascadingPadding.only(bottom: 0),
+          Styles.padding: const CascadingPadding.only(bottom: 12),
         };
       },
     ),

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:example/demos/in_the_lab/feature_stable_tags.dart';
 import 'package:example/demos/in_the_lab/selected_text_colors_demo.dart';
 import 'package:example/demos/in_the_lab/spelling_error_decorations.dart';
 import 'package:example/demos/interaction_spot_checks/toolbar_following_content_in_layer.dart';
+import 'package:example/demos/mobile_chat/demo_mobile_chat.dart';
 import 'package:example/demos/scrolling/demo_task_and_chat_with_customscrollview.dart';
 import 'package:example/demos/sliver_example_editor.dart';
 import 'package:example/demos/styles/demo_doc_styles.dart';
@@ -221,6 +222,13 @@ final _menu = <_MenuGroup>[
         title: 'Sliver Editor Demo',
         pageBuilder: (context) {
           return SliverExampleEditor();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.description,
+        title: 'Chat Demo',
+        pageBuilder: (context) {
+          return MobileChatDemo();
         },
       ),
       _MenuItem(

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1885,6 +1885,7 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
       children: [
         widget.child,
         Stack(
+          clipBehavior: Clip.none,
           children: [
             _buildFloatingCursor(),
           ],

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -790,6 +790,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
     }
 
     return Stack(
+      clipBehavior: Clip.none,
       children: [
         if (layoutData.caret != null) //
           _buildCollapsedHandle(caret: layoutData.caret!),


### PR DESCRIPTION
[SuperEditor] - Don't clip iOS drag handles, add start of chat example app

In a client app, the iOS handles were being cut off at the boundary of the editor. This PR disables clipping on the relevant `Stack`s. 

This PR also adds the start of a chat demo, which approximates the client's use-case.

<img width="378" alt="Screenshot 2024-09-15 at 10 50 07 PM" src="https://github.com/user-attachments/assets/9faf4da7-5dab-4bcd-bfc9-4947b12870a9">
