### PR TITLE
[SuperEditor][SuperReader] - Reduce uses of node index queries in Document (Resolves #2434)

### DIFF
--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -1291,7 +1291,7 @@ class MutableDocument with Iterable<DocumentNode> implements Document, Editable 
     }
 
     for (int i = 0; i < _nodes.length; ++i) {
-      if (!_nodes[i].hasEquivalentContent(other.getNodeAt(i)!)) {
+      if (!_nodes[i].hasEquivalentContent(other.getNodeById(_nodes[i].id)!)) {
         return false;
       }
     }

--- a/super_editor/lib/src/core/editor.dart
+++ b/super_editor/lib/src/core/editor.dart
@@ -1278,7 +1278,7 @@ class MutableDocument with Iterable<DocumentNode> implements Document, Editable 
     }
   }
 
-  /// Returns [true] if the content of the [other] [Document] is equivalent
+  /// Returns `true` if the content of the [other] [Document] is equivalent
   /// to the content of this [Document].
   ///
   /// Content equivalency compares types of content nodes, and the content
@@ -1289,11 +1289,21 @@ class MutableDocument with Iterable<DocumentNode> implements Document, Editable 
     if (_nodes.length != other.nodeCount) {
       return false;
     }
+    if (isEmpty) {
+      // Both documents are empty, and therefore are equivalent.
+      return true;
+    }
 
