### PR TITLE
Rework interaction gesture handling

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -51,9 +51,9 @@ class DocumentMouseInteractor extends StatefulWidget {
     required this.selectionChanges,
     this.contentTapHandler,
     required this.autoScroller,
+    required this.fillViewport,
     this.showDebugPaint = false,
     required this.child,
-    required this.fillViewport,
   }) : super(key: key);
 
   final FocusNode? focusNode;
@@ -71,6 +71,8 @@ class DocumentMouseInteractor extends StatefulWidget {
   /// Auto-scrolling delegate.
   final AutoScrollController autoScroller;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   /// Paints some extra visual ornamentation to help with

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1082,7 +1082,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void _onPanCancel() {
     // When _tapDownLongPressTimer is not null we're waiting for either tapUp or tapCancel,
     // which will deal with the long press.
-    if (_tapDownLongPressTimer == null &&_isLongPressInProgress) {
+    if (_tapDownLongPressTimer == null && _isLongPressInProgress) {
       _onLongPressEnd();
       return;
     }
@@ -1203,6 +1203,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   @override
   Widget build(BuildContext context) {
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    // PanGestureRecognizer is above contents to have first pass at gestures, but it only accepts
+    // gestures that are over caret or handles or when a long press is in progress.
+    // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
+    // tappable widgets.
     final layerAbove = RawGestureDetector(
       key: _interactor,
       behavior: HitTestBehavior.translucent,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -19,6 +19,7 @@ import 'package:super_editor/src/document_operations/selection_operations.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
+import 'package:super_editor/src/infrastructure/flutter/eager_pan_gesture_recognizer.dart';
 import 'package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart';
 import 'package:super_editor/src/infrastructure/multi_tap_gesture.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/android_document_controls.dart';
@@ -406,11 +407,12 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.selection,
     required this.openSoftwareKeyboard,
     required this.scrollController,
+    required this.fillViewport,
     this.contentTapHandler,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
     required this.dragHandleAutoScroller,
     this.showDebugPaint = false,
-    this.child,
+    required this.child,
   }) : super(key: key);
 
   final FocusNode focusNode;
@@ -438,9 +440,11 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
 
   final ValueNotifier<DragHandleAutoScroller?> dragHandleAutoScroller;
 
+  final bool fillViewport;
+
   final bool showDebugPaint;
 
-  final Widget? child;
+  final Widget child;
 
   @override
   State createState() => _AndroidDocumentTouchInteractorState();
@@ -450,14 +454,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     with WidgetsBindingObserver, SingleTickerProviderStateMixin {
   SuperEditorAndroidControlsController? _controlsController;
 
-  bool _isScrolling = false;
-
   // The ScrollPosition attached to the _ancestorScrollable, if there's an ancestor
   // Scrollable.
   ScrollPosition? _ancestorScrollPosition;
-  // The actual ScrollPosition that's used for the document layout, either
-  // the Scrollable installed by this interactor, or an ancestor Scrollable.
-  ScrollPosition? _activeScrollPosition;
 
   Offset? _globalTapDownOffset;
   Offset? _globalStartDragOffset;
@@ -465,9 +464,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   Offset? _startDragPositionOffset;
   double? _dragStartScrollOffset;
   Offset? _globalDragOffset;
-
-  /// Holds the drag gesture that scrolls the document.
-  Drag? _scrollingDrag;
 
   final _magnifierGlobalOffset = ValueNotifier<Offset?>(null);
 
@@ -492,8 +488,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       getViewportBox: () => viewportBox,
     );
 
-    _configureScrollController();
-
     widget.document.addListener(_onDocumentChange);
     widget.selection.addListener(_onSelectionChange);
 
@@ -511,14 +505,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     _controlsController = SuperEditorAndroidControlsScope.rootOf(context);
 
     _ancestorScrollPosition = context.findAncestorScrollableWithVerticalScroll?.position;
-
-    // On the next frame, check if our active scroll position changed to a
-    // different instance. If it did, move our listener to the new one.
-    //
-    // This is posted to the next frame because the first time this method
-    // runs, we haven't attached to our own ScrollController yet, so
-    // this.scrollPosition might be null.
-    onNextFrame((_) => _updateScrollPositionListener());
   }
 
   @override
@@ -533,11 +519,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     if (widget.selection != oldWidget.selection) {
       oldWidget.selection.removeListener(_onSelectionChange);
       widget.selection.addListener(_onSelectionChange);
-    }
-
-    if (widget.scrollController != oldWidget.scrollController) {
-      _teardownScrollController();
-      _configureScrollController();
     }
   }
 
@@ -575,8 +556,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     widget.document.removeListener(_onDocumentChange);
     widget.selection.removeListener(_onSelectionChange);
-
-    _teardownScrollController();
 
     widget.dragHandleAutoScroller.value!.dispose();
     widget.dragHandleAutoScroller.value = null;
@@ -619,6 +598,10 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     return viewportBox.globalToLocal(globalOffset);
   }
 
+  final _interactor = GlobalKey();
+
+  RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
+
   /// Maps the given [interactorOffset] within the interactor's coordinate space
   /// to the same screen position in the viewport's coordinate space.
   ///
@@ -630,44 +613,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   Offset _interactorOffsetInViewport(Offset interactorOffset) {
     // Viewport might be our box, or an ancestor box if we're inside someone
     // else's Scrollable.
-    final interactorBox = context.findRenderObject() as RenderBox;
     return viewportBox.globalToLocal(
       interactorBox.localToGlobal(interactorOffset),
     );
-  }
-
-  void _configureScrollController() {
-    onNextFrame((_) => scrollPosition.isScrollingNotifier.addListener(_onScrollActivityChange));
-  }
-
-  void _teardownScrollController() {
-    widget.scrollController.removeListener(_onScrollActivityChange);
-
-    if (widget.scrollController.hasClients) {
-      scrollPosition.isScrollingNotifier.removeListener(_onScrollActivityChange);
-    }
-  }
-
-  void _onScrollActivityChange() {
-    final isScrolling = scrollPosition.isScrollingNotifier.value;
-
-    if (isScrolling) {
-      _isScrolling = true;
-
-      // The user started to scroll.
-      // Cancel the timer to stop trying to detect a long press.
-      _tapDownLongPressTimer?.cancel();
-      _tapDownLongPressTimer = null;
-    } else {
-      onNextFrame((_) {
-        // Set our scrolling flag to false on the next frame, so that our tap handlers
-        // have an opportunity to see that the scrollable was scrolling when the user
-        // tapped down.
-        //
-        // See the "on tap down" handler for more info about why this flag is important.
-        _isScrolling = false;
-      });
-    }
   }
 
   void _ensureSelectionExtentIsVisible() {
@@ -718,25 +666,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     }
   }
 
-  void _updateScrollPositionListener() {
-    final newScrollPosition = scrollPosition;
-    if (newScrollPosition != _activeScrollPosition) {
-      _activeScrollPosition = newScrollPosition;
-    }
-  }
-
-  bool _wasScrollingOnTapDown = false;
   void _onTapDown(TapDownDetails details) {
-    // When the user scrolls and releases, the scrolling continues with momentum.
-    // If the user then taps down again, the momentum stops. When this happens, we
-    // still receive tap callbacks. But we don't want to take any further action,
-    // like moving the caret, when the user taps to stop scroll momentum. We have
-    // to carefully watch the scrolling activity to recognize when this happens.
-    // We can't check whether we're scrolling in "on tap up" because by then the
-    // scrolling has already stopped. So we log whether we're scrolling "on tap down"
-    // and then check this flag in "on tap up".
-    _wasScrollingOnTapDown = _isScrolling;
-
     final position = scrollPosition;
     if (position is ScrollPositionWithSingleContext) {
       position.goIdle();
@@ -789,13 +719,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       _longPressStrategy = null;
       _magnifierGlobalOffset.value = null;
       _showAndHideEditingControlsAfterTapSelection(didTapOnExistingSelection: false);
-      return;
-    }
-
-    if (_wasScrollingOnTapDown) {
-      // The scrollable was scrolling when the user touched down. We expect that the
-      // touch down stopped the scrolling momentum. We don't want to take any further
-      // action on this touch event. The user will tap again to change the selection.
       return;
     }
 
@@ -1035,24 +958,29 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       return;
     }
 
