### PR TITLE
[ExampleApp] Fix crash in spelling error decorations demo (Resolves #2374)

### DIFF
--- a/super_editor/example/lib/demos/in_the_lab/spelling_error_decorations.dart
+++ b/super_editor/example/lib/demos/in_the_lab/spelling_error_decorations.dart
@@ -48,9 +48,7 @@ class _SpellingErrorDecorationsDemoState extends State<SpellingErrorDecorationsD
   Widget build(BuildContext context) {
     return InTheLabScaffold(
       content: Center(
-        child: IntrinsicHeight(
-          child: _buildEditor(),
-        ),
+        child: _buildEditor(),
       ),
       supplemental: _buildControlPanel(),
     );
@@ -59,6 +57,7 @@ class _SpellingErrorDecorationsDemoState extends State<SpellingErrorDecorationsD
   Widget _buildEditor() {
     return SuperEditor(
       editor: _editor,
+      shrinkWrap: true,
       componentBuilders: [
         // When `_decoration` is non-null, we apply it directly to our own
         // custom component to show direct application. When it's `null`,


### PR DESCRIPTION
[ExampleApp] Fix crash in spelling error decorations demo. Resolves #2374

When trying to open the "Spelling Error Decorations" demo the editor crashes with the following exception:

```console
flutter: Creating paragraph view model with style: Instance of 'SquiggleUnderlineStyle'

════════ Exception caught by rendering library ═════════════════════════════════
The following assertion was thrown during performLayout():
RenderViewport does not support returning intrinsic dimensions.
Calculating the intrinsic dimensions would require instantiating every child of the viewport, which defeats the point of viewports being lazy.
If you are merely trying to shrink-wrap the viewport in the main axis direction, consider a RenderShrinkWrappingViewport render object (ShrinkWrappingViewport widget), which achieves that effect without implementing the intrinsic dimension API.

The relevant error-causing widget was:
    IntrinsicHeight IntrinsicHeight:file:///Users/angelosilvestre/dev/super_editor/super_editor/example/lib/demos/in_the_lab/spelling_error_decorations.dart:51:16

When the exception was thrown, this was the stack:
#0      RenderViewportBase.debugThrowIfNotCheckingIntrinsics.<anonymous closure> (package:flutter/src/rendering/viewport.dart:499:9)
#1      RenderViewportBase.debugThrowIfNotCheckingIntrinsics (package:flutter/src/rendering/viewport.dart:513:6)
#2      RenderViewportBase.computeMaxIntrinsicHeight (package:flutter/src/rendering/viewport.dart:537:12)
#3      _IntrinsicDimension.memoize.<anonymous closure> (package:flutter/src/rendering/box.dart:1064:49)
#4      _LinkedHashMapMixin.putIfAbsent (dart:_compact_hash:636:23)
#5      _IntrinsicDimension.memoize (package:flutter/src/rendering/box.dart:1064:8)
#6      RenderBox._computeWithTimeline (package:flutter/src/rendering/box.dart:1561:32)
#7      RenderBox._computeIntrinsics (package:flutter/src/rendering/box.dart:1539:26)
#8      RenderBox.getMaxIntrinsicHeight (package:flutter/src/rendering/box.dart:1897:12)
#9      RenderProxyBoxMixin.computeMaxIntrinsicHeight (package:flutter/src/rendering/proxy_box.dart:94:19)
#10     _IntrinsicDimension.memoize.<anonymous closure> (package:flutter/src/rendering/box.dart:1064:49)
#11     _LinkedHashMapMixin.putIfAbsent (dart:_compact_hash:636:23)

A lot more...
```

This seems to be related to the sliver migration. Removing the `IntrinsicHeight` widget and setting `shrinkWrap` to `true` on `SuperEditor` fixes the issue.