### PR TITLE
[SuperEditor][SuperTextField][iOS] Make caret word snapping less aggressive (Resolves #2152)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -130,6 +130,7 @@ class SuperEditorIosControlsController {
     _shouldShowToolbar.dispose();
   }
 
+  /// {@template ios_use_selection_heuristics}
   /// Whether to adjust the user's selection similar to the way iOS does.
   ///
   /// For example: iOS doesn't let users tap directly on a text offset. Instead,
@@ -139,6 +140,7 @@ class SuperEditorIosControlsController {
   /// When this property is `true`, iOS-style heuristics should be used. When
   /// this value is `false`, the user's gestures should directly impact the
   /// area they touched.
+  /// {@endtemplate}
   final bool useIosSelectionHeuristics;
 
   /// Color of the text selection drag handles on iOS.
@@ -935,7 +937,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     }
 
     final extentRect = _docLayout.getRectForPosition(collapsedPosition)!;
-    final caretRect = Rect.fromLTRB(
+    final caretHitArea = Rect.fromLTRB(
       extentRect.left - 24,
       extentRect.top,
       extentRect.right + 24,
@@ -943,7 +945,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     );
 
     final docOffset = _interactorOffsetToDocumentOffset(interactorOffset);
-    return caretRect.contains(docOffset);
+    return caretHitArea.contains(docOffset);
   }
 
   bool _isOverBaseHandle(Offset interactorOffset) {

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -423,6 +423,8 @@ class SuperEditorState extends State<SuperEditor> {
 
   late SoftwareKeyboardController _softwareKeyboardController;
 
+  late ValueNotifier<bool> _isImeConnected;
+
   @override
   void initState() {
     super.initState();
@@ -448,6 +450,8 @@ class SuperEditorState extends State<SuperEditor> {
     _selectionLinks = widget.selectionLayerLinks ?? SelectionLayerLinks();
 
     _softwareKeyboardController = widget.softwareKeyboardController ?? SoftwareKeyboardController();
+
+    _isImeConnected = widget.isImeConnected ?? ValueNotifier(false);
 
     widget.editor.context.put(
       Editor.layoutKey,
@@ -511,6 +515,10 @@ class SuperEditorState extends State<SuperEditor> {
 
     if (widget.softwareKeyboardController != oldWidget.softwareKeyboardController) {
       _softwareKeyboardController = widget.softwareKeyboardController ?? SoftwareKeyboardController();
+    }
+
+    if (widget.isImeConnected != oldWidget.isImeConnected) {
+      _isImeConnected = widget.isImeConnected ?? ValueNotifier(false);
     }
 
     _recomputeIfLayoutShouldShowCaret();
@@ -797,7 +805,7 @@ class SuperEditorState extends State<SuperEditor> {
             ..._keyboardActions,
           ],
           selectorHandlers: widget.selectorHandlers ?? defaultEditorSelectorHandlers,
-          isImeConnected: widget.isImeConnected,
+          isImeConnected: _isImeConnected,
           child: child,
         );
     }
@@ -900,6 +908,7 @@ class SuperEditorState extends State<SuperEditor> {
           selection: editContext.composer.selectionNotifier,
           openKeyboardWhenTappingExistingSelection: widget.selectionPolicies.openKeyboardWhenTappingExistingSelection,
           openSoftwareKeyboard: _openSoftareKeyboard,
+          isImeConnected: _isImeConnected,
           contentTapHandlers: _contentTapHandlers,
           scrollController: _scrollController,
           dragHandleAutoScroller: _dragHandleAutoScroller,

--- a/super_editor/lib/src/super_textfield/ios/user_interaction.dart
+++ b/super_editor/lib/src/super_textfield/ios/user_interaction.dart
@@ -37,6 +37,10 @@ final _log = iosTextFieldLog;
 ///
 /// Selection changes are made via the given [textController].
 class IOSTextFieldTouchInteractor extends StatefulWidget {
+  /// {@macro ios_use_selection_heuristics}
+  @visibleForTesting
+  static bool useIosSelectionHeuristics = true;
+
   const IOSTextFieldTouchInteractor({
     Key? key,
     required this.focusNode,
@@ -51,9 +55,6 @@ class IOSTextFieldTouchInteractor extends StatefulWidget {
     this.showDebugPaint = false,
     required this.child,
   }) : super(key: key);
-
-  @visibleForTesting
-  static bool useIosSelectionHeuristics = true;
 
   /// [FocusNode] for the text field that contains this [IOSTextFieldInteractor].
   ///

--- a/super_editor/test/flutter_test_config.dart
+++ b/super_editor/test/flutter_test_config.dart
@@ -8,7 +8,8 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Disable indeterminate animations
   BlinkController.indeterminateAnimationsEnabled = false;
 
-  // Disable iOS selection heuristics.
+  // Disable iOS selection heuristics, i.e, place the caret at the exact
+  // tapped position instead of placing it at word boundaries.
   IOSTextFieldTouchInteractor.useIosSelectionHeuristics = false;
 
   Testing.isInTest = true;

--- a/super_editor/test/flutter_test_config.dart
+++ b/super_editor/test/flutter_test_config.dart
@@ -1,11 +1,15 @@
 import 'dart:async';
 
+import 'package:super_editor/src/super_textfield/ios/ios_textfield.dart';
 import 'package:super_editor/src/test/test_globals.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Disable indeterminate animations
   BlinkController.indeterminateAnimationsEnabled = false;
+
+  // Disable iOS selection heuristics.
+  IOSTextFieldTouchInteractor.useIosSelectionHeuristics = false;
 
   Testing.isInTest = true;
 

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -220,8 +220,8 @@ void main() {
     testWidgetsOnIos("keeps current selection when tapping on caret", (tester) async {
       await _pumpSingleParagraphApp(tester, useIosSelectionHeuristics: true);
 
-      // Tap at "con|sectetur" to place the caret at the end of the word.
-      await tester.tapInParagraph("1", 32);
+      // Tap at "consectetur|" to place the caret.
+      await tester.tapInParagraph("1", 39);
 
       // Ensure that the selection was placed at the end of the word.
       expect(
@@ -234,7 +234,8 @@ void main() {
         )),
       );
 
-      // Press and drag the caret to "con|sectetur".
+      // Press and drag the caret to "con|sectetur" because dragging is the only way
+      // we can place the caret at the middle of a word when caret snapping is enabled.
       final gesture = await tester.tapDownInParagraph("1", 39);
       for (int i = 0; i < 7; i += 1) {
         await gesture.moveBy(const Offset(-19, 0));
@@ -255,6 +256,9 @@ void main() {
           ),
         )),
       );
+
+      // Ensure the toolbar is not visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
 
       // Tap on the caret.
       await tester.tapInParagraph("1", 32);

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -256,7 +256,7 @@ void main() {
         )),
       );
 
-      // Tap at the caret.
+      // Tap on the caret.
       await tester.tapInParagraph("1", 32);
 
       // Ensure the selection was kept at "con|sectetur".

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -1,10 +1,13 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../../test_runners.dart';
+import '../../test_tools.dart';
 import '../supereditor_test_tools.dart';
 
 void main() {
@@ -214,6 +217,63 @@ void main() {
       expect(SuperEditorInspector.isCaretVisible(), true);
     });
 
+    testWidgetsOnIos("keeps current selection when tapping on caret", (tester) async {
+      await _pumpSingleParagraphApp(tester, useIosSelectionHeuristics: true);
+
+      // Tap at "con|sectetur" to place the caret at the end of the word.
+      await tester.tapInParagraph("1", 32);
+
+      // Ensure that the selection was placed at the end of the word.
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 39),
+          ),
+        )),
+      );
+
+      // Press and drag the caret to "con|sectetur".
+      final gesture = await tester.tapDownInParagraph("1", 39);
+      for (int i = 0; i < 7; i += 1) {
+        await gesture.moveBy(const Offset(-19, 0));
+        await tester.pump();
+      }
+
+      // Resolve the gesture so that we don't have pending gesture timers.
+      await gesture.up();
+      await tester.pump(kDoubleTapTimeout);
+
+      // Ensure that the selection moved to "con|sectetur".
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 32),
+          ),
+        )),
+      );
+
+      // Tap at the caret.
+      await tester.tapInParagraph("1", 32);
+
+      // Ensure the selection was kept at "con|sectetur".
+      expect(
+        SuperEditorInspector.findDocumentSelection(),
+        selectionEquivalentTo(const DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: "1",
+            nodePosition: TextNodePosition(offset: 32),
+          ),
+        )),
+      );
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+    });
+
     group("on device and web > shows ", () {
       testWidgetsOnIosDeviceAndWeb("caret", (tester) async {
         await _pumpSingleParagraphApp(tester);
@@ -309,11 +369,15 @@ void main() {
   });
 }
 
-Future<void> _pumpSingleParagraphApp(WidgetTester tester) async {
+Future<void> _pumpSingleParagraphApp(
+  WidgetTester tester, {
+  bool useIosSelectionHeuristics = false,
+}) async {
   await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...
       .withSingleParagraph()
       .simulateSoftwareKeyboardInsets(true)
+      .useIosSelectionHeuristics(useIosSelectionHeuristics)
       .pump();
 }

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -50,8 +50,12 @@ void main() {
         expect(upstreamCaretOffset.dx, greaterThan(startOfFirstLineCaretOffset.dx + xExpectBuffer));
         expect(upstreamCaretOffset.dy, startOfFirstLineCaretOffset.dy);
 
+        // Tap on another character, because tapping on the same character shows the toolbar
+        // instead of changing the selection.
+        await tester.placeCaretInParagraph('1', 3);
+
         // Find the coordinates of the caret at the start of the second line (line break offset w/ downstream affinity).
-        await tester.pump(kTapTimeout * 2); // Simulate a pause to avoid a double tap.
+        await tester.pump(); // Simulate a pause to avoid a double tap.
         await tester.placeCaretInParagraph('1', lineBreakOffset, affinity: TextAffinity.downstream);
         final downstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
 

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -77,8 +77,12 @@ void main() {
         final downstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
         final downstreamSelection = SuperEditorInspector.findDocumentSelection();
 
+        // Tap on another character, because tapping on the same character shows the toolbar
+        // instead of changing the selection.
+        await tester.placeCaretInParagraph('1', 0);
+
         // Place the caret at the same offset but with an upstream affinity.
-        await tester.pump(kTapTimeout * 2); // Simulate a pause to avoid a double tap.
+        await tester.pump();
         await tester.placeCaretInParagraph('1', textOffset, affinity: TextAffinity.upstream);
         final upstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
         final upstreamSelection = SuperEditorInspector.findDocumentSelection();

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -42,7 +42,6 @@ void main() {
         final lineBreakOffset = SuperEditorInspector.findOffsetOfLineBreak('1');
 
         // Find the coordinates of the caret at the end of the first line (line break offset w/ upstream affinity).
-        await tester.pump(kTapTimeout * 2); // Simulate a pause to avoid a double tap.
         await tester.placeCaretInParagraph('1', lineBreakOffset, affinity: TextAffinity.upstream);
         final upstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
 
@@ -55,7 +54,6 @@ void main() {
         await tester.placeCaretInParagraph('1', 3);
 
         // Find the coordinates of the caret at the start of the second line (line break offset w/ downstream affinity).
-        await tester.pump(); // Simulate a pause to avoid a double tap.
         await tester.placeCaretInParagraph('1', lineBreakOffset, affinity: TextAffinity.downstream);
         final downstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
 

--- a/super_editor/test/super_editor/supereditor_caret_test.dart
+++ b/super_editor/test/super_editor/supereditor_caret_test.dart
@@ -84,7 +84,6 @@ void main() {
         await tester.placeCaretInParagraph('1', 0);
 
         // Place the caret at the same offset but with an upstream affinity.
-        await tester.pump();
         await tester.placeCaretInParagraph('1', textOffset, affinity: TextAffinity.upstream);
         final upstreamCaretOffset = SuperEditorInspector.findCaretOffsetInDocument();
         final upstreamSelection = SuperEditorInspector.findDocumentSelection();

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -116,8 +116,12 @@ void main() {
         ),
       );
 
+      // Tap on another character, because tapping on the same character shows the toolbar
+      // instead of changing the selection.
+      await tester.placeCaretInParagraph("1", 5);
+
       // Place the caret at the same offset as before but with an upstream affinity.
-      await tester.pump(kTapTimeout * 2); // Pause to avoid double tap.
+      await tester.pump();
       await tester.placeCaretInParagraph("1", 1, affinity: TextAffinity.upstream);
       // Ensure the document has the correct selection, including affinity;
       expect(

--- a/super_editor/test/super_editor/supereditor_robot_test.dart
+++ b/super_editor/test/super_editor/supereditor_robot_test.dart
@@ -121,7 +121,6 @@ void main() {
       await tester.placeCaretInParagraph("1", 5);
 
       // Place the caret at the same offset as before but with an upstream affinity.
-      await tester.pump();
       await tester.placeCaretInParagraph("1", 1, affinity: TextAffinity.upstream);
       // Ensure the document has the correct selection, including affinity;
       expect(

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/super_text_field.dart';
 
 import '../super_textfield_inspector.dart';
+import '../super_textfield_robot.dart';
 
 void main() {
   group("SuperTextField mobile selection > iOS", () {
@@ -52,6 +53,56 @@ void main() {
 
       // Ensure that the text field toolbar disappeared.
       expect(find.byType(IOSTextEditingFloatingToolbar), findsNothing);
+    });
+
+    testWidgetsOnIos("keeps current selection when tapping on caret", (tester) async {
+      IOSTextFieldTouchInteractor.useIosSelectionHeuristics = true;
+      addTearDown(() => IOSTextFieldTouchInteractor.useIosSelectionHeuristics = false);
+
+      await _pumpScaffold(
+        tester,
+        controller: AttributedTextEditingController(
+          text: AttributedText('Lorem ipsum dolor'),
+        ),
+      );
+
+      // Ensure there's no selection to begin with.
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: -1),
+      );
+
+      // Tap at "ips|um" to place the caret at the end of the word.
+      await tester.placeCaretInSuperTextField(9);
+      await tester.pump(kDoubleTapTimeout);
+
+      // Ensure the selection was placed at the end of the word.
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 11),
+      );
+
+      // Press and drag the caret to "ips|um".
+      final dragGesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-32, 0));
+      await dragGesture.up();
+
+      // Ensure the selection moved to "ips|um".
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 9),
+      );
+
+      // Tap at the caret to show the toolbar.
+      await tester.placeCaretInSuperTextField(9);
+
+      // Ensure the selection was kept at "ips|um".
+      expect(
+        SuperTextFieldInspector.findSelection(),
+        const TextSelection.collapsed(offset: 9),
+      );
+
+      // Ensure that the text field toolbar is visible.
+      expect(find.byType(IOSTextEditingFloatingToolbar), findsOneWidget);
     });
   });
 }

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -72,9 +72,8 @@ void main() {
         const TextSelection.collapsed(offset: -1),
       );
 
-      // Tap at "ips|um" to place the caret at the end of the word,
-      // because on iOS the caret is always placed at word boundaries.
-      await tester.placeCaretInSuperTextField(9);
+      // Tap at "ipsum|" to place the caret.
+      await tester.placeCaretInSuperTextField(11);
       await tester.pump(kDoubleTapTimeout);
 
       // Ensure the selection was placed at the end of the word.
@@ -83,7 +82,8 @@ void main() {
         const TextSelection.collapsed(offset: 11),
       );
 
-      // Press and drag the caret to "ips|um".
+      // Press and drag the caret to "ips|um", because dragging is the only way
+      // we can place the caret at the middle of a word when caret snapping is enabled.
       final dragGesture = await tester.dragCaretByDistanceInSuperTextField(const Offset(-32, 0));
       await dragGesture.up();
 
@@ -92,6 +92,9 @@ void main() {
         SuperTextFieldInspector.findSelection(),
         const TextSelection.collapsed(offset: 9),
       );
+
+      // Ensure that the text field toolbar is not visible.
+      expect(find.byType(IOSTextEditingFloatingToolbar), findsNothing);
 
       // Tap at the caret to show the toolbar.
       await tester.placeCaretInSuperTextField(9);

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_selection_test.dart
@@ -72,7 +72,8 @@ void main() {
         const TextSelection.collapsed(offset: -1),
       );
 
-      // Tap at "ips|um" to place the caret at the end of the word.
+      // Tap at "ips|um" to place the caret at the end of the word,
+      // because on iOS the caret is always placed at word boundaries.
       await tester.placeCaretInSuperTextField(9);
       await tester.pump(kDoubleTapTimeout);
 


### PR DESCRIPTION
[SuperEditor][SuperTextField][iOS] Make caret word snapping less aggressive. Resolves #2152

On iOS, the caret snaps to the edges of a word. However, this shouldn't happen when the user taps at the caret position.

This PR changes `SuperEditor` and `SuperTextField` to avoid snapping the caret when tapping at the caret.

Some required adjustments:
- The check for a tap over the caret was using the snapped position instead of the tap position. Modified to use the exact tap  position.
- The check for a tap over the caret was expanding the caret 24px in all directions. This causes an issue, because tapping on a line below (or up) can be interpreted as a tap on the caret. Modified to expand only horizontally.

We still have a problem in `SuperEditor` regarding showing the toolbar when tapping at the caret. We have this code:

```dart
if (didTapOnExistingSelection && _isKeyboardOpen) {
  // Toggle the toolbar display when the user taps on the collapsed caret,
  // or on top of an existing selection.
  //
  // But we only do this when the keyboard is already open. This is because
  // we don't want to show the toolbar when the user taps simply to open
  // the keyboard. That would feel unintentional, like a bug.
  _controlsController!.toggleToolbar();
} else {
  // The user tapped somewhere else in the document. Hide the toolbar.
  _controlsController!.hideToolbar();
}
```

However, `_isKeyboardOpen` uses the bottom view insets. This doesn't work if there are any `Scaffold`s in the tree without `resizeToAvoidBottomInset` set to `false`. Maybe we can check for an ancestor `KeyboardScaffoldSafeArea` and if we don't find one, we don't do the `_isKeyboardOpen` check.