### PR TITLE
Cherry-pick "[Flutter Team] - Update `TaskNode`s `Checkbox` visual density to depend on the `ThemeData.visualDensity` (#2444)" to stable

### DIFF
--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -353,6 +353,7 @@ class _TaskComponentState extends State<TaskComponent> with ProxyDocumentCompone
         Padding(
           padding: const EdgeInsets.only(left: 16, right: 4),
           child: Checkbox(
+            visualDensity: Theme.of(context).visualDensity,
             value: widget.viewModel.isComplete,
             onChanged: (newValue) {
               widget.viewModel.setComplete(newValue!);


### PR DESCRIPTION
This PR cherry-picks "[Flutter Team] - Update `TaskNode`s `Checkbox` visual density to depend on the `ThemeData.visualDensity` (#2444)" to stable.