-    if (widget.selection.value?.isCollapsed == true) {
-      final caretPosition = widget.selection.value!.extent;
-      final tapDocumentOffset = widget.getDocumentLayout().getDocumentOffsetFromAncestorOffset(_globalTapDownOffset!);
+    final isTapOverCaret = _isOverCaret(_globalTapDownOffset!);
 
-      final tapPosition = widget.getDocumentLayout().getDocumentPositionAtOffset(tapDocumentOffset);
-      final isTapOverCaret = tapPosition != null && caretPosition.isEquivalentTo(tapPosition);
+    if (isTapOverCaret) {
+      _onCaretDragPanStart(details);
+      return;
+    }
+  }
 
-      if (isTapOverCaret) {
-        _onCaretDragPanStart(details);
-        return;
-      }
+  bool _isOverCaret(Offset globalOffset) {
+    if (widget.selection.value?.isCollapsed != true) {
+      return false;
     }
 
-    _scrollingDrag = scrollPosition.drag(details, () {
-      // Allows receiving touches while scrolling due to scroll momentum.
-      // This is needed to allow the user to stop scrolling by tapping down.
-      scrollPosition.context.setIgnorePointer(false);
-    });
+    final collapsedPosition = widget.selection.value?.extent;
+    if (collapsedPosition == null) {
+      return false;
+    }
+
+    final extentRect = _docLayout.getRectForPosition(collapsedPosition)!;
+    final caretRect = Rect.fromLTWH(extentRect.left - 1, extentRect.center.dy, 1, 1).inflate(24);
+
+    final tapDocumentOffset = widget.getDocumentLayout().getDocumentOffsetFromAncestorOffset(_globalTapDownOffset!);
+    return caretRect.contains(tapDocumentOffset);
   }
 
   void _onLongPressPanStart(DragStartDetails details) {
@@ -1094,11 +1022,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       _onCaretDragPanUpdate(details);
       return;
     }
-
-    if (_scrollingDrag != null) {
-      // The user is trying to scroll the document. Change the scroll offset.
-      _scrollingDrag!.update(details);
-    }
   }
 
   void _onLongPressPanUpdate(DragUpdateDetails details) {
@@ -1137,7 +1060,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   void _updateOverlayControlsOnLongPressDrag() {
     final extentDocumentOffset = _docLayout.getRectForPosition(widget.selection.value!.extent)!.center;
     final extentGlobalOffset = _docLayout.getAncestorOffsetFromDocumentOffset(extentDocumentOffset);
-    final extentInteractorOffset = (context.findRenderObject() as RenderBox).globalToLocal(extentGlobalOffset);
+    final extentInteractorOffset = interactorBox.globalToLocal(extentGlobalOffset);
     final extentViewportOffset = _interactorOffsetInViewport(extentInteractorOffset);
     widget.dragHandleAutoScroller.value!.updateAutoScrollHandleMonitoring(dragEndInViewport: extentViewportOffset);
 
@@ -1154,16 +1077,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
       _onCaretDragEnd();
       return;
     }
-
-    if (_scrollingDrag != null) {
-      // The user was performing a drag gesture to scroll the document.
-      // End the scroll activity and let the document scrolling with momentum.
-      _scrollingDrag!.end(details);
-    }
   }
 
   void _onPanCancel() {
-    if (_isLongPressInProgress) {
+    // When _tapDownLongPressTimer is not null we're waiting for either tapUp or tapCancel,
+    // which will deal with the long press.
+    if (_tapDownLongPressTimer == null &&_isLongPressInProgress) {
       _onLongPressEnd();
       return;
     }
@@ -1171,12 +1090,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     if (_isCaretDragInProgress) {
       _onCaretDragEnd();
       return;
-    }
-
-    if (_scrollingDrag != null) {
-      // The user was performing a drag gesture to scroll the document.
-      // End the drag gesture.
-      _scrollingDrag!.cancel();
     }
   }
 
@@ -1290,7 +1203,31 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   @override
   Widget build(BuildContext context) {
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
-    return RawGestureDetector(
+    final layerAbove = RawGestureDetector(
+      key: _interactor,
+      behavior: HitTestBehavior.translucent,
+      gestures: <Type, GestureRecognizerFactory>{
+        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+          () => EagerPanGestureRecognizer(),
+          (EagerPanGestureRecognizer instance) {
+            instance
+              ..canAccept = () {
+                if (_globalTapDownOffset == null) {
+                  return false;
+                }
+                return _isOverCaret(_globalTapDownOffset!) || _isLongPressInProgress;
+              }
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onStart = _onPanStart
+              ..onUpdate = _onPanUpdate
+              ..onEnd = _onPanEnd
+              ..onCancel = _onPanCancel
+              ..gestureSettings = gestureSettings;
+          },
+        ),
+      },
+    );
+    final layerBelow = RawGestureDetector(
       behavior: HitTestBehavior.translucent,
       gestures: <Type, GestureRecognizerFactory>{
         TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
@@ -1305,20 +1242,15 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
               ..gestureSettings = gestureSettings;
           },
         ),
-        VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-          () => VerticalDragGestureRecognizer(),
-          (VerticalDragGestureRecognizer recognizer) {
-            recognizer
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onStart = _onPanStart
-              ..onUpdate = _onPanUpdate
-              ..onEnd = _onPanEnd
-              ..onCancel = _onPanCancel
-              ..gestureSettings = gestureSettings;
-          },
-        ),
       },
-      child: widget.child,
+    );
+    return SliverHybridStack(
+      fillViewport: widget.fillViewport,
+      children: [
+        layerBelow,
+        widget.child,
+        layerAbove,
+      ],
     );
   }
 }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1210,53 +1210,53 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     // gestures that are over caret or handles or when a long press is in progress.
     // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
     // tappable widgets.
