### PR TITLE
Updated CHANGELOG and pubspec.yaml for super_editor release v0.3.0-dev.12

### DIFF
--- a/super_editor/CHANGELOG.md
+++ b/super_editor/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.0-dev.12] - Dec 23, 2024
+ * FEATURE: Added support for inline widgets.
+ * FEATURE: Created a `ClearDocumentRequest`, which deletes all content and moves caret to the start.
+ * FIX: Web - option + arrow selection changes.
+ * FIX: `SuperTextField` (iOS) - native content menu focal point was wrong.
+ * FIX: Action tag not identified and triggered in expected situations.
+ * ADJUSTMENT: `KeyboardPanelScaffold` supports opening a panel before opening the software keyboard.
+ * ADJUSTMENT: `getDocumentPositionAfterExpandedDeletion` returns `null` for collapsed selections.
+ * ADJUSTMENT: `TaskNode` checkbox sets visual density based on `ThemeData.visualDensity`.
+
 ## [0.3.0-dev.11] - Nov 26, 2024
  * FEATURE: Add an (optional) tap handler that automatically inserts empty paragraph
    when user taps at the end of the document.

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_editor
 description: Configurable, composable, extensible text editor and document renderer for Flutter.
-version: 0.3.0-dev.11
+version: 0.3.0-dev.12
 homepage: https://github.com/superlistapp/super_editor
 funding:
   - https://flutterbountyhunters.com


### PR DESCRIPTION
Updated CHANGELOG and pubspec.yaml for super_editor release v0.3.0-dev.12

I forgot to push these changes and a tag when I released super_editor v0.3.0-dev.12. This PR updates the tracking info, but we're missing a dedicated commit for this release.