-    for (int i = 0; i < _nodes.length; ++i) {
-      if (!_nodes[i].hasEquivalentContent(other.getNodeById(_nodes[i].id)!)) {
+    DocumentNode? thisDocNode = first;
+    DocumentNode? otherDocNode = other.first;
+
+    while (thisDocNode != null && otherDocNode != null) {
+      if (!thisDocNode.hasEquivalentContent(otherDocNode)) {
         return false;
       }
+
+      thisDocNode = getNodeAfter(thisDocNode);
+      otherDocNode = other.getNodeAfter(otherDocNode);
     }
 
     return true;

--- a/super_editor/lib/src/core/styles.dart
+++ b/super_editor/lib/src/core/styles.dart
@@ -207,7 +207,7 @@ class _FirstBlockMatcher implements _BlockMatcher {
 
   @override
   bool matches(Document document, DocumentNode node) {
-    return document.getNodeIndexById(node.id) == 0;
+    return document.getNodeById(node.id) == document.firstOrNull;
   }
 }
 
@@ -216,7 +216,7 @@ class _LastBlockMatcher implements _BlockMatcher {
 
   @override
   bool matches(Document document, DocumentNode node) {
-    return document.getNodeIndexById(node.id) == document.nodeCount - 1;
+    return document.getNodeById(node.id) == document.lastOrNull;
   }
 }
 

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -388,9 +388,6 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine("Doc selection to delete: $docSelectionToDelete");
 
     if (docSelectionToDelete == null) {
-      final selectedNodeIndex = document.getNodeIndexById(
-        selection.value!.extent.nodeId,
-      );
       // The user is trying to delete upstream at the start of a node.
       // This action requires intervention because the IME doesn't know
       // that there's more content before this node. Instruct the editor
@@ -398,7 +395,7 @@ class TextDeltasDocumentEditor {
       // "backspace" behavior at the start of this node.
       editor.execute([
         DeleteUpstreamAtBeginningOfNodeRequest(
-          document.getNodeAt(selectedNodeIndex)!,
+          document.getNodeById(selection.value!.extent.nodeId)!,
         ),
       ]);
       return;

--- a/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_presenter.dart
@@ -164,17 +164,16 @@ class SingleColumnLayoutPresenter {
       // The document changed. All view models were invalidated. Create a
       // new base document view model.
       final viewModels = <SingleColumnLayoutComponentViewModel>[];
-      for (int i = 0; i < _document.nodeCount; i += 1) {
+      for (final node in _document) {
         SingleColumnLayoutComponentViewModel? viewModel;
         for (final builder in _componentBuilders) {
-          viewModel = builder.createViewModel(_document, _document.getNodeAt(i)!);
+          viewModel = builder.createViewModel(_document, node);
           if (viewModel != null) {
             break;
           }
         }
         if (viewModel == null) {
-          throw Exception(
-              "Couldn't find styler to create component for document node: ${_document.getNodeAt(i)!.runtimeType}");
+          throw Exception("Couldn't find styler to create component for document node: ${node.runtimeType}");
         }
         viewModels.add(viewModel);
       }

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -945,6 +945,7 @@ class DeleteContentCommand extends EditCommand {
     var nodeToDelete = document.getNodeAfter(startNode);
     while (nodeToDelete != null && nodeToDelete != endNode) {
       _log.log('_deleteNodesBetweenFirstAndLast', ' - deleting node: ${nodeToDelete.id}');
+      final nextNode = document.getNodeAfter(nodeToDelete);
       if (nodeToDelete.isDeletable) {
         // This node is deletable, so delete it.
         changes.add(DocumentEdit(
@@ -954,7 +955,7 @@ class DeleteContentCommand extends EditCommand {
       }
 
       // Move to the next node.
-      nodeToDelete = document.getNodeAfter(nodeToDelete);
+      nodeToDelete = nextNode;
     }
     return changes;
   }

--- a/super_editor/lib/src/default_editor/tap_handlers/tap_handlers.dart
+++ b/super_editor/lib/src/default_editor/tap_handlers/tap_handlers.dart
@@ -169,8 +169,8 @@ class SuperEditorAddEmptyParagraphTapHandler extends ContentTapDelegate {
     final tappedComponent = documentLayout.getComponentByNodeId(nodeId)!;
     final componentBox = tappedComponent.context.findRenderObject() as RenderBox;
     final localPosition = componentBox.globalToLocal(globalOffset);
-    final nodeIndex = document.getNodeIndexById(nodeId);
+    final node = document.getNodeById(nodeId);
 
-    return (nodeIndex == document.nodeCount - 1) && (localPosition.dy > componentBox.size.height);
+    return (node == document.lastOrNull) && (localPosition.dy > componentBox.size.height);
   }
 }

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -2093,6 +2093,8 @@ void _deleteExpandedSelection({
   );
 }
 
+// FIXME: This method appears to be the same as CommonEditorOperations.getDocumentPositionAfterExpandedDeletion
+//        De-dup this behavior in an appropriate place
 DocumentPosition _getDocumentPositionAfterExpandedDeletion({
   required Document document,
   required DocumentSelection selection,
@@ -2107,26 +2109,29 @@ DocumentPosition _getDocumentPositionAfterExpandedDeletion({
   if (baseNode == null) {
     throw Exception('Failed to _getDocumentPositionAfterDeletion because the base node no longer exists.');
   }
-  final baseNodeIndex = document.getNodeIndexById(baseNode.id);
 
   final extentPosition = selection.extent;
   final extentNode = document.getNode(extentPosition);
   if (extentNode == null) {
     throw Exception('Failed to _getDocumentPositionAfterDeletion because the extent node no longer exists.');
   }
-  final extentNodeIndex = document.getNodeIndexById(extentNode.id);
 
-  final topNodeIndex = min(baseNodeIndex, extentNodeIndex);
-  final topNode = document.getNodeAt(topNodeIndex)!;
-  final topNodePosition = baseNodeIndex < extentNodeIndex ? basePosition.nodePosition : extentPosition.nodePosition;
+  final selectionAffinity = document.getAffinityForSelection(selection);
+  final topPosition = selectionAffinity == TextAffinity.downstream //
+      ? selection.base
+      : selection.extent;
+  final topNodePosition = topPosition.nodePosition;
+  final topNode = document.getNodeById(topPosition.nodeId)!;
 
-  final bottomNodeIndex = max(baseNodeIndex, extentNodeIndex);
-  final bottomNode = document.getNodeAt(bottomNodeIndex)!;
-  final bottomNodePosition = baseNodeIndex < extentNodeIndex ? extentPosition.nodePosition : basePosition.nodePosition;
+  final bottomPosition = selectionAffinity == TextAffinity.downstream //
+      ? selection.extent
+      : selection.base;
+  final bottomNodePosition = bottomPosition.nodePosition;
+  final bottomNode = document.getNodeById(bottomPosition.nodeId)!;
 
   DocumentPosition newSelectionPosition;
 
-  if (baseNodeIndex != extentNodeIndex) {
+  if (topPosition.nodeId != bottomPosition.nodeId) {
     if (topNodePosition == topNode.beginningPosition && bottomNodePosition == bottomNode.endPosition) {
       // All nodes in the selection will be deleted. Assume that the base
       // node will be retained and converted into a paragraph, if it's not
@@ -2154,7 +2159,7 @@ DocumentPosition _getDocumentPositionAfterExpandedDeletion({
       // those nodes will remain.
 
       // The caret should end up at the base position
-      newSelectionPosition = baseNodeIndex <= extentNodeIndex ? selection.base : selection.extent;
+      newSelectionPosition = selectionAffinity == TextAffinity.downstream ? selection.base : selection.extent;
     }
   } else {
     // Selection is within a single node.

--- a/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
@@ -127,14 +127,21 @@ class AndroidTextFieldDragHandleSelectionStrategy {
     }
 
     final nearestPositionTextOffset = (nearestPosition.nodePosition as TextNodePosition).offset;
-    final nearestPositionNodeIndex = _document.getNodeIndexById(nearestPosition.nodeId);
-
     final previousNearestPositionTextOffset = (_lastFocalPosition!.nodePosition as TextNodePosition).offset;
-    final previousNearestPositionNodeIndex = _document.getNodeIndexById(_lastFocalPosition!.nodeId);
 
-    final didFocalPointMoveToDownstreamNode = nearestPositionNodeIndex > previousNearestPositionNodeIndex;
-    final didFocalPointMoveToUpstreamNode = nearestPositionNodeIndex < previousNearestPositionNodeIndex;
-    final didFocalPointStayInSameNode = nearestPositionNodeIndex == previousNearestPositionNodeIndex;
+    final didFocalPointMoveToDownstreamNode = _document.getAffinityBetween(
+          base: _lastFocalPosition!,
+          extent: nearestPosition,
+        ) ==
+        TextAffinity.downstream;
+
+    final didFocalPointMoveToUpstreamNode = _document.getAffinityBetween(
+          base: _lastFocalPosition!,
+          extent: nearestPosition,
+        ) ==
+        TextAffinity.upstream;
+
+    final didFocalPointStayInSameNode = _lastFocalPosition!.nodeId == nearestPosition.nodeId;
 
     final didFocalPointMoveDownstream = didFocalPointMoveToDownstreamNode ||
         (didFocalPointStayInSameNode && nearestPositionTextOffset > previousNearestPositionTextOffset) ||

--- a/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/drag_handle_selection.dart
@@ -129,19 +129,21 @@ class AndroidTextFieldDragHandleSelectionStrategy {
     final nearestPositionTextOffset = (nearestPosition.nodePosition as TextNodePosition).offset;
     final previousNearestPositionTextOffset = (_lastFocalPosition!.nodePosition as TextNodePosition).offset;
 
+    final didFocalPointStayInSameNode = _lastFocalPosition!.nodeId == nearestPosition.nodeId;
+
     final didFocalPointMoveToDownstreamNode = _document.getAffinityBetween(
-          base: _lastFocalPosition!,
-          extent: nearestPosition,
-        ) ==
-        TextAffinity.downstream;
+              base: _lastFocalPosition!,
+              extent: nearestPosition,
+            ) ==
+            TextAffinity.downstream &&
+        !didFocalPointStayInSameNode;
 
     final didFocalPointMoveToUpstreamNode = _document.getAffinityBetween(
-          base: _lastFocalPosition!,
-          extent: nearestPosition,
-        ) ==
-        TextAffinity.upstream;
-
-    final didFocalPointStayInSameNode = _lastFocalPosition!.nodeId == nearestPosition.nodeId;
+              base: _lastFocalPosition!,
+              extent: nearestPosition,
+            ) ==
+            TextAffinity.upstream &&
+        !didFocalPointStayInSameNode;
 
     final didFocalPointMoveDownstream = didFocalPointMoveToDownstreamNode ||
         (didFocalPointStayInSameNode && nearestPositionTextOffset > previousNearestPositionTextOffset) ||


### PR DESCRIPTION
[SuperEditor][SuperReader] - Reduce uses of node index queries in Document (Resolves #2434)

This PR changes as many calls as possible from index-based node access to either getting a node by ID, or getting a node before/after another node. This is in preparation for changes to a tree document, for which those behaviors still make sense, but accessing at an index doesn't.