### PR TITLE
[Super Editor] - Make emails clickable with "mailto:", and linkify app URLs like "obsidian://" (Resolves #2426, Resolves #2427)

### DIFF
--- a/super_editor/example/lib/demos/interaction_spot_checks/url_launching_spot_checks.dart
+++ b/super_editor/example/lib/demos/interaction_spot_checks/url_launching_spot_checks.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+import 'spot_check_scaffold.dart';
+
+class UrlLauncherSpotChecks extends StatefulWidget {
+  const UrlLauncherSpotChecks({super.key});
+
+  @override
+  State<UrlLauncherSpotChecks> createState() => _UrlLauncherSpotChecksState();
+}
+
+class _UrlLauncherSpotChecksState extends State<UrlLauncherSpotChecks> {
+  late final Editor _editor;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _editor = createDefaultDocumentEditor(
+      document: deserializeMarkdownToDocument('''
+# Linkification Spot Check
+In this spot check, we create a variety of linkification scenarios. We expect each link to be linkified, and to take the expect action when tapped.
+
+## Markdown Links (with schemes)
+[https://google.com](https://google.com)
+[mailto:somebody@gmail.com](mailto:somebody@gmail.com)
+[obsidian://open?vault=my-vault](obsidian://open?vault=my-vault)
+
+## Markdown Links (no schemes)
+[google.com](google.com)
+[somebody@gmail.com](somebody@gmail.com)
+
+## Pasted Links
+The first set of pasted links are all pasted together within a single block of text. Then the same links are pasted with one link per line.
+'''),
+      composer: MutableDocumentComposer(),
+    );
+
+    _pasteLinks();
+  }
+
+  Future<void> _pasteLinks() async {
+    final links = '''
+
+google.com https://google.com somebody@gmail.com mailto:somebody@gmail.com obsidian://open?vault=my-vault
+
+google.com
+https://google.com
+somebody@gmail.com
+mailto:somebody@gmail.com
+obsidian://open?vault=my-vault
+''';
+
+    // Put the text on the clipboard.
+    await Clipboard.setData(ClipboardData(text: links));
+
+    // Place the caret at the end of the document.
+    // TODO: Add a startPosition and endPosition to `Document`.
+    _editor.execute([
+      ChangeSelectionRequest(
+        DocumentSelection.collapsed(
+          position: DocumentPosition(
+            nodeId: _editor.document.last.id,
+            nodePosition: (_editor.document.last as TextNode).endPosition,
+          ),
+        ),
+        SelectionChangeType.placeCaret,
+        SelectionReason.userInteraction,
+      ),
+    ]);
+
+    // Paste the text from the clipboard, which should include a linkification reaction.
+    CommonEditorOperations(
+      editor: _editor,
+      document: _editor.document,
+      composer: _editor.composer,
+      documentLayoutResolver: () => throw UnimplementedError(),
+    ).paste();
+  }
+
+  @override
+  void dispose() {
+    _editor.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SpotCheckScaffold(
+      content: SuperEditor(
+        editor: _editor,
+        stylesheet: defaultStylesheet.copyWith(
+          addRulesAfter: [
+            ..._darkModeStyles,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final _darkModeStyles = [
+  StyleRule(
+    BlockSelector.all,
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFFCCCCCC),
+        ),
+      };
+    },
+  ),
+  StyleRule(
+    const BlockSelector("header1"),
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFF888888),
+        ),
+      };
+    },
+  ),
+  StyleRule(
+    const BlockSelector("header2"),
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFF888888),
+        ),
+      };
+    },
+  ),
+];

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:example/demos/in_the_lab/feature_stable_tags.dart';
 import 'package:example/demos/in_the_lab/selected_text_colors_demo.dart';
 import 'package:example/demos/in_the_lab/spelling_error_decorations.dart';
 import 'package:example/demos/interaction_spot_checks/toolbar_following_content_in_layer.dart';
+import 'package:example/demos/interaction_spot_checks/url_launching_spot_checks.dart';
 import 'package:example/demos/mobile_chat/demo_mobile_chat.dart';
 import 'package:example/demos/scrolling/demo_task_and_chat_with_customscrollview.dart';
 import 'package:example/demos/sliver_example_editor.dart';