-    final layerAbove = RawGestureDetector(
-      key: _interactor,
-      behavior: HitTestBehavior.translucent,
-      gestures: <Type, GestureRecognizerFactory>{
-        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
-          () => EagerPanGestureRecognizer(),
-          (EagerPanGestureRecognizer instance) {
-            instance
-              ..shouldAccept = () {
-                if (_globalTapDownOffset == null) {
-                  return false;
-                }
-                return _isOverCaret(_globalTapDownOffset!) || _isLongPressInProgress;
-              }
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onStart = _onPanStart
-              ..onUpdate = _onPanUpdate
-              ..onEnd = _onPanEnd
-              ..onCancel = _onPanCancel
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-    );
-    final layerBelow = RawGestureDetector(
-      behavior: HitTestBehavior.translucent,
-      gestures: <Type, GestureRecognizerFactory>{
-        TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
-          () => TapSequenceGestureRecognizer(),
-          (TapSequenceGestureRecognizer recognizer) {
-            recognizer
-              ..onTapDown = _onTapDown
-              ..onTapCancel = _onTapCancel
-              ..onTapUp = _onTapUp
-              ..onDoubleTapDown = _onDoubleTapDown
-              ..onTripleTapDown = _onTripleTapDown
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-    );
     return SliverHybridStack(
       fillViewport: widget.fillViewport,
       children: [
-        layerBelow,
+        // Layer below
+        RawGestureDetector(
+          behavior: HitTestBehavior.translucent,
+          gestures: <Type, GestureRecognizerFactory>{
+            TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
+              () => TapSequenceGestureRecognizer(),
+              (TapSequenceGestureRecognizer recognizer) {
+                recognizer
+                  ..onTapDown = _onTapDown
+                  ..onTapCancel = _onTapCancel
+                  ..onTapUp = _onTapUp
+                  ..onDoubleTapDown = _onDoubleTapDown
+                  ..onTripleTapDown = _onTripleTapDown
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+        ),
         widget.child,
-        layerAbove,
+        // Layer above
+        RawGestureDetector(
+          key: _interactor,
+          behavior: HitTestBehavior.translucent,
+          gestures: <Type, GestureRecognizerFactory>{
+            EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+              () => EagerPanGestureRecognizer(),
+              (EagerPanGestureRecognizer instance) {
+                instance
+                  ..shouldAccept = () {
+                    if (_globalTapDownOffset == null) {
+                      return false;
+                    }
+                    return _isOverCaret(_globalTapDownOffset!) || _isLongPressInProgress;
+                  }
+                  ..dragStartBehavior = DragStartBehavior.down
+                  ..onStart = _onPanStart
+                  ..onUpdate = _onPanUpdate
+                  ..onEnd = _onPanEnd
+                  ..onCancel = _onPanCancel
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+        ),
       ],
     );
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -440,6 +440,8 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
 
   final ValueNotifier<DragHandleAutoScroller?> dragHandleAutoScroller;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   final bool showDebugPaint;
@@ -476,6 +478,8 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   // Cached view metrics to ignore unnecessary didChangeMetrics calls.
   Size? _lastSize;
   ViewPadding? _lastInsets;
+
+  final _interactor = GlobalKey();
 
   @override
   void initState() {
@@ -598,8 +602,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     return viewportBox.globalToLocal(globalOffset);
   }
 
-  final _interactor = GlobalKey();
-
+  /// Returns the render box for the interactor gesture detector.
   RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
 
   /// Maps the given [interactorOffset] within the interactor's coordinate space

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -1218,7 +1218,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
           () => EagerPanGestureRecognizer(),
           (EagerPanGestureRecognizer instance) {
             instance
-              ..canAccept = () {
+              ..shouldAccept = () {
                 if (_globalTapDownOffset == null) {
                   return false;
                 }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -247,10 +246,11 @@ class IosDocumentTouchInteractor extends StatefulWidget {
     required this.openSoftwareKeyboard,
     required this.scrollController,
     required this.dragHandleAutoScroller,
+    required this.fillViewport,
     this.contentTapHandler,
     this.dragAutoScrollBoundary = const AxisOffset.symmetric(54),
     this.showDebugPaint = false,
-    this.child,
+    required this.child,
   }) : super(key: key);
 
   final FocusNode focusNode;
@@ -278,9 +278,11 @@ class IosDocumentTouchInteractor extends StatefulWidget {
   /// edges.
   final AxisOffset dragAutoScrollBoundary;
 
+  final bool fillViewport;
+
   final bool showDebugPaint;
 
-  final Widget? child;
+  final Widget child;
 
   @override
   State createState() => _IosDocumentTouchInteractorState();
@@ -288,13 +290,8 @@ class IosDocumentTouchInteractor extends StatefulWidget {
 
 class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     with WidgetsBindingObserver, SingleTickerProviderStateMixin {
-  bool _isScrolling = false;
-
   // The ScrollPosition attached to the _ancestorScrollable.
   ScrollPosition? _ancestorScrollPosition;
-  // The actual ScrollPosition that's used for the document layout, either
-  // the Scrollable installed by this interactor, or an ancestor Scrollable.
-  ScrollPosition? _activeScrollPosition;
 
   SuperEditorIosControlsController? _controlsController;
   late FloatingCursorListener _floatingCursorListener;
@@ -309,13 +306,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   final _magnifierFocalPointInDocumentSpace = ValueNotifier<Offset?>(null);
   Offset? _dragEndInInteractor;
   DragMode? _dragMode;
-  DragStartDetails? _dragStartDetails;
+
   // TODO: HandleType is the wrong type here, we need collapsed/base/extent,
   //       not collapsed/upstream/downstream. Change the type once it's working.
   HandleType? _dragHandleType;
-
-  /// Holds the drag gesture that scrolls the document.
-  Drag? _scrollingDrag;
 
   Timer? _tapDownLongPressTimer;
   Offset? _globalTapDownOffset;
@@ -336,8 +330,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       getScrollPosition: () => scrollPosition,
       getViewportBox: () => viewportBox,
     );
-
-    _configureScrollController();
 
     widget.document.addListener(_onDocumentChange);
 
@@ -367,23 +359,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     _controlsController!.floatingCursorController.cursorGeometryInViewport.addListener(_onFloatingCursorGeometryChange);
 
     _ancestorScrollPosition = context.findAncestorScrollableWithVerticalScroll?.position;
-
-    // On the next frame, check if our active scroll position changed to a
-    // different instance. If it did, move our listener to the new one.
-    //
-    // This is posted to the next frame because the first time this method
-    // runs, we haven't attached to our own ScrollController yet, so
-    // this.scrollPosition might be null.
-    onNextFrame((_) {
-      final newScrollPosition = scrollPosition;
-      if (newScrollPosition == _activeScrollPosition) {
-        return;
-      }
-
-      setState(() {
-        _activeScrollPosition = newScrollPosition;
-      });
-    });
   }
 
   @override
@@ -393,11 +368,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     if (widget.document != oldWidget.document) {
       oldWidget.document.removeListener(_onDocumentChange);
       widget.document.addListener(_onDocumentChange);
-    }
-
-    if (widget.scrollController != oldWidget.scrollController) {
-      _teardownScrollController();
-      _configureScrollController();
     }
   }
 
@@ -410,8 +380,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
         .removeListener(_onFloatingCursorGeometryChange);
 
     widget.document.removeListener(_onDocumentChange);
-
-    _teardownScrollController();
 
     widget.dragHandleAutoScroller.value?.dispose();
 
@@ -441,33 +409,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     onNextFrame((_) {
       _ensureSelectionExtentIsVisible();
     });
-  }
-
-  void _configureScrollController() {
-    onNextFrame((_) => scrollPosition.isScrollingNotifier.addListener(_onScrollActivityChange));
-  }
-
-  void _teardownScrollController() {
-    if (widget.scrollController.hasClients) {
-      scrollPosition.isScrollingNotifier.removeListener(_onScrollActivityChange);
-    }
-  }
-
-  void _onScrollActivityChange() {
-    final isScrolling = scrollPosition.isScrollingNotifier.value;
-
-    if (isScrolling) {
-      _isScrolling = true;
-    } else {
-      onNextFrame((_) {
-        // Set our scrolling flag to false on the next frame, so that our tap handlers
-        // have an opportunity to see that the scrollable was scrolling when the user
-        // tapped down.
-        //
-        // See the "on tap down" handler for more info about why this flag is important.
-        _isScrolling = false;
-      });
-    }
   }
 
   void _ensureSelectionExtentIsVisible() {
@@ -531,12 +472,14 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     return viewportBox.globalToLocal(globalOffset);
   }
 
-  RenderBox get interactorBox => context.findRenderObject() as RenderBox;
+  final _interactor = GlobalKey();
+
+  RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
 
   /// Converts the given [interactorOffset] from the [DocumentInteractor]'s coordinate
   /// space to the [DocumentLayout]'s coordinate space.
   Offset _interactorOffsetToDocumentOffset(Offset interactorOffset) {
-    final globalOffset = (context.findRenderObject() as RenderBox).localToGlobal(interactorOffset);
+    final globalOffset = interactorBox.localToGlobal(interactorOffset);
     return _docLayout.getDocumentOffsetFromAncestorOffset(globalOffset);
   }
 
@@ -556,25 +499,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     );
   }
 
-  bool _wasScrollingOnTapDown = false;
   void _onTapDown(TapDownDetails details) {
-    // When the user scrolls and releases, the scrolling continues with momentum.
-    // If the user then taps down again, the momentum stops. When this happens, we
-    // still receive tap callbacks. But we don't want to take any further action,
-    // like moving the caret, when the user taps to stop scroll momentum. We have
-    // to carefully watch the scrolling activity to recognize when this happens.
-    // We can't check whether we're scrolling in "on tap up" because by then the
-    // scrolling has already stopped. So we log whether we're scrolling "on tap down"
-    // and then check this flag in "on tap up".
-    _wasScrollingOnTapDown = _isScrolling;
-
-    if (_isScrolling) {
-      // On iOS, unlike Android, tapping while scrolling doesn't seem to stop the scrolling
-      // momentum. If we're actively scrolling, stop the momentum.
-      (scrollPosition as ScrollPositionWithSingleContext).goIdle();
-      return;
-    }
-
     _globalTapDownOffset = details.globalPosition;
     _tapDownLongPressTimer?.cancel();
     if (!disableLongPressSelectionForSuperlist) {
@@ -637,13 +562,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     _controlsController!
       ..hideMagnifier()
       ..blinkCaret();
-
-    if (_wasScrollingOnTapDown) {
-      // The scrollable was scrolling when the user touched down. We expect that the
-      // touch down stopped the scrolling momentum. We don't want to take any further
-      // action on this touch event. The user will tap again to change the selection.
-      return;
-    }
 
     final selection = widget.selection.value;
     if (selection != null &&
@@ -898,9 +816,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   }
 
   void _onPanStart(DragStartDetails details) {
-    // Store the gesture start details to disambiguate horizontal vs vertical dragging, later.
-    _dragStartDetails = details;
-
     // Stop waiting for a long-press to start, if a long press isn't already in-progress.
     _globalTapDownOffset = null;
     _tapDownLongPressTimer?.cancel();
@@ -910,11 +825,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     //       bit of slop might be the problem.
     final selection = widget.selection.value;
     if (selection == null) {
-      // There isn't a selection, but we still don't know if the user is dragging
-      // vertically or horizontally. Wait until the onPanUpdate event is fired
-      // to decide whether or not we should scroll the document.
-      _dragMode = DragMode.waitingForScrollDirection;
-      _updateDragStartLocation(details.globalPosition);
       return;
     }
 
@@ -932,12 +842,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       _dragMode = DragMode.extent;
       _dragHandleType = HandleType.downstream;
     } else {
-      // The user isn't dragging over a handle, but we still don't know if the user is dragging
-      // vertically or horizontally. Wait until the onPanUpdate event is fired
-      // to decide whether or not we should scroll the document.
-      _dragMode = DragMode.waitingForScrollDirection;
-      _updateDragStartLocation(details.globalPosition);
-
       return;
     }
 
@@ -997,31 +901,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
-    if (_dragMode == DragMode.waitingForScrollDirection) {
-      if (_globalStartDragOffset != null && (details.globalPosition.dy - _globalStartDragOffset!.dy).abs() > kPanSlop) {
-        // The user is dragging vertically. Start scrolling the document.
-        _startDragScrolling(_dragStartDetails!);
-      }
-    }
-
-    if (_dragMode == DragMode.scroll) {
-      // The user is trying to scroll the document. Scroll it, accordingly.
-      _scrollingDrag!.update(
-        DragUpdateDetails(
-          globalPosition: details.globalPosition,
-          localPosition: details.localPosition,
-          primaryDelta: details.delta.dy,
-          // Having a primary delta requires that one of the
-          // offset dimensions is zero.
-          delta: Offset(0.0, details.delta.dy),
-        ),
-      );
-
-      return;
-    }
-
     _globalDragOffset = details.globalPosition;
-    final interactorBox = context.findRenderObject() as RenderBox;
 
     _dragEndInInteractor = interactorBox.globalToLocal(details.globalPosition);
     final dragEndInViewport = _interactorOffsetToViewportOffset(_dragEndInInteractor!);
@@ -1097,13 +977,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       ..blinkCaret();
 
     switch (_dragMode) {
-      case DragMode.scroll:
-        // The user was performing a drag gesture to scroll the document.
-        // End the scroll activity and let the document scrolling with momentum.
-        _scrollingDrag!.end(details);
-        _scrollingDrag = null;
-        _dragMode = null;
-        break;
       case DragMode.collapsed:
       case DragMode.base:
       case DragMode.extent:
@@ -1112,24 +985,14 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
         // or with a long-press. Finish that interaction.
         _onDragSelectionEnd();
         break;
-      case DragMode.waitingForScrollDirection:
-        _dragMode = null;
-        break;
-      case null:
+      default:
         // The user wasn't dragging over a selection. Do nothing.
+        _dragMode = null;
         break;
     }
   }
 
   void _onPanCancel() {
-    if (_scrollingDrag != null) {
-      // The user was performing a drag gesture to scroll the document.
-      // Cancel the drag gesture.
-      _scrollingDrag!.cancel();
-      _scrollingDrag = null;
-      return;
-    }
-
     if (_dragMode != null) {
       _onDragSelectionEnd();
     }
@@ -1314,25 +1177,15 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     ]);
   }
 
-  /// Starts a drag activity to scroll the document.
-  void _startDragScrolling(DragStartDetails details) {
-    _dragMode = DragMode.scroll;
-
-    _scrollingDrag = scrollPosition.drag(details, () {
-      // Allows receiving touches while scrolling due to scroll momentum.
-      // This is needed to allow the user to stop scrolling by tapping down.
-      scrollPosition.context.setIgnorePointer(false);
-    });
-  }
-
   /// Updates the magnifier focal point in relation to the current drag position.
   void _placeFocalPointNearTouchOffset() {
     late DocumentPosition? docPositionToMagnify;
 
     if (_globalTapDownOffset != null) {
       // A drag isn't happening. Magnify the position that the user tapped.
-      docPositionToMagnify =
-          _docLayout.getDocumentPositionNearestToOffset(_globalTapDownOffset! + Offset(0, scrollPosition.pixels));
+      final interactorOffset = interactorBox.globalToLocal(_globalTapDownOffset!);
+      final tapDownDocumentOffset = _interactorOffsetToDocumentOffset(interactorOffset);
+      docPositionToMagnify = _docLayout.getDocumentPositionNearestToOffset(tapDownDocumentOffset);
     } else {
       final docDragDelta = _globalDragOffset! - _globalStartDragOffset!;
       final dragScrollDelta = _dragStartScrollOffset! - scrollPosition.pixels;
@@ -1349,7 +1202,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _updateDragStartLocation(Offset globalOffset) {
     _globalStartDragOffset = globalOffset;
-    final interactorBox = context.findRenderObject() as RenderBox;
     final handleOffsetInInteractor = interactorBox.globalToLocal(globalOffset);
     _dragStartInDoc = _interactorOffsetToDocumentOffset(handleOffsetInInteractor);
 
@@ -1386,15 +1238,45 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
         //
         // Defer adding the listener to the next frame.
         scheduleBuildAfterBuild();
-      } else {
-        if (scrollPosition != _activeScrollPosition) {
-          _activeScrollPosition = scrollPosition;
-        }
       }
     }
 
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
-    return RawGestureDetector(
+    final layerAbove = RawGestureDetector(
+      key: _interactor,
+      behavior: HitTestBehavior.translucent,
+      gestures: <Type, GestureRecognizerFactory>{
+        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+          () => EagerPanGestureRecognizer(),
+          (EagerPanGestureRecognizer instance) {
+            instance
+              ..canAccept = () {
+                if (_globalTapDownOffset == null) {
+                  return false;
+                }
+                final panDown = interactorBox.globalToLocal(_globalTapDownOffset!);
+                final isOverHandle =
+                    _isOverBaseHandle(panDown) || _isOverExtentHandle(panDown) || _isOverCollapsedHandle(panDown);
+                final res = isOverHandle || _isLongPressInProgress;
+                return res;
+              }
+              ..dragStartBehavior = DragStartBehavior.down
+              ..onDown = _onPanDown
+              ..onStart = _onPanStart
+              ..onUpdate = _onPanUpdate
+              ..onEnd = _onPanEnd
+              ..onCancel = _onPanCancel
+              ..gestureSettings = gestureSettings;
+          },
+        ),
+      },
+      child: Stack(
+        children: [
+          _buildMagnifierFocalPoint(),
+        ],
+      ),
+    );
+    final layerBelow = RawGestureDetector(
       behavior: HitTestBehavior.opaque,
       gestures: <Type, GestureRecognizerFactory>{
         TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
@@ -1409,26 +1291,15 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
               ..gestureSettings = gestureSettings;
           },
         ),
-        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
-          () => EagerPanGestureRecognizer(),
-          (EagerPanGestureRecognizer instance) {
-            instance
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onDown = _onPanDown
-              ..onStart = _onPanStart
-              ..onUpdate = _onPanUpdate
-              ..onEnd = _onPanEnd
-              ..onCancel = _onPanCancel
-              ..gestureSettings = gestureSettings;
-          },
-        ),
       },
-      child: Stack(
-        children: [
-          widget.child ?? const SizedBox(),
-          _buildMagnifierFocalPoint(),
-        ],
-      ),
+    );
+    return SliverHybridStack(
+      fillViewport: widget.fillViewport,
+      children: [
+        layerBelow,
+        widget.child,
+        layerAbove,
+      ],
     );
   }
 
@@ -1466,10 +1337,6 @@ enum DragMode {
   // Dragging after a long-press, which selects by the word
   // around the selected word.
   longPress,
-  // Dragging to scroll the document.
-  scroll,
-  // We still don't know if the user is dragging vertically or horizontally.
-  waitingForScrollDirection,
 }
 
 /// Adds and removes an iOS-style editor toolbar, as dictated by an ancestor
@@ -1511,6 +1378,7 @@ class SuperEditorIosToolbarOverlayManagerState extends State<SuperEditorIosToolb
 
   @override
   Widget build(BuildContext context) {
+    final ancestorScrollable = context.findAncestorScrollableWithVerticalScroll;
     return SliverHybridStack(
       children: [
         widget.child,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -976,19 +976,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       ..hideMagnifier()
       ..blinkCaret();
 
-    switch (_dragMode) {
-      case DragMode.collapsed:
-      case DragMode.base:
-      case DragMode.extent:
-      case DragMode.longPress:
-        // The user was dragging a selection change in some way, either with handles
-        // or with a long-press. Finish that interaction.
-        _onDragSelectionEnd();
-        break;
-      default:
-        // The user wasn't dragging over a selection. Do nothing.
-        _dragMode = null;
-        break;
+    if (_dragMode != null) {
+      // The user was dragging a selection change in some way, either with handles
+      // or with a long-press. Finish that interaction.
+      _onDragSelectionEnd();
     }
   }
 
@@ -1242,6 +1233,10 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     }
 
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    // PanGestureRecognizer is above contents to have first pass at gestures, but it only accepts
+    // gestures that are over caret or handles or when a long press is in progress.
+    // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
+    // tappable widgets.
     final layerAbove = RawGestureDetector(
       key: _interactor,
       behavior: HitTestBehavior.translucent,
@@ -1378,7 +1373,6 @@ class SuperEditorIosToolbarOverlayManagerState extends State<SuperEditorIosToolb
 
   @override
   Widget build(BuildContext context) {
-    final ancestorScrollable = context.findAncestorScrollableWithVerticalScroll;
     return SliverHybridStack(
       children: [
         widget.child,

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1240,63 +1240,63 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     // gestures that are over caret or handles or when a long press is in progress.
     // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
     // tappable widgets.
-    final layerAbove = RawGestureDetector(
-      key: _interactor,
-      behavior: HitTestBehavior.translucent,
-      gestures: <Type, GestureRecognizerFactory>{
-        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
-          () => EagerPanGestureRecognizer(),
-          (EagerPanGestureRecognizer instance) {
-            instance
-              ..shouldAccept = () {
-                if (_globalTapDownOffset == null) {
-                  return false;
-                }
-                final panDown = interactorBox.globalToLocal(_globalTapDownOffset!);
-                final isOverHandle =
-                    _isOverBaseHandle(panDown) || _isOverExtentHandle(panDown) || _isOverCollapsedHandle(panDown);
-                final res = isOverHandle || _isLongPressInProgress;
-                return res;
-              }
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onDown = _onPanDown
-              ..onStart = _onPanStart
-              ..onUpdate = _onPanUpdate
-              ..onEnd = _onPanEnd
-              ..onCancel = _onPanCancel
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-      child: Stack(
-        children: [
-          _buildMagnifierFocalPoint(),
-        ],
-      ),
-    );
-    final layerBelow = RawGestureDetector(
-      behavior: HitTestBehavior.opaque,
-      gestures: <Type, GestureRecognizerFactory>{
-        TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
-          () => TapSequenceGestureRecognizer(),
-          (TapSequenceGestureRecognizer recognizer) {
-            recognizer
-              ..onTapDown = _onTapDown
-              ..onTapCancel = _onTapCancel
-              ..onTapUp = _onTapUp
-              ..onDoubleTapUp = _onDoubleTapUp
-              ..onTripleTapUp = _onTripleTapUp
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-    );
     return SliverHybridStack(
       fillViewport: widget.fillViewport,
       children: [
-        layerBelow,
+        // Layer below
+        RawGestureDetector(
+          behavior: HitTestBehavior.opaque,
+          gestures: <Type, GestureRecognizerFactory>{
+            TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
+              () => TapSequenceGestureRecognizer(),
+              (TapSequenceGestureRecognizer recognizer) {
+                recognizer
+                  ..onTapDown = _onTapDown
+                  ..onTapCancel = _onTapCancel
+                  ..onTapUp = _onTapUp
+                  ..onDoubleTapUp = _onDoubleTapUp
+                  ..onTripleTapUp = _onTripleTapUp
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+        ),
         widget.child,
-        layerAbove,
+        // Layer above
+        RawGestureDetector(
+          key: _interactor,
+          behavior: HitTestBehavior.translucent,
+          gestures: <Type, GestureRecognizerFactory>{
+            EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+              () => EagerPanGestureRecognizer(),
+              (EagerPanGestureRecognizer instance) {
+                instance
+                  ..shouldAccept = () {
+                    if (_globalTapDownOffset == null) {
+                      return false;
+                    }
+                    final panDown = interactorBox.globalToLocal(_globalTapDownOffset!);
+                    final isOverHandle =
+                        _isOverBaseHandle(panDown) || _isOverExtentHandle(panDown) || _isOverCollapsedHandle(panDown);
+                    final res = isOverHandle || _isLongPressInProgress;
+                    return res;
+                  }
+                  ..dragStartBehavior = DragStartBehavior.down
+                  ..onDown = _onPanDown
+                  ..onStart = _onPanStart
+                  ..onUpdate = _onPanUpdate
+                  ..onEnd = _onPanEnd
+                  ..onCancel = _onPanCancel
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+          child: Stack(
+            children: [
+              _buildMagnifierFocalPoint(),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1248,7 +1248,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
           () => EagerPanGestureRecognizer(),
           (EagerPanGestureRecognizer instance) {
             instance
-              ..canAccept = () {
+              ..shouldAccept = () {
                 if (_globalTapDownOffset == null) {
                   return false;
                 }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -278,6 +278,8 @@ class IosDocumentTouchInteractor extends StatefulWidget {
   /// edges.
   final AxisOffset dragAutoScrollBoundary;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   final bool showDebugPaint;
@@ -319,6 +321,8 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   // Cached view metrics to ignore unnecessary didChangeMetrics calls.
   Size? _lastSize;
   ViewPadding? _lastInsets;
+
+  final _interactor = GlobalKey();
 
   @override
   void initState() {
@@ -472,8 +476,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     return viewportBox.globalToLocal(globalOffset);
   }
 
-  final _interactor = GlobalKey();
-
+  /// Returns the render box for the interactor gesture detector.
   RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
 
   /// Converts the given [interactorOffset] from the [DocumentInteractor]'s coordinate

--- a/super_editor/lib/src/default_editor/document_scrollable.dart
+++ b/super_editor/lib/src/default_editor/document_scrollable.dart
@@ -212,7 +212,6 @@ class _DocumentScrollableState extends State<DocumentScrollable> with SingleTick
         child: CustomScrollView(
           controller: _scrollController,
           shrinkWrap: widget.shrinkWrap,
-          physics: const NeverScrollableScrollPhysics(),
           slivers: [child],
         ),
       ),

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -26,6 +26,7 @@ import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/documents/selection_leader_document_layer.dart';
+import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
@@ -837,7 +838,10 @@ class SuperEditorState extends State<SuperEditor> {
     }
   }
 
-  Widget _buildGestureInteractor(BuildContext context) {
+  Widget _buildGestureInteractor(BuildContext context, {required Widget child}) {
+    // Ensure that gesture object fill entire viewport when not being
+    // in user specified scrollable.
+    final fillViewport = context.findAncestorScrollableWithVerticalScroll == null;
     switch (gestureMode) {
       case DocumentGestureMode.mouse:
         return DocumentMouseInteractor(
@@ -849,7 +853,9 @@ class SuperEditorState extends State<SuperEditor> {
           selectionNotifier: editContext.composer.selectionNotifier,
           contentTapHandler: _contentTapDelegate,
           autoScroller: _autoScrollController,
+          fillViewport: fillViewport,
           showDebugPaint: widget.debugPaint.gestures,
+          child: child,
         );
       case DocumentGestureMode.android:
         return AndroidDocumentTouchInteractor(
@@ -862,7 +868,9 @@ class SuperEditorState extends State<SuperEditor> {
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,
+          fillViewport: fillViewport,
           showDebugPaint: widget.debugPaint.gestures,
+          child: child,
         );
       case DocumentGestureMode.iOS:
         return IosDocumentTouchInteractor(
@@ -875,7 +883,9 @@ class SuperEditorState extends State<SuperEditor> {
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,
+          fillViewport: fillViewport,
           showDebugPaint: widget.debugPaint.gestures,
+          child: child,
         );
     }
   }

--- a/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
@@ -40,7 +40,7 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
 
   /// Builder that creates a gesture interaction widget, which is displayed
   /// beneath the document, at the same size as the viewport.
-  final WidgetBuilder gestureBuilder;
+  final Widget Function(BuildContext context, {required Widget child}) gestureBuilder;
 
   /// Builds the text input widget, if applicable. The text input system is placed
   /// above the gesture system and beneath viewport decoration.
@@ -130,24 +130,7 @@ class _DocumentScaffoldState extends State<DocumentScaffold> {
   Widget _buildGestureSystem({
     required Widget child,
   }) {
-    final ancestorScrollable = context.findAncestorScrollableWithVerticalScroll;
-    return SliverHybridStack(
-      // Ensure that gesture object fill entire viewport when not being
-      // in user specified scrollable.
-      fillViewport: ancestorScrollable == null,
-      children: [
-        // A layer that sits beneath the document and handles gestures.
-        // It's beneath the document so that components that include
-        // interactive UI, like a Checkbox, can intercept their own
-        // touch events.
-        //
-        // This layer is placed outside of `ContentLayers` because this
-        // layer needs to be wider than the document, to fill all available
-        // space.
-        widget.gestureBuilder(context),
-        child,
-      ],
-    );
+    return widget.gestureBuilder(context, child: child);
   }
 
   Widget _buildDocumentLayout() {

--- a/super_editor/lib/src/infrastructure/flutter/eager_pan_gesture_recognizer.dart
+++ b/super_editor/lib/src/infrastructure/flutter/eager_pan_gesture_recognizer.dart
@@ -17,12 +17,21 @@ class EagerPanGestureRecognizer extends DragGestureRecognizer {
     super.allowedButtonsFilter,
   });
 
+  bool Function()? canAccept;
+
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
     final minVelocity = minFlingVelocity ?? kMinFlingVelocity;
     final minDistance = minFlingDistance ?? computeHitSlop(kind, gestureSettings);
     return estimate.pixelsPerSecond.distanceSquared > minVelocity * minVelocity &&
         estimate.offset.distanceSquared > minDistance * minDistance;
+  }
+
+  @override
+  void acceptGesture(int pointer) {
+    if (canAccept?.call() ?? true) {
+      super.acceptGesture(pointer);
+    }
   }
 
   @override
@@ -45,7 +54,12 @@ class EagerPanGestureRecognizer extends DragGestureRecognizer {
     // Flutter's PanGestureRecognizer uses the pan slop, which is twice bigger than the hit slop,
     // to determine if the gesture should be accepted. Use the same distance used by the
     // VerticalDragGestureRecognizer.
-    return globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+    final res = globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+    if (res && canAccept != null) {
+      return canAccept!();
+    } else {
+      return res;
+    }
   }
 
   @override

--- a/super_editor/lib/src/infrastructure/flutter/eager_pan_gesture_recognizer.dart
+++ b/super_editor/lib/src/infrastructure/flutter/eager_pan_gesture_recognizer.dart
@@ -17,7 +17,8 @@ class EagerPanGestureRecognizer extends DragGestureRecognizer {
     super.allowedButtonsFilter,
   });
 
-  bool Function()? canAccept;
+  /// Allows to dynamically decide if the gesture should be accepted.
+  bool Function()? shouldAccept;
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
@@ -29,7 +30,7 @@ class EagerPanGestureRecognizer extends DragGestureRecognizer {
 
   @override
   void acceptGesture(int pointer) {
-    if (canAccept?.call() ?? true) {
+    if (shouldAccept?.call() ?? true) {
       super.acceptGesture(pointer);
     }
   }
@@ -55,8 +56,8 @@ class EagerPanGestureRecognizer extends DragGestureRecognizer {
     // to determine if the gesture should be accepted. Use the same distance used by the
     // VerticalDragGestureRecognizer.
     final res = globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
-    if (res && canAccept != null) {
-      return canAccept!();
+    if (res && shouldAccept != null) {
+      return shouldAccept!();
     } else {
       return res;
     }

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -105,6 +105,8 @@ class ReadOnlyAndroidDocumentTouchInteractor extends StatefulWidget {
   /// Shows, hides, and positions a floating toolbar and magnifier.
   final MagnifierAndToolbarController? overlayController;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   final bool showDebugPaint;
@@ -149,6 +151,8 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   bool get _isLongPressInProgress => _longPressStrategy != null;
   AndroidDocumentLongPressSelectionStrategy? _longPressStrategy;
   final _longPressMagnifierGlobalOffset = ValueNotifier<Offset?>(null);
+
+  final _interactor = GlobalKey();
 
   @override
   void initState() {
@@ -419,8 +423,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   /// is the viewport `RenderBox`.
   RenderBox get viewportBox => context.findViewportBox();
 
-  final _interactor = GlobalKey();
-
+  /// Returns the render box for the interactor gesture detector.
   RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
 
   Offset _getDocumentOffsetFromGlobalOffset(Offset globalOffset) {

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -992,7 +992,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
             () => EagerPanGestureRecognizer(),
             (EagerPanGestureRecognizer recognizer) {
               recognizer
-                ..canAccept = () {
+                ..shouldAccept = () {
                   if (_globalTapDownOffset == null) {
                     return false;
                   }

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -981,57 +981,57 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
   @override
   Widget build(BuildContext context) {
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
-    final layerAbove = OverlayPortal(
-      controller: _overlayPortalController,
-      overlayChildBuilder: _buildControlsOverlay,
-      child: RawGestureDetector(
-        key: _interactor,
-        behavior: HitTestBehavior.translucent,
-        gestures: <Type, GestureRecognizerFactory>{
-          EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
-            () => EagerPanGestureRecognizer(),
-            (EagerPanGestureRecognizer recognizer) {
-              recognizer
-                ..shouldAccept = () {
-                  if (_globalTapDownOffset == null) {
-                    return false;
-                  }
-                  return _isLongPressInProgress;
-                }
-                ..dragStartBehavior = DragStartBehavior.down
-                ..onStart = _onPanStart
-                ..onUpdate = _onPanUpdate
-                ..onEnd = _onPanEnd
-                ..onCancel = _onPanCancel
-                ..gestureSettings = gestureSettings;
-            },
-          ),
-        },
-      ),
-    );
-    final layerBelow = RawGestureDetector(
-      behavior: HitTestBehavior.translucent,
-      gestures: <Type, GestureRecognizerFactory>{
-        TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
-          () => TapSequenceGestureRecognizer(),
-          (TapSequenceGestureRecognizer recognizer) {
-            recognizer
-              ..onTapDown = _onTapDown
-              ..onTapCancel = _onTapCancel
-              ..onTapUp = _onTapUp
-              ..onDoubleTapDown = _onDoubleTapDown
-              ..onTripleTapDown = _onTripleTapDown
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-    );
     return SliverHybridStack(
       fillViewport: widget.fillViewport,
       children: [
-        layerBelow,
+        // Layer below
+        RawGestureDetector(
+          behavior: HitTestBehavior.translucent,
+          gestures: <Type, GestureRecognizerFactory>{
+            TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
+              () => TapSequenceGestureRecognizer(),
+              (TapSequenceGestureRecognizer recognizer) {
+                recognizer
+                  ..onTapDown = _onTapDown
+                  ..onTapCancel = _onTapCancel
+                  ..onTapUp = _onTapUp
+                  ..onDoubleTapDown = _onDoubleTapDown
+                  ..onTripleTapDown = _onTripleTapDown
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+        ),
         widget.child,
-        layerAbove,
+        // Layer above
+        OverlayPortal(
+          controller: _overlayPortalController,
+          overlayChildBuilder: _buildControlsOverlay,
+          child: RawGestureDetector(
+            key: _interactor,
+            behavior: HitTestBehavior.translucent,
+            gestures: <Type, GestureRecognizerFactory>{
+              EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+                () => EagerPanGestureRecognizer(),
+                (EagerPanGestureRecognizer recognizer) {
+                  recognizer
+                    ..shouldAccept = () {
+                      if (_globalTapDownOffset == null) {
+                        return false;
+                      }
+                      return _isLongPressInProgress;
+                    }
+                    ..dragStartBehavior = DragStartBehavior.down
+                    ..onStart = _onPanStart
+                    ..onUpdate = _onPanUpdate
+                    ..onEnd = _onPanEnd
+                    ..onCancel = _onPanCancel
+                    ..gestureSettings = gestureSettings;
+                },
+              ),
+            },
+          ),
+        ),
       ],
     );
   }

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -908,6 +908,10 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     }
 
     final gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    // PanGestureRecognizer is above contents to have first pass at gestures, but it only accepts
+    // gestures that are over caret or handles or when a long press is in progress.
+    // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
+    // tappable widgets.
     final layerAbove = RawGestureDetector(
       key: _interactor,
       behavior: HitTestBehavior.translucent,

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -915,61 +915,61 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     // gestures that are over caret or handles or when a long press is in progress.
     // TapGestureRecognizer is below contents so that it doesn't interferes with buttons and other
     // tappable widgets.
-    final layerAbove = RawGestureDetector(
-      key: _interactor,
-      behavior: HitTestBehavior.translucent,
-      gestures: <Type, GestureRecognizerFactory>{
-        EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
-          () => EagerPanGestureRecognizer(),
-          (EagerPanGestureRecognizer instance) {
-            instance
-              ..shouldAccept = () {
-                if (_globalTapDownOffset == null) {
-                  return false;
-                }
-                final panDown = interactorBox.globalToLocal(_globalTapDownOffset!);
-                final isOverHandle = _isOverBaseHandle(panDown) || _isOverExtentHandle(panDown);
-                return isOverHandle || _isLongPressInProgress;
-              }
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onDown = _onPanDown
-              ..onStart = _onPanStart
-              ..onUpdate = _onPanUpdate
-              ..onEnd = _onPanEnd
-              ..onCancel = _onPanCancel
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-      child: Stack(
-        children: [
-          _buildMagnifierFocalPoint(),
-        ],
-      ),
-    );
-    final layerBelow = RawGestureDetector(
-      behavior: HitTestBehavior.opaque,
-      gestures: <Type, GestureRecognizerFactory>{
-        TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
-          () => TapSequenceGestureRecognizer(),
-          (TapSequenceGestureRecognizer recognizer) {
-            recognizer
-              ..onTapDown = _onTapDown
-              ..onTapCancel = _onTapCancel
-              ..onTapUp = _onTapUp
-              ..onDoubleTapUp = _onDoubleTapUp
-              ..onTripleTapUp = _onTripleTapUp
-              ..gestureSettings = gestureSettings;
-          },
-        ),
-      },
-    );
     return SliverHybridStack(
       fillViewport: widget.fillViewport,
       children: [
-        layerBelow,
+        // Layer below
+        RawGestureDetector(
+          behavior: HitTestBehavior.opaque,
+          gestures: <Type, GestureRecognizerFactory>{
+            TapSequenceGestureRecognizer: GestureRecognizerFactoryWithHandlers<TapSequenceGestureRecognizer>(
+              () => TapSequenceGestureRecognizer(),
+              (TapSequenceGestureRecognizer recognizer) {
+                recognizer
+                  ..onTapDown = _onTapDown
+                  ..onTapCancel = _onTapCancel
+                  ..onTapUp = _onTapUp
+                  ..onDoubleTapUp = _onDoubleTapUp
+                  ..onTripleTapUp = _onTripleTapUp
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+        ),
         widget.child,
-        layerAbove,
+        // Layer above
+        RawGestureDetector(
+          key: _interactor,
+          behavior: HitTestBehavior.translucent,
+          gestures: <Type, GestureRecognizerFactory>{
+            EagerPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<EagerPanGestureRecognizer>(
+              () => EagerPanGestureRecognizer(),
+              (EagerPanGestureRecognizer instance) {
+                instance
+                  ..shouldAccept = () {
+                    if (_globalTapDownOffset == null) {
+                      return false;
+                    }
+                    final panDown = interactorBox.globalToLocal(_globalTapDownOffset!);
+                    final isOverHandle = _isOverBaseHandle(panDown) || _isOverExtentHandle(panDown);
+                    return isOverHandle || _isLongPressInProgress;
+                  }
+                  ..dragStartBehavior = DragStartBehavior.down
+                  ..onDown = _onPanDown
+                  ..onStart = _onPanStart
+                  ..onUpdate = _onPanUpdate
+                  ..onEnd = _onPanEnd
+                  ..onCancel = _onPanCancel
+                  ..gestureSettings = gestureSettings;
+              },
+            ),
+          },
+          child: Stack(
+            children: [
+              _buildMagnifierFocalPoint(),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -923,7 +923,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
           () => EagerPanGestureRecognizer(),
           (EagerPanGestureRecognizer instance) {
             instance
-              ..canAccept = () {
+              ..shouldAccept = () {
                 if (_globalTapDownOffset == null) {
                   return false;
                 }

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -220,6 +220,8 @@ class SuperReaderIosDocumentTouchInteractor extends StatefulWidget {
   /// edges.
   final AxisOffset dragAutoScrollBoundary;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   final bool showDebugPaint;
@@ -256,6 +258,8 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
   Offset? _globalTapDownOffset;
   bool get _isLongPressInProgress => _longPressStrategy != null;
   IosLongPressSelectionStrategy? _longPressStrategy;
+
+  final _interactor = GlobalKey();
 
   @override
   void initState() {
@@ -398,8 +402,7 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
   /// is the viewport `RenderBox`.
   RenderBox get viewportBox => context.findViewportBox();
 
-  final _interactor = GlobalKey();
-
+  /// Returns the render box for the interactor gesture detector.
   RenderBox get interactorBox => _interactor.currentContext!.findRenderObject() as RenderBox;
 
   /// Converts the given [interactorOffset] from the [DocumentInteractor]'s coordinate

--- a/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
@@ -57,6 +57,8 @@ class ReadOnlyDocumentMouseInteractor extends StatefulWidget {
   /// Auto-scrolling delegate.
   final AutoScrollController autoScroller;
 
+  /// Whether the document gesture detector should fill the entire viewport
+  /// even if the actual content is smaller.
   final bool fillViewport;
 
   /// Paints some extra visual ornamentation to help with

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -29,6 +29,7 @@ import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
 import 'package:super_editor/src/infrastructure/documents/document_selection.dart';
 import 'package:super_editor/src/infrastructure/documents/selection_leader_document_layer.dart';
+import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
@@ -483,7 +484,10 @@ class SuperReaderState extends State<SuperReader> {
     }
   }
 
-  Widget _buildGestureInteractor(BuildContext context) {
+  Widget _buildGestureInteractor(BuildContext context, {required Widget child}) {
+    // Ensure that gesture object fill entire viewport when not being
+    // in user specified scrollable.
+    final fillViewport = context.findAncestorScrollableWithVerticalScroll == null;
     switch (_gestureMode) {
       case DocumentGestureMode.mouse:
         return ReadOnlyDocumentMouseInteractor(
@@ -491,8 +495,9 @@ class SuperReaderState extends State<SuperReader> {
           readerContext: _readerContext,
           contentTapHandler: _contentTapDelegate,
           autoScroller: _autoScrollController,
+          fillViewport: fillViewport,
           showDebugPaint: widget.debugPaint.gestures,
-          child: const SizedBox(),
+          child: child,
         );
       case DocumentGestureMode.android:
         return ReadOnlyAndroidDocumentTouchInteractor(
@@ -510,6 +515,8 @@ class SuperReaderState extends State<SuperReader> {
           createOverlayControlsClipper: widget.createOverlayControlsClipper,
           showDebugPaint: widget.debugPaint.gestures,
           overlayController: widget.overlayController,
+          fillViewport: fillViewport,
+          child: child,
         );
       case DocumentGestureMode.iOS:
         return SuperReaderIosDocumentTouchInteractor(
@@ -520,7 +527,9 @@ class SuperReaderState extends State<SuperReader> {
           selection: _readerContext.selection,
           contentTapHandler: _contentTapDelegate,
           scrollController: _scrollController,
+          fillViewport: fillViewport,
           showDebugPaint: widget.debugPaint.gestures,
+          child: child,
         );
     }
   }

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -749,7 +749,7 @@ void main() {
 
       await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withLongDoc()
           .withScrollController(scrollController)
           .pump();
 
@@ -781,7 +781,7 @@ void main() {
 
       await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withLongDoc()
           .withScrollController(scrollController)
           .pump();
 

--- a/super_editor/test/super_reader/super_reader_scrolling_test.dart
+++ b/super_editor/test/super_reader/super_reader_scrolling_test.dart
@@ -283,7 +283,7 @@ void main() {
 
       await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withLongTextContent()
           .withScrollController(scrollController)
           .pump();
 
@@ -315,7 +315,7 @@ void main() {
 
       await tester //
           .createDocument()
-          .withSingleParagraph()
+          .withLongTextContent()
           .withScrollController(scrollController)
           .pump();
 

--- a/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
+++ b/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
@@ -378,6 +378,9 @@ void main() {
               const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 34)),
             );
             await tester.pumpAndSettle();
+            // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
+            // tap.
+            await tester.pump(const Duration(milliseconds: 500));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 28);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;
@@ -409,6 +412,9 @@ void main() {
               const DocumentPosition(nodeId: "1", nodePosition: TextNodePosition(offset: 34)),
             );
             await tester.pumpAndSettle();
+            // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
+            // tap.
+            await tester.pump(const Duration(milliseconds: 500));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 39);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;

--- a/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
+++ b/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/super_editor.dart';
@@ -380,7 +381,7 @@ void main() {
             await tester.pumpAndSettle();
             // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
             // tap.
-            await tester.pump(const Duration(milliseconds: 500));
+            await tester.pump(kDoubleTapTimeout + const Duration(seconds: 1));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 28);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;
@@ -414,7 +415,7 @@ void main() {
             await tester.pumpAndSettle();
             // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
             // tap.
-            await tester.pump(const Duration(milliseconds: 500));
+            await tester.pump(kDoubleTapTimeout + const Duration(seconds: 1));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 39);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;

--- a/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
+++ b/super_editor/test_goldens/editor/mobile/mobile_selection_test.dart
@@ -381,7 +381,7 @@ void main() {
             await tester.pumpAndSettle();
             // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
             // tap.
-            await tester.pump(kDoubleTapTimeout + const Duration(seconds: 1));
+            await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 28);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;
@@ -415,7 +415,7 @@ void main() {
             await tester.pumpAndSettle();
             // Wait a bit to ensure that the interactor recognizer doesn't consider this a double
             // tap.
-            await tester.pump(kDoubleTapTimeout + const Duration(seconds: 1));
+            await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
 
             final dragDelta = SuperEditorInspector.findDeltaBetweenCharactersInTextNode("1", 34, 39);
             final handleRectGlobal = SuperEditorInspector.findMobileCaret().globalRect;


### PR DESCRIPTION
This PR reworks gesture handling inside interactors with the goal of super_editor gesture detectors playing nicely with other detectors. With this PR it is no longer necessary for interactor to drive scrolling and it is now possible to have working dismissable rows in the editor.

The gesture recognizer configuration on mobile has been changed so that the document contents is sandwiched between pan and tap recognizers, i.e.

- `EagerPanGestureRecognizer` (above document)
- Document contents
- `TapSequenceGestureRecognizer` (below document)

`EagerPanGestureRecognizer` always wins, but it gets only accepted conditionally (if user drags handles or long press is in progress). 
`TapSequenceGestureRecognzer` is below document so that it doesn't interfere with checkboxes or buttons inside document.