### PR TITLE
[SuperEditor] Add tap handler to add an empty paragraph when tapping below the end of document (Resolves #2395)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -255,8 +255,24 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       return;
     }
 
+    final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+
     if (widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -264,7 +280,6 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       }
     }
 
-    final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
     final expandSelection = _isShiftPressed && _currentSelection != null;
 
     if (!tappedComponent.isVisualSelectionSupported()) {
@@ -304,8 +319,26 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
+    final tappedComponent = docPosition != null //
+        ? _docLayout.getComponentByNodeId(docPosition.nodeId)!
+        : null;
+
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final componentBox = tappedComponent!.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -313,8 +346,7 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
       }
     }
 
-    if (docPosition != null) {
-      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+    if (docPosition != null && tappedComponent != null) {
       if (!tappedComponent.isVisualSelectionSupported()) {
         return;
       }
@@ -405,8 +437,26 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     final docPosition = _docLayout.getDocumentPositionNearestToOffset(docOffset);
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
+    final tappedComponent = docPosition != null //
+        ? _docLayout.getComponentByNodeId(docPosition.nodeId)!
+        : null;
+
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final componentBox = tappedComponent!.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -806,7 +806,22 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (widget.contentTapHandler != null && docPosition != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -864,7 +879,22 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -938,7 +968,22 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -660,7 +660,22 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (widget.contentTapHandler != null && docPosition != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -774,7 +789,22 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -853,7 +883,22 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     editorGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -20,6 +20,7 @@ import 'package:super_editor/src/default_editor/document_gestures_touch_ios.dart
 import 'package:super_editor/src/default_editor/document_scrollable.dart';
 import 'package:super_editor/src/default_editor/layout_single_column/_styler_composing_region.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
+import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
@@ -1682,7 +1683,8 @@ class SuperEditorLaunchLinkTapHandler extends ContentTapDelegate {
   }
 
   @override
-  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
+  TapHandlingInstruction onTap(DocumentTapDetails details) {
+    final tapPosition = details.position;
     if (!composer.isInInteractionMode.value) {
       // The editor isn't in "interaction mode". We don't want to allow
       // users to open links by tapping on them.
@@ -1721,5 +1723,58 @@ class SuperEditorLaunchLinkTapHandler extends ContentTapDelegate {
     }
 
     return null;
+  }
+}
+
+SuperEditorAddEmptyParagraphTapHandler superEditorAddEmptyParagraphTapHandlerFactory(SuperEditorContext editContext) =>
+    SuperEditorAddEmptyParagraphTapHandler(editor: editContext.editor);
+
+/// A [ContentTapDelegate] that adds an empty paragraph at the end of the document
+/// when the user taps below the last node in the document.
+///
+/// Does nothing if the last node is a [TextNode].
+class SuperEditorAddEmptyParagraphTapHandler extends ContentTapDelegate {
+  SuperEditorAddEmptyParagraphTapHandler({
+    required this.editor,
+  });
+
+  final Editor editor;
+
+  @override
+  TapHandlingInstruction onTap(DocumentTapDetails details) {
+    if (!details.isGestureBelowEndOfDocument) {
+      return TapHandlingInstruction.continueHandling;
+    }
+
+    final node = editor.document.getNodeById(details.position.nodeId)!;
+    if (node is TextNode) {
+      return TapHandlingInstruction.continueHandling;
+    }
+
+    // The user tapped below a non-text node. Add a new paragraph
+    // to the end of the document and place the caret there.
+    final newNodeId = Editor.createNodeId();
+    editor.execute([
+      InsertNodeAfterNodeRequest(
+        existingNodeId: node.id,
+        newNode: ParagraphNode(
+          id: newNodeId,
+          text: AttributedText(),
+        ),
+      ),
+      ChangeSelectionRequest(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: newNodeId,
+            nodePosition: const TextNodePosition(offset: 0),
+          ),
+        ),
+        SelectionChangeType.insertContent,
+        SelectionReason.userInteraction,
+      ),
+      const ClearComposingRegionRequest(),
+    ]);
+
+    return TapHandlingInstruction.halt;
   }
 }

--- a/super_editor/lib/src/infrastructure/document_gestures_interaction_overrides.dart
+++ b/super_editor/lib/src/infrastructure/document_gestures_interaction_overrides.dart
@@ -12,17 +12,38 @@ abstract class ContentTapDelegate with ChangeNotifier {
     return null;
   }
 
-  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
+  TapHandlingInstruction onTap(DocumentTapDetails tapPosition) {
     return TapHandlingInstruction.continueHandling;
   }
 
-  TapHandlingInstruction onDoubleTap(DocumentPosition tapPosition) {
+  TapHandlingInstruction onDoubleTap(DocumentTapDetails tapPosition) {
     return TapHandlingInstruction.continueHandling;
   }
 
-  TapHandlingInstruction onTripleTap(DocumentPosition tapPosition) {
+  TapHandlingInstruction onTripleTap(DocumentTapDetails tapPosition) {
     return TapHandlingInstruction.continueHandling;
   }
+}
+
+/// Information about a gesture that occured near a [position].
+class DocumentTapDetails {
+  DocumentTapDetails({
+    required this.position,
+    required this.isGestureAboveStartOfDocument,
+    required this.isGestureBelowEndOfDocument,
+  });
+
+  /// The position in the document where the gesture occurred.
+  ///
+  /// When there is no content at the gesture location, this position
+  /// holds the nearest position in the document.
+  final DocumentPosition position;
+
+  /// Whether the gesture occurred above the first node in the document.
+  final bool isGestureAboveStartOfDocument;
+
+  /// Whether the gesture occurred below the last node in the document.
+  final bool isGestureBelowEndOfDocument;
 }
 
 enum TapHandlingInstruction {

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -569,7 +569,22 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (widget.contentTapHandler != null && docPosition != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -609,7 +624,21 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -657,7 +686,21 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_ios_touch_interactor.dart
@@ -519,7 +519,22 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (widget.contentTapHandler != null && docPosition != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -557,7 +572,22 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -605,7 +635,22 @@ class _SuperReaderIosDocumentTouchInteractorState extends State<SuperReaderIosDo
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = widget.document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == widget.document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
@@ -224,7 +224,24 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
     }
 
     if (widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTap(docPosition);
+      final document = widget.readerContext.document;
+
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -275,7 +292,24 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
     }
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onDoubleTap(docPosition);
+      final document = widget.readerContext.document;
+
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onDoubleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.
@@ -320,7 +354,24 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
     readerGesturesLog.fine(" - tapped document position: $docPosition");
 
     if (docPosition != null && widget.contentTapHandler != null) {
-      final result = widget.contentTapHandler!.onTripleTap(docPosition);
+      final document = widget.readerContext.document;
+
+      final tappedComponent = _docLayout.getComponentByNodeId(docPosition.nodeId)!;
+      final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
+      final localPosition = componentBox.globalToLocal(details.globalPosition);
+      final nodeIndex = document.getNodeIndexById(docPosition.nodeId);
+
+      final isAboveStartOfDocument = (nodeIndex == 0) && (localPosition.dy < 0);
+      final isBelowEndOfDocument =
+          (nodeIndex == document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+
+      final result = widget.contentTapHandler!.onTripleTap(
+        DocumentTapDetails(
+          position: docPosition,
+          isGestureAboveStartOfDocument: isAboveStartOfDocument,
+          isGestureBelowEndOfDocument: isBelowEndOfDocument,
+        ),
+      );
       if (result == TapHandlingInstruction.halt) {
         // The custom tap handler doesn't want us to react at all
         // to the tap.

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -685,7 +685,8 @@ class SuperReaderLaunchLinkTapHandler extends ContentTapDelegate {
   }
 
   @override
-  TapHandlingInstruction onTap(DocumentPosition tapPosition) {
+  TapHandlingInstruction onTap(DocumentTapDetails details) {
+    final tapPosition = details.position;
     final link = _getLinkAtPosition(tapPosition);
     if (link != null) {
       // The user tapped on a link. Launch it.

--- a/super_editor/test/super_editor/custom_tap_handlers/add_paragraph_at_end_tap_handler_test.dart
+++ b/super_editor/test/super_editor/custom_tap_handlers/add_paragraph_at_end_tap_handler_test.dart
@@ -1,0 +1,104 @@
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../../test_tools.dart';
+import '../supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > SuperEditorAddEmptyParagraphTapHandler > ', () {
+    group('when tapping below the end of the document', () {
+      testWidgetsOnAllPlatforms('adds a new empty paragraph when the last node is a non-text node', (tester) async {
+        // Pump an editor with a height big enough so we know we can tap
+        // at a space after the document ends.
+        await tester //
+            .createDocument()
+            .withCustomContent(MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText('First paragraph'),
+                ),
+                HorizontalRuleNode(id: 'hr')
+              ],
+            ))
+            .withEditorSize(const Size(500, 1000))
+            .withTapDelegateFactory(superEditorAddEmptyParagraphTapHandlerFactory)
+            .pump();
+
+        // Tap below the end of the document and wait for the double tap
+        // timeout to expire.
+        await tester.tapAt(const Offset(490, 990));
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+
+        final document = SuperEditorInspector.findDocument()!;
+
+        // Ensure a new empty paragraph was added.
+        expect(document.nodeCount, equals(3));
+        expect(document.last, isA<ParagraphNode>());
+        expect((document.last as ParagraphNode).text.text, isEmpty);
+
+        // Ensure the selection was placed in the newly added paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnAllPlatforms('does nothing when the last node is a text node', (tester) async {
+        // Pump an editor with a height big enough so we know we can tap
+        // at a space after the document ends.
+        await tester //
+            .createDocument()
+            .withCustomContent(MutableDocument(
+              nodes: [
+                HorizontalRuleNode(id: 'hr'),
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText('First paragraph'),
+                ),
+              ],
+            ))
+            .withEditorSize(const Size(500, 1000))
+            .withTapDelegateFactory(superEditorAddEmptyParagraphTapHandlerFactory)
+            .pump();
+
+        // Tap below the end of the document and wait for the double tap
+        // timeout to expire.
+        await tester.tapAt(const Offset(490, 990));
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+
+        final document = SuperEditorInspector.findDocument()!;
+
+        // Ensure the existing paragraph was kept.
+        expect(document.nodeCount, equals(2));
+        expect(document.last, isA<ParagraphNode>());
+        expect((document.last as ParagraphNode).text.text, 'First paragraph');
+
+        // Ensure the selection was placed at the end of the paragraph.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 15),
+              ),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/super_editor/test/super_editor/supereditor_test_tools.dart
+++ b/super_editor/test/super_editor/supereditor_test_tools.dart
@@ -353,6 +353,12 @@ class TestSuperEditorConfigurator {
     return this;
   }
 
+  /// Configures the [SuperEditor] to use the given [tapDelegateFactory].
+  TestSuperEditorConfigurator withTapDelegateFactory(SuperEditorContentTapDelegateFactory? tapDelegateFactory) {
+    _config.tapDelegateFactory = tapDelegateFactory;
+    return this;
+  }
+
   /// Applies the given [plugin] to the pumped [SuperEditor].
   TestSuperEditorConfigurator withPlugin(SuperEditorPlugin plugin) {
     _config.plugins.add(plugin);
@@ -588,6 +594,7 @@ class _TestSuperEditorState extends State<_TestSuperEditor> {
       focusNode: widget.testDocumentContext.focusNode,
       autofocus: widget.testConfiguration.autoFocus,
       tapRegionGroupId: widget.testConfiguration.tapRegionGroupId,
+      contentTapDelegateFactory: widget.testConfiguration.tapDelegateFactory ?? superEditorLaunchLinkTapHandlerFactory,
       editor: widget.testDocumentContext.editor,
       documentLayoutKey: widget.testDocumentContext.layoutKey,
       inputSource: widget.testConfiguration.inputSource,
@@ -712,6 +719,8 @@ class SuperEditorTestConfiguration {
   DocumentFloatingToolbarBuilder? iOSToolbarBuilder;
 
   DocumentSelection? selection;
+
+  SuperEditorContentTapDelegateFactory? tapDelegateFactory;
 
   final plugins = <SuperEditorPlugin>{};
 


### PR DESCRIPTION
[SuperEditor] Add tap handler to add an empty paragraph when tapping below the end of document. Resolves #2395 

Currently, tapping below the end of the document places the caret at the end of the last selectable component.

This PR modifies the `ContentTapDelegate` to include more detailed information about the tap, including whether or not the tap happened below the last node of above the first one. 

This PR also introduces a `SuperEditorAddEmptyParagraphTapHandler`, so apps can choose to add an empty paragraph to the end of the document instead.

This is a breaking change, but resolving it is pretty simple.

Instead of using booleans to describe if the gesture happened above the first node/after the last node, we could use an enum, because it won't make sense to have both `isGestureAboveStartOfDocument` and `isGestureBelowEndOfDocument` set to true.

