### PR TITLE
Update `TaskNode`s `Checkbox` visual density to depend on the `ThemeData.visualDensity`

### DIFF
--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -353,6 +353,7 @@ class _TaskComponentState extends State<TaskComponent> with ProxyDocumentCompone
         Padding(
           padding: const EdgeInsets.only(left: 16, right: 4),
           child: Checkbox(
+            visualDensity: Theme.of(context).visualDensity,
             value: widget.viewModel.isComplete,
             onChanged: (newValue) {
               widget.viewModel.setComplete(newValue!);


### PR DESCRIPTION
We're updating `Checkbox` default visual density to not depend on  `ThemeData.visualDensity` in order to match Material Design 3 specifications in https://github.com/flutter/flutter/pull/159081. This could produce visual changes for the users, however, if the users don't want to follow M3 compliance then they can override the `Checkbox.visualDensity` to depend on `ThemeData.visualDensity`. 

This PR makes such override to pass customer testing suite in the Flutter PR as `super_editor` is part of this suite. 

