### PR TITLE
[DemoApp] Fix editor not re-gaining focus when the app is brought to foreground (Resolves #2279)

### DIFF
--- a/super_editor/example/lib/demos/example_editor/example_editor.dart
+++ b/super_editor/example/lib/demos/example_editor/example_editor.dart
@@ -170,7 +170,16 @@ class _ExampleEditorState extends State<ExampleEditor> {
     // I tried explicitly unfocus()'ing the URL textfield
     // in the toolbar but it didn't return focus to the
     // editor. I'm not sure why.
-    _editorFocusNode.requestFocus();
+    //
+    // Only do that if the primary focus is not at the root focus scope because
+    // this might signify that the app is going to the background. Removing
+    // the focus from the root focus scope in that situation prevents the editor
+    // from re-gaining focus when the app is brought back to the foreground.
+    //
+    // See https://github.com/superlistapp/super_editor/issues/2279 for details.
+    if (FocusManager.instance.primaryFocus != FocusManager.instance.rootScope) {
+      _editorFocusNode.requestFocus();
+    }
   }
 
   DocumentGestureMode get _gestureMode {
@@ -252,7 +261,16 @@ class _ExampleEditorState extends State<ExampleEditor> {
     _imageFormatBarOverlayController.hide();
 
     // Ensure that focus returns to the editor.
-    _editorFocusNode.requestFocus();
+    //
+    // Only do that if the primary focus is not at the root focus scope because
+    // this might signify that the app is going to the background. Removing
+    // the focus from the root focus scope in that situation prevents the editor
+    // from re-gaining focus when the app is brought back to the foreground.
+    //
+    // See https://github.com/superlistapp/super_editor/issues/2279 for details.
+    if (FocusManager.instance.primaryFocus != FocusManager.instance.rootScope) {
+      _editorFocusNode.requestFocus();
+    }
   }
 
   @override

--- a/website/lib/homepage/featured_editor.dart
+++ b/website/lib/homepage/featured_editor.dart
@@ -91,7 +91,16 @@ class _FeaturedEditorState extends State<FeaturedEditor> {
     // I tried explicitly unfocus()'ing the URL textfield
     // in the toolbar but it didn't return focus to the
     // editor. I'm not sure why.
-    _editorFocusNode.requestFocus();
+    //
+    // Only do that if the primary focus is not at the root focus scope because
+    // this might signify that the app is going to the background. Removing
+    // the focus from the root focus scope in that situation prevents the editor
+    // from re-gaining focus when the app is brought back to the foreground.
+    //
+    // See https://github.com/superlistapp/super_editor/issues/2279 for details.
+    if (FocusManager.instance.primaryFocus != FocusManager.instance.rootScope) {
+      _editorFocusNode.requestFocus();
+    }
   }
 
   void _onDocumentChange(_) {


### PR DESCRIPTION
[DemoApp] Fix editor not re-gaining focus when the app is brought to foreground. Resolves #2279

There are some places where we request focus to the editor's focus node when the toolbar is closed. These code paths can be called in response to the app going to background. Doing this prevents the editor from re-gaining focus when the app is restored.

This PR changes these places to only request focus to the editor if the primary focus is not at the root  `FocusScopeNode` (which might signify that the app is going to background).