### PR TITLE
[SuperEditor][Web] Fix selection change with CMD + RIGHT (Resolves #2304)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -310,6 +310,12 @@ class CommonEditorOperations {
         extentComponent.movePositionLeft(currentExtent.nodePosition, movementModifier);
 
     if (newExtentNodePosition == null) {
+      if (movementModifier == MovementModifier.line) {
+        // The user is trying to move to the beginning of the current line,
+        // and we're already there. Do nothing.
+        return false;
+      }
+
       // Move to next node
       final nextNode = _getUpstreamSelectableNodeBefore(node);
 
@@ -410,6 +416,12 @@ class CommonEditorOperations {
         extentComponent.movePositionRight(currentExtent.nodePosition, movementModifier);
 
     if (newExtentNodePosition == null) {
+      if (movementModifier == MovementModifier.line) {
+        // The user is trying to move to the end of the current line,
+        // and we're already there. Do nothing.
+        return false;
+      }
+
       // Move to next node
       final nextNode = _getDownstreamSelectableNodeAfter(node);
 

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -694,8 +694,7 @@ ExecutionInstruction moveToStartOrEndOfLineWithArrowKeysOnWeb({
   if ((CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) ||
       (const [TargetPlatform.windows, TargetPlatform.linux].contains(defaultTargetPlatform) &&
           !HardwareKeyboard.instance.isControlPressed)) {
-    // CMD or CTRL is not pressed. For character by character, word by word movement,
-    // we rely on the IME.
+    // CMD or CTRL is not pressed.
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -635,6 +635,20 @@ ExecutionInstruction doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
+  if ((CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) ||
+      (const [TargetPlatform.windows, TargetPlatform.linux].contains(defaultTargetPlatform) &&
+          HardwareKeyboard.instance.isControlPressed)) {
+    // Pressing the arrow keys generates non-text deltas on web. However, when pressing CMD + RIGHT
+    // to move the selection to the end of the line, the selection change sometimes reports an offset which
+    // isn't at the end of the line. This seems to be an issue where our text layout is different
+    // from the browser's text layout. For example, the browser breaks the line at a different point
+    // than we do, so pressing CMD + RIGHT moves the selection to where the browser thinks the end of
+    // the line is.
+    //
+    // Don't block the event to let it be handled by our selection movement code.
+    return ExecutionInstruction.continueExecution;
+  }
+
   // On web, pressing left or right arrow keys generates non-text deltas.
   // We handle those deltas to change the selection. However, if the caret sits at the beginning
   // or end of a node, pressing these arrow keys doesn't generate any deltas.

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -635,20 +635,6 @@ ExecutionInstruction doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
-  if ((CurrentPlatform.isApple && HardwareKeyboard.instance.isMetaPressed) ||
-      (const [TargetPlatform.windows, TargetPlatform.linux].contains(defaultTargetPlatform) &&
-          HardwareKeyboard.instance.isControlPressed)) {
-    // Pressing the arrow keys generates non-text deltas on web. However, when pressing CMD + RIGHT
-    // to move the selection to the end of the line, the selection change sometimes reports an offset which
-    // isn't at the end of the line. This seems to be an issue where our text layout is different
-    // from the browser's text layout. For example, the browser breaks the line at a different point
-    // than we do, so pressing CMD + RIGHT moves the selection to where the browser thinks the end of
-    // the line is.
-    //
-    // Don't block the event to let it be handled by our selection movement code.
-    return ExecutionInstruction.continueExecution;
-  }
-
   // On web, pressing left or right arrow keys generates non-text deltas.
   // We handle those deltas to change the selection. However, if the caret sits at the beginning
   // or end of a node, pressing these arrow keys doesn't generate any deltas.
@@ -683,6 +669,63 @@ ExecutionInstruction doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb({
   }
 
   return ExecutionInstruction.continueExecution;
+}
+
+ExecutionInstruction moveToStartOrEndOfLineWithArrowKeysOnWeb({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (!CurrentPlatform.isWeb) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  const arrowKeys = [
+    LogicalKeyboardKey.arrowLeft,
+    LogicalKeyboardKey.arrowRight,
+  ];
+  if (!arrowKeys.contains(keyEvent.logicalKey)) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if ((CurrentPlatform.isApple && !HardwareKeyboard.instance.isMetaPressed) ||
+      (const [TargetPlatform.windows, TargetPlatform.linux].contains(defaultTargetPlatform) &&
+          !HardwareKeyboard.instance.isControlPressed)) {
+    // CMD or CTRL is not pressed. For character by character, word by word movement,
+    // we rely on the IME.
+    return ExecutionInstruction.continueExecution;
+  }
+
+  // Pressing the arrow keys generates non-text deltas on web. However, when pressing CMD + RIGHT
+  // to move the selection to the end of the line, the selection change sometimes reports an offset which
+  // isn't at the end of the line. This seems to be an issue where our text layout is different
+  // from the browser's text layout. For example, the browser breaks the line at a different point
+  // than we do, so pressing CMD + RIGHT moves the selection to where the browser thinks the end of
+  // the line is.
+  //
+  // See https://github.com/superlistapp/super_editor/issues/2304 for more information.
+  //
+  // Move the selection mannually.
+
+  bool didMove;
+  if (keyEvent.logicalKey == LogicalKeyboardKey.arrowLeft) {
+    // Move the caret left/upstream.
+    didMove = editContext.commonOps.moveCaretUpstream(
+      expand: HardwareKeyboard.instance.isShiftPressed,
+      movementModifier: MovementModifier.line,
+    );
+  } else {
+    // Move the caret right/downstream.
+    didMove = editContext.commonOps.moveCaretDownstream(
+      expand: HardwareKeyboard.instance.isShiftPressed,
+      movementModifier: MovementModifier.line,
+    );
+  }
+
+  return didMove ? ExecutionInstruction.haltExecution : ExecutionInstruction.continueExecution;
 }
 
 ExecutionInstruction moveToLineStartOrEndWithCtrlAOrE({

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1319,6 +1319,7 @@ final defaultImeKeyboardActions = <DocumentKeyboardAction>[
   scrollOnPageUpKeyPress,
   scrollOnPageDownKeyPress,
   moveUpAndDownWithArrowKeys,
+  moveToStartOrEndOfLineWithArrowKeysOnWeb,
   doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb,
   moveLeftAndRightWithArrowKeys,
   moveToLineStartWithHome,

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -471,6 +471,58 @@ void main() {
             ),
           );
         }, variant: inputSourceVariant);
+
+        testWidgetsOnMacDesktopAndWeb('with CMD + LEFT ARROW at the beginning of a paragraph', (tester) async {
+          await tester //
+              .createDocument()
+              .withLongTextContent()
+              .pump();
+
+          // Place caret at the beginning of the second paragraph.
+          await tester.placeCaretInParagraph('2', 0);
+
+          // Press the key combo to move to the beginning of the line.
+          await tester.pressCmdLeftArrow();
+
+          // Ensure that the caret didn't move, since we are already at the beginning.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: "2",
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnMacDesktopAndWeb('with CMD + RIGHT ARROW at the end of a paragraph', (tester) async {
+          await tester //
+              .createDocument()
+              .withLongTextContent()
+              .pump();
+
+          // Place caret at the end of the first paragraph.
+          await tester.placeCaretInParagraph('1', 439);
+
+          // Press the key combo to move to the end of the line.
+          await tester.pressCmdRightArrow();
+
+          // Ensure that the caret didn't move, since we are already at the end.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 439),
+                ),
+              ),
+            ),
+          );
+        });
       });
 
       group("Windows and Linux >", () {
@@ -1612,58 +1664,6 @@ This is a paragraph
             position: DocumentPosition(
               nodeId: "1",
               nodePosition: TextNodePosition(offset: 6),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnMacDesktopAndWeb('with CMD + LEFT ARROW at the beginning of a paragraph', (tester) async {
-        await tester //
-            .createDocument()
-            .withLongTextContent()
-            .pump();
-
-        // Place caret at the beginning of the second paragraph.
-        await tester.placeCaretInParagraph('2', 0);
-
-        // Press the key combo to move to the beginning of the line.
-        await tester.pressCmdLeftArrow();
-
-        // Ensure that the caret didn't move, since we are already at the beginning.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: "2",
-                nodePosition: TextNodePosition(offset: 0),
-              ),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnMacDesktopAndWeb('with CMD + RIGHT ARROW at the end of a paragraph', (tester) async {
-        await tester //
-            .createDocument()
-            .withLongTextContent()
-            .pump();
-
-        // Place caret at the end of the first paragraph.
-        await tester.placeCaretInParagraph('1', 439);
-
-        // Press the key combo to move to the end of the line.
-        await tester.pressCmdRightArrow();
-
-        // Ensure that the caret didn't move, since we are already at the end.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: "1",
-                nodePosition: TextNodePosition(offset: 439),
-              ),
             ),
           ),
         );

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -1632,10 +1632,12 @@ This is a paragraph
         // Ensure that the caret didn't move, since we are already at the beginning.
         expect(
           SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: "2",
-              nodePosition: TextNodePosition(offset: 0),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
             ),
           ),
         );
@@ -1656,10 +1658,12 @@ This is a paragraph
         // Ensure that the caret didn't move, since we are already at the end.
         expect(
           SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: "1",
-              nodePosition: TextNodePosition(offset: 439),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 439),
+              ),
             ),
           ),
         );

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -1617,7 +1617,7 @@ This is a paragraph
         );
       });
 