@@ -387,6 +388,13 @@ final _menu = <_MenuGroup>[
   _MenuGroup(
     title: 'Spot Checks',
     items: [
+      _MenuItem(
+        icon: Icons.link,
+        title: 'URL Parsing & Launching',
+        pageBuilder: (context) {
+          return UrlLauncherSpotChecks();
+        },
+      ),
       _MenuItem(
         icon: Icons.layers,
         title: 'Toolbar Following Content Layer',

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -323,8 +323,3 @@ class LinkAttribution implements Attribution {
     return '[LinkAttribution]: $plainTextUri${hasStructuredUri ? ' ($uri)' : ''}';
   }
 }
-
-enum LinkType {
-  url,
-  email;
-}

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -217,13 +217,22 @@ class FontFamilyAttribution implements Attribution {
 /// relationship with [AttributedText].
 class LinkAttribution implements Attribution {
   factory LinkAttribution.fromUri(Uri uri) {
-    return LinkAttribution(uri.toString());
+    return LinkAttribution(uri.toString(), LinkType.url);
   }
 
-  const LinkAttribution(this.url);
+  factory LinkAttribution.fromEmail(String email) {
+    return LinkAttribution(email, LinkType.email);
+  }
+
+  // The default [type] is set to a URL so that we could introduce a [type]
+  // property without breaking existing uses.
+  const LinkAttribution(this.url, [this.type = LinkType.url]);
 
   @override
   String get id => 'link';
+
+  /// The type of link in this attribution, e.g., URL, link.
+  final LinkType type;
 
   /// The URL associated with the attributed text, as a `String`.
   final String url;
@@ -256,4 +265,9 @@ class LinkAttribution implements Attribution {
   String toString() {
     return '[LinkAttribution]: $url';
   }
+}
+
+enum LinkType {
+  url,
+  email;
 }

--- a/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
+++ b/super_editor/lib/src/default_editor/default_document_editor_reactions.dart
@@ -674,8 +674,6 @@ class LinkifyReaction extends EditReaction {
       LinkAttribution.fromUri(uri),
       SpanRange(wordStartOffset, endOffset - 1),
     );
-
-    // Failed to parse the upstream word as a URL or URI. Don't linkify anything.
   }
 
   int? _moveOffsetByWord(String text, int textOffset, bool upstream) {

--- a/super_editor/lib/src/default_editor/tap_handlers/tap_handlers.dart
+++ b/super_editor/lib/src/default_editor/tap_handlers/tap_handlers.dart
@@ -88,7 +88,7 @@ class SuperEditorLaunchLinkTapHandler extends ContentTapDelegate {
     final tappedAttributions = textNode.text.getAllAttributionsAt(nodePosition.offset);
     for (final tappedAttribution in tappedAttributions) {
       if (tappedAttribution is LinkAttribution) {
-        return tappedAttribution.uri;
+        return tappedAttribution.launchableUri;
       }
     }
 

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -397,6 +397,7 @@ extension Words on String {
 
       offset += textSelection.end - textSelection.start + 1;
     }
+
     return textSelections;
   }
 }

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -397,7 +397,6 @@ extension Words on String {
 
       offset += textSelection.end - textSelection.start + 1;
     }
-
     return textSelections;
   }
 }

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -727,7 +727,7 @@ class SuperReaderLaunchLinkTapHandler extends ContentTapDelegate {
     final tappedAttributions = textNode.text.getAllAttributionsAt(nodePosition.offset);
     for (final tappedAttribution in tappedAttributions) {
       if (tappedAttribution is LinkAttribution) {
-        return tappedAttribution.uri;
+        return tappedAttribution.launchableUri;
       }
     }
 

--- a/super_editor/lib/src/super_textfield/infrastructure/text_field_tap_handlers.dart
+++ b/super_editor/lib/src/super_textfield/infrastructure/text_field_tap_handlers.dart
@@ -22,13 +22,9 @@ class SuperTextFieldLaunchLinkTapHandler extends SuperTextFieldTapHandler {
       return TapHandlingInstruction.continueHandling;
     }
 
-    final uri = Uri.tryParse(linkAttribution.url);
-    if (uri == null) {
-      // The link is not a valid URI. We can't open it.
-      return TapHandlingInstruction.continueHandling;
-    }
-
-    UrlLauncher.instance.launchUrl(uri);
+    UrlLauncher.instance.launchUrl(
+      linkAttribution.launchableUri,
+    );
 
     return TapHandlingInstruction.halt;
   }

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -44,13 +44,14 @@ void main() {
 
         expect(text.toPlainText(), "https://www.google.com ");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(0, text.length - 2),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 0,
+              end: text.length - 2,
+            ),
+          },
         );
       });
 
