### PR TITLE
Fix: Make KeyboardScaffoldSafeArea work when not at bottom of screen (Resolves #2489)

### DIFF
--- a/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
+++ b/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
@@ -610,12 +610,9 @@ void main() {
         final contentHeightWithNoKeyboard = tester.getSize(find.byKey(_chatPageKey)).height;
 
         // Show the keyboard. Don't show the toolbar because it's irrelevant for this test.
-        print("---- STARTING TO OPEN KEYBOARD -----");
         controller.toolbarVisibility = KeyboardToolbarVisibility.hidden;
         controller.showSoftwareKeyboard();
         await tester.pumpAndSettle();
-
-        print("---- DONE OPENING KEYBOARD -----");
 
         // Record the height of the content now that the keyboard is open.
         final contentHeightWithKeyboardPanelOpen = tester.getSize(find.byKey(_chatPageKey)).height;
@@ -782,6 +779,7 @@ class _ChatPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return KeyboardScaffoldSafeAreaScope(
+      debugLabel: "Root",
       child: Column(
         children: [
           Expanded(
@@ -806,17 +804,11 @@ class _ChatPage extends StatelessWidget {
     // a bottom mounted chat editor.
     return Positioned.fill(
       child: KeyboardScaffoldSafeArea(
-        child: Builder(builder: (context) {
-          // TODO: delete this builder
-
-          print("Building the chat page");
-          print(" - keyboard safe area insets: ${KeyboardScaffoldSafeAreaScope.of(context).geometry.bottomInsets}");
-
-          return Container(
-            key: _chatPageKey,
-            color: Colors.blue,
-          );
-        }),
+        debugLabel: "content",
+        child: Container(
+          key: _chatPageKey,
+          color: Colors.blue,
+        ),
       ),
     );
   }
@@ -828,6 +820,7 @@ class _ChatPage extends StatelessWidget {
       right: 0,
       bottom: 0,
       child: KeyboardScaffoldSafeArea(
+        debugLabel: "editor",
         child: Builder(builder: (context) {
           return KeyboardPanelScaffold(
             controller: keyboardPanelController,
@@ -859,7 +852,7 @@ class _ChatPage extends StatelessWidget {
 }
 
 class _AccountPage extends StatelessWidget {
-  const _AccountPage({super.key});
+  const _AccountPage();
 
   @override
   Widget build(BuildContext context) {
@@ -954,6 +947,7 @@ class _Screen1 extends StatelessWidget {
         // ^ This safe area is needed to receive the bottom insets from the
         //   bottom mounted editor, and then make it available to the subtree
         //   with the content behind the chat.
+        debugLabel: "_Screen1",
         child: _ChatPage(
           keyboardPanelController: keyboardPanelController,
           imeConnectionNotifier: imeConnectionNotifier,
@@ -973,6 +967,7 @@ class _Screen2 extends StatelessWidget {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: KeyboardScaffoldSafeArea(
+        debugLabel: "_Screen2",
         child: Builder(builder: (context) {
           return ListView.builder(
             key: _screen2BodyKey,

--- a/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
+++ b/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
@@ -725,26 +725,6 @@ class _TestAppScaffold extends StatelessWidget {
             ),
           ),
           resizeToAvoidBottomInset: false,
-          // body: KeyboardScaffoldSafeArea(
-          //   // ^ This safe area is needed to receive the bottom insets from the
-          //   //   bottom mounted editor, and then make it available to the subtree
-          //   //   with the content behind the chat.
-          //   //
-          //   //   Also, by including 2 of these safe areas in the same tree, we implicitly
-          //   //   verify that multiple safe areas in the same tree work together.
-          //   child: TabBarView(children: [
-          //     // ^ We build a tab view so that we can test what happens when the editor
-          //     //   has focus and a keyboard panel is up, and then the user navigates to
-          //     //   another tab, which should remove the bottom safe area when it happens.
-          //     _buildChatPage(
-          //       keyboardPanelController,
-          //       imeConnectionNotifier,
-          //       superEditor,
-          //       widgetBelowEditor,
-          //     ),
-          //     _buildAccountPage(),
-          //   ]),
-          // ),
           body: TabBarView(children: [
             // ^ We build a tab view so that we can test what happens when the editor
             //   has focus and a keyboard panel is up, and then the user navigates to


### PR DESCRIPTION
Fix: Make KeyboardScaffoldSafeArea work when not at bottom of screen (Resolves #2489)

Apparently when I recently created the new implementation of the keyboard scaffold I never tested with widgets below the chat editor, such as bottom nav tabs. When there's a widget below the editor, we were pushing the editor up too far, equal to the height of whatever was below it before pushing it up.

There's one known shortcoming even with the PR. When the content below the editor changes size, the editor position is one frame behind, leading to some jitter. This is likely to happen because the widget at the bottom of the screen is probably wrapped in a `SafeArea` to deal with bottom insets.

Here's an example of the jitter:


https://github.com/user-attachments/assets/c19d4e96-d27d-424b-ba0f-87e9fa61daf5

The same demo on an SE, which doesn't the bottom safe area space, is stable:


https://github.com/user-attachments/assets/ce7a5343-bc6a-40bb-af98-40e6d6704e2e

