### PR TITLE
upgrade markdown package reference

### DIFF
--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -24,7 +24,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
         );
 
   @override
-  md.Node? close(
+  Iterable<md.Node>? close(
     md.InlineParser parser,
     covariant md.SimpleDelimiter opener,
     md.Delimiter? closer, {
@@ -38,7 +38,8 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     if (parser.pos + 1 >= parser.source.length) {
       // The `]` is at the end of the document, but this may still be a valid
       // shortcut reference link.
-      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+      final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+      return link == null ? null : [ link ];
     }
 
     // Peek at the next character; don't advance, so as to avoid later stepping
@@ -51,7 +52,8 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       var leftParenIndex = parser.pos;
       var inlineLink = _parseInlineLink(parser);
       if (inlineLink != null) {
-        return _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren);
+        final link = _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren);
+        return link == null ? null : [ link ];
       }
       // At this point, we've matched `[...](`, but that `(` did not pan out to
       // be an inline link. We must now check if `[...]` is simply a shortcut
@@ -60,7 +62,8 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       // Reset the parser position.
       parser.pos = leftParenIndex;
       parser.advanceBy(-1);
-      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+      final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+      return link == null ? null : [ link ];
     }
 
     if (char == AsciiTable.leftBracket) {
@@ -71,18 +74,21 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
         // That opening `[` is not actually part of the link. Maybe a
         // *shortcut* reference link (followed by a `[`).
         parser.advanceBy(1);
-        return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+        final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+        return link == null ? null : [ link ];
       }
       var label = _parseReferenceLinkLabel(parser);
       if (label != null) {
-        return _tryCreateReferenceLink(parser, label, getChildren: getChildren);
+        final link = _tryCreateReferenceLink(parser, label, getChildren: getChildren);
+        return link == null ? null : [ link ];
       }
       return null;
     }
 
     // The link text (inside `[...]`) was not followed with a opening `(` nor
     // an opening `[`. Perhaps just a simple shortcut reference link (`[...]`).
-    return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+    final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
+    return link == null ? null : [ link ];
   }
 
   /// Parses a size using the notation `=widthxheight`.

--- a/super_editor_markdown/lib/src/image_syntax.dart
+++ b/super_editor_markdown/lib/src/image_syntax.dart
@@ -38,8 +38,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     if (parser.pos + 1 >= parser.source.length) {
       // The `]` is at the end of the document, but this may still be a valid
       // shortcut reference link.
-      final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
-      return link == null ? null : [ link ];
+      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
     }
 
     // Peek at the next character; don't advance, so as to avoid later stepping
@@ -52,8 +51,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       var leftParenIndex = parser.pos;
       var inlineLink = _parseInlineLink(parser);
       if (inlineLink != null) {
-        final link = _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren);
-        return link == null ? null : [ link ];
+        return [ _tryCreateInlineLink(parser, inlineLink, getChildren: getChildren) ];
       }
       // At this point, we've matched `[...](`, but that `(` did not pan out to
       // be an inline link. We must now check if `[...]` is simply a shortcut
@@ -62,8 +60,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       // Reset the parser position.
       parser.pos = leftParenIndex;
       parser.advanceBy(-1);
-      final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
-      return link == null ? null : [ link ];
+      return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
     }
 
     if (char == AsciiTable.leftBracket) {
@@ -74,21 +71,18 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
         // That opening `[` is not actually part of the link. Maybe a
         // *shortcut* reference link (followed by a `[`).
         parser.advanceBy(1);
-        final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
-        return link == null ? null : [ link ];
+        return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
       }
       var label = _parseReferenceLinkLabel(parser);
       if (label != null) {
-        final link = _tryCreateReferenceLink(parser, label, getChildren: getChildren);
-        return link == null ? null : [ link ];
+        return _tryCreateReferenceLink(parser, label, getChildren: getChildren);
       }
       return null;
     }
 
     // The link text (inside `[...]`) was not followed with a opening `(` nor
     // an opening `[`. Perhaps just a simple shortcut reference link (`[...]`).
-    final link = _tryCreateReferenceLink(parser, text, getChildren: getChildren);
-    return link == null ? null : [ link ];
+    return _tryCreateReferenceLink(parser, text, getChildren: getChildren);
   }
 
   /// Parses a size using the notation `=widthxheight`.
