### PR TITLE
WIP: [SuperEditor] Add the ability to add an empty paragraph when tapping a non-selectable node at the end of the document (Resolves #2395)

### DIFF
--- a/super_editor/lib/src/default_editor/default_document_editor.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor.dart
@@ -47,6 +47,12 @@ final defaultRequestHandlers = List.unmodifiable(<EditRequestHandler>[
           SelectionReason.userInteraction,
         )
       : null,
+  (request) => request is SelectNearestSelectableNodeRequest
+      ? SelectNearestSelectableNodeCommand(
+          targetNodeId: request.targetNodeId,
+          nearestSelection: request.nearestSelection,
+        )
+      : null,
   (request) => request is ChangeComposingRegionRequest //
       ? ChangeComposingRegionCommand(request.composingRegion)
       : null,

--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -268,11 +268,23 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     final expandSelection = _isShiftPressed && _currentSelection != null;
 
     if (!tappedComponent.isVisualSelectionSupported()) {
-      _moveToNearestSelectableComponent(
-        docPosition.nodeId,
-        tappedComponent,
-        expandSelection: expandSelection,
+      final nearestSelection = findSelectionToNearestSelectableNode(
+        document: widget.document,
+        documentLayoutResolver: widget.getDocumentLayout,
+        currentSelection: _currentSelection,
+        startingNode: widget.document.getNodeById(docPosition.nodeId)!,
       );
+      widget.editor.execute([
+        SelectNearestSelectableNodeRequest(
+          targetNodeId: docPosition.nodeId,
+          nearestSelection: nearestSelection,
+        ),
+      ]);
+
+      if (!expandSelection) {
+        _selectionType = SelectionType.position;
+      }
+
       return;
     }
 


### PR DESCRIPTION
[SuperEditor] Add the ability to add an empty paragraph when tapping a non-selectable node at the end of the document .Resolves #2395

When tapping at a non-selectable node, the editor moves the selection to the nearest selectable node.

This PR adds the ability to add a new empty paragraph when the user taps at a non-selectable node at the end of the document.

This PR isn't complete. The goal is to decide if that's how we want to implement it. We talked about using a reaction for that,  but this special handling of non-selectable nodes happens before issuing a selection change request. Also, checking if the node is selectable requires access to the document layout to get the component for the node. We don't have access to that in reactions.

This PR introduces a `SelectNearestSelectableNodeRequest`, that takes a `targetNodeId` (the id of the non-selectable node that the user tapped), and the nearest selection.

In the command, we can choose to add a new node if the node with `targetNodeId` is the last node of the document.

Open question: How should we make this configurable? Create two commands, one that only changes the selection and other that adds an empty paragraph if the non-selectable node is the last in the document? Create a constructor parameter in `SelectNearestSelectableNodeCommand` to configure this? Another option?