### PR TITLE
[SuperEditor] Fix crashing when deleting all content which contains a non-deletable node at an edge (Resolves #2393)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1423,11 +1423,13 @@ class CommonEditorOperations {
 
     if (baseNodeIndex != extentNodeIndex) {
       if (topNodePosition == topNode.beginningPosition && bottomNodePosition == bottomNode.endPosition) {
-        // All nodes in the selection will be deleted. Assume that the start
-        // node will be retained and converted into a paragraph, if it's not
+        // All deletable nodes in the selection will be deleted. Assume that one of the
+        // nodes will be retained and converted into a paragraph, if it's not
         // already a paragraph.
         newSelectionPosition = DocumentPosition(
-          nodeId: topNode.id,
+          nodeId: (topNode is BlockNode && !topNode.isDeletable) //
+              ? bottomNode.id
+              : topNode.id,
           nodePosition: const TextNodePosition(offset: 0),
         );
       } else if (topNodePosition == topNode.beginningPosition) {

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1382,7 +1382,7 @@ class CommonEditorOperations {
   /// Returns the [DocumentPosition] where the caret should sit after deleting
   /// the given [selection] from the given [document].
   ///
-  /// Returns `null` if there are no deletable nodes the [selection].
+  /// Returns `null` if there are no deletable nodes within the [selection].
   ///
   /// This method doesn't delete any content. Instead, it determines what would
   /// be deleted if a delete operation was run for the given [selection]. Based

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:attributed_text/attributed_text.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:linkify/linkify.dart';
@@ -1381,13 +1382,15 @@ class CommonEditorOperations {
   /// Returns the [DocumentPosition] where the caret should sit after deleting
   /// the given [selection] from the given [document].
   ///
+  /// Returns `null` if there are no deletable nodes the [selection].
+  ///
   /// This method doesn't delete any content. Instead, it determines what would
   /// be deleted if a delete operation was run for the given [selection]. Based
   /// on the shared understanding of content deletion rules, the resulting caret
   /// position is returned.
   // TODO: Move this method to an appropriate place. It was made public and static
   //       because document_keyboard_actions.dart also uses this behavior.
-  static DocumentPosition getDocumentPositionAfterExpandedDeletion({
+  static DocumentPosition? getDocumentPositionAfterExpandedDeletion({
     required Document document,
     required DocumentSelection selection,
   }) {
@@ -1419,6 +1422,10 @@ class CommonEditorOperations {
     final bottomNodePosition =
         baseNodeIndex < extentNodeIndex ? extentPosition.nodePosition : basePosition.nodePosition;
 
+    final normalizedRange = selection.normalize(document);
+    final nodes = document.getNodesInside(normalizedRange.start, normalizedRange.end);
+    final firstDeletableNodeId = nodes.firstWhereOrNull((node) => node.isDeletable)?.id;
+
     DocumentPosition newSelectionPosition;
 
     if (baseNodeIndex != extentNodeIndex) {
@@ -1426,10 +1433,21 @@ class CommonEditorOperations {
         // All deletable nodes in the selection will be deleted. Assume that one of the
         // nodes will be retained and converted into a paragraph, if it's not
         // already a paragraph.
+
+        final emptyParagraphId = topNode.isDeletable
+            ? topNode.id
+            : bottomNode.isDeletable
+                ? bottomNode.id
+                : firstDeletableNodeId;
+
+        if (emptyParagraphId == null) {
+          // There are no deletable nodes in the selection. Fizzle.
+          // We don't expect this method to be called if there are no deletable nodes.
+          return null;
+        }
+
         newSelectionPosition = DocumentPosition(
-          nodeId: (topNode is BlockNode && !topNode.isDeletable) //
-              ? bottomNode.id
-              : topNode.id,
+          nodeId: emptyParagraphId,
           nodePosition: const TextNodePosition(offset: 0),
         );
       } else if (topNodePosition == topNode.beginningPosition) {
@@ -2279,7 +2297,7 @@ class CommonEditorOperations {
   /// moves the caret, it's possible that the clipboard content will be pasted
   /// at the wrong spot.
   void paste() {
-    DocumentPosition pastePosition = composer.selection!.extent;
+    DocumentPosition? pastePosition = composer.selection!.extent;
 
     // Start a transaction so that we can capture both the initial deletion behavior,
     // and the clipboard content insertion, all as one transaction.
@@ -2291,6 +2309,11 @@ class CommonEditorOperations {
         document: document,
         selection: composer.selection!,
       );
+
+      if (pastePosition == null) {
+        // There are no deletable nodes in the selection. Do nothing.
+        return;
+      }
 
       // Delete the selected content.
       editor.execute([

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -789,22 +789,20 @@ class DeleteContentCommand extends EditCommand {
       );
     }
 
-    final wereAllNodesInRangeDeleted =
-        document.getNodeById(startNode.id) == null && document.getNodeById(endNode.id) == null;
-    final wereAllDeletableNodesDeleted = nodes.every(
+    final wereAllDeletableNodesInRangeDeleted = nodes.every(
       (node) => document.getNodeById(node.id) == null || !node.isDeletable,
     );
-    final hasNonDeletableNodes = nodes.any((node) => !node.isDeletable);
+    final hasNonDeletableNodesInRange = nodes.any((node) => !node.isDeletable);
 
     // If all selected nodes were deleted, e.g., the user selected from
     // the beginning of the first node to the end of the last node, then
     // we need insert an empty paragraph node so that there's a place
     // to position the caret.
-    if (wereAllNodesInRangeDeleted || wereAllDeletableNodesDeleted) {
+    if (wereAllDeletableNodesInRangeDeleted) {
       // If there are any non-deletable nodes in the range, insert the new node
       // after the last non-deletable node. Otherwise, insert the new node at
       // the position where the first selected node was.
-      final insertIndex = hasNonDeletableNodes //
+      final insertIndex = hasNonDeletableNodesInRange //
           ? document.getNodeIndexById(nodes.lastWhere((node) => !node.isDeletable).id) + 1
           : startNodeIndex;
 

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -753,7 +753,10 @@ class DeleteContentCommand extends EditCommand {
     if (endNode == null) {
       throw Exception('Could not locate end node for DeleteSelectionCommand: ${normalizedRange.end}');
     }
-    final endNodeIndex = document.getNodeIndexById(endNode.id);
+
+    // We expect that this command will only be called when the delete range
+    // contains at least one deletable node.
+    final firstDeletableNodeId = nodes.firstWhere((node) => node.isDeletable).id;
 
     executor.logChanges(
       _deleteNodesBetweenFirstAndLast(
@@ -786,34 +789,42 @@ class DeleteContentCommand extends EditCommand {
       );
     }
 
-    final wereAllNodesDeleted = document.getNodeById(startNode.id) == null && document.getNodeById(endNode.id) == null;
-    final wereAllDeletableNodesDeleted = document.every(
-      (e) => e is BlockNode && !e.isDeletable,
+    final wereAllNodesInRangeDeleted =
+        document.getNodeById(startNode.id) == null && document.getNodeById(endNode.id) == null;
+    final wereAllDeletableNodesDeleted = nodes.every(
+      (node) => document.getNodeById(node.id) == null || !node.isDeletable,
     );
+    final hasNonDeletableNodes = nodes.any((node) => !node.isDeletable);
 
     // If all selected nodes were deleted, e.g., the user selected from
     // the beginning of the first node to the end of the last node, then
     // we need insert an empty paragraph node so that there's a place
     // to position the caret.
-    if (wereAllNodesDeleted || wereAllDeletableNodesDeleted) {
-      // When we have non-deletable nodes and all deletable nodes were deleted,
-      // insert the new node at the end of the document.
-      final insertIndex = wereAllDeletableNodesDeleted //
-          ? document.nodeCount
-          : min(startNodeIndex, endNodeIndex);
+    if (wereAllNodesInRangeDeleted || wereAllDeletableNodesDeleted) {
+      // If there are any non-deletable nodes in the range, insert the new node
+      // after the last non-deletable node. Otherwise, insert the new node at
+      // the position where the first selected node was.
+      final insertIndex = hasNonDeletableNodes //
+          ? document.getNodeIndexById(nodes.lastWhere((node) => !node.isDeletable).id) + 1
+          : startNodeIndex;
 
-      // Pick the deletable node id as the id for the new paragraph.
-      final newId = (startNode is BlockNode && !startNode.isDeletable) //
-          ? endNode.id
-          : startNode.id;
+      // If one of the edge nodes is deletable, we can use it as the ID for the
+      // new empty paragraph. Otherwise, use the ID of the first deletable node in the range.
+      // We expect that this method is never called when there are no deletable nodes
+      // in the range.
+      final emptyParagraphId = startNode.isDeletable
+          ? startNode.id
+          : endNode.isDeletable
+              ? endNode.id
+              : firstDeletableNodeId;
 
       document.insertNodeAt(
         insertIndex,
-        ParagraphNode(id: newId, text: AttributedText()),
+        ParagraphNode(id: emptyParagraphId, text: AttributedText()),
       );
       executor.logChanges([
         DocumentEdit(
-          NodeChangeEvent(newId),
+          NodeChangeEvent(emptyParagraphId),
         )
       ]);
     }
@@ -1159,12 +1170,12 @@ class DeleteSelectionCommand extends EditCommand {
       }
     }
 
-    final newSelectionPosition = CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
-      document: document,
-      selection: selection,
-    );
-
     final nodes = document.getNodesInside(selection.start, selection.end);
+    if (nodes.every((node) => !node.isDeletable)) {
+      // All selected nodes are non-deletable. Do nothing.
+      return;
+    }
+
     if (nodes.length == 2) {
       final normalizedSelection = selection.normalize(document);
       final nodeAbove = document.getNode(normalizedSelection.start)!;
@@ -1212,19 +1223,26 @@ class DeleteSelectionCommand extends EditCommand {
       }
     }
 
-    executor
-      ..executeCommand(
-        DeleteContentCommand(
-          documentRange: selection,
-        ),
-      )
-      ..executeCommand(
+    final newSelectionPosition = CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
+      document: document,
+      selection: selection,
+    );
+
+    executor.executeCommand(
+      DeleteContentCommand(
+        documentRange: selection,
+      ),
+    );
+
+    if (newSelectionPosition != null) {
+      executor.executeCommand(
         ChangeSelectionCommand(
           DocumentSelection.collapsed(position: newSelectionPosition),
           SelectionChangeType.deleteContent,
           SelectionReason.userInteraction,
         ),
       );
+    }
   }
 }
 

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 
@@ -695,6 +696,140 @@ void main() {
             ),
           );
         });
+
+        testWidgetsOnDesktop('when the whole document is selected and starts with a non-deletable node',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place the caret at the beginning of the paragraph.
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 17),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressBackspace();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when the whole document is selected and ends with a non-deletable node', (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          await tester.placeCaretInParagraph("1", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressBackspace();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
       });
 
       group('with delete', () {
@@ -1162,6 +1297,140 @@ void main() {
           // Ensure the selection didn't change.
           expect(SuperEditorInspector.findDocumentSelection(), selection);
         });
+
+        testWidgetsOnDesktop('when the whole document is selected and starts with a non-deletable node',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place the caret at the beginning of the paragraph.
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: TextNodePosition(offset: 17),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressDelete();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when the whole document is selected and ends with a non-deletable node', (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          await tester.placeCaretInParagraph("1", 0);
+
+          // Select all content
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '2',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressDelete();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
       });
 
       group('when typing', () {
@@ -1609,6 +1878,162 @@ void main() {
           final document = SuperEditorInspector.findDocument()!;
           expect(document.getNodeById('hr'), isNotNull);
           expect(document.getNodeById('hr'), isA<HorizontalRuleNode>());
+        });
+
+        testWidgetsOnMobile('when the whole document is selected and starts with a non-deletable node', (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place the caret at the beginning of the paragraph.
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select the whole content.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: TextNodePosition(offset: 17),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\nThis is some text',
+              selection: TextSelection(baseOffset: 0, extentOffset: 21),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\nThis is some text',
+              deletedRange: TextSelection(baseOffset: 0, extentOffset: 21),
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.empty,
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnMobile('when the whole document is selected and ends with a non-deletable node', (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place the caret at the beginning of the paragraph.
+          await tester.placeCaretInParagraph("1", 0);
+
+          // Select the whole content.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. This is some text\n~',
+              selection: TextSelection(baseOffset: 0, extentOffset: 21),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. This is some text\n~',
+              deletedRange: TextSelection(baseOffset: 0, extentOffset: 21),
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.empty,
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rule was kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(2));
+          expect(document.first, isA<HorizontalRuleNode>());
+          expect(document.last, isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
         });
       });
     });

--- a/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
+++ b/super_editor/test/super_editor/supereditor_undeletable_content_test.dart
@@ -830,6 +830,233 @@ void main() {
             ),
           );
         });
+
+        testWidgetsOnDesktop('when the whole document is selected and starts and ends with non-deletable nodes',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressBackspace();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rules were kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when all nodes are non-deletable', (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "1",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Try to delete all content.
+          await tester.pressBackspace();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when all nodes in selection are non-deletable and document contains deletable nodes',
+            (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(id: '1', text: AttributedText()),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '4', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(id: '5', text: AttributedText()),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "2",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all non-deletable nodes.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Try to delete all content.
+          await tester.pressBackspace();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(5));
+          expect(document.getNodeAt(0), isA<ParagraphNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(3), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(4), isA<ParagraphNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '2',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '4',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+        });
       });
 
       group('with delete', () {
@@ -1431,6 +1658,233 @@ void main() {
             ),
           );
         });
+
+        testWidgetsOnDesktop('when the whole document is selected and starts and ends with non-deletable nodes',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Delete all content.
+          await tester.pressDelete();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rules were kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when all nodes are non-deletable', (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "1",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Try to delete all content.
+          await tester.pressDelete();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when all nodes in selection are non-deletable and document contains deletable nodes',
+            (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(id: '1', text: AttributedText()),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '4', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(id: '5', text: AttributedText()),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "2",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all non-deletable nodes.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Try to delete all content.
+          await tester.pressDelete();
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(5));
+          expect(document.getNodeAt(0), isA<ParagraphNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(3), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(4), isA<ParagraphNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '2',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '4',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+        });
       });
 
       group('when typing', () {
@@ -1881,7 +2335,7 @@ void main() {
         });
 
         testWidgetsOnMobile('when the whole document is selected and starts with a non-deletable node', (tester) async {
-          final testContext = await tester //
+          await tester //
               .createDocument()
               .withCustomContent(
                 MutableDocument(
@@ -1901,24 +2355,12 @@ void main() {
           // Place the caret at the beginning of the paragraph.
           await tester.placeCaretInParagraph("2", 0);
 
-          // Select the whole content.
-          testContext.editor.execute([
-            const ChangeSelectionRequest(
-              DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: '1',
-                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
-                ),
-                extent: DocumentPosition(
-                  nodeId: '2',
-                  nodePosition: TextNodePosition(offset: 17),
-                ),
-              ),
-              SelectionChangeType.expandSelection,
-              SelectionReason.userInteraction,
-            )
-          ]);
-          await tester.pump();
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
 
           // Simulate the user pressing backspace. The IME first generates a
           // selection change and then a deletion. Each block node is represented by a "~"
@@ -1959,7 +2401,7 @@ void main() {
         });
 
         testWidgetsOnMobile('when the whole document is selected and ends with a non-deletable node', (tester) async {
-          final testContext = await tester //
+          await tester //
               .createDocument()
               .withCustomContent(
                 MutableDocument(
@@ -1979,23 +2421,12 @@ void main() {
           // Place the caret at the beginning of the paragraph.
           await tester.placeCaretInParagraph("1", 0);
 
-          // Select the whole content.
-          testContext.editor.execute([
-            const ChangeSelectionRequest(
-              DocumentSelection(
-                base: DocumentPosition(
-                  nodeId: '1',
-                  nodePosition: TextNodePosition(offset: 0),
-                ),
-                extent: DocumentPosition(
-                  nodeId: '2',
-                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
-                ),
-              ),
-              SelectionChangeType.expandSelection,
-              SelectionReason.userInteraction,
-            )
-          ]);
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
           await tester.pump();
 
           // Simulate the user pressing backspace. The IME first generates a
@@ -2031,6 +2462,260 @@ void main() {
               position: DocumentPosition(
                 nodeId: document.last.id,
                 nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when the whole document is selected and starts and ends with non-deletable nodes',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(
+                      id: '2',
+                      text: AttributedText('This is some text'),
+                    ),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          await tester.placeCaretInParagraph("2", 0);
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Ensure everything is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\nThis is some text\n~',
+              selection: TextSelection(baseOffset: 0, extentOffset: 23),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\nThis is some text\n~',
+              deletedRange: TextSelection(baseOffset: 0, extentOffset: 23),
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.empty,
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure the horizontal rules were kept, the paragraph was deleted,
+          // and a new empty paragraph was added to the end of the document.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<ParagraphNode>());
+          expect((document.last as TextNode).text.text, equals(''));
+
+          // Ensure the caret was placed at the beginning of the newly inserted paragraph.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: document.last.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnMobile('when all nodes are non-deletable', (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    HorizontalRuleNode(id: '1', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "1",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all content.
+          if (CurrentPlatform.isApple) {
+            await tester.pressCmdA();
+          } else {
+            await tester.pressCtlA();
+          }
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\n~\n~',
+              selection: TextSelection(baseOffset: 0, extentOffset: 7),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\n~\n~',
+              deletedRange: TextSelection(baseOffset: 0, extentOffset: 7),
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.empty,
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(3));
+          expect(document.getNodeAt(0), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '3',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when all nodes in selection are non-deletable and document contains deletable nodes',
+            (tester) async {
+          final testContext = await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(id: '1', text: AttributedText()),
+                    HorizontalRuleNode(id: '2', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '3', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    HorizontalRuleNode(id: '4', metadata: {
+                      NodeMetadata.isDeletable: false,
+                    }),
+                    ParagraphNode(id: '5', text: AttributedText()),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Select the first horizontal rule.
+          await tester.tapAtDocumentPosition(
+            const DocumentPosition(
+              nodeId: "2",
+              nodePosition: UpstreamDownstreamNodePosition.upstream(),
+            ),
+          );
+
+          // Select all non-deletable nodes.
+          testContext.editor.execute([
+            const ChangeSelectionRequest(
+              DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '2',
+                  nodePosition: UpstreamDownstreamNodePosition.upstream(),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: UpstreamDownstreamNodePosition.downstream(),
+                ),
+              ),
+              SelectionChangeType.expandSelection,
+              SelectionReason.userInteraction,
+            )
+          ]);
+          await tester.pump();
+
+          // Simulate the user pressing backspace. The IME first generates a
+          // selection change and then a deletion. Each block node is represented by a "~"
+          // in the IME.
+          await tester.ime.sendDeltas([
+            const TextEditingDeltaNonTextUpdate(
+              oldText: '. ~\n~\n~',
+              selection: TextSelection(baseOffset: 0, extentOffset: 7),
+              composing: TextRange.empty,
+            ),
+            const TextEditingDeltaDeletion(
+              oldText: '. ~\n~\n~',
+              deletedRange: TextSelection(baseOffset: 0, extentOffset: 7),
+              selection: TextSelection.collapsed(offset: 0),
+              composing: TextRange.empty,
+            ),
+          ], getter: imeClientGetter);
+
+          final document = SuperEditorInspector.findDocument()!;
+
+          // Ensure nothing was deleted.
+          expect(document.nodeCount, equals(5));
+          expect(document.getNodeAt(0), isA<ParagraphNode>());
+          expect(document.getNodeAt(1), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(2), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(3), isA<HorizontalRuleNode>());
+          expect(document.getNodeAt(4), isA<ParagraphNode>());
+
+          // Ensure the selection was kept.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '2',
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: '4',
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
               ),
             ),
           );


### PR DESCRIPTION
[SuperEditor] Fix crashing when deleting all content which contains a non-deletable node at an edge. Resolves #2393

When all content in the document is selected using CMD+A and then pressing delete or backspace, it will throw exceptions if there is a non-deletable node at the start and/or end of the document.

When the user attempts to delete all content, `SuperEditor` inserts a new empty paragraph at the first deleted node's index and with the first deleted node's id, and places the caret on it. 

When a non-deletable node is at the beginning or end of the selection, it was breaking this logic. We were not inserting a new empty paragraph and we were trying to place a text selection for a block node.

This PR fixes this issue by also inserting a new empty paragraph when all deletable nodes were deleted and choosing the id of the existing `TextNode` to place the selection.