### PR TITLE
[SuperEditor] Add toggleable headers (Resolves #2276)

### DIFF
--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -107,6 +107,11 @@ abstract class DocumentLayout {
 
   /// Returns the [DocumentPosition] at the end of the last selectable component.
   DocumentPosition? findLastSelectablePosition();
+
+  /// Returns whether the component with the given [nodeId] is visible.
+  ///
+  /// For example, this method returns `false` if the node is collapsed.
+  bool isComponentVisible(String nodeId);
 }
 
 /// Contract for all widgets that operate as document components

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -825,9 +825,11 @@ class CommonEditorOperations {
       selectableNode = document.getNodeBefore(prevNode);
 
       if (selectableNode != null) {
-        final nextComponent = documentLayoutResolver().getComponentByNodeId(selectableNode.id);
+        final documentLayout = documentLayoutResolver();
+        final nextComponent = documentLayout.getComponentByNodeId(selectableNode.id);
         if (nextComponent != null) {
-          foundSelectableNode = nextComponent.isVisualSelectionSupported();
+          foundSelectableNode =
+              documentLayout.isComponentVisible(selectableNode.id) && nextComponent.isVisualSelectionSupported();
         }
         prevNode = selectableNode;
       }
@@ -846,9 +848,11 @@ class CommonEditorOperations {
       selectableNode = document.getNodeAfter(prevNode);
 
       if (selectableNode != null) {
-        final nextComponent = documentLayoutResolver().getComponentByNodeId(selectableNode.id);
+        final documentLayout = documentLayoutResolver();
+        final nextComponent = documentLayout.getComponentByNodeId(selectableNode.id);
         if (nextComponent != null) {
-          foundSelectableNode = nextComponent.isVisualSelectionSupported();
+          foundSelectableNode =
+              documentLayout.isComponentVisible(selectableNode.id) && nextComponent.isVisualSelectionSupported();
         }
         prevNode = selectableNode;
       }

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -28,6 +28,7 @@ import 'package:super_editor/src/infrastructure/documents/document_scroller.dart
 import 'package:super_editor/src/infrastructure/documents/selection_leader_document_layer.dart';
 import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
+import 'package:super_editor/src/infrastructure/node_grouping.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/mac/mac_ime.dart';
@@ -117,6 +118,7 @@ class SuperEditor extends StatefulWidget {
     Stylesheet? stylesheet,
     this.customStylePhases = const [],
     List<ComponentBuilder>? componentBuilders,
+    this.groupBuilders = const [],
     SelectionStyles? selectionStyle,
     this.selectionPolicies = const SuperEditorSelectionPolicies(),
     this.inputSource,
@@ -298,6 +300,9 @@ class SuperEditor extends StatefulWidget {
   /// each visual component displayed in the document layout, e.g.,
   /// paragraph component, image component, horizontal rule component, etc.
   final List<ComponentBuilder> componentBuilders;
+
+  /// {@macro group_builders}
+  final List<GroupBuilder> groupBuilders;
 
   /// All actions that this editor takes in response to key
   /// events, e.g., text entry, newlines, character deletion,
@@ -675,6 +680,7 @@ class SuperEditorState extends State<SuperEditor> {
               scroller: _scroller,
               presenter: presenter,
               componentBuilders: widget.componentBuilders,
+              groupBuilders: widget.groupBuilders,
               shrinkWrap: widget.shrinkWrap,
               underlays: [
                 // Add all underlays from plugins.

--- a/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/documents/document_scaffold.dart
@@ -5,8 +5,7 @@ import 'package:super_editor/src/default_editor/layout_single_column/_layout.dar
 import 'package:super_editor/src/default_editor/layout_single_column/_presenter.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
-import 'package:super_editor/src/infrastructure/flutter/build_context.dart';
-import 'package:super_editor/src/infrastructure/sliver_hybrid_stack.dart';
+import 'package:super_editor/src/infrastructure/node_grouping.dart';
 
 /// A scaffold that combines pieces to create a scrolling single-column document, with
 /// gestures placed beneath the document.
@@ -26,6 +25,7 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
     required this.scroller,
     required this.presenter,
     required this.componentBuilders,
+    this.groupBuilders = const [],
     required this.shrinkWrap,
     this.underlays = const [],
     this.overlays = const [],
@@ -70,6 +70,9 @@ class DocumentScaffold<ContextType> extends StatefulWidget {
   /// each visual component displayed in the document layout, e.g.,
   /// paragraph component, image component, horizontal rule component, etc.
   final List<ComponentBuilder> componentBuilders;
+
+  /// {@macro group_builders}
+  final List<GroupBuilder> groupBuilders;
 
   /// Layers that are displayed below the document layout, aligned
   /// with the location and size of the document layout.
@@ -139,6 +142,7 @@ class _DocumentScaffoldState extends State<DocumentScaffold> {
         key: widget.documentLayoutKey,
         presenter: widget.presenter,
         componentBuilders: widget.componentBuilders,
+        groupBuilders: widget.groupBuilders,
         onBuildScheduled: onBuildScheduled,
         showDebugPaint: widget.debugPaint.layout,
       ),

--- a/super_editor/lib/src/infrastructure/node_grouping.dart
+++ b/super_editor/lib/src/infrastructure/node_grouping.dart
@@ -1,0 +1,800 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_composer.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
+import 'package:super_editor/src/default_editor/list_items.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+
+/// An object that knows how to group nodes in a document layout.
+///
+/// A [GroupBuilder] is used to group nodes and create a sub-tree
+/// containing all the grouped nodes.
+///
+/// Each group has a header (the first node in the group) and one or more
+/// child nodes.
+///
+/// This object must not hold any internal state between calls, because creating
+/// a group can be recursive. For example, a [GroupBuilder] that groups
+/// content below a header can start a group when it encounters a
+/// level one header, another one when it encounters a level two header,
+/// and then resume the level one header.
+abstract class GroupBuilder {
+  const GroupBuilder();
+
+  /// Whether the component at [nodeIndex] can start a new group.
+  ///
+  /// If this method returns `true`, a new group is created even
+  /// if [canAddToGroup] returns `false` for the node immediately
+  /// before the node at [nodeIndex].
+  bool canStartGroup({
+    required int nodeIndex,
+    required List<SingleColumnLayoutComponentViewModel> viewModels,
+  });
+
+  /// Whether the component at [nodeIndex] can be added to the group
+  /// that contains [groupedComponents].
+  ///
+  /// This method does not modify [groupedComponents].
+  bool canAddToGroup({
+    required int nodeIndex,
+    required List<SingleColumnLayoutComponentViewModel> allViewModels,
+    required List<SingleColumnLayoutComponentViewModel> groupedComponents,
+  });
+
+  /// Builds a widget that represents the group.
+  ///
+  /// The [headerContentLink] can used to position widgets near to the
+  /// header widget. Since document components can take all available width in
+  /// the layout, the [headerContentLink] is necessary to know where the
+  /// actual content starts. For example, text components usually have padding
+  /// around then. The [headerContentLink] must be attached to the widget inside
+  /// the padding.
+  ///
+  /// The [onCollapsedChanged] callback is called when the group is collapsed
+  /// or expanded.
+  ///
+  /// The [children] list contains all widgets inside the group, including
+  /// the header widget.
+  Widget build(
+    BuildContext context, {
+    required LeaderLink headerContentLink,
+    required GroupItem groupInfo,
+    required OnCollapseChanged onCollapsedChanged,
+    required List<Widget> children,
+  });
+}
+
+/// A [GroupBuilder] that groups content below a header.
+///
+/// This builder creates a group when it encounters a header node
+/// that contains all nodes between the start of the group and
+/// another header with smaller or equal level.
+///
+/// Builds a toggleable [Widget] that allows collapsing and expanding
+/// the group when tapping a button near the header.
+class HeaderGroupBuilder implements GroupBuilder {
+  HeaderGroupBuilder({
+    required this.editor,
+    this.buttonBuilder,
+    this.guidelineBuilder,
+    this.animateExpansion = true,
+    this.animationDuration = _defaultAnimationDuration,
+    this.animationCurve = Curves.easeInOut,
+    this.maxChildren,
+  });
+
+  final Editor editor;
+
+  /// Builder for the button that toggles the group.
+  ///
+  /// No animations are applied to the button when [buttonBuilder] is provided,
+  /// i.e, apps that provide a custom button builder are responsible for its
+  /// animations.
+  final ToggleButtonBuilder? buttonBuilder;
+
+  /// Builder for the guideline that is displayed below the button.
+  final WidgetBuilder? guidelineBuilder;
+
+  /// Whether the expansion and collapse of the group should be animated.
+  ///
+  /// When `true`, the group will animate its expansion and collapse. When `false`,
+  /// the group will expand and collapse instantly.
+  final bool animateExpansion;
+
+  /// Duration of the animation that expands and collapses the group.
+  ///
+  /// Has no effect if [animateExpansion] is `false`.
+  final Duration animationDuration;
+
+  /// Curve of the animation that expands and collapses the group.
+  ///
+  /// Defaults to [Curves.easeInOut].
+  final Curve animationCurve;
+
+  /// Maximum number of children that can be grouped together.
+  ///
+  /// When a group reaches this limit, subsequent children will remain ungrouped.
+  final int? maxChildren;
+
+  @override
+  bool canStartGroup({
+    required int nodeIndex,
+    required List<SingleColumnLayoutComponentViewModel> viewModels,
+  }) {
+    final currentViewModel = viewModels[nodeIndex];
+    if (currentViewModel is! ParagraphComponentViewModel) {
+      // Only paragraphs can have the header attribution.
+      return false;
+    }
+
+    if (_getHeaderLevel(currentViewModel.blockType) == null) {
+      // This paragraph is not a header.
+      return false;
+    }
+
+    if (nodeIndex == viewModels.length - 1) {
+      // This is the last component in the layout. Only start a group
+      // if there is at least one child that can be grouped.
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  bool canAddToGroup({
+    required int nodeIndex,
+    required List<SingleColumnLayoutComponentViewModel> allViewModels,
+    required List<SingleColumnLayoutComponentViewModel> groupedComponents,
+  }) {
+    // +1 because the first component is the header.
+    if (maxChildren != null && groupedComponents.length >= maxChildren! + 1) {
+      return false;
+    }
+
+    final header = groupedComponents.first;
+    final headerLevel = _getHeaderLevel((header as ParagraphComponentViewModel).blockType)!;
+
+    final childViewModel = allViewModels[nodeIndex];
+    if (childViewModel is ParagraphComponentViewModel) {
+      final childHeaderLevel = _getHeaderLevel(childViewModel.blockType);
+      if (childHeaderLevel != null && childHeaderLevel <= headerLevel) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  int? _getHeaderLevel(Attribution? blockType) => switch (blockType) {
+        header1Attribution => 1,
+        header2Attribution => 2,
+        header3Attribution => 3,
+        header4Attribution => 4,
+        header5Attribution => 5,
+        header6Attribution => 6,
+        _ => null,
+      };
+
+  @override
+  Widget build(
+    BuildContext context, {
+    required LeaderLink headerContentLink,
+    required GroupItem groupInfo,
+    required List<Widget> children,
+    required OnCollapseChanged onCollapsedChanged,
+  }) {
+    return ToggleableGroup(
+      editor: editor,
+      groupInfo: groupInfo,
+      headerContentLink: headerContentLink,
+      onCollapsed: onCollapsedChanged,
+      buttonBuilder: buttonBuilder ?? defaultToggleButtonBuilder,
+      guidelineBuilder: guidelineBuilder ?? defaultGuidelineBuilder,
+      animateExpansion: animateExpansion,
+      animationDuration: animationDuration,
+      animationCurve: animationCurve,
+      header: children.first,
+      children: children.length > 1 //
+          ? children.skip(1).toList()
+          : [],
+    );
+  }
+}
+
+/// A [GroupBuilder] that groups list items.
+///
+/// This builder creates a group when it encounters a list item node
+/// that contains all list items between the start of the group and
+/// another list item with smaller or equal level.
+///
+/// Builds a toggleable [Widget] that allows collapsing and expanding
+/// the group when tapping a button near the first list item.
+class ListItemGroupBuilder implements GroupBuilder {
+  ListItemGroupBuilder({
+    required this.editor,
+    this.buttonBuilder,
+    this.guidelineBuilder,
+    this.animateExpansion = true,
+    this.animationDuration = _defaultAnimationDuration,
+    this.animationCurve = Curves.easeInOut,
+    this.maxChildren,
+  });
+
+  final Editor editor;
+
+  /// Builder for the button that toggles the group.
+  ///
+  /// No animations are applied to the button when [buttonBuilder] is provided,
+  /// i.e, apps that provide a custom button builder are responsible for its
+  /// animations.
+  final ToggleButtonBuilder? buttonBuilder;
+
+  /// Builder for the guideline that is displayed below the button.
+  final WidgetBuilder? guidelineBuilder;
+
+  /// Whether the expansion and collapse of the group should be animated.
+  ///
+  /// When `true`, the group will animate its expansion and collapse. When `false`,
+  /// the group will expand and collapse instantly.
+  final bool animateExpansion;
+
+  /// Duration of the animation that expands and collapses the group.
+  ///
+  /// Has no effect if [animateExpansion] is `false`.
+  final Duration animationDuration;
+
+  /// Curve of the animation that expands and collapses the group.
+  ///
+  /// Defaults to [Curves.easeInOut].
+  final Curve animationCurve;
+
+  /// Maximum number of children that can be grouped together.
+  ///
+  /// When a group reaches this limit, subsequent children will remain ungrouped.
+  final int? maxChildren;
+
+  @override
+  bool canStartGroup({
+    required int nodeIndex,
+    required List<SingleColumnLayoutComponentViewModel> viewModels,
+  }) {
+    if (viewModels[nodeIndex] is! ListItemComponentViewModel) {
+      return false;
+    }
+
+    if (nodeIndex == viewModels.length - 1) {
+      // This is the last component in the layout. Only start a group
+      // if there is at least one child that can be grouped.
+      return false;
+    }
+
+    if (!canAddToGroup(
+      nodeIndex: nodeIndex + 1,
+      allViewModels: viewModels,
+      groupedComponents: [viewModels[nodeIndex]],
+    )) {
+      // This node can start a group, but the next node cannot be added to it.
+      // For example, the current node is a unordered list item and the node
+      // below it is an ordered list item.
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  bool canAddToGroup(
+      {required int nodeIndex,
+      required List<SingleColumnLayoutComponentViewModel> allViewModels,
+      required List<SingleColumnLayoutComponentViewModel> groupedComponents}) {
+    // +1 because the first component is the header.
+    if (maxChildren != null && groupedComponents.length >= maxChildren! + 1) {
+      return false;
+    }
+
+    final childViewModel = allViewModels[nodeIndex];
+    if (childViewModel is! ListItemComponentViewModel) {
+      return false;
+    }
+
+    final header = groupedComponents.first;
+    if (header.runtimeType != childViewModel.runtimeType) {
+      // Don't group ordered lists with unordered lists.
+      return false;
+    }
+
+    final headerIndentLevel = (header as ListItemComponentViewModel).indent;
+    final childIndentLevel = (childViewModel).indent;
+
+    return childIndentLevel > headerIndentLevel;
+  }
+
+  @override
+  Widget build(BuildContext context,
+      {required LeaderLink headerContentLink,
+      required GroupItem groupInfo,
+      required OnCollapseChanged onCollapsedChanged,
+      required List<Widget> children}) {
+    return ToggleableGroup(
+      editor: editor,
+      groupInfo: groupInfo,
+      headerContentLink: headerContentLink,
+      onCollapsed: onCollapsedChanged,
+      buttonBuilder: buttonBuilder ?? defaultToggleButtonBuilder,
+      guidelineBuilder: guidelineBuilder ?? defaultGuidelineBuilder,
+      animateExpansion: animateExpansion,
+      animationDuration: animationDuration,
+      animationCurve: animationCurve,
+      header: children.first,
+      children: children.length > 1 //
+          ? children.skip(1).toList()
+          : [],
+    );
+  }
+}
+
+/// A [Widget] that groups other widgets below a [header].
+///
+/// Displays a button and guideline near the content of the [header] widget,
+/// that is positioned using the [headerContentLink].
+///
+/// The group can be collapsed and expanded by tapping a button near the
+/// [header]. When collapsing, the [header] is still visible and the [children]
+/// are hidden.
+///
+/// Calls [onCollapsed] when the group is collapsed or expanded.
+///
+/// When the group is collapsed, the selection is changed to avoid that the base
+/// or extent of the selection is inside the collapsed group.
+///
+/// Use [buttonBuilder] to customize the button that toggles the group. By default,
+/// displays an arrow icon that rotates when the group is collapsed or expanded.
+///
+/// Use [guidelineBuilder] to customize the guideline that is displayed below the
+/// button. By default, displays a vertical divider.
+class ToggleableGroup extends StatefulWidget {
+  const ToggleableGroup({
+    super.key,
+    required this.headerContentLink,
+    required this.editor,
+    required this.groupInfo,
+    required this.onCollapsed,
+    this.buttonBuilder = defaultToggleButtonBuilder,
+    this.guidelineBuilder = defaultGuidelineBuilder,
+    this.animateExpansion = true,
+    this.animationDuration = _defaultAnimationDuration,
+    this.animationCurve = Curves.easeInOut,
+    required this.header,
+    required this.children,
+  });
+
+  final LeaderLink headerContentLink;
+  final Editor editor;
+  final GroupItem groupInfo;
+  final OnCollapseChanged onCollapsed;
+  final ToggleButtonBuilder buttonBuilder;
+  final WidgetBuilder guidelineBuilder;
+  final bool animateExpansion;
+  final Duration animationDuration;
+  final Curve animationCurve;
+
+  final Widget header;
+  final List<Widget> children;
+
+  @override
+  State<ToggleableGroup> createState() => ToggleableGroupState();
+}
+
+@visibleForTesting
+class ToggleableGroupState extends State<ToggleableGroup> with SingleTickerProviderStateMixin {
+  /// Animates the expansion and collapse of the group.
+  late final AnimationController _animationController;
+  late final Animation _animation;
+
+  /// Whether the toggle button and guideline should be visible.
+  final _shouldDisplayButton = ValueNotifier(false);
+
+  /// Whether the group is currently expanded, i.e, showing all children.
+  bool _isExpanded = true;
+  bool get isExpanded => _isExpanded;
+
+  final _buttonKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      value: 1.0,
+      vsync: this,
+      duration: widget.animationDuration,
+    );
+    _animation = CurvedAnimation(
+      parent: _animationController,
+      curve: widget.animationCurve,
+    );
+  }
+
+  @override
+  void didUpdateWidget(ToggleableGroup oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.animationDuration != oldWidget.animationDuration) {
+      _animationController.duration = widget.animationDuration;
+    }
+
+    if (widget.animationCurve != oldWidget.animationCurve) {
+      _animation = CurvedAnimation(
+        parent: _animationController,
+        curve: widget.animationCurve,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  /// Toggles the group between expanded and collapsed.
+  void _toggle() {
+    if (_isExpanded) {
+      //_animationController.reset();
+      if (widget.animateExpansion) {
+        _animationController.reverse();
+      } else {
+        _animationController.value = 0.0;
+      }
+      _adjustSelectionOnCollapsing();
+    } else {
+      if (widget.animateExpansion) {
+        _animationController
+          ..reset()
+          ..forward();
+      } else {
+        _animationController.value = 1.0;
+      }
+    }
+
+    setState(() {
+      _isExpanded = !_isExpanded;
+    });
+
+    widget.onCollapsed(!_isExpanded);
+  }
+
+  void _onMouseEnter() {
+    _shouldDisplayButton.value = true;
+  }
+
+  void _onMouseExit() {
+    if (!_isExpanded) {
+      return;
+    }
+    _shouldDisplayButton.value = false;
+  }
+
+  /// Adjusts the selection so that the base and extent are not inside the group.
+  void _adjustSelectionOnCollapsing() {
+    final selection = widget.editor.composer.selection;
+    if (selection == null) {
+      // There is no selection to adjust.
+      return;
+    }
+
+    final headerNodeId = widget.groupInfo.rootNodeId;
+    final headerNode = widget.editor.document.getNodeById(headerNodeId)!;
+
+    final isSelectionNormalized = selection.isNormalized(widget.editor.document);
+
+    final isBaseInsideGroup = selection.base.nodeId != headerNodeId && widget.groupInfo.contains(selection.base.nodeId);
+    final isExtentInsideGroup =
+        selection.extent.nodeId != headerNodeId && widget.groupInfo.contains(selection.extent.nodeId);
+
+    if (isBaseInsideGroup && isExtentInsideGroup) {
+      // The whole selection is inside the group. Move the selection
+      // to the end of the header node.
+      widget.editor.execute([
+        ChangeSelectionRequest(
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: headerNodeId,
+              nodePosition: headerNode.endPosition,
+            ),
+          ),
+          SelectionChangeType.placeCaret,
+          SelectionReason.userInteraction,
+        )
+      ]);
+
+      return;
+    }
+
+    if (isBaseInsideGroup) {
+      if (isSelectionNormalized) {
+        // The selection starts inside this group and ends in a downstream node.
+        // Move the selection base to the beginning of the first node below the group.
+        final downstreamNodeIndex = _lastNodeIndex(widget.groupInfo) + 1;
+        final downstreamNode = widget.editor.document.getNodeAt(downstreamNodeIndex)!;
+        widget.editor.execute([
+          ChangeSelectionRequest(
+            DocumentSelection(
+              base: DocumentPosition(
+                nodeId: downstreamNode.id,
+                nodePosition: downstreamNode.beginningPosition,
+              ),
+              extent: selection.extent,
+            ),
+            SelectionChangeType.alteredContent,
+            SelectionReason.userInteraction,
+          )
+        ]);
+        return;
+      }
+
+      // The selection starts inside this group and ends in an upstream node.
+      // Move the selection base to the end of the header of the group.
+      widget.editor.execute([
+        ChangeSelectionRequest(
+          DocumentSelection(
+            base: DocumentPosition(
+              nodeId: headerNodeId,
+              nodePosition: headerNode.endPosition,
+            ),
+            extent: selection.extent,
+          ),
+          SelectionChangeType.alteredContent,
+          SelectionReason.userInteraction,
+        )
+      ]);
+
+      return;
+    }
+
+    if (isExtentInsideGroup) {
+      if (isSelectionNormalized) {
+        // The selection starts at an upstream node end ends inside this group.
+        // Move the selection extent to the end of the header node.
+        widget.editor.execute([
+          ChangeSelectionRequest(
+            DocumentSelection(
+              base: selection.base,
+              extent: DocumentPosition(
+                nodeId: headerNode.id,
+                nodePosition: headerNode.endPosition,
+              ),
+            ),
+            SelectionChangeType.alteredContent,
+            SelectionReason.userInteraction,
+          )
+        ]);
+
+        return;
+      }
+
+      // The selection starts at a downstream node end ends inside this group.
+      // Move the selection extent to the beginning of the first node below the group.
+      final downstreamNodeIndex = _lastNodeIndex(widget.groupInfo) + 1;
+      final downstreamNode = widget.editor.document.getNodeAt(downstreamNodeIndex)!;
+      widget.editor.execute([
+        ChangeSelectionRequest(
+          DocumentSelection(
+            base: selection.base,
+            extent: DocumentPosition(
+              nodeId: downstreamNode.id,
+              nodePosition: downstreamNode.beginningPosition,
+            ),
+          ),
+          SelectionChangeType.alteredContent,
+          SelectionReason.userInteraction,
+        )
+      ]);
+
+      return;
+    }
+  }
+
+  /// The index of the last node within the group.
+  ///
+  /// If the last node also starts a group, returns the last index
+  /// of that group.
+  int _lastNodeIndex(GroupItem group) {
+    final lastChild = group.children.lastOrNull;
+    if (lastChild == null) {
+      return widget.editor.document.getNodeIndexById(group.rootNodeId);
+    }
+
+    if (lastChild.isLeaf) {
+      return widget.editor.document.getNodeIndexById(lastChild.rootNodeId);
+    }
+
+    return _lastNodeIndex(lastChild);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            widget.header,
+            _buildChildren(),
+          ],
+        ),
+        Positioned.fill(
+          child: _buildFadingFollower(
+            child: _buildButtonAndGuideline(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Builds the children of the group.
+  ///
+  /// Animates its growing/shrinking when the group is expanded/collapsed.
+  Widget _buildChildren() {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return ClipRect(
+          child: Align(
+            alignment: Alignment.topCenter,
+            heightFactor: _animation.value,
+            child: child,
+          ),
+        );
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: widget.children,
+      ),
+    );
+  }
+
+  /// Builds a widget that follows the header and fades in/out
+  /// when the mouse enters/exits the [child].
+  Widget _buildFadingFollower({
+    required Widget child,
+  }) {
+    return _buildFollower(
+      child: ValueListenableBuilder(
+        valueListenable: _shouldDisplayButton,
+        builder: (context, isVisible, child) {
+          return AnimatedOpacity(
+            opacity: isVisible ? 1.0 : 0.0,
+            duration: widget.animationDuration,
+            child: child!,
+          );
+        },
+        child: MouseRegion(
+          hitTestBehavior: HitTestBehavior.deferToChild,
+          onEnter: (e) => _onMouseEnter(),
+          onExit: (e) => _onMouseExit(),
+          child: _buildButtonAndGuideline(),
+        ),
+      ),
+    );
+  }
+
+  /// Builds a [child] positioned near the content of the header.
+  Widget _buildFollower({
+    required Widget child,
+  }) {
+    return Follower.withAligner(
+      aligner: _ToggleButtonAligner(buttonKey: _buttonKey),
+      link: widget.headerContentLink,
+      child: child,
+    );
+  }
+
+  Widget _buildButtonAndGuideline() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildButton(),
+        Expanded(
+          child: _buildGuideline(),
+        ),
+      ],
+    );
+  }
+
+  /// Builds the button that toggles the group.
+  Widget _buildButton() {
+    return KeyedSubtree(
+      key: _buttonKey,
+      child: widget.buttonBuilder(
+        context,
+        _isExpanded,
+        _toggle,
+      ),
+    );
+  }
+
+  /// Builds the guideline that is displayed below the button.
+  ///
+  /// The guideline is only displayed when the group is expanded or
+  /// while the collapse animation is running.
+  Widget _buildGuideline() {
+    return ListenableBuilder(
+      listenable: _animationController,
+      builder: (context, child) {
+        return _isExpanded || _animationController.status == AnimationStatus.reverse
+            ? widget.guidelineBuilder(context)
+            : const SizedBox.shrink();
+      },
+    );
+  }
+}
+
+/// A button that rotates an arrow icon when the group is expanded or collapsed.
+Widget defaultToggleButtonBuilder(BuildContext context, bool isExpanded, VoidCallback onPressed) {
+  return AnimatedRotation(
+    duration: _defaultAnimationDuration,
+    turns: isExpanded ? 0.25 : 0.0,
+    child: SizedBox(
+      height: 24,
+      width: 24,
+      child: Center(
+        child: IconButton(
+          icon: const Icon(Icons.arrow_right),
+          padding: EdgeInsets.zero,
+          iconSize: 24,
+          onPressed: onPressed,
+        ),
+      ),
+    ),
+  );
+}
+
+Widget defaultGuidelineBuilder(BuildContext context) {
+  return const Column(
+    children: [
+      SizedBox(height: 2),
+      Expanded(
+        child: VerticalDivider(width: 4),
+      ),
+    ],
+  );
+}
+
+/// A [FollowerAligner] that centers the button vertically with the header.
+///
+/// The regular aligner does not work because it uses the height of the whole
+/// follower widget. Our follower contains both the button and the guideline,
+/// and we want to center using only the button.
+class _ToggleButtonAligner implements FollowerAligner {
+  _ToggleButtonAligner({
+    required this.buttonKey,
+  });
+
+  final GlobalKey buttonKey;
+
+  @override
+  FollowerAlignment align(Rect globalLeaderRect, Size followerSize) {
+    final buttonBox = buttonKey.currentContext?.findRenderObject() as RenderBox?;
+    final buttonHeight = buttonBox?.size.height ?? 0;
+
+    return FollowerAlignment(
+      leaderAnchor: Alignment.centerLeft,
+      followerAnchor: Alignment.topRight,
+      followerOffset: Offset(-10, -buttonHeight / 2),
+    );
+  }
+}
+
+typedef OnCollapseChanged = void Function(bool isCollapsed);
+typedef ToggleButtonBuilder = Widget Function(BuildContext context, bool isExpanded, VoidCallback onPressed);
+
+/// Duration of the animation that expands and collapses the group.
+const _defaultAnimationDuration = Duration(milliseconds: 300);

--- a/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
+++ b/super_editor/lib/src/test/super_editor_test/supereditor_inspector.dart
@@ -315,6 +315,52 @@ class SuperEditorInspector {
     return textLayout.getPositionAtEndOfLine(const TextPosition(offset: 0)).offset;
   }
 
+  /// Finds all [DocumentNode]s that are inside a group where the root is the
+  /// node with the given [rootNodeId].
+  ///
+  /// All nodes, including the root, the child nodes and nodes inside child groups, are included.
+  ///
+  /// Returns an empty list if the root node does not start a group.
+  ///
+  /// {@macro supereditor_finder}
+  static List<String> findAllNodesInGroup(String rootNodeId, [Finder? superEditorFinder]) {
+    final documentLayout = findDocumentLayout(superEditorFinder) as SingleColumnDocumentLayoutState;
+    final rootGroup = documentLayout.groups.firstWhereOrNull((group) => group.rootNodeId == rootNodeId);
+    if (rootGroup == null) {
+      return [];
+    }
+
+    return rootGroup.allNodeIds;
+  }
+
+  /// Finds the [DocumentNode] that is the header of the group where the
+  /// node with the given [nodeId] is.
+  ///
+  /// Returns `null` if the node is not in a group.
+  ///
+  /// {@macro supereditor_finder}
+  static String? findGroupHeaderNode(String nodeId, [Finder? superEditorFinder]) {
+    final documentLayout = findDocumentLayout(superEditorFinder) as SingleColumnDocumentLayoutState;
+    return documentLayout.groups.firstWhereOrNull((group) => group.contains(nodeId))?.rootNodeId;
+  }
+
+  static bool isGroupExpanded(String rootNodeId, [Finder? superEditorFinder]) {
+    final component = findWidgetForComponent(rootNodeId);
+
+    final groupFinder = find.ancestor(
+      of: find.byWidget(component),
+      matching: find.byType(ToggleableGroup),
+    );
+
+    final groupElement = groupFinder.evaluate().singleOrNull as StatefulElement?;
+    if (groupElement == null) {
+      return false;
+    }
+
+    final groupState = groupElement.state as ToggleableGroupState;
+    return groupState.isExpanded;
+  }
+
   /// Finds the [DocumentLayout] that backs a [SuperEditor] in the widget tree.
   ///
   /// {@macro supereditor_finder}

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -92,6 +92,7 @@ export 'src/infrastructure/text_input.dart';
 export 'src/infrastructure/popovers.dart';
 export 'src/infrastructure/selectable_list.dart';
 export 'src/infrastructure/actions.dart';
+export 'src/infrastructure/node_grouping.dart';
 
 // Super Reader
 export 'src/super_reader/read_only_document_android_touch_interactor.dart';

--- a/super_editor/test/super_editor/supereditor_toggleable_headers_test.dart
+++ b/super_editor/test/super_editor/supereditor_toggleable_headers_test.dart
@@ -1,0 +1,928 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_robots/flutter_test_robots.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import '../test_tools.dart';
+
+Future<void> main() async {
+  await loadAppFonts();
+  group('SuperEditor > Toggleable Headers > ', () {
+    group('creates groups', () {
+      testWidgetsOnArbitraryDesktop('upon initialization', (tester) async {
+        await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText('')),
+            ParagraphNode(id: '2', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '3', text: AttributedText('')),
+            ParagraphNode(id: '4', text: AttributedText('')),
+            ParagraphNode(id: '5', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '6', text: AttributedText('')),
+          ]),
+        );
+
+        // Ensure the groups were created.
+        final firstGroupNodes = SuperEditorInspector.findAllNodesInGroup('2');
+        expect(firstGroupNodes, collectionEqualsTo(['2', '3', '4']));
+        final secondGroupNodes = SuperEditorInspector.findAllNodesInGroup('5');
+        expect(secondGroupNodes, collectionEqualsTo(['5', '6']));
+      });
+
+      testWidgetsOnArbitraryDesktop('upon node insertion at the end', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText()),
+          ]),
+        );
+
+        // Insert the paragraph already as a header.
+        editor.execute([
+          InsertNodeAfterNodeRequest(
+            existingNodeId: '1',
+            newNode: ParagraphNode(
+              id: '2',
+              text: AttributedText(),
+              metadata: {NodeMetadata.blockType: header1Attribution},
+            ),
+          ),
+        ]);
+        await tester.pump();
+
+        // Place the caret at the end of the header and add a new node
+        // so we will have a group with two nodes.
+        await tester.placeCaretInParagraph('2', 0);
+        await tester.pressEnter();
+
+        // Ensure the group was created.
+        final allNodes = SuperEditorInspector.findAllNodesInGroup('2');
+        expect(allNodes, collectionEqualsTo(['2', editor.document.last.id]));
+      });
+
+      testWidgetsOnArbitraryDesktop('upon node insertion between nodes', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText()),
+            ParagraphNode(id: '3', text: AttributedText()),
+          ]),
+        );
+
+        // Insert the paragraph already as a header.
+        editor.execute([
+          InsertNodeAfterNodeRequest(
+            existingNodeId: '1',
+            newNode: ParagraphNode(
+              id: '2',
+              text: AttributedText(),
+              metadata: {NodeMetadata.blockType: header1Attribution},
+            ),
+          ),
+        ]);
+        await tester.pump();
+
+        // Ensure the group was created.
+        final allNodes = SuperEditorInspector.findAllNodesInGroup('2');
+        expect(allNodes, collectionEqualsTo(['2', '3']));
+      });
+
+      testWidgetsOnArbitraryDesktop('when converting a node to a header', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText('')),
+            ParagraphNode(id: '2', text: AttributedText('')),
+            ParagraphNode(id: '3', text: AttributedText('')),
+          ]),
+        );
+
+        // Ensure there are no groups.
+        expect(SuperEditorInspector.findAllNodesInGroup('1'), []);
+        expect(SuperEditorInspector.findAllNodesInGroup('2'), []);
+        expect(SuperEditorInspector.findAllNodesInGroup('3'), []);
+
+        // Place the caret at the beginning of the first paragraph.
+        await tester.placeCaretInParagraph('1', 0);
+
+        // Type "# " to convert the paragraph to a header.
+        await tester.typeImeText('# ');
+
+        // Ensure the paragraph was converted to a header.
+        expect(editor.document.first.getMetadataValue('blockType'), header1Attribution);
+
+        // Ensure the nodes were grouped.
+        expect(SuperEditorInspector.findAllNodesInGroup('1'), collectionEqualsTo(['1', '2', '3']));
+      });
+    });
+
+    group('removes groups', () {
+      testWidgetsOnArbitraryDesktop('when deleting the root node', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText('')),
+            ParagraphNode(id: '2', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '3', text: AttributedText('')),
+            ParagraphNode(id: '4', text: AttributedText('')),
+            ParagraphNode(id: '5', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+          ]),
+        );
+
+        // Ensure the nodes are grouped.
+        expect(SuperEditorInspector.findGroupHeaderNode('3'), '2');
+        expect(SuperEditorInspector.findGroupHeaderNode('4'), '2');
+
+        // Delete the root of the group.
+        //
+        // Use a delete request to ensure we are deleting, because pressing
+        // backspace will first convert the header into a regular paragraph.
+        editor.execute([DeleteNodeRequest(nodeId: '2')]);
+        await tester.pump();
+
+        // Ensure the nodes are not grouped anymore.
+        expect(SuperEditorInspector.findGroupHeaderNode('3'), isNull);
+        expect(SuperEditorInspector.findGroupHeaderNode('4'), isNull);
+      });
+
+      testWidgetsOnArbitraryDesktop('when converting the root node to a regular paragraph', (tester) async {
+        await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText('')),
+            ParagraphNode(id: '2', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '3', text: AttributedText('')),
+            ParagraphNode(id: '4', text: AttributedText('')),
+            ParagraphNode(id: '5', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+          ]),
+        );
+
+        // Ensure the nodes are grouped.
+        expect(SuperEditorInspector.findGroupHeaderNode('3'), '2');
+        expect(SuperEditorInspector.findGroupHeaderNode('4'), '2');
+
+        // Place the caret at the beginning of the header.
+        await tester.placeCaretInParagraph('2', 0);
+
+        // Press backspace to convert the header to a regular paragraph.
+        await tester.pressBackspace();
+
+        // Ensure the nodes are not grouped anymore.
+        expect(SuperEditorInspector.findGroupHeaderNode('3'), isNull);
+        expect(SuperEditorInspector.findGroupHeaderNode('4'), isNull);
+      });
+    });
+
+    group('splits groups', () {
+      testWidgetsOnArbitraryDesktop('when inserting a header of same level', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '2', text: AttributedText('')),
+            ParagraphNode(id: '3', text: AttributedText('')),
+            ParagraphNode(id: '4', text: AttributedText('')),
+          ]),
+        );
+
+        // Ensure all nodes are in the same group.
+        expect(SuperEditorInspector.findAllNodesInGroup('1'), collectionEqualsTo(['1', '2', '3', '4']));
+
+        // Place the caret at the end of the second node.
+        await tester.placeCaretInParagraph('2', 0);
+
+        // Create a new node and convert it to a header.
+        await tester.pressEnter();
+        await tester.typeImeText('# ');
+
+        // Ensure the nodes were split into two groups.
+        expect(SuperEditorInspector.findAllNodesInGroup('1'), collectionEqualsTo(['1', '2']));
+        final newNodeId = editor.document.getNodeAt(2)!.id;
+        expect(SuperEditorInspector.findAllNodesInGroup(newNodeId), collectionEqualsTo([newNodeId, '3', '4']));
+      });
+    });
+
+    group('preserves expanded state', () {
+      testWidgetsOnArbitraryDesktop('when adding an item to the group', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '2', text: AttributedText('')),
+            ParagraphNode(id: '3', text: AttributedText('')),
+          ]),
+        );
+
+        // Ensure the group is expanded uppon initialization.
+        expect(SuperEditorInspector.isGroupExpanded('1'), isTrue);
+
+        // Place the caret at the last child of the header.
+        await tester.placeCaretInParagraph('3', 0);
+
+        // Press enter to add a new node to the group.
+        await tester.pressEnter();
+
+        // Ensure the group is still expanded.
+        expect(SuperEditorInspector.isGroupExpanded('1'), isTrue);
+
+        // Ensure the node was added to the group.
+        expect(
+          SuperEditorInspector.findAllNodesInGroup('1'),
+          collectionEqualsTo(['1', '2', '3', editor.document.last.id]),
+        );
+      });
+    });
+
+    group('preserves collapsed state', () {
+      testWidgetsOnArbitraryDesktop('when removing items from the group', (tester) async {
+        final editor = await _buildToggleableTestApp(
+          tester,
+          document: MutableDocument(nodes: [
+            ParagraphNode(id: '1', text: AttributedText(''), metadata: {NodeMetadata.blockType: header1Attribution}),
+            ParagraphNode(id: '2', text: AttributedText('')),
+            ParagraphNode(id: '3', text: AttributedText('')),
+          ]),
+        );
+
+        // Ensure the group is expanded uppon initialization.
+        expect(SuperEditorInspector.isGroupExpanded('1'), isTrue);
+
+        // Collapse the group.
+        await pressToggleButton(tester, '1');
+
+        // Ensure the group was collapsed.
+        expect(SuperEditorInspector.isGroupExpanded('1'), isFalse);
+
+        // Remove the last child of the group. Since the group is collapsed,
+        // we cannot delete just the child node with an user interaction.
+        editor.execute([DeleteNodeRequest(nodeId: '3')]);
+        await tester.pump();
+
+        // Ensure the group is still collapsed.
+        expect(SuperEditorInspector.isGroupExpanded('1'), isFalse);
+      });
+    });
+
+    group('selection', () {
+      group('does not select a collapsed component', () {
+        testWidgetsOnArbitraryDesktop('when placing caret', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Store the offset of the level two header. This component will be hidden
+          // when the group collapses.
+          final hiddenComponentOffset = SuperEditorInspector.findComponentOffset('2', Alignment.center);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Tap where the level two header was positioned before being hidden.
+          await tester.tapAt(hiddenComponentOffset);
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure the caret was placed at the downstream level one header.
+          final selection = SuperEditorInspector.findDocumentSelection();
+          expect(selection, isNotNull);
+          expect(selection!.isCollapsed, isTrue);
+          expect(selection.extent.nodeId, equals('4'));
+        });
+
+        testWidgetsOnArbitraryDesktop('at extent (dragging downstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Store the offset of the first child component. This component will be hidden
+          // when the group collapses.
+          final offset = SuperEditorInspector.findComponentOffset('1.1', Alignment.center);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Start dragging from the beginning of the first header.
+          final testGesture = await tester.startDocumentDragFromPosition(
+            from: const DocumentPosition(
+              nodeId: '1',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          );
+
+          // Drag down to the position where the hidden component was.
+          await testGesture.moveTo(offset);
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure only the first header is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnArbitraryDesktop('at extent (dragging upstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Store the offset of the first child component. This component will be hidden
+          // when the group collapses.
+          final hiddenComponentOffset = SuperEditorInspector.findComponentOffset('1.1', Alignment.center);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Start dragging from the end of the last level one header.
+          final testGesture = await tester.startDocumentDragFromPosition(
+            from: const DocumentPosition(
+              nodeId: '4',
+              nodePosition: TextNodePosition(offset: 16),
+            ),
+          );
+
+          // Drag up to the position where the hidden component was.
+          await testGesture.moveTo(hiddenComponentOffset);
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure only the last header is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 16),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnArbitraryDesktop('at base (dragging downstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Store the offset of the first child component. This component will be hidden
+          // when the group collapses.
+          final hiddenComponentOffset = SuperEditorInspector.findComponentOffset('1.1', Alignment.topLeft);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Start dragging from the position where the hidden component was.
+          final testGesture = await tester.startGesture(
+            hiddenComponentOffset,
+            kind: PointerDeviceKind.mouse,
+          );
+          await tester.pump();
+
+          // Move a tiny amount to start the pan gesture.
+          await testGesture.moveBy(const Offset(2, 2));
+          await tester.pump();
+
+          // Drag to the end of the last header.
+          await testGesture.moveTo(
+            SuperEditorInspector.findComponentOffset('4', Alignment.bottomRight),
+          );
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure only the last header is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 16),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnArbitraryDesktop('at base (dragging upstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Store the offset of last child component. This component will be hidden
+          // when the group collapses.
+          final hiddenComponentOffset = SuperEditorInspector.findComponentOffset('4.1', Alignment.bottomRight);
+
+          // Collapse the last header.
+          await pressToggleButton(tester, '4');
+
+          // Start dragging from the position where the hidden component was.
+          final testGesture = await tester.startGesture(
+            hiddenComponentOffset,
+            kind: PointerDeviceKind.mouse,
+          );
+          await tester.pump();
+
+          // Move a tiny amount to start the pan gesture.
+          await testGesture.moveBy(const Offset(2, 2));
+          await tester.pump();
+
+          // Drag to beginning end of the last header.
+          await testGesture.moveTo(
+            SuperEditorInspector.findComponentOffset('4', Alignment.topLeft),
+          );
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure only the last header is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 16),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+      });
+
+      group('selects a collapsed component', () {
+        testWidgetsOnArbitraryDesktop('when selecting surrounding components (dragging downstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Start dragging from the beginning of the document.
+          final testGesture = await tester.startDocumentDragFromPosition(
+            from: const DocumentPosition(
+              nodeId: '0',
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+          );
+
+          // Drag down to the end of the last header.
+          await testGesture.moveTo(SuperEditorInspector.findComponentOffset('4', Alignment.bottomRight));
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure the whole range was selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '0',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 16),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnArbitraryDesktop('when selecting surrounding components (dragging upstream)', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Start dragging from the end of the last header.
+          final testGesture = await tester.startDocumentDragFromPosition(
+            from: const DocumentPosition(
+              nodeId: '4',
+              nodePosition: TextNodePosition(offset: 16),
+            ),
+          );
+
+          // Drag up to the beginning of the document.
+          await testGesture.moveTo(SuperEditorInspector.findComponentOffset('0', Alignment.topLeft));
+          await tester.pump();
+          await testGesture.up();
+          await tester.pump(kDoubleTapTimeout);
+
+          // Ensure the whole range was selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 16),
+                ),
+                extent: DocumentPosition(
+                  nodeId: '0',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+      });
+    });
+
+    group('keyboard navigation', () {
+      group('skips collapsed components', () {
+        testWidgetsOnDesktop('when moving down with ARROW DOWN', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Place the caret at the beginning of the first header.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Move the caret down.
+          await tester.pressDownArrow();
+
+          // Ensure the caret skipped the collapsed components and
+          // was placed at the beginning of the next header.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when moving down with ARROW RIGHT at the end of a node', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Place the caret at the end of the first header.
+          await tester.placeCaretInParagraph('1', 8);
+
+          // Move the caret down.
+          await tester.pressRightArrow();
+
+          // Ensure the caret skipped the collapsed components and
+          // was placed at the beginning of the next header.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '4',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when moving up with ARROW UP', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Place the caret at the beginning of the last header.
+          await tester.placeCaretInParagraph('4', 0);
+
+          // Move the caret up.
+          await tester.pressUpArrow();
+
+          // Ensure the caret skipped the collapsed components and
+          // was placed at the beginning of the first header.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnDesktop('when moving up with ARROW LEFT at the beginning of a node', (tester) async {
+          await _buildToggleableTestApp(tester);
+
+          // Collapse the first header.
+          await pressToggleButton(tester, '1');
+
+          // Place the caret at the beginning of the last header.
+          await tester.placeCaretInParagraph('4', 0);
+
+          // Move the caret up.
+          await tester.pressLeftArrow();
+
+          // Ensure the caret skipped the collapsed components and
+          // was placed at the beginning of the first header.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection.collapsed(
+                position: DocumentPosition(
+                  nodeId: '1',
+                  nodePosition: TextNodePosition(offset: 8),
+                ),
+              ),
+            ),
+          );
+        });
+      });
+    });
+
+    group('is adjusted when toggled > ', () {
+      testWidgetsOnArbitraryDesktop('when extent is collapsed (downstream)', (tester) async {
+        await _buildToggleableTestApp(tester);
+
+        await tester.dragSelectDocumentFromPositionToPosition(
+          from: const DocumentPosition(
+            nodeId: '1',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+          to: const DocumentPosition(
+            nodeId: '3',
+            nodePosition: TextNodePosition(offset: 8),
+          ),
+        );
+
+        // Collapse the first header.
+        await pressToggleButton(tester, '1');
+
+        // Ensure the extent moved to the end of the header.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnArbitraryDesktop('when extent is collapsed (upstream)', (tester) async {
+        await _buildToggleableTestApp(tester);
+
+        // Select the text from the end of the last header to the beginning of the last
+        // child node which will be collapsed.
+        await tester.dragSelectDocumentFromPositionToPosition(
+          from: const DocumentPosition(
+            nodeId: '4',
+            nodePosition: TextNodePosition(offset: 16),
+          ),
+          to: const DocumentPosition(
+            nodeId: '3.2',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Collapse the first header.
+        await pressToggleButton(tester, '1');
+
+        // Ensure the extent moved to the beginning of the last header.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '4',
+                nodePosition: TextNodePosition(offset: 16),
+              ),
+              extent: DocumentPosition(
+                nodeId: '4',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnArbitraryDesktop('when base is collapsed (downstream)', (tester) async {
+        await _buildToggleableTestApp(tester);
+
+        // Select from the first child of the first header to the end of the last header.
+        await tester.dragSelectDocumentFromPositionToPosition(
+          from: const DocumentPosition(
+            nodeId: '1.1',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+          to: const DocumentPosition(
+            nodeId: '4',
+            nodePosition: TextNodePosition(offset: 16),
+          ),
+        );
+
+        // Collapse the first header.
+        await pressToggleButton(tester, '1');
+
+        // Ensure the base moved to the beginning of the last header.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '4',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: '4',
+                nodePosition: TextNodePosition(offset: 16),
+              ),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnArbitraryDesktop('when base is collapsed (upstream)', (tester) async {
+        await _buildToggleableTestApp(tester);
+
+        // Select from the end of the first child of the first header to the beginning of
+        // the first regular paragraph.
+        await tester.dragSelectDocumentFromPositionToPosition(
+          from: const DocumentPosition(
+            nodeId: '1.1',
+            nodePosition: TextNodePosition(offset: 9),
+          ),
+          to: const DocumentPosition(
+            nodeId: '0',
+            nodePosition: TextNodePosition(offset: 0),
+          ),
+        );
+
+        // Collapse the first header.
+        await pressToggleButton(tester, '1');
+
+        // Ensure the base moved to the end of the group header.
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          selectionEquivalentTo(
+            const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: '1',
+                nodePosition: TextNodePosition(offset: 8),
+              ),
+              extent: DocumentPosition(
+                nodeId: '0',
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}
+
+Future<Editor> _buildToggleableTestApp(
+  WidgetTester tester, {
+  MutableDocument? document,
+}) async {
+  final effectiveDocument = document ??
+      MutableDocument(nodes: [
+        ParagraphNode(
+          id: '0',
+          text: AttributedText('Regular Paragraph'),
+        ),
+        ParagraphNode(
+          id: '1',
+          text: AttributedText('Header 1'),
+          metadata: {NodeMetadata.blockType: header1Attribution},
+        ),
+        ParagraphNode(
+          id: '1.1',
+          text: AttributedText('Some text'),
+        ),
+        ParagraphNode(
+          id: '2',
+          text: AttributedText('Header 2'),
+          metadata: {NodeMetadata.blockType: header2Attribution},
+        ),
+        ParagraphNode(
+          id: '3',
+          text: AttributedText('Header 3'),
+          metadata: {NodeMetadata.blockType: header3Attribution},
+        ),
+        ParagraphNode(
+          id: '3.1',
+          text: AttributedText('Another text'),
+        ),
+        ParagraphNode(
+          id: '3.2',
+          text: AttributedText('Another text'),
+        ),
+        ParagraphNode(
+          id: '4',
+          text: AttributedText('Another Header 1'),
+          metadata: {NodeMetadata.blockType: header1Attribution},
+        ),
+        ParagraphNode(
+          id: '4.1',
+          text: AttributedText('Another text'),
+        ),
+      ]);
+  final composer = MutableDocumentComposer();
+  final editor = createDefaultDocumentEditor(document: effectiveDocument, composer: composer);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SuperEditor(
+            editor: editor,
+            groupBuilders: [
+              HeaderGroupBuilder(
+                editor: editor,
+              )
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+
+  return editor;
+}
+
+Future<void> pressToggleButton(
+  WidgetTester tester,
+  String nodeId, [
+  Finder? superEditorFinder,
+]) async {
+  final documentLayout = SuperEditorInspector.findDocumentLayout(superEditorFinder);
+
+  final componentState = documentLayout.getComponentByNodeId(nodeId) as State;
+
+  // Find the group where the component is located.
+  final groupFinder = find.ancestor(
+    of: find.byKey(componentState.widget.key!),
+    matching: find.byType(ToggleableGroup),
+  );
+
+  // Find the toggle button inside the group.
+  //
+  // For some reason, when there are nested groups, the last one
+  // is the toggle for the group. Probably because the parent group
+  // places the toggle button above all the other groups.
+  final toggleButtonFinder = find
+      .descendant(
+        of: groupFinder,
+        matching: find.byIcon(Icons.arrow_right),
+      )
+      .last;
+
+  // Simulate the tap manually because we need to hover over the
+  // button to make it visible.
+  final testPointer = TestPointer(1, PointerDeviceKind.mouse);
+
+  // Hover over the toggle button to make it visible.
+  await tester.sendEventToBinding(
+    testPointer.hover(tester.getCenter(toggleButtonFinder)),
+  );
+  await tester.pumpAndSettle();
+
+  // Press the button.
+  await tester.sendEventToBinding(
+    testPointer.down(tester.getCenter(toggleButtonFinder)),
+  );
+  await tester.pumpAndSettle();
+
+  // Release the button.
+  await tester.sendEventToBinding(testPointer.up());
+  await tester.pumpAndSettle();
+}

--- a/super_editor/test/test_tools.dart
+++ b/super_editor/test/test_tools.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/links.dart';
@@ -128,5 +129,46 @@ class EquivalentSelectionMatcher extends Matcher {
     }
 
     return null;
+  }
+}
+
+/// A [Matcher] that compares two lists for deep equality.
+Matcher collectionEqualsTo(List<Object> expectedList) => CollectionEqualityMatcher(expectedList);
+
+/// A [Matcher] that compares two lists for deep equality.
+class CollectionEqualityMatcher extends Matcher {
+  const CollectionEqualityMatcher(this.expected);
+
+  final List<Object> expected;
+
+  @override
+  Description describe(Description description) {
+    return description.add("given the list contains the same elements in the same order as the expected list");
+  }
+
+  @override
+  bool matches(covariant Object target, Map<dynamic, dynamic> matchState) {
+    return const DeepCollectionEquality().equals(target, expected);
+  }
+
+  @override
+  Description describeMismatch(
+    covariant Object target,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    if (target is! List) {
+      mismatchDescription.add('The target is not a list');
+      return mismatchDescription;
+    }
+
+    final expectedList = '[${expected.join(', ')}]';
+    final targetList = '[${target.join(', ')}]';
+
+    mismatchDescription
+        .add('The lists don\'t have the same elements in the same order\nExpected: $expectedList\nActual: $targetList');
+
+    return mismatchDescription;
   }
 }


### PR DESCRIPTION
[SuperEditor] Add toggleable headers. Resolves #2276 

This PR adds the ability to group nodes together under header nodes or list item nodes, where each group can be collapsed/expanded by tapping on a button near it.

The groups are created upon initialization, when adding or removing a node, and when changing a node that couldn’t start a group to a node that can start a group. For example, typing "# " at the beginning of a paragraph converts it to a header node and creates a new group.

Navigating using the arrow keys skips nodes inside a collapsed group. For example, pressing ARROW DOWN skips nodes that are inside a collapsed group.

The user cannot start or end a selection inside a collapsed group. Also, if the selection starts or ends within a group and the user collapses the group, the selection is adjusted to avoid starting or ending inside the collapsed group.

Node grouping is customizable and apps can implement their own grouping logic, if desirable.

## Implementation

A `GroupBuilder` interface was added with the methods required to grouping nodes:

`canStartGroup`: to signal the document layout that the current node can start a group, for example, when it is a level one header.

`canAddToGroup`: to signal the document layout that a node can be added to an existing group.

`build`: to create the widget for this group.

`SuperEditor` will take a list of `GroupBuilder`s as a constructor parameter.

Previously, all components were organized into a vertical list of components inside the `SingleColumnDocumentLayout`. Now, whenever a `GroupBuilder` returns `true` for  `canStartGroup`, the document layout will call `canAddToGroup` to each node below it, until `canAddToGroup` returns `false`. After gathering all nodes that are part of the group, `SingleColumnDocumentLayout` calls `build` on the `GroupBuilder` to create a widget subtree for that group.

To handle the key navigation, at the current state of this PR, it was added an `isComponentVisible` method to the `DocumentLayout` interface, so the layout can report that a component is not currently visible. This is yet subject to change, depending on how we expose an API to programmatically collapse/expand/check state of a group.

This PR adds `HeaderGroupBuilder` and `ListItemGroupBuilder` with default behavior for headers and list items. All customization can be done using constructor parameters for these builders. For example, customizing the toggle button, restricting the maximum number of children of a group, etc.

`ToggleableGroup` is the default widget used for headers and list items, which includes a default button that fades in when the mouse enters, fades out when the mouse leaves, animates upon tap. It also includes a vertical line below the button, that also fades in/out. The widget can optionally animate the expanding/collapsing of a group.

A change that might be regrettable is that I changed `_SingleColumnDocumentLayoutState` to be public, so I can access information about groups inside tests. Once we figure out a public API for  that this can be reverted.

## Remaining work

- Define a public API to allow apps to expand/collapse groups programmatically and obtain information about the groups.
- Modify the behavior for when the user presses enter at the end of the header of a collapsed group. This action should expand the group. This change depends of the API to expand/collapse groups.
- Add mobile support. On mobile we might not have enough room to display a button near the content, so we need to find another way for that. Also, on mobile the buttons must be always visible (or at least when the caret sits within the node) because, of course, there is no mouse to hover over the button to make it appear.

https://github.com/user-attachments/assets/2cb80bb1-da27-4394-a4d5-0e53faa93e88