@@ -87,13 +88,14 @@ void main() {
 
         expect(text.toPlainText(), "https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty paragraph.
@@ -137,13 +139,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the paragraph.
@@ -188,13 +191,14 @@ void main() {
 
         expect(text.toPlainText(), "https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty paragraph.
@@ -241,13 +245,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the paragraph.
@@ -292,13 +297,14 @@ void main() {
 
         expect(text.toPlainText(), "https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty line.
@@ -346,13 +352,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the paragraph.
@@ -396,13 +403,14 @@ void main() {
 
         expect(text.toPlainText(), "Item https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(5, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 5,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty list item.
@@ -446,13 +454,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the list item.
@@ -499,13 +508,14 @@ void main() {
 
         expect(text.toPlainText(), "Item https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(5, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 5,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty list item.
@@ -552,13 +562,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the list item.
@@ -605,13 +616,14 @@ void main() {
 
         expect(text.toPlainText(), "Item https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(5, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 5,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty list item.
@@ -659,13 +671,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the list item.
@@ -723,13 +736,14 @@ void main() {
 
         expect(text.toPlainText(), "This is a task https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(15, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 15,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty task.
@@ -787,13 +801,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the task
@@ -854,13 +869,14 @@ void main() {
 
         expect(text.toPlainText(), "This is a task https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(15, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 15,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty task.
@@ -921,13 +937,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the task.
@@ -988,13 +1005,14 @@ void main() {
 
         expect(text.toPlainText(), "This is a task https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(15, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 15,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we added a new empty task.
@@ -1055,13 +1073,14 @@ void main() {
 
         expect(text.toPlainText(), "Before link https://www.google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
-            },
-            range: SpanRange(12, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://www.google.com")),
+              start: 12,
+              end: text.length - 1,
+            ),
+          },
         );
 
         // Ensure we split the task.
@@ -1105,39 +1124,6 @@ void main() {
         );
       });
 
-      testWidgetsOnAllPlatforms('recognizes an email URL', (tester) async {
-        await tester //
-            .createDocument()
-            .withSingleEmptyParagraph()
-            .withInputSource(TextInputSource.ime)
-            .pump();
-
-        // Place the caret at the beginning of the empty document.
-        await tester.placeCaretInParagraph("1", 0);
-
-        // Type a URL. It shouldn't linkify until we add a space.
-        await tester.typeImeText("me@gmail.com");
-
-        // Type a space, to cause a linkify reaction.
-        await tester.typeImeText(" ");
-
-        // Ensure it's linkified with a URL schema.
-        var text = SuperEditorInspector.findTextInComponent("1");
-        text = SuperEditorInspector.findTextInComponent("1");
-
-        expect(text.toPlainText(), "me@gmail.com ");
-        expect(
-          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
-          {
-            AttributionSpan(
-              attribution: LinkAttribution.fromUri(Uri.parse("me@gmail.com")),
-              start: 0,
-              end: 11,
-            ),
-          },
-        );
-      });
-
       testWidgetsOnAllPlatforms('recognizes an app URL', (tester) async {
         await tester //
             .createDocument()
@@ -1158,7 +1144,7 @@ void main() {
         var text = SuperEditorInspector.findTextInComponent("1");
         text = SuperEditorInspector.findTextInComponent("1");
 
-        expect(text.text, "obsidian://open?vault=MyVault ");
+        expect(text.toPlainText(), "obsidian://open?vault=MyVault ");
         expect(
           text.getAttributionSpansByFilter((a) => a is LinkAttribution),
           {
@@ -1321,14 +1307,71 @@ void main() {
           },
         );
       });
+
+      testWidgetsOnDesktop('recognizes multiple pasted URLs', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Paste text with multiple URLs.
+        tester.simulateClipboard();
+        await tester.setSimulatedClipboardContent(
+          "Some URLS: google.com https://google.com somebody@gmail.com mailto:somebody@gmail.com obsidian://open?vault=my-vault",
+        );
+        // TODO: create and use something like tester.pressPasteAdaptive()
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          await tester.pressCmdV();
+        } else {
+          await tester.pressCtlV();
+        }
+
+        // Ensure all URLs were linkified.
+        final text = SuperEditorInspector.findTextInComponent("1");
+        expect(
+          text.toPlainText(),
+          "Some URLS: google.com https://google.com somebody@gmail.com mailto:somebody@gmail.com obsidian://open?vault=my-vault",
+        );
+
+        expect(
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://google.com")),
+              start: 11,
+              end: 20,
+            ),
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("https://google.com")),
+              start: 22,
+              end: 39,
+            ),
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("mailto:somebody@gmail.com")),
+              start: 41,
+              end: 58,
+            ),
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("mailto:somebody@gmail.com")),
+              start: 60,
+              end: 84,
+            ),
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("obsidian://open?vault=my-vault")),
+              start: 86,
+              end: 115,
+            ),
+          },
+        );
+      });
     });
 
-    group('recognizes a URL for an app and converts it to a link', () {
-      // This group of tests are just spot checks for recognizing an app-based
-      // URL. The tests for a generic URL already cover the many moments when
-      // recognition might take place.
-
-      testWidgetsOnAllPlatforms('when typing', (tester) async {
+    group('URI protocol >', () {
+      testWidgetsOnAllPlatforms('recognizes an email URI', (tester) async {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
@@ -1339,37 +1382,25 @@ void main() {
         await tester.placeCaretInParagraph("1", 0);
 
         // Type a URL. It shouldn't linkify until we add a space.
-        await tester.typeImeText("obsidian://open?vault=98_Obsidian_NEW_2023&file=30-");
-
-        // Ensure it's not linkified yet.
-        var text = SuperEditorInspector.findTextInComponent("1");
-
-        expect(text.toPlainText(), "obsidian://open?vault=98_Obsidian_NEW_2023&file=30-");
-        expect(
-          text.getAttributionSpansInRange(
-            attributionFilter: (attribution) => true,
-            range: SpanRange(0, text.length - 1),
-          ),
-          isEmpty,
-        );
+        await tester.typeImeText("me@gmail.com");
 
         // Type a space, to cause a linkify reaction.
         await tester.typeImeText(" ");
 
-        // Ensure it's linkified.
+        // Ensure it's linkified with a URL schema.
+        var text = SuperEditorInspector.findTextInComponent("1");
         text = SuperEditorInspector.findTextInComponent("1");
 
-        expect(text.toPlainText(), "obsidian://open?vault=98_Obsidian_NEW_2023&file=30- ");
+        expect(text.toPlainText(), "me@gmail.com ");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(
-                Uri.parse("obsidian://open?vault=98_Obsidian_NEW_2023&file=30-"),
-              ),
-            },
-            range: SpanRange(0, text.length - 2),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromEmail("me@gmail.com"),
+              start: 0,
+              end: 11,
+            ),
+          },
         );
       });
     });
@@ -1570,20 +1601,22 @@ void main() {
 
         expect(text.toPlainText(), "www.googoooole.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
       });
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
             .pump();
@@ -1600,15 +1633,16 @@ void main() {
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.googoooole.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.googoooole.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution("${scheme}www.googoooole.com"),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
         await tester //
@@ -1635,9 +1669,10 @@ void main() {
 
     group('can delete characters at the beginning of a link', () {
       testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .pump();
 
@@ -1658,20 +1693,22 @@ void main() {
 
         expect(text.toPlainText(), "google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
             .pump();
@@ -1687,20 +1724,24 @@ void main() {
         await tester.pressDelete();
         await tester.pressDelete();
 
-        // Ensure the characters were delete and link attribution was updated.
+        // Ensure the characters were deleted and link attribution was updated.
+        //
+        // We expect the leading "www." to removed, but we expect to retain the
+        // scheme.
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "google.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution("${scheme}google.com"),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
 
-        // Delete more 9 characters, leaving only the last "m".
+        // Delete 9 more characters, leaving only the last "m".
         await tester.pressDelete();
         await tester.pressDelete();
         await tester.pressDelete();
@@ -1715,8 +1756,8 @@ void main() {
         final textAfter = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(textAfter.toPlainText(), "m");
         expect(
-          (textAfter.getAllAttributionsAt(0).first as LinkAttribution).url.toString(),
-          "https://m",
+          (textAfter.getAllAttributionsAt(0).first as LinkAttribution).plainTextUri.toString(),
+          "${scheme}m",
         );
 
         // Press delete to remove the last character.
@@ -1724,7 +1765,7 @@ void main() {
 
         // Ensure the text was deleted.
         expect(SuperEditorInspector.findTextInComponent(doc.first.id).toPlainText(), isEmpty);
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
         await tester //
@@ -1754,9 +1795,10 @@ void main() {
 
     group('can delete characters in the middle of a link', () {
       testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .pump();
 
@@ -1776,20 +1818,22 @@ void main() {
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.g.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
             .pump();
@@ -1814,15 +1858,16 @@ void main() {
         var text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.duckduckgo.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.duckduckgo.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.duckduckgo.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
         await tester //
@@ -1849,9 +1894,10 @@ void main() {
 
     group('can delete characters at the end of a link', () {
       testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .pump();
 
@@ -1872,20 +1918,22 @@ void main() {
 
         expect(text.toPlainText(), "www.google");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
             .pump();
@@ -1903,15 +1951,16 @@ void main() {
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.google.c");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.google.c")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.c")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
         await tester //
@@ -1938,9 +1987,10 @@ void main() {
 
     group('can replace characters in the middle of a link', () {
       testWidgetsOnAllPlatforms('without updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .pump();
 
@@ -1956,20 +2006,22 @@ void main() {
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.duckduckgo.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("www.google.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('updating the attribution', (tester) async {
+        final scheme = _urlSchemeVariant.currentValue;
         await tester //
             .createDocument()
-            .fromMarkdown("[www.google.com](www.google.com)")
+            .fromMarkdown("[www.google.com](${scheme}www.google.com)")
             .withInputSource(TextInputSource.ime)
             .withAddedReactions([const LinkifyReaction(updatePolicy: LinkUpdatePolicy.update)]) //
             .pump();
@@ -1986,15 +2038,16 @@ void main() {
         final text = SuperEditorInspector.findTextInComponent(doc.first.id);
         expect(text.toPlainText(), "www.duckduckgo.com");
         expect(
-          text.hasAttributionsThroughout(
-            attributions: {
-              LinkAttribution.fromUri(Uri.parse("https://www.duckduckgo.com")),
-            },
-            range: SpanRange(0, text.length - 1),
-          ),
-          isTrue,
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.duckduckgo.com")),
+              start: 0,
+              end: text.length - 1,
+            ),
+          },
         );
-      });
+      }, variant: _urlSchemeVariant);
 
       testWidgetsOnAllPlatforms('removing the attribution', (tester) async {
         await tester //
@@ -2020,9 +2073,10 @@ void main() {
     });
 
     testWidgetsOnAllPlatforms('user can delete characters at the end of a link and then keep typing', (tester) async {
+      final scheme = _urlSchemeVariant.currentValue;
       await tester //
           .createDocument()
-          .fromMarkdown("[www.google.com](www.google.com)")
+          .fromMarkdown("[www.google.com](${scheme}www.google.com)")
           .withInputSource(TextInputSource.ime)
           .pump();
 
@@ -2043,24 +2097,25 @@ void main() {
 
       expect(text.toPlainText(), "www.google.co hello");
       expect(
-        text.hasAttributionsThroughout(
-          attributions: {
-            LinkAttribution.fromUri(Uri.parse("www.google.com")),
-          },
-          range: const SpanRange(0, 12),
-        ),
-        isTrue,
+        text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+        {
+          AttributionSpan(
+            attribution: LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
+            start: 0,
+            end: 12,
+          ),
+        },
       );
       expect(
         text.hasAttributionsThroughout(
           attributions: {
-            LinkAttribution.fromUri(Uri.parse("www.google.com")),
+            LinkAttribution.fromUri(Uri.parse("${scheme}www.google.com")),
           },
           range: SpanRange(13, text.length - 1),
         ),
         isFalse,
       );
-    });
+    }, variant: _urlSchemeVariant);
 
     testWidgetsOnAllPlatforms('does not extend link to new paragraph', (tester) async {
       await tester //
@@ -2195,3 +2250,11 @@ void main() {
     // TODO: once it's easier to configure task components (#1295), add a test that checks link attributions when inserting a new task
   });
 }
+
+/// A variety of URL schemes, including an empty scheme.
+///
+/// Comparing empty vs non-empty schemes is especially important because URL
+/// schemes are often omitted, and we need to ensure that link attribution
+/// adjustments preserve existing schemes, but that we don't add schemes when
+/// they didn't exist in the first place.
+final _urlSchemeVariant = ValueVariant({"", "https://"});

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -1105,7 +1105,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAllPlatforms('inserts email scheme if it is missing', (tester) async {
+      testWidgetsOnAllPlatforms('recognizes an email URL', (tester) async {
         await tester //
             .createDocument()
             .withSingleEmptyParagraph()
@@ -1133,6 +1133,39 @@ void main() {
               attribution: LinkAttribution.fromUri(Uri.parse("me@gmail.com")),
               start: 0,
               end: 11,
+            ),
+          },
+        );
+      });
+
+      testWidgetsOnAllPlatforms('recognizes an app URL', (tester) async {
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .withInputSource(TextInputSource.ime)
+            .pump();
+
+        // Place the caret at the beginning of the empty document.
+        await tester.placeCaretInParagraph("1", 0);
+
+        // Type an app URL.
+        await tester.typeImeText("obsidian://open?vault=MyVault");
+
+        // Type a space, to cause a linkify reaction.
+        await tester.typeImeText(" ");
+
+        // Ensure it's linkified with a URL schema.
+        var text = SuperEditorInspector.findTextInComponent("1");
+        text = SuperEditorInspector.findTextInComponent("1");
+
+        expect(text.text, "obsidian://open?vault=MyVault ");
+        expect(
+          text.getAttributionSpansByFilter((a) => a is LinkAttribution),
+          {
+            AttributionSpan(
+              attribution: LinkAttribution.fromUri(Uri.parse("obsidian://open?vault=MyVault")),
+              start: 0,
+              end: 28,
             ),
           },
         );

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -1109,7 +1109,6 @@ void main() {
 
         // Ensure it's linkified with a URL schema.
         var text = SuperEditorInspector.findTextInComponent("1");
-        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.toPlainText(), "www.google.com ");
         expect(
@@ -1142,7 +1141,6 @@ void main() {
 
         // Ensure it's linkified with a URL schema.
         var text = SuperEditorInspector.findTextInComponent("1");
-        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.toPlainText(), "obsidian://open?vault=MyVault ");
         expect(
@@ -1258,7 +1256,6 @@ void main() {
 
         // Ensure it's linkified with a URL schema.
         var text = SuperEditorInspector.findTextInComponent("1");
-        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.toPlainText(), "Hello www.google.com world");
         expect(
@@ -1389,7 +1386,6 @@ void main() {
 
         // Ensure it's linkified with a URL schema.
         var text = SuperEditorInspector.findTextInComponent("1");
-        text = SuperEditorInspector.findTextInComponent("1");
 
         expect(text.toPlainText(), "me@gmail.com ");
         expect(


### PR DESCRIPTION
[Super Editor] - Make emails clickable with "mailto:", and linkify app URLs like "obsidian://" (Resolves #2426, Resolves #2427)

I added some nuance to how we store info in `LinkAttribution`. We now store a plain text version of a URI and (if provided) a structured `Uri` object.

The reason we need to support plain-text URIs is because content might come from existing documents, with invalid or incomplete URIs. Even a value like "google.com" can't be given a `Uri` with confidence. We'd have to assume the scheme. So sometimes the best we can do is plain text.

However, it's often possible to provide the scheme, e.g., "https://", "mailto:", "obsidian://". When possible, a structured `Uri` object should be provided to a `LinkAttribution`.

When we have a scheme, we have a launchable URI. When we don't have a scheme, we're forced to guess what the scheme should be. So by holding a `Uri` with a scheme, we know we have a launchable URI.

I added a property on `LinkAttribution` called `launchableUri`. This provides a "best guess" URI that can hopefully be launched. That property is now used by the tap handlers.

**Tests**
I added some relevant tests. 

I also altered a bunch of existing tests so that they try to match an attribution instead of trying to match `true` when looking for an attribution. When those tests fail, the message is just "Expected 'true' but got 'false'" which is very unhelpful when diagnosing what went wrong with the given attribution value.

I added a test variant to switch between URLs with a scheme vs no scheme, e.g., "https://google.com" vs "google.com". This distinction is now relevant, especially when altering an existing link.

**Demo**
I added a demo with a variety of URIs, which are inserted both as Markdown and as a paste operation.

<img width="989" alt="Screenshot 2025-01-06 at 9 44 37 PM" src="https://github.com/user-attachments/assets/53b6efd0-401f-481f-b47e-934f3df3d207" />
