### PR TITLE
[SuperTextField][iOS] Fix selection highlight (Resolves #2346)

### DIFF
--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -629,17 +629,17 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
         return Stack(
           clipBehavior: Clip.none,
           children: [
-            if (widget.textController?.selection.isValid == true)
+            if (_textEditingController.selection.isValid == true)
               // Selection highlight beneath the text.
               TextLayoutSelectionHighlight(
                 textLayout: textLayout,
                 style: SelectionHighlightStyle(
                   color: widget.selectionColor,
                 ),
-                selection: widget.textController?.selection,
+                selection: _textEditingController.selection,
               ),
             // Underline beneath the composing region.
-            if (widget.textController?.composingRegion.isValid == true && widget.showComposingUnderline)
+            if (_textEditingController.composingRegion.isValid == true && widget.showComposingUnderline)
               TextUnderlineLayer(
                 textLayout: textLayout,
                 style: StraightUnderlineStyle(
@@ -648,7 +648,7 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
                 ),
                 underlines: [
                   TextLayoutUnderline(
-                    range: widget.textController!.composingRegion,
+                    range: _textEditingController.composingRegion,
                   ),
                 ],
               ),

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
+import 'package:super_editor/super_editor_test.dart';
 import 'package:super_editor/super_text_field.dart';
+import 'package:super_text_layout/super_text_layout.dart';
 
 import '../super_textfield_inspector.dart';
 import '../super_textfield_robot.dart';
@@ -107,6 +109,38 @@ void main() {
 
       // Ensure that the text field toolbar is visible.
       expect(find.byType(IOSTextEditingFloatingToolbar), findsOneWidget);
+    });
+
+    testWidgetsOnIos('displays selection highlight for expanded selection', (tester) async {
+      // Pump a tree with a SuperIOSTextField without providing it a controller.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 300),
+              child: const SuperIOSTextField(
+                padding: EdgeInsets.all(12),
+                caretStyle: CaretStyle(color: Colors.red),
+                selectionColor: defaultSelectionColor,
+                handlesColor: Colors.red,
+                textStyleBuilder: defaultTextFieldStyleBuilder,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Place the caret at the beginning of the text.
+      await tester.placeCaretInSuperTextField(0, find.byType(SuperIOSTextField));
+
+      // Type some text.
+      await tester.typeImeText('This is some text');
+
+      // Double tap to select the word "some".
+      await tester.doubleTapAtSuperTextField(10, find.byType(SuperIOSTextField));
+
+      // Ensure the selection highlight is displayed.
+      expect(find.byType(TextLayoutSelectionHighlight), findsOneWidget);
     });
   });
 }

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -111,8 +111,11 @@ void main() {
       expect(find.byType(IOSTextEditingFloatingToolbar), findsOneWidget);
     });
 
-    testWidgetsOnIos('displays selection highlight for expanded selection', (tester) async {
-      // Pump a tree with a SuperIOSTextField without providing it a controller.
+    testWidgetsOnIos('displays selection highlight when controller is not provided', (tester) async {
+      // Pump a tree with a SuperIOSTextField without providing it a controller to make sure
+      // SuperIOSTextField does not rely on the provided controller to show the selection highlight.
+      //
+      // See https://github.com/superlistapp/super_editor/issues/2346 for details.
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(


### PR DESCRIPTION
[SuperTextField][iOS] Fix selection highlight. Resolves #2346

When using a `SuperIOSTextField` (not a `SuperTextField`), the selection highlight doesn't appear. This only happens if we don't provide a `textController` in `SuperIOSTextField` constructor.

The issue is that, in the places we check for an existing selection to add the highlights, we are always checking for the  `textController` provided by the widget constructor instead of using the internal controller (which uses the constructor's `textController` if provided).

This PR fixes the issue by making `SuperIOSTextField` always use the internal `textController`.

I'm not sure the text is good, since we are looking at too much implementation details. Maybe we should just use a golden test instead.

