### PR TITLE
[SuperEditorMarkdown] Attributions not placed according to markdown standard when serializing document (#2424)

### DIFF
--- a/super_editor_markdown/test/attributed_text_markdown_test.dart
+++ b/super_editor_markdown/test/attributed_text_markdown_test.dart
@@ -119,5 +119,24 @@ void main() {
         "This is ***bold*** text.",
       );
     });
+
+    test("First and last character in one attribution span is white space", () {
+      expect(
+        AttributedText(
+          //       b  b
+          //      i    i
+          "This is bold text.",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.end), 
+              const SpanMarker(attribution: italicsAttribution, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: italicsAttribution, offset: 12, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ).toMarkdown(),
+        "This is ***bold*** text.",
+      );
+    });
   });
 }

--- a/super_editor_markdown/test/attributed_text_markdown_test.dart
+++ b/super_editor_markdown/test/attributed_text_markdown_test.dart
@@ -68,5 +68,56 @@ void main() {
         "This is **ove*rla**pping* styles.",
       );
     });
+
+    test("First character in the attribution span is white space", () {
+      expect(
+        AttributedText(
+          //      b   b
+          "This is bold text.",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ).toMarkdown(),
+        "This is **bold** text.",
+      );
+    });
+
+    test("Last character in the attribution span is white space", () {
+      expect(
+        AttributedText(
+          //       b   b
+          "This is bold text.",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: boldAttribution, offset: 8, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 12, markerType: SpanMarkerType.end), 
+            ],
+          ),
+        ).toMarkdown(),
+        "This is **bold** text.",
+      );
+    });
+
+    test("First and last character in overlapping attribution spans is white space", () {
+      expect(
+        AttributedText(
+          //      b    b
+          //      i    i
+          "This is bold text.",
+          AttributedSpans(
+            attributions: [
+              const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: boldAttribution, offset: 12, markerType: SpanMarkerType.end), 
+              const SpanMarker(attribution: italicsAttribution, offset: 7, markerType: SpanMarkerType.start),
+              const SpanMarker(attribution: italicsAttribution, offset: 12, markerType: SpanMarkerType.end),
+            ],
+          ),
+        ).toMarkdown(),
+        "This is ***bold*** text.",
+      );
+    });
   });
 }


### PR DESCRIPTION
Hi @matthew-carroll, hi @angelosilvestre :) Here's a PR with failing tests following up on your comment [here](https://github.com/superlistapp/super_editor/issues/2424#issuecomment-2524134384). I also added some background below to motivate why I think this is an issue. Thanks again for your support here and I hope I can contribute myself after some guidance!

### Background
The `AttributedTextMarkdownSerializer` places markdown formatting symbols according to the offset of attribution markers. This results in invalid markdown, as the markdown standard doesn't allow leading/trailing whitespaces. The closest official source I find to back my issue of incorrect markdown annoations is the following:

> To bold/italicize text, add one/two asterisks before and after a word or phrase. ([markdownguide.org](https://www.markdownguide.org/basic-syntax/#bold))

Also from the original spec from [John Gruber](https://daringfireball.net/projects/markdown/syntax#em), it's obvious that the annotation should be around a word/phrase and not white space.

GitHub  shows ** bold text** and not **bold text** just as `flutter_markdown`.
