### PR TITLE
Replace Color.withOpacity with Color.withValues (Resolves #2437)

### DIFF
--- a/super_editor/clones/quill/lib/deltas/deltas_display.dart
+++ b/super_editor/clones/quill/lib/deltas/deltas_display.dart
@@ -77,7 +77,7 @@ class _DeltasDisplayState extends State<DeltasDisplay> implements EditListener {
       child: Column(
         children: [
           _buildToolbar(),
-          Divider(height: 1, color: Colors.white.withOpacity(0.1)),
+          Divider(height: 1, color: Colors.white.withValues(alpha: 0.1)),
           Expanded(
             child: _buildDeltaList(),
           ),
@@ -133,7 +133,7 @@ class _DeltasDisplayState extends State<DeltasDisplay> implements EditListener {
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: Colors.white.withOpacity(0.1))),
+            border: Border(bottom: BorderSide(color: Colors.white.withValues(alpha: 0.1))),
           ),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -150,7 +150,7 @@ class _DeltasDisplayState extends State<DeltasDisplay> implements EditListener {
                 Text(
                   op.attributes?.entries.map((entry) => "${entry.key}: ${entry.value}").join(", ") ?? "",
                   style: TextStyle(
-                    color: Colors.white.withOpacity(0.5),
+                    color: Colors.white.withValues(alpha: 0.5),
                     fontFamily: "Monospace",
                     fontSize: 10,
                     fontWeight: FontWeight.bold,

--- a/super_editor/clones/quill/lib/editor/toolbar.dart
+++ b/super_editor/clones/quill/lib/editor/toolbar.dart
@@ -743,7 +743,7 @@ class _NamedTextSizeSelectorState extends State<_NamedTextSizeSelector> {
       itemBuilder: (context, item, isActive, onTap) {
         return DecoratedBox(
           decoration: BoxDecoration(
-            color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+            color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
           ),
           child: InkWell(
             onTap: onTap,
@@ -873,7 +873,7 @@ class _HeaderSelectorState extends State<_HeaderSelector> {
       ),
       itemBuilder: (context, item, isActive, onTap) => DecoratedBox(
         decoration: BoxDecoration(
-          color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+          color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
         ),
         child: InkWell(
           onTap: onTap,
@@ -1101,7 +1101,7 @@ class _FontFamilySelectorState extends State<_FontFamilySelector> {
       ),
       itemBuilder: (context, item, isActive, onTap) => DecoratedBox(
         decoration: BoxDecoration(
-          color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+          color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
         ),
         child: InkWell(
           onTap: onTap,

--- a/super_editor/clones/quill/lib/infrastructure/popovers/icon_selector.dart
+++ b/super_editor/clones/quill/lib/infrastructure/popovers/icon_selector.dart
@@ -108,7 +108,7 @@ class _IconSelectorState extends State<IconSelector> {
         color: item == widget.selectedIcon
             ? toolbarButtonSelectedColor
             : isActive
-                ? Colors.grey.withOpacity(0.2)
+                ? Colors.grey.withValues(alpha: 0.2)
                 : Colors.transparent,
       ),
       child: InkWell(

--- a/super_editor/clones/quill/lib/infrastructure/popovers/text_item_selector.dart
+++ b/super_editor/clones/quill/lib/infrastructure/popovers/text_item_selector.dart
@@ -147,7 +147,7 @@ class _TextItemSelectorState extends State<TextItemSelector> {
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.left,
                 style: TextStyle(
-                  color: Colors.black.withOpacity(0.7),
+                  color: Colors.black.withValues(alpha: 0.7),
                   fontSize: 14,
                   fontWeight: FontWeight.bold,
                 ),
@@ -188,7 +188,7 @@ class _TextItemSelectorState extends State<TextItemSelector> {
 Widget defaultPopoverListItemBuilder(BuildContext context, TextItem item, bool isActive, VoidCallback onTap) {
   return DecoratedBox(
     decoration: BoxDecoration(
-      color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+      color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
     ),
     child: InkWell(
       onTap: onTap,

--- a/super_editor/example/lib/demos/demo_attributed_text.dart
+++ b/super_editor/example/lib/demos/demo_attributed_text.dart
@@ -265,7 +265,7 @@ class _TextRangeSelectorState extends State<TextRangeSelector> {
             height: widget.cellHeight,
             decoration: BoxDecoration(
               border: Border.all(width: 1, color: _isSelected(index) ? Colors.red : Colors.grey),
-              color: _isSelected(index) ? Colors.red.withOpacity(0.7) : Colors.grey.withOpacity(0.7),
+              color: _isSelected(index) ? Colors.red.withValues(alpha: 0.7) : Colors.grey.withValues(alpha: 0.7),
             ),
           ),
         ),

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_android.dart
@@ -192,7 +192,7 @@ class _MobileEditingAndroidDemoState extends State<MobileEditingAndroidDemo> {
               borderRadius: BorderRadius.circular(8),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.2),
+                  color: Colors.black.withValues(alpha: 0.2),
                   blurRadius: 5,
                   offset: const Offset(0, 3),
                 ),

--- a/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
+++ b/super_editor/example/lib/demos/editor_configs/demo_mobile_editing_ios.dart
@@ -199,7 +199,7 @@ class _MobileEditingIOSDemoState extends State<MobileEditingIOSDemo> with Single
               borderRadius: BorderRadius.circular(8),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.2),
+                  color: Colors.black.withValues(alpha: 0.2),
                   blurRadius: 5,
                   offset: const Offset(0, 3),
                 ),

--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -394,7 +394,7 @@ class _ExampleEditorState extends State<ExampleEditor> {
               selectionStyle: isLight
                   ? defaultSelectionStyle
                   : SelectionStyles(
-                      selectionColor: Colors.red.withOpacity(0.3),
+                      selectionColor: Colors.red.withValues(alpha: 0.3),
                     ),
               stylesheet: defaultStylesheet.copyWith(
                 addRulesAfter: [

--- a/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_ios_native_context_menu.dart
@@ -80,7 +80,7 @@ class _NativeIosContextMenuFeatureDemoState extends State<NativeIosContextMenuFe
           editor: _editor,
           documentLayoutKey: _documentLayoutKey,
           selectionStyle: SelectionStyles(
-            selectionColor: Colors.red.withOpacity(0.3),
+            selectionColor: Colors.red.withValues(alpha: 0.3),
           ),
           stylesheet: defaultStylesheet.copyWith(
             addRulesAfter: [

--- a/super_editor/example/lib/demos/in_the_lab/in_the_lab_scaffold.dart
+++ b/super_editor/example/lib/demos/in_the_lab/in_the_lab_scaffold.dart
@@ -73,14 +73,14 @@ class InTheLabScaffold extends StatelessWidget {
       width: 250,
       height: double.infinity,
       decoration: BoxDecoration(
-        border: Border(left: BorderSide(color: Colors.white.withOpacity(0.1))),
+        border: Border(left: BorderSide(color: Colors.white.withValues(alpha: 0.1))),
       ),
       child: Stack(
         children: [
           Center(
             child: Icon(
               Icons.biotech,
-              color: Colors.white.withOpacity(0.05),
+              color: Colors.white.withValues(alpha: 0.05),
               size: 84,
             ),
           ),
@@ -125,14 +125,14 @@ class InTheLabScaffold extends StatelessWidget {
       width: double.infinity,
       height: 200,
       decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: Colors.white.withOpacity(0.1))),
+        border: Border(top: BorderSide(color: Colors.white.withValues(alpha: 0.1))),
       ),
       child: Stack(
         children: [
           Center(
             child: Icon(
               Icons.biotech,
-              color: Colors.white.withOpacity(0.05),
+              color: Colors.white.withValues(alpha: 0.05),
               size: 84,
             ),
           ),

--- a/super_editor/example/lib/demos/in_the_lab/popover_list.dart
+++ b/super_editor/example/lib/demos/in_the_lab/popover_list.dart
@@ -182,7 +182,7 @@ class _PopoverListState extends State<PopoverList> {
           for (int i = 0; i < widget.listItems.length; i += 1) ...[
             ColoredBox(
               color: i == _selectedValueIndex && _focusNode.hasPrimaryFocus
-                  ? Colors.white.withOpacity(0.05)
+                  ? Colors.white.withValues(alpha: 0.05)
                   : Colors.transparent,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -209,7 +209,7 @@ class _PopoverListState extends State<PopoverList> {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 child: Divider(
-                  color: Colors.white.withOpacity(0.2),
+                  color: Colors.white.withValues(alpha: 0.2),
                   height: 1,
                 ),
               ),
@@ -229,7 +229,7 @@ class _PopoverListState extends State<PopoverList> {
           "NO ACTIONS",
           textAlign: TextAlign.center,
           style: TextStyle(
-            color: Colors.black.withOpacity(0.5),
+            color: Colors.black.withValues(alpha: 0.5),
             fontSize: 12,
             fontWeight: FontWeight.bold,
           ),

--- a/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
+++ b/super_editor/example/lib/demos/in_the_lab/selected_text_colors_demo.dart
@@ -180,7 +180,7 @@ class _SelectedTextColorsDemoState extends State<SelectedTextColorsDemo> {
           border: Border.all(color: Colors.white, width: 4),
           color: color,
           boxShadow: [
-            BoxShadow(color: Colors.black.withOpacity(0.5), blurRadius: 5, offset: Offset(0, 5)),
+            BoxShadow(color: Colors.black.withValues(alpha: 0.5), blurRadius: 5, offset: Offset(0, 5)),
           ],
         ),
       ),
@@ -299,7 +299,7 @@ class ColorPickerPopoverModal extends StatelessWidget {
             border: Border.all(color: Colors.white, width: 2),
             color: color,
             boxShadow: [
-              BoxShadow(color: Colors.black.withOpacity(0.2), blurRadius: 3, offset: Offset(0, 3)),
+              BoxShadow(color: Colors.black.withValues(alpha: 0.2), blurRadius: 3, offset: Offset(0, 3)),
             ],
           ),
         ),

--- a/super_editor/example/lib/demos/infrastructure/super_editor_item_selector.dart
+++ b/super_editor/example/lib/demos/infrastructure/super_editor_item_selector.dart
@@ -142,7 +142,7 @@ class _SuperEditorDemoTextItemSelectorState extends State<SuperEditorDemoTextIte
   Widget _buildPopoverListItem(BuildContext context, SuperEditorDemoTextItem item, bool isActive, VoidCallback onTap) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+        color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
       ),
       child: InkWell(
         onTap: onTap,
@@ -303,7 +303,7 @@ class _SuperEditorDemoIconItemSelectorState extends State<SuperEditorDemoIconIte
   Widget _buildItem(BuildContext context, SuperEditorDemoIconItem item, bool isActive, VoidCallback onTap) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+        color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
       ),
       child: InkWell(
         onTap: onTap,

--- a/super_editor/example/lib/demos/interaction_spot_checks/spot_check_scaffold.dart
+++ b/super_editor/example/lib/demos/interaction_spot_checks/spot_check_scaffold.dart
@@ -57,14 +57,14 @@ class SpotCheckScaffold extends StatelessWidget {
       width: 250,
       height: double.infinity,
       decoration: BoxDecoration(
-        border: Border(left: BorderSide(color: Colors.white.withOpacity(0.1))),
+        border: Border(left: BorderSide(color: Colors.white.withValues(alpha: 0.1))),
       ),
       child: Stack(
         children: [
           Center(
             child: Icon(
               Icons.biotech,
-              color: Colors.white.withOpacity(0.05),
+              color: Colors.white.withValues(alpha: 0.05),
               size: 84,
             ),
           ),

--- a/super_editor/example/lib/demos/interaction_spot_checks/toolbar_following_content_in_layer.dart
+++ b/super_editor/example/lib/demos/interaction_spot_checks/toolbar_following_content_in_layer.dart
@@ -60,7 +60,7 @@ class _ToolbarFollowingContentInLayerState extends State<ToolbarFollowingContent
                             height: 12,
                             width: _baseContentWidth + (2 * expansionExtent) + 2, // +2 for border
                             decoration: BoxDecoration(
-                              border: Border.all(color: Colors.white.withOpacity(0.1)),
+                              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
                             ),
                             child: Align(
                               alignment: Alignment.centerLeft,
@@ -68,7 +68,7 @@ class _ToolbarFollowingContentInLayerState extends State<ToolbarFollowingContent
                                 key: _leaderBoundsKey,
                                 width: _baseContentWidth + expansionExtent,
                                 height: 10,
-                                color: Colors.white.withOpacity(0.2),
+                                color: Colors.white.withValues(alpha: 0.2),
                               ),
                             ),
                           );

--- a/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
+++ b/super_editor/example/lib/demos/mobile_chat/demo_mobile_chat.dart
@@ -131,7 +131,7 @@ class _MobileChatDemoState extends State<MobileChatDemo> {
                           border: Border.all(color: Colors.grey.shade200),
                           boxShadow: [
                             BoxShadow(
-                              color: Colors.black.withOpacity(0.2),
+                              color: Colors.black.withValues(alpha: 0.2),
                               blurRadius: 16,
                               offset: Offset(0, 8),
                             ),
@@ -197,7 +197,7 @@ class _MobileChatDemoState extends State<MobileChatDemo> {
                 ),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.075),
+                    color: Colors.black.withValues(alpha: 0.075),
                     blurRadius: 8,
                     spreadRadius: 4,
                   ),

--- a/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
+++ b/super_editor/example/lib/demos/scrolling/demo_task_and_chat_with_customscrollview.dart
@@ -96,7 +96,7 @@ class _TaskAndChatWithCustomScrollViewDemoState extends State<TaskAndChatWithCus
               BoxShadow(
                 offset: const Offset(0, 5),
                 blurRadius: 5,
-                color: Colors.black.withOpacity(0.4),
+                color: Colors.black.withValues(alpha: 0.4),
               ),
             ],
           ),

--- a/super_editor/example/lib/demos/sliver_example_editor.dart
+++ b/super_editor/example/lib/demos/sliver_example_editor.dart
@@ -122,7 +122,7 @@ class _SliverExampleEditorState extends State<SliverExampleEditor> {
       right: 0,
       width: 200,
       child: ColoredBox(
-        color: Colors.black.withOpacity(0.2),
+        color: Colors.black.withValues(alpha: 0.2),
         child: Center(
           child: ScrollingMinimap.fromRepository(
             key: _minimapKey,

--- a/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
+++ b/super_editor/example/lib/demos/supertextfield/_interactive_demo.dart
@@ -139,7 +139,7 @@ class _InteractiveTextFieldDemoState extends State<InteractiveTextFieldDemo> {
                   borderRadius: BorderRadius.circular(4),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.3),
+                      color: Colors.black.withValues(alpha: 0.3),
                       blurRadius: 5,
                       offset: const Offset(3, 3),
                     ),

--- a/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/android/demo_superandroidtextfield.dart
@@ -62,7 +62,7 @@ class _SuperAndroidTextFieldDemoState extends State<SuperAndroidTextFieldDemo> {
           hintTextStyleBuilder: (attributions) {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           }).build,
-      selectionColor: Colors.blue.withOpacity(0.4),
+      selectionColor: Colors.blue.withValues(alpha: 0.4),
       caretStyle: const CaretStyle(color: Colors.green),
       blinkTimingMode: BlinkTimingMode.timer,
       handlesColor: Colors.lightGreen,

--- a/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
+++ b/super_editor/example/lib/demos/supertextfield/ios/demo_superiostextfield.dart
@@ -68,7 +68,7 @@ class _SuperIOSTextFieldDemoState extends State<SuperIOSTextFieldDemo> {
             return config.styleBuilder(attributions).copyWith(color: Colors.grey);
           },
         ).build,
-        selectionColor: Colors.blue.withOpacity(0.4),
+        selectionColor: Colors.blue.withValues(alpha: 0.4),
         caretStyle: const CaretStyle(color: Colors.blue),
         blinkTimingMode: BlinkTimingMode.timer,
         handlesColor: Colors.blue,

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -596,7 +596,7 @@ class _DrawerButton extends StatelessWidget {
               }
 
               if (states.contains(WidgetState.hovered)) {
-                return Colors.grey.withOpacity(0.1);
+                return Colors.grey.withValues(alpha: 0.1);
               }
 
               return Colors.transparent;

--- a/super_editor/example/lib/main_super_editor.dart
+++ b/super_editor/example/lib/main_super_editor.dart
@@ -183,7 +183,7 @@ class _EditorHistoryPanelState extends State<_EditorHistoryPanel> {
                       "${history.commands.map((command) => command.describe()).join("\n\n")}\n-------------\n${history.changes.map((event) => event.describe()).join("\n\n")}",
                     ),
                     subtitleTextStyle: TextStyle(
-                      color: Colors.white.withOpacity(0.5),
+                      color: Colors.white.withValues(alpha: 0.5),
                       fontSize: 10,
                       height: 1.4,
                     ),

--- a/super_editor/example_docs/lib/app_menu.dart
+++ b/super_editor/example_docs/lib/app_menu.dart
@@ -127,7 +127,7 @@ class _DocsAppMenuState extends State<DocsAppMenu> {
   Widget _buildPopoverListItem(BuildContext context, DocsAppMenuItem item, bool isActive, VoidCallback onTap) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+        color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
       ),
       child: InkWell(
         onTap: onTap,

--- a/super_editor/example_docs/lib/infrastructure/icon_selector.dart
+++ b/super_editor/example_docs/lib/infrastructure/icon_selector.dart
@@ -108,7 +108,7 @@ class _IconSelectorState extends State<IconSelector> {
         color: item == widget.selectedIcon
             ? toolbarButtonSelectedColor
             : isActive
-                ? Colors.grey.withOpacity(0.2)
+                ? Colors.grey.withValues(alpha: 0.2)
                 : Colors.transparent,
       ),
       child: InkWell(

--- a/super_editor/example_docs/lib/infrastructure/text_item_selector.dart
+++ b/super_editor/example_docs/lib/infrastructure/text_item_selector.dart
@@ -145,7 +145,7 @@ class _TextItemSelectorState extends State<TextItemSelector> {
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.left,
               style: TextStyle(
-                color: Colors.black.withOpacity(0.7),
+                color: Colors.black.withValues(alpha: 0.7),
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
               ),
@@ -185,7 +185,7 @@ class _TextItemSelectorState extends State<TextItemSelector> {
 Widget defaultPopoverListItemBuilder(BuildContext context, TextItem item, bool isActive, VoidCallback onTap) {
   return DecoratedBox(
     decoration: BoxDecoration(
-      color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+      color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
     ),
     child: InkWell(
       onTap: onTap,

--- a/super_editor/example_docs/lib/toolbar.dart
+++ b/super_editor/example_docs/lib/toolbar.dart
@@ -865,7 +865,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
               itemBuilder: (context, item, isActive, onTap) => SizedBox(
                 height: 40,
                 child: ColoredBox(
-                  color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+                  color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
                   child: Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: Row(
@@ -936,7 +936,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
         onSelected: _onChangeBlockTypeRequested,
         itemBuilder: (context, item, isActive, onTap) => DecoratedBox(
           decoration: BoxDecoration(
-            color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+            color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
           ),
           child: InkWell(
             onTap: onTap,
@@ -995,7 +995,7 @@ class _DocsEditorToolbarState extends State<DocsEditorToolbar> {
         ),
         itemBuilder: (context, item, isActive, onTap) => DecoratedBox(
           decoration: BoxDecoration(
-            color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+            color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
           ),
           child: InkWell(
             onTap: onTap,

--- a/super_editor/example_perf/lib/main.dart
+++ b/super_editor/example_perf/lib/main.dart
@@ -247,7 +247,7 @@ class _DrawerButton extends StatelessWidget {
               }
 
               if (states.contains(WidgetState.hovered)) {
-                return Colors.grey.withOpacity(0.1);
+                return Colors.grey.withValues(alpha: 0.1);
               }
 
               return Colors.transparent;

--- a/super_editor/lib/src/default_editor/box_component.dart
+++ b/super_editor/lib/src/default_editor/box_component.dart
@@ -307,7 +307,7 @@ class SelectableBox extends StatelessWidget {
       child: IgnorePointer(
         child: DecoratedBox(
           decoration: BoxDecoration(
-            color: isSelected ? selectionColor.withOpacity(0.5) : Colors.transparent,
+            color: isSelected ? selectionColor.withValues(alpha: 0.5) : Colors.transparent,
           ),
           position: DecorationPosition.foreground,
           child: child,

--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -217,7 +217,7 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
                       key: DocumentKeys.caret,
                       width: widget.caretStyle.width,
                       decoration: BoxDecoration(
-                        color: widget.caretStyle.color.withOpacity(_blinkController.opacity),
+                        color: widget.caretStyle.color.withValues(alpha: _blinkController.opacity),
                         borderRadius: widget.caretStyle.borderRadius,
                       ),
                     );

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -1812,7 +1812,7 @@ class _EditorFloatingCursorState extends State<EditorFloatingCursor> {
           rect: floatingCursorRect,
           child: IgnorePointer(
             child: ColoredBox(
-              color: Colors.red.withOpacity(0.75),
+              color: Colors.red.withValues(alpha: 0.75),
             ),
           ),
         );

--- a/super_editor/lib/src/default_editor/document_ime/mobile_toolbar.dart
+++ b/super_editor/lib/src/default_editor/document_ime/mobile_toolbar.dart
@@ -159,7 +159,8 @@ class _KeyboardEditingToolbarState extends State<KeyboardEditingToolbar> with Wi
     return Theme(
       data: Theme.of(context).copyWith(
         brightness: brightness,
-        disabledColor: brightness == Brightness.light ? Colors.black.withOpacity(0.5) : Colors.white.withOpacity(0.5),
+        disabledColor:
+            brightness == Brightness.light ? Colors.black.withValues(alpha: 0.5) : Colors.white.withValues(alpha: 0.5),
       ),
       child: IconTheme(
         data: IconThemeData(

--- a/super_editor/lib/src/infrastructure/blinking_caret.dart
+++ b/super_editor/lib/src/infrastructure/blinking_caret.dart
@@ -128,7 +128,7 @@ class _CaretPainter extends CustomPainter {
       return;
     }
 
-    caretPaint.color = caretColor.withOpacity(blinkController.opacity);
+    caretPaint.color = caretColor.withValues(alpha: blinkController.opacity);
 
     final height = caretHeight?.roundToDouble() ?? size.height;
 

--- a/super_editor/lib/src/infrastructure/flutter/material_scrollbar.dart
+++ b/super_editor/lib/src/infrastructure/flutter/material_scrollbar.dart
@@ -189,15 +189,17 @@ class _MaterialScrollbarState extends RawScrollbarWithCustomPhysicsState<_Materi
     late Color idleColor;
     switch (brightness) {
       case Brightness.light:
-        dragColor = onSurface.withOpacity(0.6);
-        hoverColor = onSurface.withOpacity(0.5);
-        idleColor =
-            _useAndroidScrollbar ? Theme.of(context).highlightColor.withOpacity(1.0) : onSurface.withOpacity(0.1);
+        dragColor = onSurface.withValues(alpha: 0.6);
+        hoverColor = onSurface.withValues(alpha: 0.5);
+        idleColor = _useAndroidScrollbar
+            ? Theme.of(context).highlightColor.withValues(alpha: 1.0)
+            : onSurface.withValues(alpha: 0.1);
       case Brightness.dark:
-        dragColor = onSurface.withOpacity(0.75);
-        hoverColor = onSurface.withOpacity(0.65);
-        idleColor =
-            _useAndroidScrollbar ? Theme.of(context).highlightColor.withOpacity(1.0) : onSurface.withOpacity(0.3);
+        dragColor = onSurface.withValues(alpha: 0.75);
+        hoverColor = onSurface.withValues(alpha: 0.65);
+        idleColor = _useAndroidScrollbar
+            ? Theme.of(context).highlightColor.withValues(alpha: 1.0)
+            : onSurface.withValues(alpha: 0.3);
     }
 
     return WidgetStateProperty.resolveWith((Set<WidgetState> states) {
@@ -225,7 +227,7 @@ class _MaterialScrollbarState extends RawScrollbarWithCustomPhysicsState<_Materi
     return WidgetStateProperty.resolveWith((Set<WidgetState> states) {
       if (showScrollbar && _trackVisibility.resolve(states)) {
         return _scrollbarTheme.trackColor?.resolve(states) ??
-            (brightness == Brightness.light ? onSurface.withOpacity(0.03) : onSurface.withOpacity(0.05));
+            (brightness == Brightness.light ? onSurface.withValues(alpha: 0.03) : onSurface.withValues(alpha: 0.05));
       }
       return const Color(0x00000000);
     });
@@ -237,7 +239,7 @@ class _MaterialScrollbarState extends RawScrollbarWithCustomPhysicsState<_Materi
     return WidgetStateProperty.resolveWith((Set<WidgetState> states) {
       if (showScrollbar && _trackVisibility.resolve(states)) {
         return _scrollbarTheme.trackBorderColor?.resolve(states) ??
-            (brightness == Brightness.light ? onSurface.withOpacity(0.1) : onSurface.withOpacity(0.25));
+            (brightness == Brightness.light ? onSurface.withValues(alpha: 0.1) : onSurface.withValues(alpha: 0.25));
       }
       return const Color(0x00000000);
     });

--- a/super_editor/lib/src/infrastructure/flutter/scrollbar.dart
+++ b/super_editor/lib/src/infrastructure/flutter/scrollbar.dart
@@ -1615,17 +1615,17 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   // - Painting
 
   Paint get _paintThumb {
-    return Paint()..color = color.withOpacity(color.opacity * fadeoutOpacityAnimation.value);
+    return Paint()..color = color.withValues(alpha: color.a * fadeoutOpacityAnimation.value);
   }
 
   Paint _paintTrack({bool isBorder = false}) {
     if (isBorder) {
       return Paint()
-        ..color = trackBorderColor.withOpacity(trackBorderColor.opacity * fadeoutOpacityAnimation.value)
+        ..color = trackBorderColor.withValues(alpha: trackBorderColor.a * fadeoutOpacityAnimation.value)
         ..style = PaintingStyle.stroke
         ..strokeWidth = 1.0;
     }
-    return Paint()..color = trackColor.withOpacity(trackColor.opacity * fadeoutOpacityAnimation.value);
+    return Paint()..color = trackColor.withValues(alpha: trackColor.a * fadeoutOpacityAnimation.value);
   }
 
   void _paintScrollbar(Canvas canvas, Size size) {

--- a/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/android_document_controls.dart
@@ -414,7 +414,7 @@ class AndroidControlsDocumentLayerState
           builder: (context, child) {
             return ColoredBox(
               key: DocumentKeys.caret,
-              color: caretColor.withOpacity(_caretBlinkController.opacity),
+              color: caretColor.withValues(alpha: _caretBlinkController.opacity),
             );
           },
         ),

--- a/super_editor/lib/src/infrastructure/platforms/android/selection_handles.dart
+++ b/super_editor/lib/src/infrastructure/platforms/android/selection_handles.dart
@@ -64,7 +64,7 @@ class AndroidSelectionHandle extends StatelessWidget {
       padding: touchRegionExpansion,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: showDebugTouchRegion ? Colors.red.withOpacity(0.5) : Colors.transparent,
+        color: showDebugTouchRegion ? Colors.red.withValues(alpha: 0.5) : Colors.transparent,
       ),
       child: handle,
     );

--- a/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/ios_document_controls.dart
@@ -123,7 +123,7 @@ class _IosFloatingToolbarOverlayState extends State<IosFloatingToolbarOverlay> w
       child: Container(
         width: double.infinity,
         height: double.infinity,
-        color: Colors.yellow.withOpacity(0.2),
+        color: Colors.yellow.withValues(alpha: 0.2),
       ),
     );
   }

--- a/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
+++ b/super_editor/lib/src/infrastructure/platforms/ios/magnifier.dart
@@ -218,7 +218,7 @@ class IOSRoundedRectangleMagnifyingGlass extends StatelessWidget {
                       width: borderWidth,
                     ),
                   ),
-                  color: borderColor.withOpacity(tintOpacity),
+                  color: borderColor.withValues(alpha: tintOpacity),
                   shadows: const [
                     OuterBoxShadow(
                       color: Color(0x33000000),

--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -1314,7 +1314,7 @@ class _AndroidDocumentTouchEditingControlsState extends State<AndroidDocumentTou
                       child: Container(
                         width: double.infinity,
                         height: double.infinity,
-                        color: Colors.yellow.withOpacity(0.2),
+                        color: Colors.yellow.withValues(alpha: 0.2),
                       ),
                     ),
                 ],

--- a/super_editor/lib/src/super_textfield/android/_caret.dart
+++ b/super_editor/lib/src/super_textfield/android/_caret.dart
@@ -138,7 +138,7 @@ class AndroidCursorPainter extends CustomPainter {
   void _drawCaret({
     required Canvas canvas,
   }) {
-    caretPaint.color = caretColor.withOpacity(blinkController.opacity);
+    caretPaint.color = caretColor.withValues(alpha: blinkController.opacity);
 
     double caretHeight = textLayout.getHeightForCaret(selection.extent) ?? emptyTextCaretHeight;
     final caretOffset = textLayout.getOffsetAtPosition(selection.extent);

--- a/super_editor/lib/src/super_textfield/android/_user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/android/_user_interaction.dart
@@ -541,7 +541,7 @@ class AndroidTextFieldTouchInteractorState extends State<AndroidTextFieldTouchIn
                 child: Container(
                   width: 20,
                   height: 20,
-                  color: Colors.purpleAccent.withOpacity(0.5),
+                  color: Colors.purpleAccent.withValues(alpha: 0.5),
                 ),
               )
             : const SizedBox(width: 1, height: 1),

--- a/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_scrollview.dart
@@ -448,7 +448,7 @@ class _TextScrollViewState extends State<TextScrollView>
           child: IgnorePointer(
             child: Container(
               height: _mulitlineFieldAutoScrollGap,
-              color: Colors.purpleAccent.withOpacity(0.5),
+              color: Colors.purpleAccent.withValues(alpha: 0.5),
             ),
           ),
         ),
@@ -459,7 +459,7 @@ class _TextScrollViewState extends State<TextScrollView>
           child: IgnorePointer(
             child: Container(
               height: _mulitlineFieldAutoScrollGap,
-              color: Colors.purpleAccent.withOpacity(0.5),
+              color: Colors.purpleAccent.withValues(alpha: 0.5),
             ),
           ),
         ),
@@ -472,7 +472,7 @@ class _TextScrollViewState extends State<TextScrollView>
           bottom: 0,
           child: Container(
             width: _singleLineFieldAutoScrollGap,
-            color: Colors.purpleAccent.withOpacity(0.5),
+            color: Colors.purpleAccent.withValues(alpha: 0.5),
           ),
         ),
         Positioned(
@@ -481,7 +481,7 @@ class _TextScrollViewState extends State<TextScrollView>
           bottom: 0,
           child: Container(
             width: _singleLineFieldAutoScrollGap,
-            color: Colors.purpleAccent.withOpacity(0.5),
+            color: Colors.purpleAccent.withValues(alpha: 0.5),
           ),
         ),
       ];

--- a/super_editor/lib/src/super_textfield/ios/caret.dart
+++ b/super_editor/lib/src/super_textfield/ios/caret.dart
@@ -119,7 +119,7 @@ class _IOSCursorPainter extends CustomPainter {
   }
 
   void _drawCaret(Canvas canvas) {
-    caretPaint.color = caretColor.withOpacity(blinkController.opacity);
+    caretPaint.color = caretColor.withValues(alpha: blinkController.opacity);
 
     final textPosition = selection.extent;
     double caretHeight = textLayout.getCharacterBox(textPosition)?.toRect().height ?? 0.0;

--- a/super_editor/lib/src/super_textfield/ios/floating_cursor.dart
+++ b/super_editor/lib/src/super_textfield/ios/floating_cursor.dart
@@ -34,7 +34,7 @@ class IOSFloatingCursor extends StatelessWidget {
                 child: Container(
                   width: 2,
                   height: controller.floatingCursorHeight,
-                  color: Colors.red.withOpacity(0.75),
+                  color: Colors.red.withValues(alpha: 0.75),
                 ),
               ),
           ],

--- a/super_editor/lib/src/super_textfield/ios/user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/user_interaction.dart
@@ -536,7 +536,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
           rect: selectionRect,
           child: Leader(
             link: widget.editingOverlayController.toolbarFocalPoint,
-            child: widget.showDebugPaint ? ColoredBox(color: Colors.green.withOpacity(0.2)) : const SizedBox(),
+            child: widget.showDebugPaint ? ColoredBox(color: Colors.green.withValues(alpha: 0.2)) : const SizedBox(),
           ),
         );
       },
@@ -593,7 +593,7 @@ class IOSTextFieldTouchInteractorState extends State<IOSTextFieldTouchInteractor
                 child: Container(
                   width: 20,
                   height: 20,
-                  color: Colors.purpleAccent.withOpacity(0.5),
+                  color: Colors.purpleAccent.withValues(alpha: 0.5),
                 ),
               )
             : const SizedBox(width: 1, height: 1),

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_error_suggestion_overlay.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_error_suggestion_overlay.dart
@@ -442,7 +442,7 @@ class _DesktopSpellingSuggestionToolbarState extends State<DesktopSpellingSugges
             boxShadow: [
               BoxShadow(
                 offset: const Offset(0, 4),
-                color: Colors.black.withOpacity(0.2),
+                color: Colors.black.withValues(alpha: 0.2),
                 blurRadius: 6,
               ),
             ],

--- a/super_text_layout/example/lib/main.dart
+++ b/super_text_layout/example/lib/main.dart
@@ -251,7 +251,7 @@ class _SuperTextExampleScreenState extends State<SuperTextExampleScreen> with Ti
               RainbowBuilder(builder: (context, color) {
                 return TextLayoutSelectionHighlight(
                   textLayout: textLayout,
-                  style: _primaryHighlightStyle.copyWith(color: color.withOpacity(0.2)),
+                  style: _primaryHighlightStyle.copyWith(color: color.withValues(alpha: 0.2)),
                   selection: const TextSelection(baseOffset: 11, extentOffset: 21),
                 );
               }),
@@ -481,7 +481,7 @@ const _johnCaretStyle = CaretStyle(
   color: Colors.red,
 );
 final _johnHighlightStyle = SelectionHighlightStyle(
-  color: Colors.red.withOpacity(0.5),
+  color: Colors.red.withValues(alpha: 0.5),
 );
 const _johnUserLabelStyle = UserLabelStyle(
   color: Colors.red,
@@ -499,7 +499,7 @@ const _sallyCaretStyle = CaretStyle(
   color: Colors.purpleAccent,
 );
 final _sallyHighlightStyle = SelectionHighlightStyle(
-  color: Colors.purpleAccent.withOpacity(0.5),
+  color: Colors.purpleAccent.withValues(alpha: 0.5),
 );
 const _sallyUserLabelStyle = UserLabelStyle(
   color: Colors.purpleAccent,

--- a/super_text_layout/lib/src/caret_layer.dart
+++ b/super_text_layout/lib/src/caret_layer.dart
@@ -179,7 +179,7 @@ class CaretPainter extends CustomPainter {
         //       update painter to support generic geometry
         _caretStyle.borderRadius.resolve(TextDirection.ltr).topLeft,
       ),
-      Paint()..color = _caretStyle.color.withOpacity(blinkController?.opacity ?? 1.0),
+      Paint()..color = _caretStyle.color.withValues(alpha: blinkController?.opacity ?? 1.0),
     );
   }
 

--- a/website/lib/homepage/header.dart
+++ b/website/lib/homepage/header.dart
@@ -88,7 +88,7 @@ class _DrawerLayoutState extends State<DrawerLayout> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 250),
               curve: Curves.ease,
-              color: Colors.black.withOpacity(_open ? 0.64 : 0),
+              color: Colors.black.withValues(alpha: _open ? 0.64 : 0),
             ),
           ),
         ),

--- a/website/lib/homepage/home_page.dart
+++ b/website/lib/homepage/home_page.dart
@@ -99,7 +99,7 @@ class HomePage extends StatelessWidget {
             boxShadow: [
               BoxShadow(
                 offset: const Offset(0, 10),
-                color: Colors.black.withOpacity(0.79),
+                color: Colors.black.withValues(alpha: 0.79),
                 blurRadius: 75,
               ),
             ],

--- a/website/lib/homepage/inside_the_toolbox.dart
+++ b/website/lib/homepage/inside_the_toolbox.dart
@@ -387,7 +387,7 @@ class _TextRangeSelectorState extends State<TextRangeSelector> {
             height: widget.cellHeight,
             decoration: BoxDecoration(
               border: Border.all(color: _isSelected(index) ? Colors.tealAccent : Colors.grey),
-              color: _isSelected(index) ? Colors.tealAccent.withOpacity(0.7) : Colors.grey.withOpacity(0.7),
+              color: _isSelected(index) ? Colors.tealAccent.withValues(alpha: 0.7) : Colors.grey.withValues(alpha: 0.7),
             ),
           ),
         ),

--- a/website/lib/infrastructure/super_editor_item_selector.dart
+++ b/website/lib/infrastructure/super_editor_item_selector.dart
@@ -142,7 +142,7 @@ class _SuperEditorDemoTextItemSelectorState extends State<SuperEditorDemoTextIte
   Widget _buildPopoverListItem(BuildContext context, SuperEditorDemoTextItem item, bool isActive, VoidCallback onTap) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+        color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
       ),
       child: InkWell(
         onTap: onTap,
@@ -303,7 +303,7 @@ class _SuperEditorDemoIconItemSelectorState extends State<SuperEditorDemoIconIte
   Widget _buildItem(BuildContext context, SuperEditorDemoIconItem item, bool isActive, VoidCallback onTap) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isActive ? Colors.grey.withOpacity(0.2) : Colors.transparent,
+        color: isActive ? Colors.grey.withValues(alpha: 0.2) : Colors.transparent,
       ),
       child: InkWell(
         onTap: onTap,


### PR DESCRIPTION
Replace Color.withOpacity with Color.withValues. Resolves #2437

The CI is failing on the super_text_layout analysis due to `Color.withOpacity` being deprecated:

```console
Analyzing super_text_layout...                                  

   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • example/lib/main.dart:254:71 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • example/lib/main.dart:4[8](https://github.com/superlistapp/super_editor/actions/runs/12129129760/job/33816940663?pr=2436#step:5:9)4:21 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • example/lib/main.dart:502:30 • deprecated_member_use
   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/src/caret_layer.dart:182:42 • deprecated_member_use
```

To migrate, all we need is to replace calls to `withOpacity` to `withValues` passing the opacity as the `alpha` argument.

Source: https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity