### PR TITLE
[SuperEditor] Add ability to set a block node as non-deletable (Resolves #2334)

### DIFF
--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -416,6 +416,8 @@ abstract class DocumentNode implements ChangeNotifier {
 
   DocumentNode copy();
 
+  bool get isDeletable => _metadata[NodeMetadata.isDeletable] != false;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -309,6 +309,10 @@ class DocumentPosition {
 
 /// A single content node within a [Document].
 abstract class DocumentNode implements ChangeNotifier {
+  DocumentNode({
+    Map<String, dynamic>? metadata,
+  }) : _metadata = metadata ?? {};
+
   /// ID that is unique within a [Document].
   String get id;
 
@@ -373,7 +377,7 @@ abstract class DocumentNode implements ChangeNotifier {
   /// Returns all metadata attached to this [DocumentNode].
   Map<String, dynamic> get metadata => _metadata;
 
-  final Map<String, dynamic> _metadata = {};
+  final Map<String, dynamic> _metadata;
 
   /// Sets all metadata for this [DocumentNode], removing all
   /// existing values.
@@ -465,8 +469,11 @@ class NodeMetadata {
 
   /// Whether or not the node is deletable.
   ///
-  /// A deletable node can be removed from the document, for example,
-  /// when pressing backspace when the node is selected.
+  /// A non-deletable node cannot be removed from the document by user
+  /// interaction. For exammple, selecting a non-deletable node and pressing
+  /// backspace has no effect.
+  ///
+  /// Apps can still remove non-deletable nodes by issuing a `DeleteNodeRequest`.
   ///
   /// If the node doesn't have this metadata, it is assumed to be deletable.
   static const String isDeletable = 'isDeletable';

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -465,6 +465,9 @@ class NodeMetadata {
 
   /// Whether or not the node is deletable.
   ///
+  /// A deletable node can be removed from the document, for example,
+  /// when pressing backspace when the node is selected.
+  ///
   /// If the node doesn't have this metadata, it is assumed to be deletable.
-  static const String deletable = 'deletable';
+  static const String isDeletable = 'isDeletable';
 }

--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -457,3 +457,14 @@ abstract class NodePosition {
   /// even though [==] returns `false`.
   bool isEquivalentTo(NodePosition other);
 }
+
+/// Keys to access metadata on a [DocumentNode].
+class NodeMetadata {
+  /// Applies an [Attribution] to the node.
+  static const String blockType = 'blockType';
+
+  /// Whether or not the node is deletable.
+  ///
+  /// If the node doesn't have this metadata, it is assumed to be deletable.
+  static const String deletable = 'deletable';
+}

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -16,6 +16,10 @@ final _log = Logger(scope: 'box_component.dart');
 
 /// Base implementation for a [DocumentNode] that only supports [UpstreamDownstreamNodeSelection]s.
 abstract class BlockNode extends DocumentNode {
+  BlockNode({
+    Map<String, dynamic>? metadata,
+  }) : super(metadata: metadata);
+
   @override
   UpstreamDownstreamNodePosition get beginningPosition => const UpstreamDownstreamNodePosition.upstream();
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1251,9 +1251,18 @@ class CommonEditorOperations {
   ///
   /// This can be used, for example, to effectively delete an image by replacing
   /// it with an empty paragraph.
-  void replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(String nodeId) {
+  ///
+  /// If [abortIfUndeletable] is `true`, the operation is be aborted if the
+  /// node is not deletable.
+  void replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(
+    String nodeId, {
+    bool abortIfUndeletable = true,
+  }) {
     editor.execute([
-      ReplaceNodeWithEmptyParagraphWithCaretRequest(nodeId: nodeId),
+      ReplaceNodeWithEmptyParagraphWithCaretRequest(
+        nodeId: nodeId,
+        abortIfUndeletable: abortIfUndeletable,
+      ),
     ]);
   }
 
@@ -1284,11 +1293,9 @@ class CommonEditorOperations {
 
     // Delete the selected content.
     editor.execute([
-      DeleteContentRequest(documentRange: composer.selection!),
-      ChangeSelectionRequest(
-        DocumentSelection.collapsed(position: newSelectionPosition),
-        SelectionChangeType.deleteContent,
-        SelectionReason.userInteraction,
+      DeleteContentRequest(
+        documentRange: composer.selection!,
+        newSelection: DocumentSelection.collapsed(position: newSelectionPosition),
       ),
     ]);
   }

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -865,7 +865,7 @@ class CommonEditorOperations {
 
     if (!composer.selection!.isCollapsed) {
       // A span of content is selected. Delete the selection.
-      _deleteExpandedSelection();
+      _deleteExpandedSelection(TextAffinity.downstream);
       return true;
     }
 
@@ -1056,7 +1056,7 @@ class CommonEditorOperations {
 
     if (!composer.selection!.isCollapsed) {
       // A span of content is selected. Delete the selection.
-      _deleteExpandedSelection();
+      _deleteExpandedSelection(TextAffinity.upstream);
       return true;
     }
 
@@ -1332,7 +1332,7 @@ class CommonEditorOperations {
   ///
   /// Returns [true] if content was deleted, or [false] if no content was
   /// selected.
-  bool deleteSelection() {
+  bool deleteSelection(TextAffinity affinity) {
     if (composer.selection == null) {
       return false;
     }
@@ -1343,14 +1343,14 @@ class CommonEditorOperations {
 
     // The document selection includes a span of content. It may or may not
     // cross nodes. Either way, delete the selected content.
-    _deleteExpandedSelection();
+    _deleteExpandedSelection(affinity);
     return true;
   }
 
-  void _deleteExpandedSelection() {
+  void _deleteExpandedSelection(TextAffinity affinity) {
     // Delete the selected content.
     editor.execute([
-      const DeleteSelectionRequest(),
+      DeleteSelectionRequest(affinity: affinity),
     ]);
   }
 
@@ -1602,7 +1602,7 @@ class CommonEditorOperations {
       // Without this, the new text doesn't preserve the attributions of the replaced text.
       final composerAttributions = {...composer.preferences.currentAttributions};
 
-      _deleteExpandedSelection();
+      _deleteExpandedSelection(TextAffinity.downstream);
 
       // Restore the previous attributions.
       composer.preferences
@@ -1659,7 +1659,7 @@ class CommonEditorOperations {
     }
 
     if (!composer.selection!.isCollapsed) {
-      _deleteExpandedSelection();
+      _deleteExpandedSelection(TextAffinity.downstream);
     }
 
     final extentNodePosition = composer.selection!.extent.nodePosition;
@@ -1745,7 +1745,7 @@ class CommonEditorOperations {
       // The selection is not collapsed. Delete the selected content first,
       // then continue the process.
       editorOpsLog.finer("Deleting selection before inserting block-level newline");
-      _deleteExpandedSelection();
+      _deleteExpandedSelection(TextAffinity.downstream);
     }
 
     final newNodeId = Editor.createNodeId();
@@ -2183,7 +2183,7 @@ class CommonEditorOperations {
     //       need to be carried out in response to user input.
     _saveToClipboard(textToCut);
 
-    deleteSelection();
+    deleteSelection(TextAffinity.downstream);
   }
 
   Future<void> _saveToClipboard(String text) {

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1252,16 +1252,16 @@ class CommonEditorOperations {
   /// This can be used, for example, to effectively delete an image by replacing
   /// it with an empty paragraph.
   ///
-  /// If [abortIfUndeletable] is `true`, the operation is be aborted if the
+  /// If [ignoreIfUndeletable] is `true`, the operation is be aborted if the
   /// node is not deletable.
   void replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(
     String nodeId, {
-    bool abortIfUndeletable = true,
+    bool ignoreIfUndeletable = true,
   }) {
     editor.execute([
       ReplaceNodeWithEmptyParagraphWithCaretRequest(
         nodeId: nodeId,
-        abortIfUndeletable: abortIfUndeletable,
+        ignoreIfUndeletable: ignoreIfUndeletable,
       ),
     ]);
   }

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -871,9 +871,15 @@ class CommonEditorOperations {
     if (composer.selection!.extent.nodePosition is UpstreamDownstreamNodePosition) {
       final nodePosition = composer.selection!.extent.nodePosition as UpstreamDownstreamNodePosition;
       if (nodePosition.affinity == TextAffinity.upstream) {
-        // The caret is sitting on the upstream edge of block-level content. Delete the
-        // whole block by replacing it with an empty paragraph.
+        // The caret is sitting on the upstream edge of block-level content.
         final nodeId = composer.selection!.extent.nodeId;
+
+        if (document.getNodeById(nodeId)!.metadata[NodeMetadata.isDeletable] == false) {
+          // The node is not deletable. Fizzle.
+          return false;
+        }
+
+        //Delete the whole block by replacing it with an empty paragraph.
         replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(nodeId);
 
         return true;
@@ -1057,9 +1063,15 @@ class CommonEditorOperations {
     if (composer.selection!.extent.nodePosition is UpstreamDownstreamNodePosition) {
       final nodePosition = composer.selection!.extent.nodePosition as UpstreamDownstreamNodePosition;
       if (nodePosition.affinity == TextAffinity.downstream) {
-        // The caret is sitting on the downstream edge of block-level content. Delete the
-        // whole block by replacing it with an empty paragraph.
+        // The caret is sitting on the downstream edge of block-level content.
         final nodeId = composer.selection!.extent.nodeId;
+
+        if (document.getNodeById(nodeId)!.metadata[NodeMetadata.isDeletable] == false) {
+          // The node is not deletable. Fizzle.
+          return false;
+        }
+
+        // Delete the whole block by replacing it with an empty paragraph.
         replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(nodeId);
 
         return true;
@@ -1251,18 +1263,9 @@ class CommonEditorOperations {
   ///
   /// This can be used, for example, to effectively delete an image by replacing
   /// it with an empty paragraph.
-  ///
-  /// If [ignoreIfUndeletable] is `true`, the operation is be aborted if the
-  /// node is not deletable.
-  void replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(
-    String nodeId, {
-    bool ignoreIfUndeletable = true,
-  }) {
+  void replaceBlockNodeWithEmptyParagraphAndCollapsedSelection(String nodeId) {
     editor.execute([
-      ReplaceNodeWithEmptyParagraphWithCaretRequest(
-        nodeId: nodeId,
-        ignoreIfUndeletable: ignoreIfUndeletable,
-      ),
+      ReplaceNodeWithEmptyParagraphWithCaretRequest(nodeId: nodeId),
     ]);
   }
 
@@ -1288,7 +1291,7 @@ class CommonEditorOperations {
   void _deleteExpandedSelection() {
     // Delete the selected content.
     editor.execute([
-      DeleteSelectionRequest(),
+      const DeleteSelectionRequest(),
     ]);
   }
 

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1286,17 +1286,9 @@ class CommonEditorOperations {
   }
 
   void _deleteExpandedSelection() {
-    final newSelectionPosition = getDocumentPositionAfterExpandedDeletion(
-      document: document,
-      selection: composer.selection!,
-    );
-
     // Delete the selected content.
     editor.execute([
-      DeleteContentRequest(
-        documentRange: composer.selection!,
-        newSelection: DocumentSelection.collapsed(position: newSelectionPosition),
-      ),
+      DeleteSelectionRequest(),
     ]);
   }
 

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -102,14 +102,14 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
   (request) => request is ReplaceNodeWithEmptyParagraphWithCaretRequest
       ? ReplaceNodeWithEmptyParagraphWithCaretCommand(
           nodeId: request.nodeId,
-          abortIfUndeletable: request.abortIfUndeletable,
+          ignoreIfUndeletable: request.ignoreIfUndeletable,
         )
       : null,
   (request) => request is DeleteContentRequest //
       ? DeleteContentCommand(documentRange: request.documentRange)
       : null,
   (request) => request is DeleteSelectionRequest //
-      ? DeleteSelectionCommand(ignoreUndeletableNodes: request.abortIfUndeletable)
+      ? DeleteSelectionCommand(ignoreUndeletableNodes: request.ignoreIfUndeletable)
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)
@@ -123,7 +123,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
   (request) => request is DeleteNodeRequest //
       ? DeleteNodeCommand(
           nodeId: request.nodeId,
-          abortIfUndeletable: request.abortIfUndeletable,
+          ignoreIfUndeletable: request.ignoreIfUndeletable,
         )
       : null,
   (request) => request is DeleteUpstreamCharacterRequest //

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -100,10 +100,17 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? ReplaceNodeCommand(existingNodeId: request.existingNodeId, newNode: request.newNode)
       : null,
   (request) => request is ReplaceNodeWithEmptyParagraphWithCaretRequest
-      ? ReplaceNodeWithEmptyParagraphWithCaretCommand(nodeId: request.nodeId)
+      ? ReplaceNodeWithEmptyParagraphWithCaretCommand(
+          nodeId: request.nodeId,
+          abortIfUndeletable: request.abortIfUndeletable,
+        )
       : null,
   (request) => request is DeleteContentRequest //
-      ? DeleteContentCommand(documentRange: request.documentRange)
+      ? DeleteContentCommand(
+          documentRange: request.documentRange,
+          newSelection: request.newSelection,
+          abortIfUndeletable: request.abortIfUndeletable,
+        )
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)
@@ -115,7 +122,10 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? DeleteUpstreamAtBeginningOfBlockNodeCommand(request.node)
       : null,
   (request) => request is DeleteNodeRequest //
-      ? DeleteNodeCommand(nodeId: request.nodeId)
+      ? DeleteNodeCommand(
+          nodeId: request.nodeId,
+          abortIfUndeletable: request.abortIfUndeletable,
+        )
       : null,
   (request) => request is DeleteUpstreamCharacterRequest //
       ? const DeleteUpstreamCharacterCommand()

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -100,16 +100,13 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? ReplaceNodeCommand(existingNodeId: request.existingNodeId, newNode: request.newNode)
       : null,
   (request) => request is ReplaceNodeWithEmptyParagraphWithCaretRequest
-      ? ReplaceNodeWithEmptyParagraphWithCaretCommand(
-          nodeId: request.nodeId,
-          ignoreIfUndeletable: request.ignoreIfUndeletable,
-        )
+      ? ReplaceNodeWithEmptyParagraphWithCaretCommand(nodeId: request.nodeId)
       : null,
   (request) => request is DeleteContentRequest //
       ? DeleteContentCommand(documentRange: request.documentRange)
       : null,
   (request) => request is DeleteSelectionRequest //
-      ? DeleteSelectionCommand(ignoreUndeletableNodes: request.ignoreIfUndeletable)
+      ? DeleteSelectionCommand()
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)
@@ -121,10 +118,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? DeleteUpstreamAtBeginningOfBlockNodeCommand(request.node)
       : null,
   (request) => request is DeleteNodeRequest //
-      ? DeleteNodeCommand(
-          nodeId: request.nodeId,
-          ignoreIfUndeletable: request.ignoreIfUndeletable,
-        )
+      ? DeleteNodeCommand(nodeId: request.nodeId)
       : null,
   (request) => request is DeleteUpstreamCharacterRequest //
       ? const DeleteUpstreamCharacterCommand()

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -106,11 +106,10 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
         )
       : null,
   (request) => request is DeleteContentRequest //
-      ? DeleteContentCommand(
-          documentRange: request.documentRange,
-          newSelection: request.newSelection,
-          abortIfUndeletable: request.abortIfUndeletable,
-        )
+      ? DeleteContentCommand(documentRange: request.documentRange)
+      : null,
+  (request) => request is DeleteSelectionRequest //
+      ? DeleteSelectionCommand(abortIfUndeletable: request.abortIfUndeletable)
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -109,7 +109,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? DeleteContentCommand(documentRange: request.documentRange)
       : null,
   (request) => request is DeleteSelectionRequest //
-      ? DeleteSelectionCommand(abortIfUndeletable: request.abortIfUndeletable)
+      ? DeleteSelectionCommand(ignoreUndeletableNodes: request.abortIfUndeletable)
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)

--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -106,7 +106,7 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
       ? DeleteContentCommand(documentRange: request.documentRange)
       : null,
   (request) => request is DeleteSelectionRequest //
-      ? DeleteSelectionCommand()
+      ? DeleteSelectionCommand(affinity: request.affinity)
       : null,
   (request) => request is DeleteUpstreamAtBeginningOfNodeRequest && request.node is ListItemNode
       ? ConvertListItemToParagraphCommand(nodeId: request.node.id, paragraphMetadata: request.node.metadata)

--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -402,7 +402,9 @@ ExecutionInstruction anyCharacterOrDestructiveKeyToDeleteSelection({
     return ExecutionInstruction.continueExecution;
   }
 
-  editContext.commonOps.deleteSelection();
+  editContext.commonOps.deleteSelection(
+    keyEvent.logicalKey == LogicalKeyboardKey.backspace ? TextAffinity.upstream : TextAffinity.downstream,
+  );
 
   if (isCharacterKey) {
     // We continue handler execution even though we deleted the selection.
@@ -777,7 +779,7 @@ ExecutionInstruction deleteToStartOfLineWithCmdBackspaceOnMac({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.upstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }
@@ -810,7 +812,7 @@ ExecutionInstruction deleteToEndOfLineWithCmdDeleteOnMac({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.downstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }
@@ -843,7 +845,7 @@ ExecutionInstruction deleteWordUpstreamWithAltBackspaceOnMac({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.upstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }
@@ -876,7 +878,7 @@ ExecutionInstruction deleteWordUpstreamWithControlBackspaceOnWindowsAndLinux({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.upstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }
@@ -909,7 +911,7 @@ ExecutionInstruction deleteWordDownstreamWithAltDeleteOnMac({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.downstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }
@@ -942,7 +944,7 @@ ExecutionInstruction deleteWordDownstreamWithControlDeleteOnWindowsAndLinux({
   );
 
   if (didMove) {
-    return editContext.commonOps.deleteSelection()
+    return editContext.commonOps.deleteSelection(TextAffinity.downstream)
         ? ExecutionInstruction.haltExecution
         : ExecutionInstruction.continueExecution;
   }

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -411,8 +411,8 @@ class TextDeltasDocumentEditor {
         docSelectionToDelete.isCollapsed ? SelectionChangeType.collapseSelection : SelectionChangeType.expandSelection,
         SelectionReason.contentChange,
       ),
+      DeleteSelectionRequest(),
     ]);
-    commonOps.deleteSelection();
   }
 
   void insertNewline() {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -411,7 +411,7 @@ class TextDeltasDocumentEditor {
         docSelectionToDelete.isCollapsed ? SelectionChangeType.collapseSelection : SelectionChangeType.expandSelection,
         SelectionReason.contentChange,
       ),
-      const DeleteSelectionRequest(),
+      const DeleteSelectionRequest(affinity: TextAffinity.upstream),
     ]);
   }
 
@@ -576,7 +576,7 @@ class TextDeltasDocumentEditor {
 
   void _insertNewlineFromHardwareKey() {
     if (!selection.value!.isCollapsed) {
-      commonOps.deleteSelection();
+      commonOps.deleteSelection(TextAffinity.downstream);
     }
     commonOps.insertBlockLevelNewline();
   }

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -411,7 +411,7 @@ class TextDeltasDocumentEditor {
         docSelectionToDelete.isCollapsed ? SelectionChangeType.collapseSelection : SelectionChangeType.expandSelection,
         SelectionReason.contentChange,
       ),
-      const DeleteSelectionRequest(affinity: TextAffinity.upstream),
+      const DeleteSelectionRequest(TextAffinity.upstream),
     ]);
   }
 

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -411,7 +411,7 @@ class TextDeltasDocumentEditor {
         docSelectionToDelete.isCollapsed ? SelectionChangeType.collapseSelection : SelectionChangeType.expandSelection,
         SelectionReason.contentChange,
       ),
-      DeleteSelectionRequest(),
+      const DeleteSelectionRequest(),
     ]);
   }
 

--- a/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
+++ b/super_editor/lib/src/default_editor/document_ime/supereditor_ime_interactor.dart
@@ -661,7 +661,7 @@ void deleteWordBackward(SuperEditorContext context) {
   );
 
   if (didMove) {
-    context.commonOps.deleteSelection();
+    context.commonOps.deleteSelection(TextAffinity.upstream);
   }
 }
 
@@ -674,7 +674,7 @@ void deleteWordForward(SuperEditorContext context) {
   );
 
   if (didMove) {
-    context.commonOps.deleteSelection();
+    context.commonOps.deleteSelection(TextAffinity.downstream);
   }
 }
 
@@ -687,7 +687,7 @@ void deleteToBeginningOfLine(SuperEditorContext context) {
   );
 
   if (didMove) {
-    context.commonOps.deleteSelection();
+    context.commonOps.deleteSelection(TextAffinity.upstream);
   }
 }
 
@@ -700,7 +700,7 @@ void deleteToEndOfLine(SuperEditorContext context) {
   );
 
   if (didMove) {
-    context.commonOps.deleteSelection();
+    context.commonOps.deleteSelection(TextAffinity.downstream);
   }
 }
 

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -12,7 +12,9 @@ import 'layout_single_column/layout_single_column.dart';
 class HorizontalRuleNode extends BlockNode with ChangeNotifier {
   HorizontalRuleNode({
     required this.id,
+    Map<String, dynamic>? metadata,
   }) {
+    super.metadata = metadata ?? {};
     putMetadataValue("blockType", const NamedAttribution("horizontalRule"));
   }
 

--- a/super_editor/lib/src/default_editor/horizontal_rule.dart
+++ b/super_editor/lib/src/default_editor/horizontal_rule.dart
@@ -12,9 +12,8 @@ import 'layout_single_column/layout_single_column.dart';
 class HorizontalRuleNode extends BlockNode with ChangeNotifier {
   HorizontalRuleNode({
     required this.id,
-    Map<String, dynamic>? metadata,
+    super.metadata,
   }) {
-    super.metadata = metadata ?? {};
     putMetadataValue("blockType", const NamedAttribution("horizontalRule"));
   }
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -1078,12 +1078,16 @@ class DeleteContentCommand extends EditCommand {
 
 /// Deletes the selected content within the document.
 ///
-/// Any non-deletable nodes within the selection are ignored.
+/// Any selected, non-deletable nodes are retained without removal.
 ///
 /// The [affinity] defines the direction to where the user is trying to
 /// delete. For example, if the users presses the backspace key, the
 /// [affinity] should be [TextAffinity.upstream]. If the user presses the
-/// delete key, the [affinity] should be [TextAffinity.downstream].
+/// delete key, the [affinity] should be [TextAffinity.downstream]. The
+/// [affinity] influences the new selection after the deletion when the
+/// dowstream of upstream node is non-deletable. For example, pressing
+/// backspace when the upstream node is not deletable doesn't change
+/// the selection, but pressing delete does.
 class DeleteSelectionRequest implements EditRequest {
   const DeleteSelectionRequest(this.affinity);
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -616,11 +616,11 @@ class ReplaceNodeCommand extends EditCommand {
 class ReplaceNodeWithEmptyParagraphWithCaretRequest implements EditRequest {
   const ReplaceNodeWithEmptyParagraphWithCaretRequest({
     required this.nodeId,
-    this.abortIfUndeletable = true,
+    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool abortIfUndeletable;
+  final bool ignoreIfUndeletable;
 
   @override
   bool operator ==(Object other) =>
@@ -628,20 +628,20 @@ class ReplaceNodeWithEmptyParagraphWithCaretRequest implements EditRequest {
       other is ReplaceNodeWithEmptyParagraphWithCaretRequest &&
           runtimeType == other.runtimeType &&
           nodeId == other.nodeId &&
-          abortIfUndeletable == other.abortIfUndeletable;
+          ignoreIfUndeletable == other.ignoreIfUndeletable;
 
   @override
-  int get hashCode => nodeId.hashCode ^ abortIfUndeletable.hashCode;
+  int get hashCode => nodeId.hashCode ^ ignoreIfUndeletable.hashCode;
 }
 
 class ReplaceNodeWithEmptyParagraphWithCaretCommand extends EditCommand {
   ReplaceNodeWithEmptyParagraphWithCaretCommand({
     required this.nodeId,
-    this.abortIfUndeletable = true,
+    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool abortIfUndeletable;
+  final bool ignoreIfUndeletable;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -655,7 +655,7 @@ class ReplaceNodeWithEmptyParagraphWithCaretCommand extends EditCommand {
       return;
     }
 
-    if (abortIfUndeletable && oldNode.metadata[NodeMetadata.isDeletable] == false) {
+    if (ignoreIfUndeletable && oldNode.metadata[NodeMetadata.isDeletable] == false) {
       return;
     }
 
@@ -729,7 +729,7 @@ class DeleteContentCommand extends EditCommand {
     if (nodes.length == 1) {
       // This is a selection within a single node.
 
-      if (nodes.first.metadata[NodeMetadata.isDeletable] == false) {
+      if (ignoreUndeletableNodes && nodes.first.metadata[NodeMetadata.isDeletable] == false) {
         // The node is not deletable. Abort the deletion.
         if (nodes.first is BlockNode && selection?.isCollapsed == false) {
           // On iOS, pressing backspace generates a non-text delta expanding the selection
@@ -791,7 +791,7 @@ class DeleteContentCommand extends EditCommand {
       ),
     );
 
-    if (startNode.metadata[NodeMetadata.isDeletable] != false) {
+    if (ignoreUndeletableNodes && startNode.metadata[NodeMetadata.isDeletable] != false) {
       _log.log('DeleteSelectionCommand', ' - deleting partial selection within the starting node.');
       executor.logChanges(
         _deleteRangeWithinNodeFromPositionToEnd(
@@ -803,7 +803,7 @@ class DeleteContentCommand extends EditCommand {
       );
     }
 
-    if (endNode.metadata[NodeMetadata.isDeletable] != false) {
+    if (ignoreUndeletableNodes && endNode.metadata[NodeMetadata.isDeletable] != false) {
       _log.log('DeleteSelectionCommand', ' - deleting partial selection within ending node.');
       executor.logChanges(
         _deleteRangeWithinNodeFromStartToPosition(
@@ -959,7 +959,7 @@ class DeleteContentCommand extends EditCommand {
     for (int i = endIndex - 1; i > startIndex; --i) {
       _log.log('_deleteNodesBetweenFirstAndLast', ' - deleting node $i: ${document.getNodeAt(i)?.id}');
       final removedNode = document.getNodeAt(i)!;
-      if (removedNode.metadata[NodeMetadata.isDeletable] == false) {
+      if (ignoreUndeletableNodes && removedNode.metadata[NodeMetadata.isDeletable] == false) {
         // This node is not deletable. Ignore it.
         continue;
       }
@@ -1124,10 +1124,10 @@ class DeleteContentCommand extends EditCommand {
 
 class DeleteSelectionRequest implements EditRequest {
   DeleteSelectionRequest({
-    this.abortIfUndeletable = true,
+    this.ignoreIfUndeletable = true,
   });
 
-  final bool abortIfUndeletable;
+  final bool ignoreIfUndeletable;
 }
 
 class DeleteSelectionCommand extends EditCommand {
@@ -1193,21 +1193,21 @@ class DeleteUpstreamAtBeginningOfNodeRequest implements EditRequest {
 class DeleteNodeRequest implements EditRequest {
   DeleteNodeRequest({
     required this.nodeId,
-    this.abortIfUndeletable = true,
+    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool abortIfUndeletable;
+  final bool ignoreIfUndeletable;
 }
 
 class DeleteNodeCommand extends EditCommand {
   DeleteNodeCommand({
     required this.nodeId,
-    this.abortIfUndeletable = true,
+    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool abortIfUndeletable;
+  final bool ignoreIfUndeletable;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -1223,7 +1223,7 @@ class DeleteNodeCommand extends EditCommand {
       return;
     }
 
-    if (abortIfUndeletable && node.metadata[NodeMetadata.isDeletable] == false) {
+    if (ignoreIfUndeletable && node.metadata[NodeMetadata.isDeletable] == false) {
       // The node is marked as undeletable. Fizzle.
       return;
     }

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -711,7 +711,7 @@ class DeleteContentCommand extends EditCommand {
     if (nodes.length == 1) {
       // This is a selection within a single node.
 
-      if (nodes.first.metadata[NodeMetadata.isDeletable] == false) {
+      if (!nodes.first.isDeletable) {
         // The node is not deletable. Abort the deletion.
         if (nodes.first is BlockNode && selection?.isCollapsed == false) {
           // On iOS, pressing backspace generates a non-text delta expanding the selection
@@ -763,7 +763,7 @@ class DeleteContentCommand extends EditCommand {
       ),
     );
 
-    if (startNode.metadata[NodeMetadata.isDeletable] != false) {
+    if (startNode.isDeletable) {
       _log.log('DeleteSelectionCommand', ' - deleting partial selection within the starting node.');
       executor.logChanges(
         _deleteRangeWithinNodeFromPositionToEnd(
@@ -775,7 +775,7 @@ class DeleteContentCommand extends EditCommand {
       );
     }
 
-    if (endNode.metadata[NodeMetadata.isDeletable] != false) {
+    if (endNode.isDeletable) {
       _log.log('DeleteSelectionCommand', ' - deleting partial selection within ending node.');
       executor.logChanges(
         _deleteRangeWithinNodeFromStartToPosition(
@@ -913,7 +913,7 @@ class DeleteContentCommand extends EditCommand {
     for (int i = endIndex - 1; i > startIndex; --i) {
       _log.log('_deleteNodesBetweenFirstAndLast', ' - deleting node $i: ${document.getNodeAt(i)?.id}');
       final removedNode = document.getNodeAt(i)!;
-      if (removedNode.metadata[NodeMetadata.isDeletable] == false) {
+      if (!removedNode.isDeletable) {
         // This node is not deletable. Ignore it.
         continue;
       }
@@ -1076,10 +1076,16 @@ class DeleteContentCommand extends EditCommand {
   }
 }
 
+/// Deletes the selected content within the document.
+///
+/// Any non-deletable nodes within the selection are ignored.
+///
+/// The [affinity] defines the direction to where the user is trying to
+/// delete. For example, if the users presses the backspace key, the
+/// [affinity] should be [TextAffinity.upstream]. If the user presses the
+/// delete key, the [affinity] should be [TextAffinity.downstream].
 class DeleteSelectionRequest implements EditRequest {
-  const DeleteSelectionRequest({
-    required this.affinity,
-  });
+  const DeleteSelectionRequest(this.affinity);
 
   final TextAffinity affinity;
 }
@@ -1112,7 +1118,7 @@ class DeleteSelectionCommand extends EditCommand {
       // if the node is non-deletable. When there are multiple nodes selected,
       // non-deletable nodes are ignored inside DeleteContentCommand.
       final node = document.getNodeById(selection.base.nodeId)!;
-      if (node.metadata[NodeMetadata.isDeletable] == false) {
+      if (!node.isDeletable) {
         if (node is BlockNode && !selection.isCollapsed) {
           // On iOS, pressing backspace generates a non-text delta expanding the selection
           // prior to its deletion. Since we can't delete the block, we'll just collapse the

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -699,17 +699,17 @@ class DeleteContentCommand extends EditCommand {
   DeleteContentCommand({
     required this.documentRange,
     this.newSelection,
-    this.abortIfUndeletable = true,
+    this.ignoreUndeletableNodes = true,
   });
 
   final DocumentRange documentRange;
   final DocumentSelection? newSelection;
 
-  /// If `true`, the command will abort if any of the nodes in [documentRange]
-  /// have the `deletable` metadata set to `false`.
+  /// If `true`, the command will ignore any nodes which have the `deletable`
+  /// metadata set to `false`.
   ///
   /// Defaults to `true`.
-  final bool abortIfUndeletable;
+  final bool ignoreUndeletableNodes;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -1113,14 +1113,14 @@ class DeleteSelectionRequest implements EditRequest {
 
 class DeleteSelectionCommand extends EditCommand {
   DeleteSelectionCommand({
-    this.abortIfUndeletable = true,
+    this.ignoreUndeletableNodes = true,
   });
 
-  /// If `true`, the command will abort if any of the nodes in [documentRange]
+  /// If `true`, the command will ignore any nodes in the selection which
   /// have the `isDeletable` metadata set to `false`.
   ///
   /// Defaults to `true`.
-  final bool abortIfUndeletable;
+  final bool ignoreUndeletableNodes;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -1147,7 +1147,7 @@ class DeleteSelectionCommand extends EditCommand {
       DeleteContentCommand(
         documentRange: selection,
         newSelection: DocumentSelection.collapsed(position: newSelectionPosition),
-        abortIfUndeletable: abortIfUndeletable,
+        ignoreUndeletableNodes: ignoreUndeletableNodes,
       ),
     );
   }

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -616,32 +616,27 @@ class ReplaceNodeCommand extends EditCommand {
 class ReplaceNodeWithEmptyParagraphWithCaretRequest implements EditRequest {
   const ReplaceNodeWithEmptyParagraphWithCaretRequest({
     required this.nodeId,
-    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool ignoreIfUndeletable;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ReplaceNodeWithEmptyParagraphWithCaretRequest &&
           runtimeType == other.runtimeType &&
-          nodeId == other.nodeId &&
-          ignoreIfUndeletable == other.ignoreIfUndeletable;
+          nodeId == other.nodeId;
 
   @override
-  int get hashCode => nodeId.hashCode ^ ignoreIfUndeletable.hashCode;
+  int get hashCode => nodeId.hashCode;
 }
 
 class ReplaceNodeWithEmptyParagraphWithCaretCommand extends EditCommand {
   ReplaceNodeWithEmptyParagraphWithCaretCommand({
     required this.nodeId,
-    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool ignoreIfUndeletable;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -652,10 +647,6 @@ class ReplaceNodeWithEmptyParagraphWithCaretCommand extends EditCommand {
 
     final oldNode = document.getNodeById(nodeId);
     if (oldNode == null) {
-      return;
-    }
-
-    if (ignoreIfUndeletable && oldNode.metadata[NodeMetadata.isDeletable] == false) {
       return;
     }
 
@@ -1123,23 +1114,11 @@ class DeleteContentCommand extends EditCommand {
 }
 
 class DeleteSelectionRequest implements EditRequest {
-  DeleteSelectionRequest({
-    this.ignoreIfUndeletable = true,
-  });
-
-  final bool ignoreIfUndeletable;
+  const DeleteSelectionRequest();
 }
 
 class DeleteSelectionCommand extends EditCommand {
-  DeleteSelectionCommand({
-    this.ignoreUndeletableNodes = true,
-  });
-
-  /// If `true`, the command will ignore any nodes in the selection which
-  /// have the `isDeletable` metadata set to `false`.
-  ///
-  /// Defaults to `true`.
-  final bool ignoreUndeletableNodes;
+  DeleteSelectionCommand();
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -1166,7 +1145,7 @@ class DeleteSelectionCommand extends EditCommand {
       DeleteContentCommand(
         documentRange: selection,
         newSelection: DocumentSelection.collapsed(position: newSelectionPosition),
-        ignoreUndeletableNodes: ignoreUndeletableNodes,
+        ignoreUndeletableNodes: true,
       ),
     );
   }
@@ -1193,21 +1172,17 @@ class DeleteUpstreamAtBeginningOfNodeRequest implements EditRequest {
 class DeleteNodeRequest implements EditRequest {
   DeleteNodeRequest({
     required this.nodeId,
-    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool ignoreIfUndeletable;
 }
 
 class DeleteNodeCommand extends EditCommand {
   DeleteNodeCommand({
     required this.nodeId,
-    this.ignoreIfUndeletable = true,
   });
 
   final String nodeId;
-  final bool ignoreIfUndeletable;
 
   @override
   HistoryBehavior get historyBehavior => HistoryBehavior.undoable;
@@ -1220,11 +1195,6 @@ class DeleteNodeCommand extends EditCommand {
     final node = document.getNodeById(nodeId);
     if (node == null) {
       _log.log('DeleteNodeCommand', 'No such node. Returning.');
-      return;
-    }
-
-    if (ignoreIfUndeletable && node.metadata[NodeMetadata.isDeletable] == false) {
-      // The node is marked as undeletable. Fizzle.
       return;
     }
 

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -483,7 +483,7 @@ class CombineParagraphsCommand extends EditCommand {
       return;
     }
 
-    // Search for the node above the second node that matches the first node.
+    // Search for a node above the second node that has the id equal to `firstNodeId`.
     //
     // A `CombineParagraphsRequest` might reference nodes that are not contiguous.
     // For example, we might have:
@@ -783,7 +783,7 @@ class DeleteUpstreamAtBeginningOfParagraphCommand extends EditCommand {
   /// Merges the selected [TextNode] with the upstream [TextNode].
   ///
   /// If there are non-deletable [BlockNode]s between the two [TextNode]s,
-  /// the [BlockNode]s are ignored.
+  /// the [BlockNode]s are retained without modification.
   bool mergeTextNodeWithUpstreamTextNode(
     CommandExecutor executor,
     MutableDocument document,

--- a/super_editor/lib/src/default_editor/paragraph.dart
+++ b/super_editor/lib/src/default_editor/paragraph.dart
@@ -10,6 +10,7 @@ import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/blocks/indentation.dart';
+import 'package:super_editor/src/default_editor/box_component.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -476,12 +477,29 @@ class CombineParagraphsCommand extends EditCommand {
       return;
     }
 
-    final nodeAbove = document.getNodeBefore(secondNode);
+    DocumentNode? nodeAbove = document.getNodeBefore(secondNode);
     if (nodeAbove == null) {
       editorDocLog.info('At top of document. Cannot merge with node above.');
       return;
     }
-    if (nodeAbove.id != firstNodeId) {
+
+    // Search for the node above the second node that matches the first node.
+    //
+    // A `CombineParagraphsRequest` might reference nodes that are not contiguous.
+    // For example, we might have:
+    // - Paragraph 1
+    // - <hr> (non-selectable, non-deletable)
+    // - Paragraph 2
+    //
+    // If this case, it's possible to combine Paragraph 1 and Paragraph 2.
+    //
+    // Because of this, we need to loop until we find the node instead of just
+    // comparing with the node immediately above the second node.
+    while (nodeAbove != null && nodeAbove.id != firstNodeId) {
+      nodeAbove = document.getNodeBefore(nodeAbove);
+    }
+
+    if (nodeAbove == null) {
       editorDocLog.info('The specified `firstNodeId` is not the node before `secondNodeId`.');
       return;
     }
@@ -725,7 +743,11 @@ class DeleteUpstreamAtBeginningOfParagraphCommand extends EditCommand {
       return;
     }
 
-    final nodeBefore = document.getNodeBefore(node);
+    DocumentNode? nodeBefore = document.getNodeBefore(node);
+    while (nodeBefore is BlockNode && !nodeBefore.isDeletable) {
+      nodeBefore = document.getNodeBefore(nodeBefore);
+    }
+
     if (nodeBefore == null) {
       return;
     }
@@ -758,6 +780,10 @@ class DeleteUpstreamAtBeginningOfParagraphCommand extends EditCommand {
     }
   }
 
+  /// Merges the selected [TextNode] with the upstream [TextNode].
+  ///
+  /// If there are non-deletable [BlockNode]s between the two [TextNode]s,
+  /// the [BlockNode]s are ignored.
   bool mergeTextNodeWithUpstreamTextNode(
     CommandExecutor executor,
     MutableDocument document,
@@ -768,7 +794,11 @@ class DeleteUpstreamAtBeginningOfParagraphCommand extends EditCommand {
       return false;
     }
 
-    final nodeAbove = document.getNodeBefore(node);
+    DocumentNode? nodeAbove = document.getNodeBefore(node);
+    while (nodeAbove is BlockNode && !nodeAbove.isDeletable) {
+      nodeAbove = document.getNodeBefore(nodeAbove);
+    }
+
     if (nodeAbove == null) {
       return false;
     }

--- a/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
+++ b/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
@@ -42,7 +43,7 @@ void main() {
           documentLayoutResolver: () => FakeDocumentLayout(),
         );
 
-        commonOps.deleteSelection();
+        commonOps.deleteSelection(TextAffinity.downstream);
 
         expect(document.nodeCount, 1);
         expect(document.first.id, "2");
@@ -80,7 +81,7 @@ void main() {
           documentLayoutResolver: () => FakeDocumentLayout(),
         );
 
-        commonOps.deleteSelection();
+        commonOps.deleteSelection(TextAffinity.downstream);
 
         expect(document.nodeCount, 1);
         expect(document.first.id, "2");
@@ -118,7 +119,7 @@ void main() {
           documentLayoutResolver: () => FakeDocumentLayout(),
         );
 
-        commonOps.deleteSelection();
+        commonOps.deleteSelection(TextAffinity.downstream);
 
         expect(document.nodeCount, 1);
         expect(document.first.id, "1");
@@ -151,7 +152,7 @@ void main() {
           documentLayoutResolver: () => FakeDocumentLayout(),
         );
 
-        commonOps.deleteSelection();
+        commonOps.deleteSelection(TextAffinity.downstream);
 
         expect(document.nodeCount, 1);
         expect(document.first, isA<ParagraphNode>());

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -1,0 +1,863 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../test_tools.dart';
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > undeletable content > prevents deletion > ', () {
+    group('with backspace', () {
+      testWidgetsOnArbitraryDesktop('at the downstream edge of the node', (tester) async {
+        await _pumpHrThenParagraphTestApp(tester);
+
+        // Place the caret at the downstream edge of the horizontal rule.
+        await tester.tapAtDocumentPosition(
+          const DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          ),
+        );
+
+        // Ensure the selection is at the downstream edge of the horizontal ruler.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.downstream(),
+            ),
+          ),
+        );
+
+        // Press backspace a few times trying to delete the node.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace a few times trying to delete the node.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace a few times trying to delete the node.
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnAllPlatforms('when multiple deletable and undeletable nodes are selected', (tester) async {
+        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+        // Select from "Para>graph 1" to "Paragraph <3".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: TextNodePosition(offset: 10),
+              ),
+            ),
+            SelectionChangeType.alteredContent,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected nodes.
+        await tester.pressBackspace();
+
+        // Ensure that the deletable content was deleted and selection moved to upstream edge
+        // of the first deletable node.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.nodeCount, 4);
+        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the undeletable content was not deleted.
+        expect(document.getNodeById('hr1'), isNotNull);
+        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr2'), isNotNull);
+        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr3'), isNotNull);
+        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'graph 1',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the deletable content was deleted and selection moved to the upstream edge
+        // of the selection
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'Para',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop(
+          'when selection starts at an upstream deletable node and ends at the downstream edge', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop(
+          'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the "Para|graph 2" to the upstream edge of the second horizontal ruler.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+    });
+
+    group('with delete', () {
+      testWidgetsOnArbitraryDesktop('at the upstream edge of the node', (tester) async {
+        await _pumpParagraphThenHrTestApp(tester);
+
+        // Place the caret at the upstream edge of the horizontal rule.
+        await tester.tapAtDocumentPosition(
+          const DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.upstream(),
+          ),
+        );
+
+        // Ensure the selection is at the beginning of the horizontal rule.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          ),
+        );
+
+        // Press delete a few times trying to delete the node.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete a few times trying to delete the node.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete a few times trying to delete the node.
+        await tester.pressDelete();
+        await tester.pressDelete();
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('when multiple deletable and undeletable nodes are selected', (tester) async {
+        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+        // Select from "Para>graph 1" to "Paragraph <3".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: TextNodePosition(offset: 10),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to delete the selected nodes.
+        await tester.pressDelete();
+
+        // Ensure that the deletable content was deleted and selection moved to upstream edge
+        // of the first deletable node.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.nodeCount, 4);
+        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the undeletable content was not deleted.
+        expect(document.getNodeById('hr1'), isNotNull);
+        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr2'), isNotNull);
+        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr3'), isNotNull);
+        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'graph 1',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the deletable content was deleted and selection moved to the upstream edge
+        // of the selection
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'Para',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal ruler was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop(
+          'when selection starts at an upstream deletable node and ends at the downstream edge', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnArbitraryDesktop(
+          'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the "Para|graph 2" to the upstream edge of the second horizontal ruler.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+    });
+
+    group('when typing', () {
+      testWidgetsOnArbitraryDesktop('when typing with multiple nodes selected', (tester) async {
+        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+        // Select from "Para>graph 1" to "Paragraph <3".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: TextNodePosition(offset: 10),
+              ),
+            ),
+            SelectionChangeType.alteredContent,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Type a character to replace the selected nodes.
+        await tester.typeImeText('X');
+
+        // Ensure that the deletable content was deleted and the text was inserted at the upstream
+        // edge of the selection.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.nodeCount, 4);
+        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('ParaX3'));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
+            ),
+          ),
+        );
+
+        // Ensure that the undeletable content was not deleted.
+        expect(document.getNodeById('hr1'), isNotNull);
+        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr2'), isNotNull);
+        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr3'), isNotNull);
+        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+      });
+    });
+
+    // group('with backspace in software keyboard', () {
+    //   testWidgetsOnMobile('at the downstream edge of the node', (tester) async {
+    //     await _pumpHrThenParagraphTestApp(tester);
+
+    //     // Place the caret at the downstream edge of the horizontal rule.
+    //     await tester.tapAtDocumentPosition(
+    //       const DocumentPosition(
+    //         nodeId: 'hr',
+    //         nodePosition: UpstreamDownstreamNodePosition.downstream(),
+    //       ),
+    //     );
+    //     await tester.pump();
+
+    //     // Simulate pressing backspace.
+    //     await tester.ime.sendDeltas([
+    //       const TextEditingDeltaNonTextUpdate(
+    //         oldText: '. ~',
+    //         selection: TextSelection.collapsed(offset: 3),
+    //         composing: TextRange(start: -1, end: -1),
+    //       ),
+    //       const TextEditingDeltaDeletion(
+    //         oldText: '. ~',
+    //         deletedRange: TextRange.collapsed(2),
+    //         selection: TextSelection.collapsed(offset: 2),
+    //         composing: TextRange(start: -1, end: -1),
+    //       ),
+    //     ], getter: imeClientGetter);
+
+    //     // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+    //     final document = SuperEditorInspector.findDocument()!;
+    //     expect(document.getNodeById('hr'), isNotNull);
+    //     expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+    //     // Ensure the selection was kept where it was.
+    //     expect(
+    //       SuperEditorInspector.findDocumentSelection(),
+    //       const DocumentSelection.collapsed(
+    //         position: DocumentPosition(
+    //           nodeId: 'hr',
+    //           nodePosition: UpstreamDownstreamNodePosition.downstream(),
+    //         ),
+    //       ),
+    //     );
+    //   });
+    // });
+  });
+}
+
+/// Pumps a widget tree with a paragraph followed by a horizontal rule.
+Future<TestDocumentContext> _pumpParagraphThenHrTestApp(WidgetTester tester) async {
+  return await tester
+      .createDocument()
+      .withCustomContent(
+        MutableDocument(
+          nodes: [
+            ParagraphNode(
+              id: '1',
+              text: AttributedText('Paragraph 1'),
+            ),
+            HorizontalRuleNode(id: 'hr', metadata: {
+              NodeMetadata.isDeletable: false,
+            }),
+          ],
+        ),
+      )
+      .withInputSource(TextInputSource.ime)
+      .autoFocus(true)
+      .pump();
+}
+
+/// Pumps a widget tree with a horizontal rule followed by a paragraph.
+Future<TestDocumentContext> _pumpHrThenParagraphTestApp(WidgetTester tester) async {
+  return await tester
+      .createDocument()
+      .withCustomContent(
+        MutableDocument(
+          nodes: [
+            HorizontalRuleNode(id: 'hr', metadata: {
+              NodeMetadata.isDeletable: false,
+            }),
+            ParagraphNode(
+              id: '1',
+              text: AttributedText('Paragraph 1'),
+            ),
+          ],
+        ),
+      )
+      .withInputSource(TextInputSource.ime)
+      .autoFocus(true)
+      .pump();
+}
+
+/// Pumps a widget tree containing:
+///
+/// - Paragraph.
+/// - Horizontal rule.
+/// - Horizontal rule.
+/// - Paragraph.
+/// - Horizontal rule.
+/// - Paragraph.
+Future<TestDocumentContext> _pumpMultipleDeletableAndUndeletableNodesTestApp(WidgetTester tester) async {
+  return await tester
+      .createDocument()
+      .withCustomContent(
+        MutableDocument(
+          nodes: [
+            ParagraphNode(
+              id: '1',
+              text: AttributedText('Paragraph 1'),
+            ),
+            HorizontalRuleNode(id: 'hr1', metadata: {
+              NodeMetadata.isDeletable: false,
+            }),
+            HorizontalRuleNode(id: 'hr2', metadata: {
+              NodeMetadata.isDeletable: false,
+            }),
+            ParagraphNode(
+              id: '2',
+              text: AttributedText('Paragraph 2'),
+            ),
+            HorizontalRuleNode(id: 'hr3', metadata: {
+              NodeMetadata.isDeletable: false,
+            }),
+            ParagraphNode(
+              id: '3',
+              text: AttributedText('Paragraph 3'),
+            ),
+          ],
+        ),
+      )
+      .withInputSource(TextInputSource.ime)
+      .autoFocus(true)
+      .pump();
+}

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -67,7 +67,13 @@ void main() {
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
 
-        // Ensure the caret moved to the end of the first paragraph.
+        // Ensure the two paragraphs were merged.
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'Paragraph 1Paragraph 2',
+        );
+
+        // Ensure the caret moved to the end of existing test of the first paragraph.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           selectionEquivalentTo(
@@ -434,6 +440,12 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the two paragraphs were merged.
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'Paragraph 1Paragraph 2',
+        );
 
         // Ensure the caret stayed where it was.
         expect(

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -10,8 +10,11 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor > undeletable content > prevents deletion > ', () {
+    // The desktop tests run for all desktop platforms because on mac the backspace
+    // is handled by selectors and on the other platforms it is handled by the keyboard handlers.
+    // See `MacOsSelectors` for more information.
     group('with backspace', () {
-      testWidgetsOnArbitraryDesktop('at the downstream edge of the node', (tester) async {
+      testWidgetsOnDesktop('at the downstream edge of the node', (tester) async {
         await _pumpHrThenParagraphTestApp(tester);
 
         const hrDownstreamEdgePosition = DocumentPosition(
@@ -49,7 +52,7 @@ void main() {
         );
       });
 
-      testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
+      testWidgetsOnDesktop('with an expanded downstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select the whole hr. Use a command instead of a user gesture to have
@@ -83,7 +86,7 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
+      testWidgetsOnDesktop('with an expanded upstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select the whole hr. Use a command instead of a user gesture to have
@@ -167,7 +170,7 @@ void main() {
         expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+      testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
           (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
@@ -214,7 +217,7 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+      testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
           (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
@@ -261,8 +264,8 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop(
-          'when selection starts at an upstream deletable node and ends at the downstream edge', (tester) async {
+      testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
+          (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
@@ -305,8 +308,8 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop(
-          'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
+      testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
+          (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
         // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
@@ -351,7 +354,7 @@ void main() {
     });
 
     group('with delete', () {
-      testWidgetsOnArbitraryDesktop('at the upstream edge of the node', (tester) async {
+      testWidgetsOnDesktop('at the upstream edge of the node', (tester) async {
         await _pumpParagraphThenHrTestApp(tester);
 
         const hrUpstreamEdgePosition = DocumentPosition(
@@ -389,7 +392,7 @@ void main() {
         );
       });
 
-      testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
+      testWidgetsOnDesktop('with an expanded downstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select the whole hr. Use a command instead of a user gesture to have
@@ -423,7 +426,7 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
+      testWidgetsOnDesktop('with an expanded upstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select the whole hr. Use a command instead of a user gesture to have
@@ -457,7 +460,7 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('when multiple deletable and undeletable nodes are selected', (tester) async {
+      testWidgetsOnDesktop('when multiple deletable and undeletable nodes are selected', (tester) async {
         final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
 
         // Select from "Para>graph 1" to "Paragraph <3".
@@ -507,7 +510,7 @@ void main() {
         expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+      testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
           (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
@@ -554,7 +557,7 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+      testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
           (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
@@ -601,8 +604,8 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop(
-          'when selection starts at an upstream deletable node and ends at the downstream edge', (tester) async {
+      testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
+          (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
         // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
@@ -645,8 +648,8 @@ void main() {
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
 
-      testWidgetsOnArbitraryDesktop(
-          'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
+      testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
+          (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
         // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
@@ -691,7 +694,7 @@ void main() {
     });
 
     group('when typing', () {
-      testWidgetsOnArbitraryDesktop('when typing with multiple nodes selected', (tester) async {
+      testWidgetsOnDesktop('when typing with multiple nodes selected', (tester) async {
         final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
 
         // Select from "Para>graph 1" to "Paragraph <3".

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -386,6 +386,172 @@ void main() {
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
       });
+
+      testWidgetsOnDesktop(
+          'when selection starts at the dowstream edge and ends at the beginning of the downstream node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        const selection = DocumentSelection(
+          base: DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          ),
+          extent: DocumentPosition(
+            nodeId: '1',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Select from the end of the horizontal rule to the beginning of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            selection,
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(SuperEditorInspector.findDocumentSelection(), selection);
+      });
+
+      testWidgetsOnDesktop(
+          'when selection starts at the upstream edge and ends at the beginning of the downstream node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        const selection = DocumentSelection(
+          base: DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.upstream(),
+          ),
+          extent: DocumentPosition(
+            nodeId: '1',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Select from the beginning of the horizontal rule to the beginning of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            selection,
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(SuperEditorInspector.findDocumentSelection(), selection);
+      });
+
+      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the beginning of the horizontal rule to the end of the upstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 11),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection moved to the end of the upstream node.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 11),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the end of the horizontal rule to the end of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 11),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressBackspace();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection moved to the end of the upstream node.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 11),
+              ),
+            ),
+          ),
+        );
+      });
     });
 
     group('with delete', () {
@@ -759,6 +925,170 @@ void main() {
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the beginning of the downstream node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the end of horizontal rule to the beginning of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection moved to the beginning of the downstream node.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the beginning of the downstream node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the beginning of horizontal rule to the beginning of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press backspace to delete the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection moved to the beginning of the downstream node.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        const selection = DocumentSelection(
+          base: DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.upstream(),
+          ),
+          extent: DocumentPosition(
+            nodeId: '1',
+            nodePosition: TextNodePosition(offset: 11),
+          ),
+        );
+
+        // Select from the beginning of the horizontal rule to the end of the upstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            selection,
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(SuperEditorInspector.findDocumentSelection(), selection);
+      });
+
+      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        const selection = DocumentSelection(
+          base: DocumentPosition(
+            nodeId: 'hr',
+            nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          ),
+          extent: DocumentPosition(
+            nodeId: '1',
+            nodePosition: TextNodePosition(offset: 11),
+          ),
+        );
+
+        // Select from the end of the horizontal rule to the end of the downstream node.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            selection,
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Press delete to remove the selected content.
+        await tester.pressDelete();
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(SuperEditorInspector.findDocumentSelection(), selection);
       });
     });
 

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -14,1580 +14,1602 @@ void main() {
     // The desktop tests run for all desktop platforms because on mac the backspace
     // is handled by selectors and on the other platforms it is handled by the keyboard handlers.
     // See `MacOsSelectors` for more information.
-    group('with backspace', () {
-      testWidgetsOnDesktop('at the downstream edge of the node', (tester) async {
-        await _pumpHrThenParagraphTestApp(tester);
+    group('with collapsed selection > ', () {
+      group('with backspace', () {
+        testWidgetsOnDesktop('at the downstream edge of the node', (tester) async {
+          await _pumpHrThenParagraphTestApp(tester);
 
-        const hrDownstreamEdgePosition = DocumentPosition(
-          nodeId: 'hr',
-          nodePosition: UpstreamDownstreamNodePosition.downstream(),
-        );
-
-        // Place the caret at the downstream edge of the horizontal rule.
-        await tester.tapAtDocumentPosition(hrDownstreamEdgePosition);
-
-        // Ensure the selection is at the downstream edge of the horizontal rule.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrDownstreamEdgePosition,
-          ),
-        );
-
-        // Press backspace a few times trying to delete the node.
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection didn't change.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrDownstreamEdgePosition,
-          ),
-        );
-      });
-
-      testWidgetsOnDesktop('at the beginning of the downstream node', (tester) async {
-        await _pumpParagraphThenHrThenParagraphTestApp(tester);
-
-        // Place the caret at the beginning of the second paragraph.
-        await tester.placeCaretInParagraph('2', 0);
-
-        // Press backspace trying to delete the horizontal rule.
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the two paragraphs were merged.
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'Paragraph 1Paragraph 2',
-        );
-
-        // Ensure the caret moved to the end of existing test of the first paragraph.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
-              ),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnDesktop('with an expanded downstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace a few times trying to delete the node.
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('with an expanded upstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace a few times trying to delete the node.
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnAllPlatforms('when multiple deletable and undeletable nodes are selected', (tester) async {
-        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
-
-        // Select from "Para>graph 1" to "Paragraph <3".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: '3',
-                nodePosition: TextNodePosition(offset: 10),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected nodes.
-        await tester.pressBackspace();
-
-        // Ensure that the deletable content was deleted and the selection moved to upstream edge
-        // of the selection.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.nodeCount, 4);
-        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the undeletable content was not deleted.
-        expect(document.getNodeById('hr1'), isNotNull);
-        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr2'), isNotNull);
-        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr3'), isNotNull);
-        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'graph 1',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the deletable content was deleted and selection moved to the upstream edge
-        // of the selection
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'Para',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop(
-          'when selection starts at the dowstream edge and ends at the beginning of the downstream node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        const selection = DocumentSelection(
-          base: DocumentPosition(
+          const hrDownstreamEdgePosition = DocumentPosition(
             nodeId: 'hr',
             nodePosition: UpstreamDownstreamNodePosition.downstream(),
-          ),
-          extent: DocumentPosition(
-            nodeId: '1',
-            nodePosition: TextNodePosition(offset: 0),
-          ),
-        );
+          );
 
-        // Select from the end of the horizontal rule to the beginning of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            selection,
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          // Place the caret at the downstream edge of the horizontal rule.
+          await tester.tapAtDocumentPosition(hrDownstreamEdgePosition);
 
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
+          // Ensure the selection is at the downstream edge of the horizontal rule.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: hrDownstreamEdgePosition,
+            ),
+          );
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          // Press backspace a few times trying to delete the node.
+          await tester.pressBackspace();
+          await tester.pressBackspace();
+          await tester.pressBackspace();
 
-        // Ensure the selection didn't change.
-        expect(SuperEditorInspector.findDocumentSelection(), selection);
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection didn't change.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: hrDownstreamEdgePosition,
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('at the beginning of the downstream node', (tester) async {
+          await _pumpParagraphThenHrThenParagraphTestApp(tester);
+
+          // Place the caret at the beginning of the second paragraph.
+          await tester.placeCaretInParagraph('2', 0);
+
+          // Press backspace trying to delete the horizontal rule.
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the two paragraphs were merged.
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'Paragraph 1Paragraph 2',
+          );
+
+          // Ensure the caret moved to the end of existing test of the first paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
+              ),
+            ),
+          );
+        });
       });
 
-      testWidgetsOnDesktop(
-          'when selection starts at the upstream edge and ends at the beginning of the downstream node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
+      group('with delete', () {
+        testWidgetsOnDesktop('at the upstream edge of the node', (tester) async {
+          await _pumpParagraphThenHrTestApp(tester);
 
-        const selection = DocumentSelection(
-          base: DocumentPosition(
+          const hrUpstreamEdgePosition = DocumentPosition(
             nodeId: 'hr',
             nodePosition: UpstreamDownstreamNodePosition.upstream(),
-          ),
-          extent: DocumentPosition(
-            nodeId: '1',
-            nodePosition: TextNodePosition(offset: 0),
-          ),
-        );
+          );
 
-        // Select from the beginning of the horizontal rule to the beginning of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            selection,
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          // Place the caret at the upstream edge of the horizontal rule.
+          await tester.tapAtDocumentPosition(hrUpstreamEdgePosition);
 
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection didn't change.
-        expect(SuperEditorInspector.findDocumentSelection(), selection);
-      });
-
-      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the beginning of the horizontal rule to the end of the upstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection moved to the end of the upstream node.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
+          // Ensure the selection is at the beginning of the horizontal rule.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
-              ),
+              position: hrUpstreamEdgePosition,
             ),
-          ),
-        );
-      });
+          );
 
-      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
+          // Press delete a few times trying to delete the node.
+          await tester.pressDelete();
+          await tester.pressDelete();
+          await tester.pressDelete();
 
-        // Select from the end of the horizontal rule to the end of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
 
-        // Press backspace to delete the selected content.
-        await tester.pressBackspace();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection moved to the end of the upstream node.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
+          // Ensure the selection didn't change.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
             const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
+              position: hrUpstreamEdgePosition,
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('at the end of the upstream node', (tester) async {
+          await _pumpParagraphThenHrThenParagraphTestApp(tester);
+
+          // Place the caret at the end of the first paragraph.
+          await tester.placeCaretInParagraph('1', 11);
+
+          // Press backspace trying to delete the horizontal rule.
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the two paragraphs were merged.
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'Paragraph 1Paragraph 2',
+          );
+
+          // Ensure the caret stayed where it was.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
               ),
             ),
-          ),
-        );
-      });
-    });
-
-    group('with delete', () {
-      testWidgetsOnDesktop('at the upstream edge of the node', (tester) async {
-        await _pumpParagraphThenHrTestApp(tester);
-
-        const hrUpstreamEdgePosition = DocumentPosition(
-          nodeId: 'hr',
-          nodePosition: UpstreamDownstreamNodePosition.upstream(),
-        );
-
-        // Place the caret at the upstream edge of the horizontal rule.
-        await tester.tapAtDocumentPosition(hrUpstreamEdgePosition);
-
-        // Ensure the selection is at the beginning of the horizontal rule.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrUpstreamEdgePosition,
-          ),
-        );
-
-        // Press delete a few times trying to delete the node.
-        await tester.pressDelete();
-        await tester.pressDelete();
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection didn't change.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrUpstreamEdgePosition,
-          ),
-        );
+          );
+        });
       });
 
-      testWidgetsOnDesktop('at the end of the upstream node', (tester) async {
-        await _pumpParagraphThenHrThenParagraphTestApp(tester);
+      group('with backspace in software keyboard', () {
+        testWidgetsOnMobile('at the downstream edge of the node', (tester) async {
+          await _pumpHrThenParagraphTestApp(tester);
 
-        // Place the caret at the end of the first paragraph.
-        await tester.placeCaretInParagraph('1', 11);
-
-        // Press backspace trying to delete the horizontal rule.
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the two paragraphs were merged.
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'Paragraph 1Paragraph 2',
-        );
-
-        // Ensure the caret stayed where it was.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 11),
-              ),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnDesktop('with an expanded downstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete a few times trying to delete the node.
-        await tester.pressDelete();
-        await tester.pressDelete();
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('with an expanded upstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete a few times trying to delete the node.
-        await tester.pressDelete();
-        await tester.pressDelete();
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when multiple deletable and undeletable nodes are selected', (tester) async {
-        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
-
-        // Select from "Para>graph 1" to "Paragraph <3".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: '3',
-                nodePosition: TextNodePosition(offset: 10),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to delete the selected nodes.
-        await tester.pressDelete();
-
-        // Ensure that the deletable content was deleted and selection moved to upstream edge
-        // of the first deletable node.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.nodeCount, 4);
-        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the undeletable content was not deleted.
-        expect(document.getNodeById('hr1'), isNotNull);
-        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr2'), isNotNull);
-        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr3'), isNotNull);
-        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'graph 1',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the deletable content was deleted and selection moved to the upstream edge
-        // of the selection
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'Para',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            ),
-          ),
-        );
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the beginning of the downstream node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the end of horizontal rule to the beginning of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 0),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection moved to the beginning of the downstream node.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 0),
-              ),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the beginning of the downstream node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the beginning of horizontal rule to the beginning of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 0),
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press backspace to delete the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection moved to the beginning of the downstream node.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 0),
-              ),
-            ),
-          ),
-        );
-      });
-
-      testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        const selection = DocumentSelection(
-          base: DocumentPosition(
-            nodeId: 'hr',
-            nodePosition: UpstreamDownstreamNodePosition.upstream(),
-          ),
-          extent: DocumentPosition(
-            nodeId: '1',
-            nodePosition: TextNodePosition(offset: 11),
-          ),
-        );
-
-        // Select from the beginning of the horizontal rule to the end of the upstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            selection,
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
-
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-
-        // Ensure the selection didn't change.
-        expect(SuperEditorInspector.findDocumentSelection(), selection);
-      });
-
-      testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        const selection = DocumentSelection(
-          base: DocumentPosition(
+          const hrDownstreamPosition = DocumentPosition(
             nodeId: 'hr',
             nodePosition: UpstreamDownstreamNodePosition.downstream(),
-          ),
-          extent: DocumentPosition(
-            nodeId: '1',
-            nodePosition: TextNodePosition(offset: 11),
-          ),
-        );
+          );
 
-        // Select from the end of the horizontal rule to the end of the downstream node.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            selection,
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          // Place the caret at the downstream edge of the horizontal rule.
+          await tester.tapAtDocumentPosition(hrDownstreamPosition);
+          await tester.pump();
 
-        // Press delete to remove the selected content.
-        await tester.pressDelete();
+          // Ensure the caret is at the downstream edge of the horizontal rule.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: hrDownstreamPosition,
+            ),
+          );
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~',
+              selection: TextSelection(baseOffset: 2, extentOffset: 3),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~',
+              deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
 
-        // Ensure the selection didn't change.
-        expect(SuperEditorInspector.findDocumentSelection(), selection);
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection was kept where it was.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: hrDownstreamPosition,
+            ),
+          );
+        });
       });
     });
 
-    group('when typing', () {
-      testWidgetsOnDesktop('when typing with multiple nodes selected', (tester) async {
-        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+    group('with expanded selection > ', () {
+      group('with backspace', () {
+        testWidgetsOnDesktop('for downstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select from "Para>graph 1" to "Paragraph <3".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: '3',
-                nodePosition: TextNodePosition(offset: 10),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace a few times trying to delete the node.
+          await tester.pressBackspace();
+          await tester.pressBackspace();
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
+        });
 
-        // Type a character to replace the selected nodes.
-        await tester.typeImeText('X');
+        testWidgetsOnDesktop('for upstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Ensure that the deletable content was deleted and the text was inserted at the upstream
-        // edge of the selection.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.nodeCount, 4);
-        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('ParaX3'));
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace a few times trying to delete the node.
+          await tester.pressBackspace();
+          await tester.pressBackspace();
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnAllPlatforms('when multiple deletable and undeletable nodes are selected', (tester) async {
+          final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+          // Select from "Para>graph 1" to "Paragraph <3".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '3',
+                  nodePosition: TextNodePosition(offset: 10),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected nodes.
+          await tester.pressBackspace();
+
+          // Ensure that the deletable content was deleted and the selection moved to upstream edge
+          // of the selection.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.nodeCount, 4);
+          expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
             ),
-          ),
-        );
+          );
 
-        // Ensure that the undeletable content was not deleted.
-        expect(document.getNodeById('hr1'), isNotNull);
-        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+          // Ensure that the undeletable content was not deleted.
+          expect(document.getNodeById('hr1'), isNotNull);
+          expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
 
-        expect(document.getNodeById('hr2'), isNotNull);
-        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+          expect(document.getNodeById('hr2'), isNotNull);
+          expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
 
-        expect(document.getNodeById('hr3'), isNotNull);
-        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+          expect(document.getNodeById('hr3'), isNotNull);
+          expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'graph 1',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the deletable content was deleted and selection moved to the upstream edge
+          // of the selection
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'Para',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop(
+            'when selection starts at the dowstream edge and ends at the beginning of the downstream node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          const selection = DocumentSelection(
+            base: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.downstream(),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          );
+
+          // Select from the end of the horizontal rule to the beginning of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              selection,
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection didn't change.
+          expect(SuperEditorInspector.findDocumentSelection(), selection);
+        });
+
+        testWidgetsOnDesktop(
+            'when selection starts at the upstream edge and ends at the beginning of the downstream node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          const selection = DocumentSelection(
+            base: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          );
+
+          // Select from the beginning of the horizontal rule to the beginning of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              selection,
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection didn't change.
+          expect(SuperEditorInspector.findDocumentSelection(), selection);
+        });
+
+        testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the beginning of the horizontal rule to the end of the upstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection moved to the end of the upstream node.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the end of the horizontal rule to the end of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressBackspace();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection moved to the end of the upstream node.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 11),
+                ),
+              ),
+            ),
+          );
+        });
       });
-    });
 
-    group('with backspace in software keyboard', () {
-      testWidgetsOnMobile('at the downstream edge of the node', (tester) async {
-        await _pumpHrThenParagraphTestApp(tester);
+      group('with delete', () {
+        testWidgetsOnDesktop('for downstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        const hrDownstreamPosition = DocumentPosition(
-          nodeId: 'hr',
-          nodePosition: UpstreamDownstreamNodePosition.downstream(),
-        );
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
 
-        // Place the caret at the downstream edge of the horizontal rule.
-        await tester.tapAtDocumentPosition(hrDownstreamPosition);
-        await tester.pump();
+          // Press delete a few times trying to delete the node.
+          await tester.pressDelete();
+          await tester.pressDelete();
+          await tester.pressDelete();
 
-        // Ensure the caret is at the downstream edge of the horizontal rule.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrDownstreamPosition,
-          ),
-        );
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. ~',
-            selection: TextSelection(baseOffset: 2, extentOffset: 3),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. ~',
-            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+        testWidgetsOnDesktop('for upstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
 
-        // Ensure the selection was kept where it was.
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          const DocumentSelection.collapsed(
-            position: hrDownstreamPosition,
-          ),
-        );
+          // Press delete a few times trying to delete the node.
+          await tester.pressDelete();
+          await tester.pressDelete();
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when multiple deletable and undeletable nodes are selected', (tester) async {
+          final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+          // Select from "Para>graph 1" to "Paragraph <3".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '3',
+                  nodePosition: TextNodePosition(offset: 10),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to delete the selected nodes.
+          await tester.pressDelete();
+
+          // Ensure that the deletable content was deleted and selection moved to upstream edge
+          // of the first deletable node.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.nodeCount, 4);
+          expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
+            ),
+          );
+
+          // Ensure that the undeletable content was not deleted.
+          expect(document.getNodeById('hr1'), isNotNull);
+          expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+
+          expect(document.getNodeById('hr2'), isNotNull);
+          expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+          expect(document.getNodeById('hr3'), isNotNull);
+          expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at upstream edge and ends at a downstream deletable node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'graph 1',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at downstream edge and ends at an upstream deletable node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the deletable content was deleted and selection moved to the upstream edge
+          // of the selection
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'Para',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at an upstream deletable node and ends at the downstream edge',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop('when selection starts at a downstream deletable node and ends at the upstream edge',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnDesktop(
+            'when selection starts at downstream edge and ends at the beginning of the downstream node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the end of horizontal rule to the beginning of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection moved to the beginning of the downstream node.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when selection starts at upstream edge and ends at the beginning of the downstream node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the beginning of horizontal rule to the beginning of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press backspace to delete the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection moved to the beginning of the downstream node.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when selection starts at upstream edge and ends at the end of the upstream node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          const selection = DocumentSelection(
+            base: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 11),
+            ),
+          );
+
+          // Select from the beginning of the horizontal rule to the end of the upstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              selection,
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection didn't change.
+          expect(SuperEditorInspector.findDocumentSelection(), selection);
+        });
+
+        testWidgetsOnDesktop('when selection starts at downstream edge and ends at the end of the upstream node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          const selection = DocumentSelection(
+            base: DocumentPosition(
+              nodeId: 'hr',
+              nodePosition: UpstreamDownstreamNodePosition.downstream(),
+            ),
+            extent: DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 11),
+            ),
+          );
+
+          // Select from the end of the horizontal rule to the end of the downstream node.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              selection,
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Press delete to remove the selected content.
+          await tester.pressDelete();
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+          // Ensure the selection didn't change.
+          expect(SuperEditorInspector.findDocumentSelection(), selection);
+        });
       });
 
-      testWidgetsOnMobile('with an expanded downstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
+      group('when typing', () {
+        testWidgetsOnDesktop('with multiple nodes selected', (tester) async {
+          final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
 
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+          // Select from "Para>graph 1" to "Paragraph <3".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '3',
+                  nodePosition: TextNodePosition(offset: 10),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Type a character to replace the selected nodes.
+          await tester.typeImeText('X');
+
+          // Ensure that the deletable content was deleted and the text was inserted at the upstream
+          // edge of the selection.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.nodeCount, 4);
+          expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('ParaX3'));
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 5)),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. ~',
-            selection: TextSelection(baseOffset: 2, extentOffset: 3),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. ~',
-            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+          // Ensure that the undeletable content was not deleted.
+          expect(document.getNodeById('hr1'), isNotNull);
+          expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          expect(document.getNodeById('hr2'), isNotNull);
+          expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+          expect(document.getNodeById('hr3'), isNotNull);
+          expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+        });
       });
 
-      testWidgetsOnMobile('with an expanded upstream selection', (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
+      group('with backspace in software keyboard', () {
+        testWidgetsOnMobile('for downstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select the whole hr. Use a command instead of a user gesture to have
-        // precise control over the selection.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~',
+              selection: TextSelection(baseOffset: 2, extentOffset: 3),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~',
+              deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnMobile('for upstream selection', (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+          // Select the whole hr. Use a command instead of a user gesture to have
+          // precise control over the selection.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~',
+              selection: TextSelection(baseOffset: 2, extentOffset: 3),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~',
+              deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnMobile('when multiple deletable and undeletable nodes are selected', (tester) async {
+          final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+          // Select from "Para>graph 1" to "Paragraph <3".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '3',
+                  nodePosition: TextNodePosition(offset: 10),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
+              selection: TextSelection(baseOffset: 6, extentOffset: 42),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
+              deletedRange: TextSelection(baseOffset: 6, extentOffset: 42),
+              selection: TextSelection.collapsed(offset: 6),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          // Ensure that the deletable content was deleted and selection moved to upstream edge
+          // of the first deletable node.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.nodeCount, 4);
+          expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. ~',
-            selection: TextSelection(baseOffset: 2, extentOffset: 3),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. ~',
-            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+          // Ensure that the undeletable content was not deleted.
+          expect(document.getNodeById('hr1'), isNotNull);
+          expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
+          expect(document.getNodeById('hr2'), isNotNull);
+          expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
 
-      testWidgetsOnMobile('when multiple deletable and undeletable nodes are selected', (tester) async {
-        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+          expect(document.getNodeById('hr3'), isNotNull);
+          expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+        });
 
-        // Select from "Para>graph 1" to "Paragraph <3".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
+        testWidgetsOnMobile('when selection starts at upstream edge and ends at a downstream deletable node',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: '3',
-                nodePosition: TextNodePosition(offset: 10),
-              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\nParagraph 1',
+              selection: TextSelection(baseOffset: 2, extentOffset: 8),
+              composing: TextRange(start: -1, end: -1),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
-            selection: TextSelection(baseOffset: 6, extentOffset: 42),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
-            deletedRange: TextSelection(baseOffset: 6, extentOffset: 42),
-            selection: TextSelection.collapsed(offset: 6),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        // Ensure that the deletable content was deleted and selection moved to upstream edge
-        // of the first deletable node.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.nodeCount, 4);
-        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\nParagraph 1',
+              deletedRange: TextSelection(baseOffset: 2, extentOffset: 8),
+              selection: TextSelection.collapsed(offset: 6),
+              composing: TextRange(start: -1, end: -1),
             ),
-          ),
-        );
+          ], getter: imeClientGetter);
 
-        // Ensure that the undeletable content was not deleted.
-        expect(document.getNodeById('hr1'), isNotNull);
-        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr2'), isNotNull);
-        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
-
-        expect(document.getNodeById('hr3'), isNotNull);
-        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnMobile('when selection starts at upstream edge and ends at a downstream deletable node',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
-              ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'graph 1',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. ~\nParagraph 1',
-            selection: TextSelection(baseOffset: 2, extentOffset: 8),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. ~\nParagraph 1',
-            deletedRange: TextSelection(baseOffset: 2, extentOffset: 8),
-            selection: TextSelection.collapsed(offset: 6),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
 
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'graph 1',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
-            ),
-          ),
-        );
+        testWidgetsOnMobile('when selection starts at downstream edge and ends at an upstream deletable node',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnMobile('when selection starts at downstream edge and ends at an upstream deletable node',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. Paragraph 1\n~',
+              selection: TextSelection(baseOffset: 15, extentOffset: 6),
+              composing: TextRange(start: -1, end: -1),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
-
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. Paragraph 1\n~',
-            selection: TextSelection(baseOffset: 15, extentOffset: 6),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. Paragraph 1\n~',
-            deletedRange: TextSelection(baseOffset: 15, extentOffset: 6),
-            selection: TextSelection.collapsed(offset: 6),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
-
-        // Ensure that the deletable content was deleted and selection moved to the upstream edge
-        // of the selection
-        expect(
-          SuperEditorInspector.findTextInComponent('1').text,
-          'Para',
-        );
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            const TextEditingDeltaDeletion(
+              oldText: '. Paragraph 1\n~',
+              deletedRange: TextSelection(baseOffset: 15, extentOffset: 6),
+              selection: TextSelection.collapsed(offset: 6),
+              composing: TextRange(start: -1, end: -1),
             ),
-          ),
-        );
+          ], getter: imeClientGetter);
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnMobile('when selection starts at an upstream deletable node and ends at the downstream edge',
-          (tester) async {
-        final testContext = await _pumpParagraphThenHrTestApp(tester);
-
-        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
-              ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+          // Ensure that the deletable content was deleted and selection moved to the upstream edge
+          // of the selection
+          expect(
+            SuperEditorInspector.findTextInComponent('1').text,
+            'Para',
+          );
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. Paragraph 1\n~',
-            selection: TextSelection(baseOffset: 6, extentOffset: 15),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. Paragraph 1\n~',
-            deletedRange: TextSelection(baseOffset: 6, extentOffset: 15),
-            selection: TextSelection.collapsed(offset: 6),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
 
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
-            ),
-          ),
-        );
+        testWidgetsOnMobile('when selection starts at an upstream deletable node and ends at the downstream edge',
+            (tester) async {
+          final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
-      });
-
-      testWidgetsOnMobile('when selection starts at a downstream deletable node and ends at the upstream edge',
-          (tester) async {
-        final testContext = await _pumpHrThenParagraphTestApp(tester);
-
-        // Select from the "Para|graph 1" to the upstream edge of the second horizontal rule.
-        testContext.editor.execute([
-          const ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: '1',
-                nodePosition: TextNodePosition(offset: 4),
+          // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
               ),
-              extent: DocumentPosition(
-                nodeId: 'hr',
-                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. Paragraph 1\n~',
+              selection: TextSelection(baseOffset: 6, extentOffset: 15),
+              composing: TextRange(start: -1, end: -1),
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. Paragraph 1\n~',
+              deletedRange: TextSelection(baseOffset: 6, extentOffset: 15),
+              selection: TextSelection.collapsed(offset: 6),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
+
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
               ),
             ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          )
-        ]);
-        await tester.pump();
+          );
 
-        // Simulate the user pressing backspace. The IME first generates a
-        // selection change and then a deletion. Each block node is represented by a "~"
-        // in the IME.
-        await tester.ime.sendDeltas([
-          const TextEditingDeltaNonTextUpdate(
-            oldText: '. ~\nParagraph 1',
-            selection: TextSelection(baseOffset: 8, extentOffset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-          const TextEditingDeltaDeletion(
-            oldText: '. ~\nParagraph 1',
-            deletedRange: TextSelection(baseOffset: 8, extentOffset: 2),
-            selection: TextSelection.collapsed(offset: 2),
-            composing: TextRange(start: -1, end: -1),
-          ),
-        ], getter: imeClientGetter);
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
 
-        // Ensure that the deletable content was deleted and selection moved to the beginning
-        // of the selected paragraph.
-        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
-        expect(
-          SuperEditorInspector.findDocumentSelection(),
-          selectionEquivalentTo(
-            const DocumentSelection.collapsed(
-              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+        testWidgetsOnMobile('when selection starts at a downstream deletable node and ends at the upstream edge',
+            (tester) async {
+          final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+          // Select from the "Para|graph 1" to the upstream edge of the second horizontal rule.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+                extent: DocumentPosition(
+                  nodeId: 'hr',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\nParagraph 1',
+              selection: TextSelection(baseOffset: 8, extentOffset: 2),
+              composing: TextRange(start: -1, end: -1),
             ),
-          ),
-        );
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\nParagraph 1',
+              deletedRange: TextSelection(baseOffset: 8, extentOffset: 2),
+              selection: TextSelection.collapsed(offset: 2),
+              composing: TextRange(start: -1, end: -1),
+            ),
+          ], getter: imeClientGetter);
 
-        // Ensure that the horizontal rule was not deleted.
-        final document = SuperEditorInspector.findDocument()!;
-        expect(document.getNodeById('hr'), isNotNull);
-        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+          // Ensure that the deletable content was deleted and selection moved to the beginning
+          // of the selected paragraph.
+          expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+              ),
+            ),
+          );
+
+          // Ensure that the horizontal rule was not deleted.
+          final document = SuperEditorInspector.findDocument()!;
+          expect(document.getNodeById('hr'), isNotNull);
+          expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
       });
     });
   });

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
@@ -13,22 +14,19 @@ void main() {
       testWidgetsOnArbitraryDesktop('at the downstream edge of the node', (tester) async {
         await _pumpHrThenParagraphTestApp(tester);
 
-        // Place the caret at the downstream edge of the horizontal rule.
-        await tester.tapAtDocumentPosition(
-          const DocumentPosition(
-            nodeId: 'hr',
-            nodePosition: UpstreamDownstreamNodePosition.downstream(),
-          ),
+        const hrDownstreamEdgePosition = DocumentPosition(
+          nodeId: 'hr',
+          nodePosition: UpstreamDownstreamNodePosition.downstream(),
         );
 
-        // Ensure the selection is at the downstream edge of the horizontal ruler.
+        // Place the caret at the downstream edge of the horizontal rule.
+        await tester.tapAtDocumentPosition(hrDownstreamEdgePosition);
+
+        // Ensure the selection is at the downstream edge of the horizontal rule.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: 'hr',
-              nodePosition: UpstreamDownstreamNodePosition.downstream(),
-            ),
+            position: hrDownstreamEdgePosition,
           ),
         );
 
@@ -37,16 +35,25 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: hrDownstreamEdgePosition,
+          ),
+        );
       });
 
       testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select the whole hr.
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -70,7 +77,7 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -79,7 +86,8 @@ void main() {
       testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select the whole hr.
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -103,7 +111,7 @@ void main() {
         await tester.pressBackspace();
         await tester.pressBackspace();
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -125,7 +133,7 @@ void main() {
                 nodePosition: TextNodePosition(offset: 10),
               ),
             ),
-            SelectionChangeType.alteredContent,
+            SelectionChangeType.expandSelection,
             SelectionReason.userInteraction,
           )
         ]);
@@ -134,8 +142,8 @@ void main() {
         // Press backspace to delete the selected nodes.
         await tester.pressBackspace();
 
-        // Ensure that the deletable content was deleted and selection moved to upstream edge
-        // of the first deletable node.
+        // Ensure that the deletable content was deleted and the selection moved to upstream edge
+        // of the selection.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.nodeCount, 4);
         expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
@@ -200,7 +208,7 @@ void main() {
           ),
         );
 
-        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -247,7 +255,7 @@ void main() {
           ),
         );
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -291,7 +299,7 @@ void main() {
           ),
         );
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -301,7 +309,7 @@ void main() {
           'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
-        // Select from the "Para|graph 2" to the upstream edge of the second horizontal ruler.
+        // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -335,7 +343,7 @@ void main() {
           ),
         );
 
-        // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -346,22 +354,19 @@ void main() {
       testWidgetsOnArbitraryDesktop('at the upstream edge of the node', (tester) async {
         await _pumpParagraphThenHrTestApp(tester);
 
-        // Place the caret at the upstream edge of the horizontal rule.
-        await tester.tapAtDocumentPosition(
-          const DocumentPosition(
-            nodeId: 'hr',
-            nodePosition: UpstreamDownstreamNodePosition.upstream(),
-          ),
+        const hrUpstreamEdgePosition = DocumentPosition(
+          nodeId: 'hr',
+          nodePosition: UpstreamDownstreamNodePosition.upstream(),
         );
+
+        // Place the caret at the upstream edge of the horizontal rule.
+        await tester.tapAtDocumentPosition(hrUpstreamEdgePosition);
 
         // Ensure the selection is at the beginning of the horizontal rule.
         expect(
           SuperEditorInspector.findDocumentSelection(),
           const DocumentSelection.collapsed(
-            position: DocumentPosition(
-              nodeId: 'hr',
-              nodePosition: UpstreamDownstreamNodePosition.upstream(),
-            ),
+            position: hrUpstreamEdgePosition,
           ),
         );
 
@@ -370,16 +375,25 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection didn't change.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: hrUpstreamEdgePosition,
+          ),
+        );
       });
 
       testWidgetsOnArbitraryDesktop('with an expanded downstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select the whole hr.
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -403,7 +417,7 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-        // Ensure that the horizontal rule was not deleted and not converted to a paragraph.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -412,7 +426,8 @@ void main() {
       testWidgetsOnArbitraryDesktop('with an expanded upstream selection', (tester) async {
         final testContext = await _pumpParagraphThenHrTestApp(tester);
 
-        // Select the whole hr.
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -580,7 +595,7 @@ void main() {
           ),
         );
 
-        // Ensure that the horizontal ruler was not deleted.
+        // Ensure that the horizontal rule was not deleted.
         final document = SuperEditorInspector.findDocument()!;
         expect(document.getNodeById('hr'), isNotNull);
         expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
@@ -634,7 +649,7 @@ void main() {
           'when selection starts at a downstream deletable node and ends at the upstream edge', (tester) async {
         final testContext = await _pumpHrThenParagraphTestApp(tester);
 
-        // Select from the "Para|graph 2" to the upstream edge of the second horizontal ruler.
+        // Select from the "Para|graph 2" to the upstream edge of the second horizontal rule.
         testContext.editor.execute([
           const ChangeSelectionRequest(
             DocumentSelection(
@@ -692,7 +707,7 @@ void main() {
                 nodePosition: TextNodePosition(offset: 10),
               ),
             ),
-            SelectionChangeType.alteredContent,
+            SelectionChangeType.expandSelection,
             SelectionReason.userInteraction,
           )
         ]);
@@ -727,51 +742,452 @@ void main() {
       });
     });
 
-    // group('with backspace in software keyboard', () {
-    //   testWidgetsOnMobile('at the downstream edge of the node', (tester) async {
-    //     await _pumpHrThenParagraphTestApp(tester);
+    group('with backspace in software keyboard', () {
+      testWidgetsOnMobile('at the downstream edge of the node', (tester) async {
+        await _pumpHrThenParagraphTestApp(tester);
 
-    //     // Place the caret at the downstream edge of the horizontal rule.
-    //     await tester.tapAtDocumentPosition(
-    //       const DocumentPosition(
-    //         nodeId: 'hr',
-    //         nodePosition: UpstreamDownstreamNodePosition.downstream(),
-    //       ),
-    //     );
-    //     await tester.pump();
+        const hrDownstreamPosition = DocumentPosition(
+          nodeId: 'hr',
+          nodePosition: UpstreamDownstreamNodePosition.downstream(),
+        );
 
-    //     // Simulate pressing backspace.
-    //     await tester.ime.sendDeltas([
-    //       const TextEditingDeltaNonTextUpdate(
-    //         oldText: '. ~',
-    //         selection: TextSelection.collapsed(offset: 3),
-    //         composing: TextRange(start: -1, end: -1),
-    //       ),
-    //       const TextEditingDeltaDeletion(
-    //         oldText: '. ~',
-    //         deletedRange: TextRange.collapsed(2),
-    //         selection: TextSelection.collapsed(offset: 2),
-    //         composing: TextRange(start: -1, end: -1),
-    //       ),
-    //     ], getter: imeClientGetter);
+        // Place the caret at the downstream edge of the horizontal rule.
+        await tester.tapAtDocumentPosition(hrDownstreamPosition);
+        await tester.pump();
 
-    //     // Ensure that the horizontal ruler was not deleted and not converted to a paragraph.
-    //     final document = SuperEditorInspector.findDocument()!;
-    //     expect(document.getNodeById('hr'), isNotNull);
-    //     expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        // Ensure the caret is at the downstream edge of the horizontal rule.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: hrDownstreamPosition,
+          ),
+        );
 
-    //     // Ensure the selection was kept where it was.
-    //     expect(
-    //       SuperEditorInspector.findDocumentSelection(),
-    //       const DocumentSelection.collapsed(
-    //         position: DocumentPosition(
-    //           nodeId: 'hr',
-    //           nodePosition: UpstreamDownstreamNodePosition.downstream(),
-    //         ),
-    //       ),
-    //     );
-    //   });
-    // });
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. ~',
+            selection: TextSelection(baseOffset: 2, extentOffset: 3),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. ~',
+            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+
+        // Ensure the selection was kept where it was.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          const DocumentSelection.collapsed(
+            position: hrDownstreamPosition,
+          ),
+        );
+      });
+
+      testWidgetsOnMobile('with an expanded downstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. ~',
+            selection: TextSelection(baseOffset: 2, extentOffset: 3),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. ~',
+            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('with an expanded upstream selection', (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select the whole hr. Use a command instead of a user gesture to have
+        // precise control over the selection.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. ~',
+            selection: TextSelection(baseOffset: 2, extentOffset: 3),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. ~',
+            deletedRange: TextSelection(baseOffset: 2, extentOffset: 3),
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('when multiple deletable and undeletable nodes are selected', (tester) async {
+        final testContext = await _pumpMultipleDeletableAndUndeletableNodesTestApp(tester);
+
+        // Select from "Para>graph 1" to "Paragraph <3".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: TextNodePosition(offset: 10),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
+            selection: TextSelection(baseOffset: 6, extentOffset: 42),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. Paragraph 1\n~\n~\nParagraph 2\n~\nParagraph 3',
+            deletedRange: TextSelection(baseOffset: 6, extentOffset: 42),
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the deletable content was deleted and selection moved to upstream edge
+        // of the first deletable node.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.nodeCount, 4);
+        expect(SuperEditorInspector.findTextInComponent('1'), AttributedText('Para3'));
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the undeletable content was not deleted.
+        expect(document.getNodeById('hr1'), isNotNull);
+        expect(document.getNodeById('hr1'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr2'), isNotNull);
+        expect(document.getNodeById('hr2'), isA<HorizontalRuleNode>());
+
+        expect(document.getNodeById('hr3'), isNotNull);
+        expect(document.getNodeById('hr3'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('when selection starts at upstream edge and ends at a downstream deletable node',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the upstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. ~\nParagraph 1',
+            selection: TextSelection(baseOffset: 2, extentOffset: 8),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. ~\nParagraph 1',
+            deletedRange: TextSelection(baseOffset: 2, extentOffset: 8),
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'graph 1',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('when selection starts at downstream edge and ends at an upstream deletable node',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the downstream edge of the horizontal rule to "Para|graph 1".
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. Paragraph 1\n~',
+            selection: TextSelection(baseOffset: 15, extentOffset: 6),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. Paragraph 1\n~',
+            deletedRange: TextSelection(baseOffset: 15, extentOffset: 6),
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the deletable content was deleted and selection moved to the upstream edge
+        // of the selection
+        expect(
+          SuperEditorInspector.findTextInComponent('1').text,
+          'Para',
+        );
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('when selection starts at an upstream deletable node and ends at the downstream edge',
+          (tester) async {
+        final testContext = await _pumpParagraphThenHrTestApp(tester);
+
+        // Select from the "Para|graph 1" to the downstream edge of the horizontal rule.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. Paragraph 1\n~',
+            selection: TextSelection(baseOffset: 6, extentOffset: 15),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. Paragraph 1\n~',
+            deletedRange: TextSelection(baseOffset: 6, extentOffset: 15),
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'Para');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 4)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+
+      testWidgetsOnMobile('when selection starts at a downstream deletable node and ends at the upstream edge',
+          (tester) async {
+        final testContext = await _pumpHrThenParagraphTestApp(tester);
+
+        // Select from the "Para|graph 1" to the upstream edge of the second horizontal rule.
+        testContext.editor.execute([
+          const ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 4),
+              ),
+              extent: DocumentPosition(
+                nodeId: 'hr',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+            SelectionChangeType.expandSelection,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        await tester.pump();
+
+        // Simulate the user pressing backspace. The IME first generates a
+        // selection change and then a deletion. Each block node is represented by a "~"
+        // in the IME.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. ~\nParagraph 1',
+            selection: TextSelection(baseOffset: 8, extentOffset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. ~\nParagraph 1',
+            deletedRange: TextSelection(baseOffset: 8, extentOffset: 2),
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange(start: -1, end: -1),
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure that the deletable content was deleted and selection moved to the beginning
+        // of the selected paragraph.
+        expect(SuperEditorInspector.findTextInComponent('1').text, 'graph 1');
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(nodeId: '1', nodePosition: TextNodePosition(offset: 0)),
+            ),
+          ),
+        );
+
+        // Ensure that the horizontal rule was not deleted.
+        final document = SuperEditorInspector.findDocument()!;
+        expect(document.getNodeById('hr'), isNotNull);
+        expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+      });
+    });
   });
 }
 

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -11,9 +11,9 @@ import 'supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor > undeletable content > prevents deletion > ', () {
-    // The desktop tests run for all desktop platforms because on mac the backspace
-    // is handled by selectors and on the other platforms it is handled by the keyboard handlers.
-    // See `MacOsSelectors` for more information.
+    // Instead of only testing a single arbitrary desktop, the desktop tests run for all desktop
+    // platforms because on mac the backspace is handled by selectors and on the other platforms
+    // it is handled by the keyboard handlers. See `MacOsSelectors` for more information.
     group('with collapsed selection > ', () {
       group('with backspace', () {
         testWidgetsOnDesktop('at the downstream edge of the node', (tester) async {


### PR DESCRIPTION
[SuperEditor] Add ability to set a block node as undeletable. Resolves #2334

The issue ticket also mentions making block nodes unselectable. This is already possible by setting `isVisuallySelectable` `true` in  `BoxComponent`. There is a demo in `UnselectableHrDemo`.

This PR adds the ability to mark a node as undeletable. The goal at this moment is for us to decide if this is the approach that we want and also confirm the expected behavior for some cases. After that, I'll add tests to the PR.

Marking a node as undeletable can be achieved by setting a flag in the node's metadata:

```dart
HorizontalRuleNode(
  id: Editor.createNodeId(),
  metadata: {
    NodeMetadata.deletable: false,
  },
),
```

https://github.com/user-attachments/assets/56bbeb27-7275-47dc-98ab-089af5fea128


https://github.com/user-attachments/assets/06dfc0d0-f5d5-40e0-9860-b84bec16ea4a

