### PR TITLE
[Guides] Fix quickstart link (Resolves #2330)

### DIFF
--- a/doc/website/source/index.jinja
+++ b/doc/website/source/index.jinja
@@ -77,7 +77,7 @@ layout:
                 <img src="images/homepage/synopsis_super-editor.png" class="featured-image">
                 <p class="title">A Document Editor</p>
                 <p class="description">Configure your very own document editing experience with the <code>SuperEditor</code> widget.</p>
-                <a href="/super-editor-guides/quickstart">Get started</a>
+                <a href="/super-editor/guides/quickstart">Get started</a>
               </div>
               <div class="col">
                 <img src="images/homepage/synopsis_super-reader.png" class="featured-image">


### PR DESCRIPTION
[Guides] Fix quickstart link. Resolves #2330

The link to the quickstart was pointing to "/super-editor-guides/quickstart" where it should be pointing to "/super-editor/guides/quickstart"