### PR TITLE
[SuperEditor] Make getDocumentPositionAfterExpandedDeletion return null for collapsed selections (Resolves #2431)

### DIFF
--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -1396,6 +1396,13 @@ class CommonEditorOperations {
   }) {
     // Figure out where the caret should appear after the
     // deletion.
+
+    if (selection.isCollapsed) {
+      // There is no expanded deletion when the selection is collapsed. Therefore,
+      // no selection change is expected.
+      return null;
+    }
+
     // TODO: This calculation depends upon the first
     //       selected node still existing after the deletion. This
     //       is a fragile expectation and should be revisited.

--- a/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
+++ b/super_editor/test/super_editor/infrastructure/common_editor_operations_test.dart
@@ -186,6 +186,29 @@ void main() {
         );
       });
     });
+
+    group('getDocumentPositionAfterExpandedDeletion', () {
+      test('returns null for collapsed selection', () {
+        final node = HorizontalRuleNode(
+          id: "1",
+        );
+
+        expect(
+          CommonEditorOperations.getDocumentPositionAfterExpandedDeletion(
+            document: MutableDocument(nodes: [
+              node,
+            ]),
+            selection: DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: node.id,
+                nodePosition: node.endPosition,
+              ),
+            ),
+          ),
+          isNull,
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
[SuperEditor] Make getDocumentPositionAfterExpandedDeletion return null for collapsed selections. Resolves #2431

The `CommonEditorOperations.getDocumentPositionAfterExpandedDeletion` returns a `TextNodePosition` even when the selection is collapsed. In this situation, we expect nothing to be deleted and no selection change.

Currently, if all nodes in the selection are non-deletable, this method returns `null`. To keep consistency, this PR changes this method to also return `null` when the selection is collapsed.f