### PR TITLE
[SuperEditor] Limit tag expansion to caret position (Resolves #2240, #2241, #2242)

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1396,9 +1396,12 @@ class RemoveTextAttributionsCommand extends EditCommand {
 
         startOffset = (normalizedRange.start.nodePosition as TextPosition).offset;
 
-        // -1 because TextPosition's offset indexes the character after the
-        // selection, not the final character in the selection.
-        endOffset = (normalizedRange.end.nodePosition as TextPosition).offset - 1;
+        endOffset = normalizedRange.start != normalizedRange.end
+            // -1 because TextPosition's offset indexes the character after the
+            // selection, not the final character in the selection.
+            ? (normalizedRange.end.nodePosition as TextPosition).offset - 1
+            // The selection is collapsed. Don't decrement the offset.
+            : startOffset;
       } else if (textNode == nodes.first) {
         // Handle partial node selection in first node.
         editorDocLog.info(' - selecting part of the first node: ${textNode.id}');

--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -216,11 +216,6 @@ class CancelComposingActionTagCommand extends EditCommand {
     TagAroundPosition? composingToken;
     TextNode? textNode;
 
-    final normalizedSelection = selection.normalize(document);
-    final endPosition = normalizedSelection.end.nodePosition is TextNodePosition
-        ? normalizedSelection.end.nodePosition as TextNodePosition
-        : null;
-
     if (base.nodePosition is TextNodePosition) {
       textNode = document.getNodeById(selection.base.nodeId) as TextNode;
       composingToken = TagFinder.findTagAroundPosition(
@@ -249,12 +244,14 @@ class CancelComposingActionTagCommand extends EditCommand {
       return;
     }
 
+    final indexedTag = _constrainTagToCaret(composingToken, document, selection);
+
     // Remove the composing attribution.
     executor.executeCommand(
       RemoveTextAttributionsCommand(
         documentRange: textNode!.selectionBetween(
-          composingToken.indexedTag.startOffset,
-          composingToken.indexedTag.endOffset,
+          indexedTag.startOffset,
+          indexedTag.endOffset,
         ),
         attributions: {actionTagComposingAttribution},
       ),
@@ -262,8 +259,8 @@ class CancelComposingActionTagCommand extends EditCommand {
     executor.executeCommand(
       AddTextAttributionsCommand(
         documentRange: textNode.selectionBetween(
-          composingToken.indexedTag.startOffset,
-          composingToken.indexedTag.startOffset + 1,
+          indexedTag.startOffset,
+          indexedTag.startOffset + 1,
         ),
         attributions: {actionTagCancelledAttribution},
       ),

--- a/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/action_tags.dart
@@ -457,17 +457,15 @@ class ActionTagComposingReaction extends EditReaction {
         ),
         attributions: {actionTagComposingAttribution},
       ),
-      // Only cancel the attribution if the tag is longer than just the trigger.
-      if (composingTag.length > 1)
-        AddTextAttributionsRequest(
-          documentRange: DocumentSelection(
-            base: composingTag.start,
-            extent: composingTag.start.copyWith(
-              nodePosition: TextNodePosition(offset: composingTag.startOffset + 1),
-            ),
+      AddTextAttributionsRequest(
+        documentRange: DocumentSelection(
+          base: composingTag.start,
+          extent: composingTag.start.copyWith(
+            nodePosition: TextNodePosition(offset: composingTag.startOffset + 1),
           ),
-          attributions: {actionTagCancelledAttribution},
         ),
+        attributions: {actionTagCancelledAttribution},
+      ),
     ]);
   }
 }

--- a/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
@@ -10,15 +10,11 @@ import 'package:super_editor/src/default_editor/text.dart';
 class TagFinder {
   /// Finds a tag that touches the given [expansionPosition] and returns that tag,
   /// indexed within the document, along with the [expansionPosition].
-  ///
-  /// If [endPosition] is provided, the search will be limited to the range between
-  /// the [expansionPosition] and the [endPosition].
   static TagAroundPosition? findTagAroundPosition({
     required TagRule tagRule,
     required String nodeId,
     required AttributedText text,
     required TextNodePosition expansionPosition,
-    TextNodePosition? endPosition,
     required bool Function(Set<Attribution> tokenAttributions) isTokenCandidate,
   }) {
     final rawText = text.text;
@@ -35,7 +31,7 @@ class TagFinder {
     final charactersBefore = rawText.substring(0, splitIndex).characters;
     final iteratorUpstream = charactersBefore.iteratorAtEnd;
 
-    final charactersAfter = rawText.substring(splitIndex, endPosition?.offset).characters;
+    final charactersAfter = rawText.substring(splitIndex).characters;
     final iteratorDownstream = charactersAfter.iterator;
 
     if (charactersBefore.isNotEmpty && tagRule.excludedCharacters.contains(charactersBefore.last)) {

--- a/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
+++ b/super_editor/lib/src/default_editor/text_tokenizing/tags.dart
@@ -10,11 +10,15 @@ import 'package:super_editor/src/default_editor/text.dart';
 class TagFinder {
   /// Finds a tag that touches the given [expansionPosition] and returns that tag,
   /// indexed within the document, along with the [expansionPosition].
+  ///
+  /// If [endPosition] is provided, the search will be limited to the range between
+  /// the [expansionPosition] and the [endPosition].
   static TagAroundPosition? findTagAroundPosition({
     required TagRule tagRule,
     required String nodeId,
     required AttributedText text,
     required TextNodePosition expansionPosition,
+    TextNodePosition? endPosition,
     required bool Function(Set<Attribution> tokenAttributions) isTokenCandidate,
   }) {
     final rawText = text.text;
@@ -31,7 +35,7 @@ class TagFinder {
     final charactersBefore = rawText.substring(0, splitIndex).characters;
     final iteratorUpstream = charactersBefore.iteratorAtEnd;
 
-    final charactersAfter = rawText.substring(splitIndex).characters;
+    final charactersAfter = rawText.substring(splitIndex, endPosition?.offset).characters;
     final iteratorDownstream = charactersAfter.iterator;
 
     if (charactersBefore.isNotEmpty && tagRule.excludedCharacters.contains(charactersBefore.last)) {
@@ -282,6 +286,9 @@ class IndexedTag {
 
   /// The [DocumentRange] from [start] to [end].
   DocumentRange get range => DocumentRange(start: start, end: end);
+
+  /// The length of the [tag]'s text.
+  int get length => tag.raw.length;
 
   /// Collects and returns all attributions in this tag's [TextNode], between the
   /// [start] of the tag and the [end] of the tag.

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -58,6 +58,41 @@ void main() {
         );
       });
 
+      testWidgetsOnAllPlatforms("can start at the beginning of a word", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |after"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Compose an action tag, typing at "|after".
+        await tester.typeImeText("/header");
+
+        // Ensure that "/header" was attributed but "after" was left unnattributed.
+        final spans = SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
+          range: const SpanRange(0, 19),
+        );
+        expect(spans.length, 1);
+        expect(
+          spans.first,
+          const AttributionSpan(
+            attribution: actionTagComposingAttribution,
+            start: 7,
+            end: 13,
+          ),
+        );
+      });
+
       testWidgetsOnAllPlatforms("by default does not continue after a space", (tester) async {
         await _pumpTestEditor(
           tester,
@@ -500,6 +535,119 @@ void main() {
         );
       });
 
+      testWidgetsOnDesktop("cancels composing when deleting the trigger character", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |after"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Start composing a tag.
+        await tester.typeImeText("/");
+
+        // Press backspace to delete the tag.
+        await tester.pressBackspace();
+
+        // Ensure nothing is attributed, because we didn't type any characters
+        // after the initial "/".
+        expect(
+          SuperEditorInspector.findTextInComponent("1").getAllAttributionsThroughout(
+            const SpanRange(0, 13),
+          ),
+          isEmpty,
+        );
+
+        // Start composing the tag again.
+        await tester.typeImeText("/header");
+
+        // Ensure that "/header" is attributed.
+        final spans = SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
+          range: const SpanRange(0, 19),
+        );
+        expect(spans.length, 1);
+        expect(
+          spans.first,
+          const AttributionSpan(
+            attribution: actionTagComposingAttribution,
+            start: 7,
+            end: 13,
+          ),
+        );
+      });
+
+      testWidgetsOnMobile("cancels composing when deleting the trigger character with software keyboard",
+          (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |after"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Start composing a tag.
+        await tester.typeImeText("/");
+
+        // Simulate the user pressing backspace on the software keyboard.
+        await tester.ime.sendDeltas([
+          const TextEditingDeltaNonTextUpdate(
+            oldText: '. before /after',
+            selection: TextSelection(baseOffset: 9, extentOffset: 9),
+            composing: TextRange.empty,
+          ),
+          const TextEditingDeltaDeletion(
+            oldText: '. before /after',
+            deletedRange: TextSelection(baseOffset: 9, extentOffset: 10),
+            selection: TextSelection(baseOffset: 9, extentOffset: 9),
+            composing: TextRange.empty,
+          ),
+        ], getter: imeClientGetter);
+
+        // Ensure nothing is attributed, because we didn't type any characters
+        // after the initial "/".
+        expect(
+          SuperEditorInspector.findTextInComponent("1").getAllAttributionsThroughout(
+            const SpanRange(0, 13),
+          ),
+          isEmpty,
+        );
+
+        // Start composing the tag again.
+        await tester.typeImeText("/header");
+
+        // Ensure that "/header" is attributed.
+        final spans = SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
+          range: const SpanRange(0, 19),
+        );
+        expect(spans.length, 1);
+        expect(
+          spans.first,
+          const AttributionSpan(
+            attribution: actionTagComposingAttribution,
+            start: 7,
+            end: 13,
+          ),
+        );
+      });
+
       testWidgetsOnAllPlatforms("only notifies tag index listeners when tags change", (tester) async {
         final actionTagPlugin = ActionTagsPlugin();
 
@@ -623,6 +771,56 @@ void main() {
         // Ensure that the action tag was removed.
         final text = SuperEditorInspector.findTextInComponent("1");
         expect(text.text, "before  after");
+        expect(
+          text.getAttributionSpansInRange(
+            attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
+            range: const SpanRange(0, 12),
+          ),
+          isEmpty,
+        );
+      });
+
+      testWidgetsOnAllPlatforms("at the beginning of a word", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |after".
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Compose an action tag.
+        await tester.typeImeText("/header");
+
+        // Ensure only "/header" is attributed.
+        AttributedText? text = SuperEditorInspector.findTextInComponent("1");
+        final spans = text.getAttributionSpansInRange(
+          attributionFilter: (attribution) => attribution == actionTagComposingAttribution,
+          range: const SpanRange(0, 19),
+        );
+        expect(spans.length, 1);
+        expect(
+          spans.first,
+          const AttributionSpan(
+            attribution: actionTagComposingAttribution,
+            start: 7,
+            end: 13,
+          ),
+        );
+
+        // Submit the tag.
+        await tester.pressEnter();
+
+        // Ensure that the action tag was removed.
+        text = SuperEditorInspector.findTextInComponent("1");
+        expect(text.text, "before after");
         expect(
           text.getAttributionSpansInRange(
             attributionFilter: (attribution) => attribution == actionTagComposingAttribution,

--- a/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/action_tags_test.dart
@@ -560,8 +560,9 @@ void main() {
         // Ensure nothing is attributed, because we didn't type any characters
         // after the initial "/".
         expect(
-          SuperEditorInspector.findTextInComponent("1").getAllAttributionsThroughout(
-            const SpanRange(0, 13),
+          SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+            attributionFilter: (candidate) => candidate == actionTagComposingAttribution,
+            range: const SpanRange(0, 13),
           ),
           isEmpty,
         );
@@ -623,8 +624,9 @@ void main() {
         // Ensure nothing is attributed, because we didn't type any characters
         // after the initial "/".
         expect(
-          SuperEditorInspector.findTextInComponent("1").getAllAttributionsThroughout(
-            const SpanRange(0, 13),
+          SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+            attributionFilter: (candidate) => candidate == actionTagComposingAttribution,
+            range: const SpanRange(0, 13),
           ),
           isEmpty,
         );
@@ -645,6 +647,57 @@ void main() {
             start: 7,
             end: 13,
           ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms("does not re-apply a canceled tag", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before  after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before | after"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Start composing a tag.
+        await tester.typeImeText("/");
+
+        // Ensure that we're composing.
+        var text = SuperEditorInspector.findTextInComponent("1");
+        expect(
+          text.getAttributedRange({actionTagComposingAttribution}, 7),
+          const SpanRange(7, 7),
+        );
+
+        // Move the caret to "before |/ after"
+        await tester.pressLeftArrow();
+
+        // Ensure we are not composing anymore.
+        expect(
+          SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+            attributionFilter: (candidate) => candidate == actionTagComposingAttribution,
+            range: const SpanRange(0, 14),
+          ),
+          isEmpty,
+        );
+
+        // Move the caret to "before /| after"
+        await tester.pressRightArrow();
+
+        // Ensure we are still not composing.
+        expect(
+          SuperEditorInspector.findTextInComponent("1").getAttributionSpansInRange(
+            attributionFilter: (candidate) => candidate == actionTagComposingAttribution,
+            range: const SpanRange(0, 14),
+          ),
+          isEmpty,
         );
       });
 

--- a/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/pattern_tags_test.dart
@@ -76,6 +76,34 @@ void main() {
         );
       });
 
+      testWidgetsOnAllPlatforms("can start at the beginning of an existing word", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before flutter after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |flutter".
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Type the trigger to start composing a tag.
+        await tester.typeImeText("#");
+
+        // Ensure that the tag has a composing attribution.
+        final text = SuperEditorInspector.findTextInComponent("1");
+        expect(text.text, "before #flutter after");
+        expect(
+          text.getAttributedRange({const PatternTagAttribution()}, 7),
+          const SpanRange(7, 14),
+        );
+      });
+
       testWidgetsOnAllPlatforms("removes tag when deleting back to the #", (tester) async {
         await _pumpTestEditor(
           tester,

--- a/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
+++ b/super_editor/test/super_editor/text_entry/tagging/stable_tags_test.dart
@@ -76,6 +76,34 @@ void main() {
         );
       });
 
+      testWidgetsOnAllPlatforms("can start at the beginning of an existing word", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before john after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |john"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Type the trigger to start composing a tag.
+        await tester.typeImeText("@");
+
+        // Ensure that "@john" was attributed.
+        final text = SuperEditorInspector.findTextInComponent("1");
+        expect(text.text, "before @john after");
+        expect(
+          text.getAttributedRange({stableTagComposingAttribution}, 7),
+          const SpanRange(7, 11),
+        );
+      });
+
       testWidgetsOnAllPlatforms("by default does not continue after a space", (tester) async {
         await _pumpTestEditor(
           tester,
@@ -436,6 +464,37 @@ void main() {
         expect(
           text.getAttributedRange({const CommittedStableTagAttribution("john")}, 0),
           const SpanRange(0, 4),
+        );
+      });
+
+      testWidgetsOnAllPlatforms("at the beginning of an existing word", (tester) async {
+        await _pumpTestEditor(
+          tester,
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("before john after"),
+              ),
+            ],
+          ),
+        );
+
+        // Place the caret at "before |john"
+        await tester.placeCaretInParagraph("1", 7);
+
+        // Type the trigger to start composing a tag.
+        await tester.typeImeText("@");
+
+        // Press left arrow to move away and commit the tag.
+        await tester.pressLeftArrow();
+
+        // Ensure that "@john" was attributed.
+        final text = SuperEditorInspector.findTextInComponent("1");
+        expect(text.text, "before @john after");
+        expect(
+          text.getAttributedRange({const CommittedStableTagAttribution("john")}, 7),
+          const SpanRange(7, 11),
         );
       });
 


### PR DESCRIPTION
[SuperEditor] Limit tag expansion to caret position. Resolves #2240, #2241, #2242

Steps to reproduce:

1. Go to the "Action Tags" section of the example app
2. Type some text
3. Place the cursor in the middle of the text
4. Type "/"
5. Press backspace
6. Type "/" again

The editor crashes with the following exception:

```console
════════ Exception caught by services library ══════════════════════════════════
The following _Exception was thrown during method call TextInputClient.updateEditingStateWithDeltas:
Exception: removeAttribution() did not satisfy start < 0 and start > end, start: 6, end: 5

When the exception was thrown, this was the stack:
#0      AttributedSpans.removeAttribution (package:attributed_text/src/attributed_spans.dart:514:7)
attributed_spans.dart:514
#1      RemoveTextAttributionsCommand.execute (package:super_editor/src/default_editor/text.dart:1439:15)
text.dart:1439
#2      _DocumentEditorCommandExecutor.executeCommand (package:super_editor/src/core/editor.dart:701:15)
editor.dart:701
#3      Editor._executeCommand (package:super_editor/src/core/editor.dart:304:22)
editor.dart:304
#4      Editor.execute (package:super_editor/src/core/editor.dart:266:30)
editor.dart:266
#5      ActionTagComposingReaction._healCancelledTags (package:super_editor/src/default_editor/text_tokenizing/action_tags.dart:364:23)
action_tags.dart:364
#6      ActionTagComposingReaction.react (package:super_editor/src/default_editor/text_tokenizing/action_tags.dart:286:5)
action_tags.dart:286
#7      Editor._reactToChanges (package:super_editor/src/core/editor.dart:357:16)
editor.dart:357
#8      Editor.endTransaction (package:super_editor/src/core/editor.dart:222:5)
editor.dart:222
... many more
```

While investigating this, I noticed that typing "/" at the middle of the word causes all the text that comes after the "/" to be part of the action tag:

https://github.com/user-attachments/assets/a7e3a359-ad31-494f-8593-ea75c91de951

This doesn't look like is expected.

This PR changes this behavior. Now, the tag is expanded only until the caret position:

https://github.com/user-attachments/assets/f3f79c33-04ca-4f08-bf90-fcd39a74224f

Changing this seems to already fix the issue, and also https://github.com/superlistapp/super_editor/issues/2241 and https://github.com/superlistapp/super_editor/issues/2242
