### PR TITLE
Use Timer instead of Ticker with mobile caret blink controller to avoid constantly pumping frames (Resolves #2340)

### DIFF
--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1210,7 +1210,7 @@ const defaultComponentBuilders = <ComponentBuilder>[
 
 /// Default list of document overlays that are displayed on top of the document
 /// layout in a [SuperEditor].
-const defaultSuperEditorDocumentOverlayBuilders = [
+const defaultSuperEditorDocumentOverlayBuilders = <SuperEditorLayerBuilder>[
   // Adds a Leader around the document selection at a focal point for the
   // iOS floating toolbar.
   SuperEditorIosToolbarFocalPointDocumentLayerBuilder(),

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -193,7 +193,7 @@ class AndroidControlsDocumentLayerState
   @override
   void initState() {
     super.initState();
-    _caretBlinkController = BlinkController(tickerProvider: this);
+    _caretBlinkController = BlinkController.withTimer();
 
     _previousSelection = widget.selection.value;
     widget.selection.addListener(_onSelectionChange);

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -564,7 +564,7 @@ class IosControlsDocumentLayerState extends DocumentLayoutLayerState<IosHandlesD
   @override
   void initState() {
     super.initState();
-    _caretBlinkController = BlinkController(tickerProvider: this);
+    _caretBlinkController = BlinkController.withTimer();
 
     widget.selection.addListener(_onSelectionChange);
     widget.shouldCaretBlink.addListener(_onBlinkModeChange);


### PR DESCRIPTION
Use Timer instead of Ticker with mobile caret blink controller to avoid constantly pumping frames (Resolves #2340)