### PR TITLE
[SuperEditor] - Handle automatic refocus selection when the doc content has changed (Resolves #2386)

### DIFF
--- a/super_editor/lib/src/core/document.dart
+++ b/super_editor/lib/src/core/document.dart
@@ -328,6 +328,11 @@ abstract class DocumentNode implements ChangeNotifier {
   /// For example, a [ParagraphNode] would return [TextNodePosition(offset: text.length)].
   NodePosition get endPosition;
 
+  /// Returns `true` if this [DocumentNode] contains the given [position], or `false`
+  /// if the [position] doesn't sit within this node, or if the [position] type doesn't
+  /// apply to this [DocumentNode].
+  bool containsPosition(Object position);
+
   /// Inspects [position1] and [position2] and returns the one that's
   /// positioned further upstream in this [DocumentNode].
   ///

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -27,6 +27,15 @@ abstract class BlockNode extends DocumentNode {
   UpstreamDownstreamNodePosition get endPosition => const UpstreamDownstreamNodePosition.downstream();
 
   @override
+  bool containsPosition(Object position) {
+    if (position is! UpstreamDownstreamNodePosition) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
   UpstreamDownstreamNodePosition selectUpstreamPosition(NodePosition position1, NodePosition position2) {
     if (position1 is! UpstreamDownstreamNodePosition) {
       throw Exception(

--- a/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
+++ b/super_editor/lib/src/default_editor/document_focus_and_selection_policies.dart
@@ -130,12 +130,62 @@ class _EditorSelectionAndFocusPolicyState extends State<EditorSelectionAndFocusP
           return;
         }
 
+        if (_previousSelection == null) {
+          // There's no selection to restore.
+          return;
+        }
+
         // Restore the previous selection.
         editorPoliciesLog
             .info("[${widget.runtimeType}] - restoring previous editor selection because the editor re-gained focus");
+        final previousSelection = _previousSelection!;
+        late final DocumentSelection restoredSelection;
+        final baseNode = widget.editor.context.document.getNodeById(previousSelection.base.nodeId);
+        final extentNode = widget.editor.context.document.getNodeById(previousSelection.extent.nodeId);
+        if (baseNode == null && extentNode == null) {
+          // The node(s) where the selection was previously are gone. Possibly deleted.
+          // Therefore, we can't restore the previous selection. Fizzle.
+          return;
+        }
+
+        if (baseNode != null && extentNode != null) {
+          if (!baseNode.containsPosition(previousSelection.base.nodePosition)) {
+            // Either the base node content changed and the selection no longer fits, or the
+            // type of content in the node changed. Either way, we can't restore this selection.
+            return;
+          }
+          if (!extentNode.containsPosition(previousSelection.extent.nodePosition)) {
+            // Either the extent node content changed and the selection no longer fits, or the
+            // type of content in the node changed. Either way, we can't restore this selection.
+            return;
+          }
+
+          // The base and extent nodes both still exist. Use the previous selection
+          // without modification.
+          restoredSelection = previousSelection;
+        } else if (baseNode == null) {
+          // The base node disappeared, but the extent node remains.
+          if (!extentNode!.containsPosition(previousSelection.extent.nodePosition)) {
+            // Either the extent node content changed and the selection no longer fits, or the
+            // type of content in the node changed. Either way, we can't restore this selection.
+            return;
+          }
+
+          restoredSelection = DocumentSelection.collapsed(position: previousSelection.extent);
+        } else if (extentNode == null) {
+          // The extent node disappeared, but the base node remains.
+          if (!baseNode.containsPosition(previousSelection.base.nodePosition)) {
+            // Either the base node content changed and the selection no longer fits, or the
+            // type of content in the node changed. Either way, we can't restore this selection.
+            return;
+          }
+
+          restoredSelection = DocumentSelection.collapsed(position: previousSelection.extent);
+        }
+
         widget.editor.execute([
           ChangeSelectionRequest(
-            _previousSelection,
+            restoredSelection,
             SelectionChangeType.placeCaret,
             SelectionReason.contentChange,
           ),
@@ -177,6 +227,7 @@ class _EditorSelectionAndFocusPolicyState extends State<EditorSelectionAndFocusP
     // (Maybe) remove the editor's selection when it loses focus.
     if (!widget.focusNode.hasFocus && widget.clearSelectionWhenEditorLosesFocus) {
       editorPoliciesLog.info("[${widget.runtimeType}] - clearing editor selection because the editor lost all focus");
+
       widget.editor.execute([
         const ClearSelectionRequest(),
       ]);

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -71,6 +71,19 @@ class TextNode extends DocumentNode with ChangeNotifier {
   TextNodePosition get endPosition => TextNodePosition(offset: text.length);
 
   @override
+  bool containsPosition(Object position) {
+    if (position is! TextNodePosition) {
+      return false;
+    }
+
+    if (position.offset < 0 || position.offset > text.length) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
   NodePosition selectUpstreamPosition(NodePosition position1, NodePosition position2) {
     if (position1 is! TextNodePosition) {
       throw Exception('Expected a TextNodePosition for position1 but received a ${position1.runtimeType}');

--- a/super_editor/test/super_editor/supereditor_focus_test.dart
+++ b/super_editor/test/super_editor/supereditor_focus_test.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
 import '../test_tools_user_input.dart';
@@ -48,5 +51,593 @@ void main() {
         expect(SuperEditorInspector.hasFocus(), true);
       }, variant: inputAndGestureVariants);
     });
+
+    group("throws away stale selection after re-focus", () {
+      group("with caret", () {
+        testWidgetsOnAllPlatforms("when content type changes", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithSingleParagraph(tester, editorFocusNode: focusNode);
+
+          // Place caret in the middle of a word.
+          await tester.placeCaretInParagraph('1', 8);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the paragraph with a horizontal rule.
+          testContext.editor.execute([
+            ReplaceNodeRequest(
+              existingNodeId: '1',
+              newNode: HorizontalRuleNode(id: '1'),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when it no longer fits in text", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithSingleParagraph(tester, editorFocusNode: focusNode);
+
+          // Place caret in the middle of a word.
+          await tester.placeCaretInParagraph('1', 8);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the paragraph with a horizontal rule.
+          final textNode = testContext.document.first as TextNode;
+          testContext.editor.execute([
+            DeleteContentRequest(
+              documentRange: DocumentRange(
+                start: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.beginningPosition),
+                end: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.endPosition),
+              ),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+      });
+
+      group("with expanded selection within a node", () {
+        testWidgetsOnAllPlatforms("when downstream no longer fits", (tester) async {
+          final editorFocusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithSingleParagraph(tester, editorFocusNode: editorFocusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Delete the text so that the selection extent is no longer valid.
+          final textNode = testContext.document.first as TextNode;
+          testContext.editor.execute([
+            DeleteContentRequest(
+              documentRange: DocumentRange(
+                start: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.beginningPosition),
+                end: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.endPosition),
+              ),
+            ),
+          ]);
+
+          // Focus the editor.
+          editorFocusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when content type changes", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithSingleParagraph(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the paragraph with a horizontal rule.
+          testContext.editor.execute([
+            ReplaceNodeRequest(
+              existingNodeId: '1',
+              newNode: HorizontalRuleNode(id: '1'),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+      });
+
+      group("with expanded selection across nodes", () {
+        testWidgetsOnAllPlatforms("when the base and extent content type changes", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithTwoParagraphs(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the paragraphs with horizontal rules.
+          testContext.editor.execute([
+            ReplaceNodeRequest(
+              existingNodeId: '1',
+              newNode: HorizontalRuleNode(id: '1'),
+            ),
+            ReplaceNodeRequest(
+              existingNodeId: '2',
+              newNode: HorizontalRuleNode(id: '2'),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when the base content type changes", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithTwoParagraphs(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the base paragraph with a horizontal rule.
+          testContext.editor.execute([
+            ReplaceNodeRequest(
+              existingNodeId: '1',
+              newNode: HorizontalRuleNode(id: '1'),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when the extent content type changes", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithTwoParagraphs(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Replace the extent paragraph with a horizontal rule.
+          testContext.editor.execute([
+            ReplaceNodeRequest(
+              existingNodeId: '2',
+              newNode: HorizontalRuleNode(id: '2'),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when the upstream no longer fits", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithTwoParagraphs(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 1),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 1),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Delete the text in the upstream node.
+          final textNode = testContext.editor.context.document.first as TextNode;
+          testContext.editor.execute([
+            DeleteContentRequest(
+              documentRange: DocumentRange(
+                start: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.beginningPosition),
+                end: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.endPosition),
+              ),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+
+        testWidgetsOnAllPlatforms("when the downstream no longer fits", (tester) async {
+          final focusNode = FocusNode();
+          final testContext = await _pumpFocusChangeLayoutWithTwoParagraphs(tester, editorFocusNode: focusNode);
+
+          // Tap on editor to give it focus.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Select some text.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+              SelectionChangeType.placeCaret,
+              SelectionReason.userInteraction,
+            ),
+          ]);
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          );
+
+          // Focus the textfield.
+          await tester.tap(find.byType(TextField));
+          await tester.pumpAndSettle();
+
+          // Ensure selection was cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+
+          // Delete the text in the downstream node.
+          final textNode = testContext.editor.context.document.last as TextNode;
+          testContext.editor.execute([
+            DeleteContentRequest(
+              documentRange: DocumentRange(
+                start: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.beginningPosition),
+                end: DocumentPosition(nodeId: textNode.id, nodePosition: textNode.endPosition),
+              ),
+            ),
+          ]);
+
+          // Focus the editor.
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          // Ensure selection is cleared.
+          expect(SuperEditorInspector.findDocumentSelection(), isNull);
+        });
+      });
+    });
   });
+}
+
+Future<TestDocumentContext> _pumpFocusChangeLayoutWithSingleParagraph(
+  WidgetTester tester, {
+  required FocusNode editorFocusNode,
+  FocusNode? textFieldFocusNode,
+}) async {
+  return await tester
+      .createDocument()
+      .withSingleParagraph()
+      .withInputSource(TextInputSource.ime)
+      .withFocusNode(editorFocusNode)
+      .withCustomWidgetTreeBuilder(
+        (superEditor) => MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                // Add a textfield as a place to temporarily move focus.
+                TextField(
+                  focusNode: textFieldFocusNode,
+                ),
+                Expanded(child: superEditor),
+              ],
+            ),
+          ),
+        ),
+      )
+      .pump();
+}
+
+Future<TestDocumentContext> _pumpFocusChangeLayoutWithTwoParagraphs(
+  WidgetTester tester, {
+  required FocusNode editorFocusNode,
+  FocusNode? textFieldFocusNode,
+}) async {
+  return await tester
+      .createDocument()
+      .withCustomContent(MutableDocument(nodes: [
+        ParagraphNode(id: "1", text: AttributedText("Hello, world - 1")),
+        ParagraphNode(id: "2", text: AttributedText("Hello, world - 2")),
+      ]))
+      .withInputSource(TextInputSource.ime)
+      .withFocusNode(editorFocusNode)
+      .withCustomWidgetTreeBuilder(
+        (superEditor) => MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                // Add a textfield as a place to temporarily move focus.
+                TextField(
+                  focusNode: textFieldFocusNode,
+                ),
+                Expanded(child: superEditor),
+              ],
+            ),
+          ),
+        ),
+      )
+      .pump();
 }


### PR DESCRIPTION
[SuperEditor] - Handle automatic refocus selection when the doc content has changed (Resolves #2386)

Situation: Super Editor has focus and a selection, then focus is given to something else, then focus returns to Super Editor and restores the previous selection.

Problem: If the document content changes while Super Editor has no focus, then when the focus comes back, the selection might be incompatible with the new structure of the content.

This PR looks for cases where certain changes to content take place. If those changes happen, then no selection is restored.