@@ -146,7 +140,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   /// Tries to create a reference link node.
   ///
   /// Returns the link if it was successfully created, `null` otherwise.
-  md.Node? _tryCreateReferenceLink(md.InlineParser parser, String label,
+  List<md.Node>? _tryCreateReferenceLink(md.InlineParser parser, String label,
       {required List<md.Node> Function() getChildren}) {
     return _resolveReferenceLink(label, parser.document.linkReferences, getChildren: getChildren);
   }
@@ -242,19 +236,21 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
   /// Otherwise, returns `null`.
   ///
   /// [label] does not need to be normalized.
-  md.Node? _resolveReferenceLink(
+ List<md.Node>? _resolveReferenceLink(
     String label,
     Map<String, md.LinkReference> linkReferences, {
     required List<md.Node> Function() getChildren,
   }) {
     final linkReference = linkReferences[_normalizeLinkLabel(label)];
     if (linkReference != null) {
-      return createNode(
-        linkReference.destination,
-        linkReference.title,
-        //size: linkReference.size,
-        getChildren: getChildren,
-      );
+      return [
+        createNode(
+          linkReference.destination,
+          linkReference.title,
+          //size: linkReference.size,
+          getChildren: getChildren,
+        ) 
+      ];
     } else {
       // This link has no reference definition. But we allow users of the
       // library to specify a custom resolver function ([linkResolver]) that
@@ -268,7 +264,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
       if (resolved != null) {
         getChildren();
       }
-      return resolved;
+      return resolved != null ? [resolved] : null;
     }
   }
 
@@ -486,6 +482,7 @@ class SuperEditorImageSyntax extends md.LinkSyntax {
     }
   }
 
+  @override
   md.Element createNode(
     String destination,
     String? title, {

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -528,6 +528,10 @@ abstract class ElementToNodeConverter {
 /// This [DelimiterSyntax] produces `Element`s with a `u` tag.
 class UnderlineSyntax extends md.DelimiterSyntax {
 
+  /// This is required by md.DelimiterSyntax, in theory the constructor takes an optional tags member, but a bug in
+  /// the Markdown lib replaces that with a const [], and then tries to sort it.
+  static final _tags = [ md.DelimiterTag("u", 1) ];
+
   UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true, tags: _tags);
 
   @override
@@ -541,7 +545,6 @@ class UnderlineSyntax extends md.DelimiterSyntax {
     final element = md.Element('u', getChildren());
     return [ element ];
   }
-  static final _tags = [ md.DelimiterTag("u", 1) ];
 }
 
 /// Parses a paragraph preceded by an alignment token.

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -23,9 +23,12 @@ MutableDocument deserializeMarkdownToDocument(
   List<ElementToNodeConverter> customElementToNodeConverters = const [],
   bool encodeHtml = false,
 }) {
-  final markdownLines = const LineSplitter().convert(markdown);
+  final markdownLines = const LineSplitter().convert(markdown).map((l) {
+    return md.Line(l);
+  }).toList();
 
   final markdownDoc = md.Document(
+    encodeHtml: encodeHtml,
     blockSyntaxes: [
       ...customBlockSyntax,
       if (syntax == MarkdownSyntax.superEditor) ...[
@@ -519,22 +522,26 @@ abstract class ElementToNodeConverter {
   DocumentNode? handleElement(md.Element element);
 }
 
-/// A Markdown [TagSyntax] that matches underline spans of text, which are represented in
+/// A Markdown [DelimiterSyntax] that matches underline spans of text, which are represented in
 /// Markdown with surrounding `¬` tags, e.g., "this is ¬underline¬ text".
 ///
-/// This [TagSyntax] produces `Element`s with a `u` tag.
-class UnderlineSyntax extends md.TagSyntax {
-  UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true);
+/// This [DelimiterSyntax] produces `Element`s with a `u` tag.
+class UnderlineSyntax extends md.DelimiterSyntax {
+
+  UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true, tags: _tags);
 
   @override
-  md.Node? close(
+  Iterable<md.Node>? close(
     md.InlineParser parser,
     md.Delimiter opener,
     md.Delimiter closer, {
     required List<md.Node> Function() getChildren,
+    required String tag,
   }) {
-    return md.Element('u', getChildren());
+    final element = md.Element('u', getChildren());
+    return [ element ];
   }
+  static final _tags = [ md.DelimiterTag("u", 1) ];
 }
 
 /// Parses a paragraph preceded by an alignment token.
@@ -548,7 +555,7 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
 
   @override
   bool canParse(md.BlockParser parser) {
-    if (!_alignmentNotationPattern.hasMatch(parser.current)) {
+    if (!_alignmentNotationPattern.hasMatch(parser.current.content)) {
       return false;
     }
 
@@ -564,7 +571,7 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
     /// We found a paragraph alignment token, but the block after the alignment token isn't a paragraph.
     /// Therefore, the paragraph alignment token is actually regular content. This parser doesn't need to
     /// take any action.
-    if (_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(nextLine))) {
+    if (_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(nextLine.content))) {
       return false;
     }
 
@@ -575,7 +582,7 @@ class _ParagraphWithAlignmentSyntax extends _EmptyLinePreservingParagraphSyntax 
 
   @override
   md.Node? parse(md.BlockParser parser) {
-    final match = _alignmentNotationPattern.firstMatch(parser.current);
+    final match = _alignmentNotationPattern.firstMatch(parser.current.content);
 
     // We've parsed the alignment token on the current line. We know a paragraph starts on the
     // next line. Move the parser to the next line so that we can parse the paragraph.
@@ -630,13 +637,13 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
       return false;
     }
 
-    if (parser.current.isEmpty) {
+    if (parser.current.content.isEmpty) {
       // We consider this input to be a separator between blocks because
       // it started with an empty line. We want to parse this input.
       return true;
     }
 
-    if (_isAtParagraphEnd(parser, ignoreEmptyBlocks: _endsWithHardLineBreak(parser.current))) {
+    if (_isAtParagraphEnd(parser, ignoreEmptyBlocks: _endsWithHardLineBreak(parser.current.content))) {
       // Another parser wants to parse this input. Let the other parser run.
       return false;
     }
@@ -648,12 +655,12 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
   @override
   md.Node? parse(md.BlockParser parser) {
     final childLines = <String>[];
-    final startsWithEmptyLine = parser.current.isEmpty;
+    final startsWithEmptyLine = parser.current.content.isEmpty;
 
     // A hard line break causes the next line to be treated
     // as part of the same paragraph, except if the next line is
     // the beginning of another block element.
-    bool hasHardLineBreak = _endsWithHardLineBreak(parser.current);
+    bool hasHardLineBreak = _endsWithHardLineBreak(parser.current.content);
 
     if (startsWithEmptyLine) {
       // The parser started at an empty line.
@@ -669,7 +676,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
         return null;
       }
 
-      if (!_blankLinePattern.hasMatch(parser.current)) {
+      if (!_blankLinePattern.hasMatch(parser.current.content)) {
         // We found an empty line, but the following line isn't blank.
         // As there is no hard line break, the first line is consumed
         // as a separator between blocks.
@@ -682,7 +689,7 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
       childLines.add('');
 
       // Check for a hard line break, so we consume the next line if we found one.
-      hasHardLineBreak = _endsWithHardLineBreak(parser.current);
+      hasHardLineBreak = _endsWithHardLineBreak(parser.current.content);
       parser.advance();
     }
 
@@ -691,9 +698,9 @@ class _EmptyLinePreservingParagraphSyntax extends md.BlockSyntax {
     // ends with a hard line break.
     while (!_isAtParagraphEnd(parser, ignoreEmptyBlocks: hasHardLineBreak)) {
       final currentLine = parser.current;
-      childLines.add(currentLine);
+      childLines.add(currentLine.content);
 
-      hasHardLineBreak = _endsWithHardLineBreak(currentLine);
+      hasHardLineBreak = _endsWithHardLineBreak(currentLine.content);
 
       parser.advance();
     }
@@ -777,7 +784,7 @@ class _TaskSyntax extends md.BlockSyntax {
 
   @override
   md.Node? parse(md.BlockParser parser) {
-    final match = pattern.firstMatch(parser.current);
+    final match = pattern.firstMatch(parser.current.content);
     if (match == null) {
       return null;
     }
@@ -795,8 +802,8 @@ class _TaskSyntax extends md.BlockSyntax {
     // - find a blank line OR
     // - find the start of another block element (including another task)
     while (!parser.isDone &&
-        !_blankLinePattern.hasMatch(parser.current) &&
-        !_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(parser.current))) {
+        !_blankLinePattern.hasMatch(parser.current.content) &&
+        !_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(parser.current.content))) {
       buffer.write('\n');
       buffer.write(parser.current);
 
@@ -832,7 +839,7 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
 
   @override
   bool canParse(md.BlockParser parser) {
-    if (!_alignmentNotationPattern.hasMatch(parser.current)) {
+    if (!_alignmentNotationPattern.hasMatch(parser.current.content)) {
       return false;
     }
 
@@ -846,7 +853,7 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
     }
 
     // Only parse if the next line is header.
-    if (!_headerSyntax.pattern.hasMatch(nextLine)) {
+    if (!_headerSyntax.pattern.hasMatch(nextLine.content)) {
       return false;
     }
 
@@ -855,7 +862,7 @@ class _HeaderWithAlignmentSyntax extends md.BlockSyntax {
 
   @override
   md.Node? parse(md.BlockParser parser) {
-    final match = _alignmentNotationPattern.firstMatch(parser.current);
+    final match = _alignmentNotationPattern.firstMatch(parser.current.content);
 
     // We've parsed the alignment token on the current line. We know a header starts on the
     // next line. Move the parser to the next line so that we can parse the header.

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -64,7 +64,7 @@ MutableDocument deserializeMarkdownToDocument(
   // Add 1 hanging line for every 2 blank lines at the end, need this to preserve behavior pre markdown 7.2.1
   final hangingEmptyLines = markdownLines.reversed.takeWhile((md.Line l) => l.isBlankLine);
   if(hangingEmptyLines.isNotEmpty && documentNodes.lastOrNull is ListItemNode) {
-    for(var i = 0; i < hangingEmptyLines.length >> 1; i++) {
+    for(var i = 0; i < hangingEmptyLines.length ~/ 2; i++) {
       documentNodes.add(ParagraphNode(id: Editor.createNodeId(), text: AttributedText()));
     }
   }

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -537,8 +537,16 @@ abstract class ElementToNodeConverter {
 /// This [DelimiterSyntax] produces `Element`s with a `u` tag.
 class UnderlineSyntax extends md.DelimiterSyntax {
 
-  /// This is required by md.DelimiterSyntax, in theory the constructor takes an optional tags member, but a bug in
-  /// the Markdown lib replaces that with a const [], and then tries to sort it.
+  /// According to the docs:
+  ///
+  /// https://pub.dev/documentation/markdown/latest/markdown/DelimiterSyntax-class.html
+  ///
+  /// The DelimiterSyntax constructor takes a nullable. However, the problem is there is a bug in the underlying dart
+  /// library if you don't pass it. Due to these two lines, one sets it to const [] if not passed, then the next tries
+  /// to sort. So we have to pass something at the moment or it blows up.
+  ///
+  /// https://github.com/dart-lang/markdown/blob/d53feae0760a4f0aae5ffdfb12d8e6acccf14b40/lib/src/inline_syntaxes/delimiter_syntax.dart#L67
+  /// https://github.com/dart-lang/markdown/blob/d53feae0760a4f0aae5ffdfb12d8e6acccf14b40/lib/src/inline_syntaxes/delimiter_syntax.dart#L319
   static final _tags = [ md.DelimiterTag("u", 1) ];
 
   UnderlineSyntax() : super('¬', requiresDelimiterRun: true, allowIntraWord: true, tags: _tags);

--- a/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
+++ b/super_editor_markdown/lib/src/markdown_to_document_parsing.dart
@@ -808,7 +808,7 @@ class _TaskSyntax extends md.BlockSyntax {
         !_blankLinePattern.hasMatch(parser.current.content) &&
         !_standardNonParagraphBlockSyntaxes.any((syntax) => syntax.pattern.hasMatch(parser.current.content))) {
       buffer.write('\n');
-      buffer.write(parser.current);
+      buffer.write(parser.current.content);
 
       parser.advance();
     }

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 
   super_editor: ^0.3.0-dev.3
   logging: ^1.0.1
-  markdown: ^5.0.0
+  markdown: ^7.2.1
 
 #dependency_overrides:
   # Override to local mono-repo path so devs can test this repo

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -95,6 +95,7 @@ _InlineMarkdownToDocument _parseInline(md.Element element) {
     element.textContent,
     md.Document(
       inlineSyntaxes: [
+        SingleStrikethroughSyntax(), // this needs to be before md.StrikethroughSyntax to be recognized
         md.StrikethroughSyntax(),
         UnderlineSyntax(),
       ],

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -22,26 +22,26 @@ class CalloutBlockSyntax extends md.BlockSyntax {
   // This method was adapted from the standard Blockquote parser, and
   // the standard code fence block parser.
   @override
-  List<String> parseChildLines(md.BlockParser parser) {
+  List<md.Line?> parseChildLines(md.BlockParser parser) {
     // Grab all of the lines that form the custom block, stripping off the
     // first line, e.g., "@@@ customBlock", and the last line, e.g., "@@@".
     var childLines = <String>[];
 
     while (!parser.isDone) {
-      final openingLine = pattern.firstMatch(parser.current);
+      final openingLine = pattern.firstMatch(parser.current.content);
       if (openingLine != null) {
         // This is the first line. Ignore it.
         parser.advance();
         continue;
       }
-      final closingLine = _endLinePattern.firstMatch(parser.current);
+      final closingLine = _endLinePattern.firstMatch(parser.current.content);
       if (closingLine != null) {
         // This is the closing line. Ignore it.
         parser.advance();
 
         // If we're followed by a blank line, skip it, so that we don't end
         // up with an extra paragraph for that blank line.
-        if (parser.current.trim().isEmpty) {
+        if (parser.current.content.isEmpty) {
           parser.advance();
         }
 
@@ -49,11 +49,11 @@ class CalloutBlockSyntax extends md.BlockSyntax {
         break;
       }
 
-      childLines.add(parser.current);
+      childLines.add(parser.current.content);
       parser.advance();
     }
 
-    return childLines;
+    return childLines.map((l) => md.Line(l)).toList();
   }
 
   // This method was adapted from the standard Blockquote parser, and

--- a/super_editor_markdown/test/custom_parsers/callout_block.dart
+++ b/super_editor_markdown/test/custom_parsers/callout_block.dart
@@ -41,7 +41,7 @@ class CalloutBlockSyntax extends md.BlockSyntax {
 
         // If we're followed by a blank line, skip it, so that we don't end
         // up with an extra paragraph for that blank line.
-        if (parser.current.content.isEmpty) {
+        if (parser.current.content.trim().isEmpty) {
           parser.advance();
         }
 

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1437,13 +1437,13 @@ with multiple lines
         expect(document.getNodeAt(25)!, isA<ParagraphNode>());
       });
 
-      test('paragraph with single ~ should not be strikethrough', () {
+      test('paragraph with single strikethrough', () {
         final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
         final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
 
         // Ensure text within the range isn't attributed.
-        expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), false);
-        expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), false);
+        expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), true);
+        expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), true);
 
         // Ensure text outside the range isn't attributed.
         expect(styledText.getAllAttributionsAt(7).contains(strikethroughAttribution), false);
@@ -1555,6 +1555,23 @@ Paragraph3""";
         expect((doc.getNodeAt(0)! as ParagraphNode).text.text, 'Paragraph1');
         expect((doc.getNodeAt(1)! as ParagraphNode).text.text, '');
         expect((doc.getNodeAt(2)! as ParagraphNode).text.text, 'Paragraph3');
+      });
+
+       test('empty paragraph after paragraphs', () {
+        const input ='''
+1. First item
+2. Second item
+3. Third item
+
+
+''';
+        final doc = deserializeMarkdownToDocument(input);
+
+        expect(doc.nodeCount, 4);
+        expect((doc.getNodeAt(0)! as ListItemNode).text.text, 'First item');
+        expect((doc.getNodeAt(1)! as ListItemNode).text.text, 'Second item');
+        expect((doc.getNodeAt(2)! as ListItemNode).text.text, 'Third item');
+        expect((doc.getNodeAt(3)! as ParagraphNode).text.text, '');
       });
 
       test('multiple empty paragraph between paragraphs', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1130,8 +1130,7 @@ This is some code
       });
 
       test('unordered list followed by empty list item', () {
-        const markdown = """
-- list item 1
+        const markdown = """- list item 1
 - """;
 
         final document = deserializeMarkdownToDocument(markdown);
@@ -1441,7 +1440,7 @@ with multiple lines
         final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
         final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
 
-        // Ensure text within the range isn't attributed.
+        // Ensure text within the range is attributed.
         expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), true);
         expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), true);
 
@@ -1557,21 +1556,25 @@ Paragraph3""";
         expect((doc.getNodeAt(2)! as ParagraphNode).text.text, 'Paragraph3');
       });
 
-       test('empty paragraph after paragraphs', () {
+       test('every 2 newlines after a list are a paragraph', () {
         const input ='''
 1. First item
 2. Second item
 3. Third item
 
 
+
+
 ''';
         final doc = deserializeMarkdownToDocument(input);
 
-        expect(doc.nodeCount, 4);
+        expect(doc.nodeCount, 5);
         expect((doc.getNodeAt(0)! as ListItemNode).text.text, 'First item');
         expect((doc.getNodeAt(1)! as ListItemNode).text.text, 'Second item');
         expect((doc.getNodeAt(2)! as ListItemNode).text.text, 'Third item');
+        // super_editor tests expect empty newlines after a list to be retained
         expect((doc.getNodeAt(3)! as ParagraphNode).text.text, '');
+        expect((doc.getNodeAt(4)! as ParagraphNode).text.text, '');
       });
 
       test('multiple empty paragraph between paragraphs', () {

--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1129,17 +1129,21 @@ This is some code
         expect((document.first as ListItemNode).text.text, isEmpty);
       });
 
-      test('unordered list followd by empty list item', () {
-        const markdown = """- list item 1
-    - """;
+      test('unordered list followed by empty list item', () {
+        const markdown = """
+- list item 1
+- """;
 
         final document = deserializeMarkdownToDocument(markdown);
 
-        expect(document.nodeCount, 1);
+        expect(document.nodeCount, 2);
 
         expect(document.getNodeAt(0)!, isA<ListItemNode>());
         expect((document.getNodeAt(0)! as ListItemNode).type, ListItemType.unordered);
         expect((document.getNodeAt(0)! as ListItemNode).text.text, 'list item 1');
+        expect(document.getNodeAt(1)!, isA<ListItemNode>());
+        expect((document.getNodeAt(1)! as ListItemNode).type, ListItemType.unordered);
+        expect((document.getNodeAt(1)! as ListItemNode).text.text, '');
       });
 
       test('parses mixed unordered and ordered items', () {
@@ -1433,8 +1437,20 @@ with multiple lines
         expect(document.getNodeAt(25)!, isA<ParagraphNode>());
       });
 
-      test('paragraph with strikethrough', () {
+      test('paragraph with single ~ should not be strikethrough', () {
         final doc = deserializeMarkdownToDocument('~This is~ a paragraph.');
+        final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
+
+        // Ensure text within the range isn't attributed.
+        expect(styledText.getAllAttributionsAt(0).contains(strikethroughAttribution), false);
+        expect(styledText.getAllAttributionsAt(6).contains(strikethroughAttribution), false);
+
+        // Ensure text outside the range isn't attributed.
+        expect(styledText.getAllAttributionsAt(7).contains(strikethroughAttribution), false);
+      });
+
+      test('paragraph with double strikethrough', () {
+        final doc = deserializeMarkdownToDocument('~~This is~~ a paragraph.');
         final styledText = (doc.getNodeAt(0)! as ParagraphNode).text;
 
         // Ensure text within the range is attributed.


### PR DESCRIPTION
This upgrades the markdown package to 7.2.1, also fixes an issue where encodeHtml is not passed to the markdown parser.