### PR TITLE
Fix Sliver crash in Demo Website (Resolves #2329)

### DIFF
--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -142,14 +142,16 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
       overlayChildBuilder: _buildFloatingToolbar,
       child: KeyedSubtree(
         key: _viewportKey,
-        child: SuperEditor(
-          editor: _docEditor,
-          document: _doc,
-          composer: _composer,
-          documentLayoutKey: _docLayoutKey,
-          focusNode: _editorFocusNode,
-          stylesheet: _getEditorStyleSheet(),
-          selectionLayerLinks: _selectionLayerLinks,
+        child: CustomScrollView(
+          slivers: [
+            SuperEditor(
+              editor: _docEditor,
+              documentLayoutKey: _docLayoutKey,
+              focusNode: _editorFocusNode,
+              stylesheet: _getEditorStyleSheet(),
+              selectionLayerLinks: _selectionLayerLinks,
+            ),
+          ],
         ),
       ),
     );

--- a/website/lib/homepage/home_page.dart
+++ b/website/lib/homepage/home_page.dart
@@ -104,10 +104,8 @@ class HomePage extends StatelessWidget {
               ),
             ],
           ),
-          child: SingleChildScrollView(
-            child: FeaturedEditor(
-              displayMode: displayMode,
-            ),
+          child: FeaturedEditor(
+            displayMode: displayMode,
           ),
         ),
       ),


### PR DESCRIPTION
Fix Sliver crash in Demo Website. Resolves #2329

The original ticket mentions a different issue, which I could not reproduce. With the latest main, the editor is crashing immediately with the following exception:

```console
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following _TypeError was thrown building DocumentMouseInteractor(dependencies: [MediaQuery],
state: _DocumentMouseInteractorState#72a71):
TypeError: Instance of '_RenderSliverHybridStack': type '_RenderSliverHybridStack' is not a subtype
of type 'RenderBox'

The relevant error-causing widget was:
  DocumentMouseInteractor
  DocumentMouseInteractor:file:///Users/angelosilvestre/dev/super_editor/super_editor/lib/src/default_editor/super_editor.dart:865:16
```

The issue is that, when the editor has an ancestor `Scrollable`, it doesn't add it's own `CustomScrollView` to the widget tree. In the demo website, there is an ancestor `SingleChildScrollView`, which doesn't work for scrolling the editor anymore, since now `SuperEditor` is a sliver.

This PR removes the `SingleChildScrollView` and places a `CustomScrollView` directly above `SuperEditor`.

We cannot just remove the `SingleChildScrollView` because the editor will then try to scroll the page's scrollable, which will also cause a crash, because the page's scrollable isn't a `CustomScrollView`.

Maybe we need a way to signal to the editor that it should ignore the ancestor scrollable.

