### PR TITLE
[SuperTextField] Fix golden failure (Resolves #2343)

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -47,13 +47,13 @@ dependencies:
   flutter_test_robots: ^0.0.24
   clock: ^1.1.1
 
-#dependency_overrides:
+dependency_overrides:
   # Override to local mono-repo path so devs can test this repo
   # against changes that they're making to other mono-repo packages
-#  attributed_text:
-#    path: ../attributed_text
-#  super_text_layout:
-#    path: ../super_text_layout
+  #  attributed_text:
+  #    path: ../attributed_text
+  super_text_layout:
+    path: ../super_text_layout
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/super_text_layout/lib/src/super_text.dart
+++ b/super_text_layout/lib/src/super_text.dart
@@ -429,7 +429,11 @@ class RenderLayoutAwareParagraph extends RenderParagraph {
           ..textDirection = textDirection
           ..textAlign = textAlign
           ..layout();
-        size = Size(size.width, _textPainter.height);
+
+        // Constrain the computed size because it can be bigger than the
+        // incoming constraints. Not respecting the incoming constraints
+        // is a Flutter violation and it causes a crash.
+        size = constraints.constrain(Size(size.width, _textPainter.height));
       }
     }
   }

--- a/super_text_layout/lib/src/super_text.dart
+++ b/super_text_layout/lib/src/super_text.dart
@@ -430,9 +430,11 @@ class RenderLayoutAwareParagraph extends RenderParagraph {
           ..textAlign = textAlign
           ..layout();
 
-        // Constrain the computed size because it can be bigger than the
-        // incoming constraints. Not respecting the incoming constraints
-        // is a Flutter violation and it causes a crash.
+        // We have no text, so we set the height of this render object to the line height
+        // of an arbitrary character of the given style. However, it's possible that our
+        // parent render object imposed constraints that are shorter than a single line
+        // of text. To avoid breaking Flutter's layout rules, we take the minimum height
+        // between the single line of text, and the incoming height constraints.
         size = constraints.constrain(Size(size.width, _textPainter.height));
       }
     }


### PR DESCRIPTION
[SuperTextField] Fix golden failure. Resolves #2343

The goldens are failing due to a layout crash with the following exception:

```console
The following assertion was thrown during performLayout():
RenderLeaderLayer does not meet its constraints.
Constraints:
  BoxConstraints(200.0<=w<=Infinity, 0.0<=h<=20.0)
Size:
  Size(200.0, 23.0)
```

This seems to be introduced by https://github.com/superlistapp/super_editor/pull/2338.

The crash is happening for an empty `SuperTextField` without any padding. The cause is that the height reported by the workaround code is bigger than the incoming constraints. This causes a crash during layout, because we are supposed to respect the incoming constraints.

This PR only fixes the crash by constraining the computed height, but we probably want to dig deeper to find out why the viewport is being smaller than it should be.