-      testWidgetsOnApple('with CMD + LEFT ARROW at the beginning of a paragraph', (tester) async {
+      testWidgetsOnMacDesktopAndWeb('with CMD + LEFT ARROW at the beginning of a paragraph', (tester) async {
         await tester //
             .createDocument()
             .withLongTextContent()
@@ -1643,7 +1643,7 @@ This is a paragraph
         );
       });
 
-      testWidgetsOnApple('with CMD + RIGHT ARROW at the end of a paragraph', (tester) async {
+      testWidgetsOnMacDesktopAndWeb('with CMD + RIGHT ARROW at the end of a paragraph', (tester) async {
         await tester //
             .createDocument()
             .withLongTextContent()

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -1616,6 +1616,54 @@ This is a paragraph
           ),
         );
       });
+
+      testWidgetsOnApple('with CMD + LEFT ARROW at the beginning of a paragraph', (tester) async {
+        await tester //
+            .createDocument()
+            .withLongTextContent()
+            .pump();
+
+        // Place caret at the beginning of the second paragraph.
+        await tester.placeCaretInParagraph('2', 0);
+
+        // Press the key combo to move to the beginning of the line.
+        await tester.pressCmdLeftArrow();
+
+        // Ensure that the caret didn't move, since we are already at the beginning.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "2",
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnApple('with CMD + RIGHT ARROW at the end of a paragraph', (tester) async {
+        await tester //
+            .createDocument()
+            .withLongTextContent()
+            .pump();
+
+        // Place caret at the end of the first paragraph.
+        await tester.placeCaretInParagraph('1', 439);
+
+        // Press the key combo to move to the end of the line.
+        await tester.pressCmdRightArrow();
+
+        // Ensure that the caret didn't move, since we are already at the end.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: "1",
+              nodePosition: TextNodePosition(offset: 439),
+            ),
+          ),
+        );
+      });
     });
 
     group("shortcuts for Windows and Linux do nothing on mac", () {

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -57,6 +57,17 @@ void testWidgetsOnWebMobile(
 }
 
 @isTestGroup
+void testWidgetsOnMacDesktopAndWeb(
+  String description,
+  WidgetTesterCallback test, {
+  bool skip = false,
+  TestVariant<Object?> variant = const DefaultTestVariant(),
+}) {
+  testWidgetsOnMac("$description (on MAC)", test, skip: skip, variant: variant);
+  testWidgetsOnMacWeb("$description (on MAC Web)", test, skip: skip, variant: variant);
+}
+
+@isTestGroup
 void testWidgetsOnMacWeb(
   String description,
   WidgetTesterCallback test, {


### PR DESCRIPTION
[SuperEditor][Web] Fix selection change with CMD + RIGHT. Resolves #2304

Steps to reproduce: 

1. Run the example app with Chrome 
2. Place cursor on the beginning of the line "To get started with your own editing experience, take the following steps:"
3. Press CMD+Right arrow

Expected: Cursor is placed at the end of the line, Actual: Cursor is placed at the beginning of the word "steps"

This wrong offset is being reported by the selection change delta. On web, Flutter relies on html inputs to handle text input. When the user presses CMD + RIGHT, the browser moves the selection to where it thinks the end of the line is, and the Flutter code generates text deltas for us.

I haven't dug deep into this, but this seems our text layout and the browser text layout are different. For example, in the repro text, the browser thinks the line ends before "steps".

We started handling deltas for moving the caret with the arrow keys in https://github.com/superlistapp/super_editor/pull/1269. I think I failed to document why we need to let the IME generate non-text deltas for this. However, I tested the issues reported in the original ticket (https://github.com/superlistapp/super_editor/issues/1224) and I wasn't able to reproduce any of them.

This PR changes `doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb` to avoid sending the key event back to the OS if CMD is pressed.

The ideal solution would be to investigate why our line breaks are different from the browser line breaks, but this will require a deeper investigation.

As a reference, in our "Regular Flutter TextField Demo", if we limit the width of the Flutter TextField to 400px, we can also see the caret moving to the wrong position.