### PR TITLE
[SuperEditor][SuperTextField][iOS] Fix focal point for native toolbar (Resolves #2345)

### DIFF
--- a/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
@@ -133,7 +133,6 @@ class _NativeIosContextMenuFeatureDemoState extends State<NativeIosContextMenuFe
       focalPoint,
       _commonEditorOperations,
       SuperEditorIosControlsScope.rootOf(context),
-      _documentLayoutKey.currentState as DocumentLayout,
     );
   }
 

--- a/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
@@ -133,7 +133,6 @@ class _NativeIosContextMenuFeatureDemoState extends State<NativeIosContextMenuFe
       focalPoint,
       _commonEditorOperations,
       SuperEditorIosControlsScope.rootOf(context),
-      _editor.composer.selection!,
       _documentLayoutKey.currentState as DocumentLayout,
     );
   }

--- a/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
@@ -123,12 +123,18 @@ class _NativeIosContextMenuFeatureDemoState extends State<NativeIosContextMenuFe
     Key mobileToolbarKey,
     LeaderLink focalPoint,
   ) {
+    if (_editor.composer.selection == null) {
+      return const SizedBox();
+    }
+
     return iOSSystemPopoverEditorToolbarWithFallbackBuilder(
       context,
       mobileToolbarKey,
       focalPoint,
       _commonEditorOperations,
       SuperEditorIosControlsScope.rootOf(context),
+      _editor.composer.selection!,
+      _documentLayoutKey.currentState as DocumentLayout,
     );
   }
 

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -917,7 +917,6 @@ Widget iOSSystemPopoverEditorToolbarWithFallbackBuilder(
   LeaderLink focalPoint,
   CommonEditorOperations editorOps,
   SuperEditorIosControlsController editorControlsController,
-  DocumentLayout documentLayout,
 ) {
   if (CurrentPlatform.isWeb) {
     // On web, we defer to the browser's internal overlay controls for mobile.

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -917,7 +917,6 @@ Widget iOSSystemPopoverEditorToolbarWithFallbackBuilder(
   LeaderLink focalPoint,
   CommonEditorOperations editorOps,
   SuperEditorIosControlsController editorControlsController,
-  DocumentRange documentRange,
   DocumentLayout documentLayout,
 ) {
   if (CurrentPlatform.isWeb) {
@@ -926,21 +925,8 @@ Widget iOSSystemPopoverEditorToolbarWithFallbackBuilder(
   }
 
   if (IOSSystemContextMenu.isSupported(context)) {
-    // The size reported by the focalPoint is one frame behind. Query the selection bounds
-    // from the DocumentLayout instead.
-    final selectionBounds = documentLayout.getRectForSelection(documentRange.start, documentRange.end);
-    if (selectionBounds == null) {
-      // The selection bounds can be null if we can't find the component for the nodes in the
-      // selected range. We don't expect that to happen when trying to show the toolbar.
-      return const SizedBox();
-    }
-
-    // The selection bounds are in the layout coordinate space, so we need to convert them to
-    // global coordinate space.
-    final selectionTopLeft = documentLayout.getGlobalOffsetFromDocumentOffset(selectionBounds.topLeft);
-
     return IOSSystemContextMenu(
-      anchor: selectionTopLeft & selectionBounds.size,
+      leaderLink: focalPoint,
     );
   }
 

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -926,6 +926,8 @@ Widget iOSSystemPopoverEditorToolbarWithFallbackBuilder(
   }
 
   if (IOSSystemContextMenu.isSupported(context)) {
+    // The size reported by the focalPoint is one frame behind. Query the selection bounds
+    // from the DocumentLayout instead.
     final selectionBounds = documentLayout.getRectForSelection(documentRange.start, documentRange.end);
     if (selectionBounds == null) {
       // The selection bounds can be null if we can't find the component for the nodes in the

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_system_context_menu.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_system_context_menu.dart
@@ -66,7 +66,7 @@ class _IOSSystemContextMenuState extends State<IOSSystemContextMenu> {
       onSystemHide: widget.onSystemHide,
     );
     widget.leaderLink.addListener(_onLeaderChanged);
-    onNextFrame((_) => _showSystemMenu());
+    onNextFrame((_) => _positionSystemMenu());
   }
 
   @override
@@ -75,7 +75,7 @@ class _IOSSystemContextMenuState extends State<IOSSystemContextMenu> {
     if (widget.leaderLink != oldWidget.leaderLink) {
       oldWidget.leaderLink.removeListener(_onLeaderChanged);
       widget.leaderLink.addListener(_onLeaderChanged);
-      onNextFrame((_) => _showSystemMenu());
+      onNextFrame((_) => _positionSystemMenu());
     }
   }
 
@@ -92,11 +92,11 @@ class _IOSSystemContextMenuState extends State<IOSSystemContextMenu> {
     }
 
     onNextFrame((_) {
-      _showSystemMenu();
+      _positionSystemMenu();
     });
   }
 
-  void _showSystemMenu() {
+  void _positionSystemMenu() {
     _systemContextMenuController.show(widget.leaderLink.offset! & widget.leaderLink.leaderSize!);
   }
 

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -704,8 +704,17 @@ typedef IOSPopoverToolbarBuilder = Widget Function(BuildContext, IOSEditingOverl
 /// iOS is recent enough, otherwise builds [defaultIosPopoverToolbarBuilder].
 Widget iOSSystemPopoverTextFieldToolbarWithFallback(BuildContext context, IOSEditingOverlayController controller) {
   if (IOSSystemContextMenu.isSupported(context)) {
+    final topAnchor = controller.overlayController.toolbarBottomAnchor;
+    final bottomAnchor = controller.overlayController.toolbarTopAnchor;
+
+    if (topAnchor == null || bottomAnchor == null) {
+      // We don't expect the toolbar builder to be called without having the anchors
+      // defined. But, since these properties are nullable, we account for that.
+      return const SizedBox();
+    }
+
     return IOSSystemContextMenu(
-      anchor: controller.toolbarFocalPoint.offset! & controller.toolbarFocalPoint.leaderSize!,
+      anchor: Rect.fromLTRB(topAnchor.dx, topAnchor.dy, bottomAnchor.dx, bottomAnchor.dy),
     );
   }
 

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -774,7 +774,7 @@ class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSy
     _systemContextMenuController = SystemContextMenuController();
     widget.controller.addListener(_onControllerChanged);
     onNextFrame((_) {
-      _showSystemMenu();
+      _positionSystemMenu();
     });
   }
 
@@ -786,7 +786,7 @@ class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSy
       widget.controller.addListener(_onControllerChanged);
     }
     onNextFrame((_) {
-      _showSystemMenu();
+      _positionSystemMenu();
     });
   }
 
@@ -799,11 +799,11 @@ class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSy
 
   void _onControllerChanged() {
     onNextFrame((_) {
-      _showSystemMenu();
+      _positionSystemMenu();
     });
   }
 
-  void _showSystemMenu() {
+  void _positionSystemMenu() {
     // The size reported by the controller's toolbarFocalPoint is one frame behind. Query the information
     // overlayController instead.
     final topAnchor = widget.controller.overlayController.toolbarTopAnchor;

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -704,19 +704,8 @@ typedef IOSPopoverToolbarBuilder = Widget Function(BuildContext, IOSEditingOverl
 /// iOS is recent enough, otherwise builds [defaultIosPopoverToolbarBuilder].
 Widget iOSSystemPopoverTextFieldToolbarWithFallback(BuildContext context, IOSEditingOverlayController controller) {
   if (IOSSystemContextMenu.isSupported(context)) {
-    // The size reported by the controller's toolbarFocalPoint is one frame behind. Query the information
-    // overlayController instead.
-    final topAnchor = controller.overlayController.toolbarBottomAnchor;
-    final bottomAnchor = controller.overlayController.toolbarTopAnchor;
-
-    if (topAnchor == null || bottomAnchor == null) {
-      // We don't expect the toolbar builder to be called without having the anchors
-      // defined. But, since these properties are nullable, we account for that.
-      return const SizedBox();
-    }
-
-    return IOSSystemContextMenu(
-      anchor: Rect.fromLTRB(topAnchor.dx, topAnchor.dy, bottomAnchor.dx, bottomAnchor.dy),
+    return IOSSuperTextFieldSystemContextMenu(
+      controller: controller,
     );
   }
 
@@ -762,4 +751,76 @@ Widget defaultIosPopoverToolbarBuilder(BuildContext context, IOSEditingOverlayCo
       }
     },
   );
+}
+
+class IOSSuperTextFieldSystemContextMenu extends StatefulWidget {
+  const IOSSuperTextFieldSystemContextMenu({
+    super.key,
+    required this.controller,
+  });
+
+  final IOSEditingOverlayController controller;
+
+  @override
+  State<IOSSuperTextFieldSystemContextMenu> createState() => _IOSSuperTextFieldSystemContextMenuState();
+}
+
+class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSystemContextMenu> {
+  late final SystemContextMenuController _systemContextMenuController;
+
+  @override
+  void initState() {
+    super.initState();
+    _systemContextMenuController = SystemContextMenuController();
+    widget.controller.addListener(_onControllerChanged);
+    onNextFrame((_) {
+      _showSystemMenu();
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant IOSSuperTextFieldSystemContextMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+    }
+    onNextFrame((_) {
+      _showSystemMenu();
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChanged);
+    _systemContextMenuController.dispose();
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    onNextFrame((_) {
+      _showSystemMenu();
+    });
+  }
+
+  void _showSystemMenu() {
+    // The size reported by the controller's toolbarFocalPoint is one frame behind. Query the information
+    // overlayController instead.
+    final topAnchor = widget.controller.overlayController.toolbarTopAnchor;
+    final bottomAnchor = widget.controller.overlayController.toolbarTopAnchor;
+
+    if (topAnchor == null || bottomAnchor == null) {
+      // We don't expect the toolbar builder to be called without having the anchors
+      // defined. But, since these properties are nullable, we account for that.
+      return;
+    }
+
+    _systemContextMenuController.show(Rect.fromLTRB(topAnchor.dx, topAnchor.dy, bottomAnchor.dx, bottomAnchor.dy));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(IOSSystemContextMenu.isSupported(context));
+    return const SizedBox.shrink();
+  }
 }

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -704,6 +704,8 @@ typedef IOSPopoverToolbarBuilder = Widget Function(BuildContext, IOSEditingOverl
 /// iOS is recent enough, otherwise builds [defaultIosPopoverToolbarBuilder].
 Widget iOSSystemPopoverTextFieldToolbarWithFallback(BuildContext context, IOSEditingOverlayController controller) {
   if (IOSSystemContextMenu.isSupported(context)) {
+    // The size reported by the controller's toolbarFocalPoint is one frame behind. Query the information
+    // overlayController instead.
     final topAnchor = controller.overlayController.toolbarBottomAnchor;
     final bottomAnchor = controller.overlayController.toolbarTopAnchor;
 


### PR DESCRIPTION
[SuperEditor][SuperTextField][iOS] Fix focal point for native toolbar. Resolves #2345

When using the native iOS toolbar, the toolbar has a wrong focal point:

https://github.com/user-attachments/assets/e87b8b7e-b326-4fa3-8e2f-10be3fc39ae7

We compute the toolbar anchor using the `LeaderLink`'s offset and size. The issue is that we are trying to get the leader size before it is computed, because the toolbar builder is being called before the `Leader` runs `performLayout`.

I added some print statements to show what's happening:

```console
flutter: after RenderLeader performLayout(), leader size: Size(0.0, 25.2)
flutter: building toolbar, leader size: Size(0.0, 25.2)
flutter: after RenderLeader performLayout(), leader size: Size(85.3, 21.5)
```

The first `performLayout` runs after the first tap and it's the result is the caret size. This means we are using the bounds computed for the caret instead of the bounds of the expanded selection.

This PR changes the native iOS toolbar builder to query the selection bounds from the `DocumentLayout` instead of relying on the `LeaderLink`. Maybe we want to change `iOSSystemPopoverEditorToolbarWithFallbackBuilder` to use named parameters instead of positional parameters.

https://github.com/user-attachments/assets/41ef3a83-2b07-4104-b391-55d1ded55929



