### PR TITLE
[SuperEditor][Web] Fix option + arrow key selection changes (Resolves #2415)

### DIFF
--- a/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
+++ b/super_editor/lib/src/default_editor/document_hardware_keyboard/document_keyboard_actions.dart
@@ -627,7 +627,8 @@ ExecutionInstruction doNothingWithLeftRightArrowKeysAtMiddleOfTextOnWeb({
     return ExecutionInstruction.continueExecution;
   }
 
-  if (defaultTargetPlatform == TargetPlatform.windows && HardwareKeyboard.instance.isAltPressed) {
+  if ((defaultTargetPlatform == TargetPlatform.windows || CurrentPlatform.isApple) &&
+      HardwareKeyboard.instance.isAltPressed) {
     return ExecutionInstruction.continueExecution;
   }
 

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -626,7 +626,7 @@ void main() {
           // Press SHIFT + OPTION + RIGHT ARROW to remove the first word from the selection.
           await tester.pressShiftAltRightArrow();
 
-          // Ensure that the last word was removed from the selection.
+          // Ensure that the first word was removed from the selection.
           expect(
             SuperEditorInspector.findDocumentSelection(),
             selectionEquivalentTo(

--- a/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
+++ b/super_editor/test/super_editor/supereditor_input_keyboard_actions_test.dart
@@ -523,6 +523,126 @@ void main() {
             ),
           );
         });
+
+        testWidgetsOnMacDesktopAndWeb('SHIFT + OPTION + LEFT ARROW: removes upstream word from selection',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('This is a paragraph'),
+                    ),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place caret at the beginning of the paragraph.
+          await tester.placeCaretInParagraph('1', 0);
+
+          // Press CMD + SHIFT + RIGHT ARROW to expand the selection to the end of the line.
+          await tester.pressShiftCmdRightArrow();
+
+          // Ensure that the whole line is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 19),
+                ),
+              ),
+            ),
+          );
+
+          // Press SHIFT + OPTION + LEFT ARROW to remove the last word from the selection.
+          await tester.pressShiftAltLeftArrow();
+
+          // Ensure that the last word was removed from the selection.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+                extent: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 10),
+                ),
+              ),
+            ),
+          );
+        });
+
+        testWidgetsOnMacDesktopAndWeb('SHIFT + OPTION + RIGHT ARROW: removes downstream word from selection',
+            (tester) async {
+          await tester //
+              .createDocument()
+              .withCustomContent(
+                MutableDocument(
+                  nodes: [
+                    ParagraphNode(
+                      id: '1',
+                      text: AttributedText('This is a paragraph'),
+                    ),
+                  ],
+                ),
+              )
+              .pump();
+
+          // Place caret at the end of the paragraph.
+          await tester.placeCaretInParagraph('1', 19);
+
+          // Press CMD + SHIFT + LEFT ARROW to expand the selection to the beginning of the line.
+          await tester.pressShiftCmdLeftArrow();
+
+          // Ensure that the whole line is selected.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 19),
+                ),
+                extent: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 0),
+                ),
+              ),
+            ),
+          );
+
+          // Press SHIFT + OPTION + RIGHT ARROW to remove the first word from the selection.
+          await tester.pressShiftAltRightArrow();
+
+          // Ensure that the last word was removed from the selection.
+          expect(
+            SuperEditorInspector.findDocumentSelection(),
+            selectionEquivalentTo(
+              const DocumentSelection(
+                base: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 19),
+                ),
+                extent: DocumentPosition(
+                  nodeId: "1",
+                  nodePosition: TextNodePosition(offset: 4),
+                ),
+              ),
+            ),
+          );
+        });
       });
 
       group("Windows and Linux >", () {


### PR DESCRIPTION
[SuperEditor][Web] Fix option + arrow key selection changes. Resolves #2415

Steps to reproduce the behavior:
1. Run Example app on Chrome
2. Place cursor at beginning of line
3. Use CMD + SHIFT + RIGHT ARROW to select until the end of line
4. Use SHIFT + ALT + LEFT ARROW to remove last word from selection

When doing this the caret moves to the beginning of the line:

https://github.com/user-attachments/assets/5f598a39-8177-4282-878b-b6f88561a960

This seems to be caused by IME deltas. I ran the example editor without any keyboard handlers and the issue also happens. It might be related to the same issue fixed in https://github.com/superlistapp/super_editor/pull/2327, where the line breaks on the browser HTML input are different from Flutter.

Currently, we have a keyboard handler that sends the event back to the IME when pressing LEFT or RIGHT ARROW at the middle of the text. I modified this handler to not do that if ALT is pressed.

https://github.com/user-attachments/assets/f83098e7-a143-46b1-991f-1aa17f8a830e

This PR adds tests for this, but to effectively test these web keyboard interactions we would need an integration test that runs on the browser.
 