### PR TITLE
[super_editor_markdown] Fix compilation error

### DIFF
--- a/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
+++ b/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
@@ -40,7 +40,7 @@ Future<void> pasteMarkdown({
   required Document document,
   required DocumentComposer composer,
 }) async {
-  DocumentPosition pastePosition = composer.selection!.extent;
+  DocumentPosition? pastePosition = composer.selection!.extent;
 
   // Delete all currently selected content.
   if (!composer.selection!.isCollapsed) {
@@ -48,6 +48,10 @@ Future<void> pasteMarkdown({
       document: document,
       selection: composer.selection!,
     );
+
+    if (pastePosition == null) {
+      return;
+    }
 
     // Delete the selected content.
     editor.execute([

--- a/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
+++ b/super_editor_markdown/lib/src/super_editor_paste_markdown.dart
@@ -40,16 +40,16 @@ Future<void> pasteMarkdown({
   required Document document,
   required DocumentComposer composer,
 }) async {
-  DocumentPosition? pastePosition = composer.selection!.extent;
-
   // Delete all currently selected content.
   if (!composer.selection!.isCollapsed) {
-    pastePosition = CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
+    final pastePosition = CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
       document: document,
       selection: composer.selection!,
     );
 
     if (pastePosition == null) {
+      // A null pastePosition means that the selection can't be deleted. This might happen
+      // when the selection contains only non-deletable nodes. Therefore, we cannot paste.
       return;
     }
 
@@ -71,7 +71,7 @@ Future<void> pasteMarkdown({
   editor.execute([
     PasteStructuredContentEditorRequest(
       content: deserializedMarkdown,
-      pastePosition: pastePosition,
+      pastePosition: composer.selection!.extent,
     ),
   ]);
 }


### PR DESCRIPTION
[super_editor_markdown] Fix compilation error

Now `CommonEditorOperations.getDocumentPositionAfterExpandedDeletion` returns a nullable type. This caused a compilation error in `pasteMarkdown`.

This PR fixes that issue.