### PR TITLE
[Super Editor] - Fix KeyboardScaffoldSafeArea so that when there's only a single scope, that scope is used instead of MediaQuery (Resolves #2502)

### DIFF
--- a/super_editor/clones/quill/pubspec.lock
+++ b/super_editor/clones/quill/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: "../../../attributed_text"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -506,21 +506,21 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.3.0-dev.12"
+    version: "0.3.0-dev.13"
   super_editor_markdown:
     dependency: "direct main"
     description:
       path: "../../../super_editor_markdown"
       relative: true
     source: path
-    version: "0.1.6"
+    version: "0.1.7"
   super_editor_quill:
     dependency: "direct main"
     description:
       path: "../../../super_editor_quill"
       relative: true
     source: path
-    version: "0.1.0-dev.7"
+    version: "0.1.0-dev.8"
   super_keyboard:
     dependency: transitive
     description:
@@ -535,7 +535,7 @@ packages:
       path: "../../../super_text_layout"
       relative: true
     source: path
-    version: "0.1.17"
+    version: "0.1.18"
   term_glyph:
     dependency: transitive
     description:

--- a/super_editor/example_docs/pubspec.lock
+++ b/super_editor/example_docs/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.11.0"
   args:
     dependency: transitive
     description:
@@ -44,7 +44,7 @@ packages:
       path: "../../attributed_text"
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -167,6 +167,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.24"
+  flutter_test_runners:
+    dependency: transitive
+    description:
+      name: flutter_test_runners
+      sha256: cc575117ed66a79185a26995399d7048341517a1bd21188cb43753739627832d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -248,18 +256,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -296,10 +304,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   markdown:
     dependency: transitive
     description:
@@ -525,10 +533,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -551,21 +559,29 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0-dev.10"
+    version: "0.3.0-dev.13"
   super_editor_markdown:
     dependency: "direct overridden"
     description:
       path: "../../super_editor_markdown"
       relative: true
     source: path
-    version: "0.1.6"
+    version: "0.1.7"
+  super_keyboard:
+    dependency: transitive
+    description:
+      name: super_keyboard
+      sha256: c8e303cd7bc1fc62732213f0f2660273a078be23eae7a4219d0ab3dd0b0ccb9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   super_text_layout:
     dependency: "direct main"
     description:
       path: "../../super_text_layout"
       relative: true
     source: path
-    version: "0.1.15"
+    version: "0.1.18"
   term_glyph:
     dependency: transitive
     description:
@@ -690,10 +706,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:

--- a/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
@@ -1080,11 +1080,9 @@ class _KeyboardScaffoldSafeAreaState extends State<KeyboardScaffoldSafeArea> {
         // There's no ancestor KeyboardScaffoldSafeArea, but there might be an ancestor
         // KeyboardScaffoldSafeAreaScope, whose insets we should use.
         final inheritedGeometry = _ancestorSafeAreaScope?.geometry;
-        final keyboardSafeArea = inheritedGeometry ??
-            KeyboardSafeAreaGeometry(
-              bottomInsets: MediaQuery.viewInsetsOf(context).bottom,
-              bottomPadding: MediaQuery.paddingOf(context).bottom,
-            );
+
+        // Either use the ancestor geometry, or use our own.
+        final keyboardSafeArea = inheritedGeometry ?? KeyboardScaffoldSafeAreaScope.of(safeAreaContext).geometry;
 
         // Get the current keyboard safe area bottom insets, and then adjust that
         // value based on our global bottom y-value. When this widget appears at

--- a/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
+++ b/super_editor/test/infrastructure/keyboard_panel_scaffold_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('Keyboard panel scaffold >', () {
     group('phones >', () {
       testWidgetsOnMobilePhone('does not show toolbar upon initialization when IME is disconnected', (tester) async {
-        await _pumpTestAppWithTabs(tester);
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(tester);
 
         // Ensure the toolbar isn't visible.
         expect(find.byKey(_aboveKeyboardToolbarKey), findsNothing);
@@ -20,7 +20,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -41,7 +41,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -65,7 +65,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -90,7 +90,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -123,7 +123,7 @@ void main() {
           final softwareKeyboardController = SoftwareKeyboardController();
           final controller = KeyboardPanelController(softwareKeyboardController);
 
-          await _pumpTestAppWithTabs(
+          await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
             tester,
             controller: controller,
             softwareKeyboardController: softwareKeyboardController,
@@ -156,7 +156,7 @@ void main() {
       );
 
       testWidgetsOnMobilePhone('does not show keyboard panel upon keyboard appearance', (tester) async {
-        await _pumpTestAppWithTabs(tester);
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(tester);
 
         // Place the caret at the beginning of the document to show the software keyboard.
         await tester.placeCaretInParagraph('1', 0);
@@ -169,7 +169,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -190,7 +190,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -224,7 +224,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -262,7 +262,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -299,7 +299,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -331,7 +331,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -371,7 +371,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -396,7 +396,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -454,7 +454,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -479,7 +479,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -533,11 +533,40 @@ void main() {
     });
 
     group('safe area >', () {
-      testWidgetsOnMobilePhone('makes room for keyboard panel', (tester) async {
+      testWidgetsOnMobilePhone('makes room for keyboard panel (with single scope)', (tester) async {
+        final softwareKeyboardController = SoftwareKeyboardController();
+        final keyboardPanelController = KeyboardPanelController(softwareKeyboardController);
+        final imeConnectionNotifier = ValueNotifier<bool>(false);
+
+        await _pumpTestAppWithSingleSafeAreaScope(
+          tester,
+          softwareKeyboardController: softwareKeyboardController,
+          keyboardPanelController: keyboardPanelController,
+          isImeConnected: imeConnectionNotifier,
+        );
+
+        // Record the height of the content when no keyboard or panel is open.
+        final contentHeightWithNoKeyboard = tester.getSize(find.byKey(_chatPageKey)).height;
+
+        // Show the keyboard.
+        keyboardPanelController.showSoftwareKeyboard();
+        await tester.pumpAndSettle();
+
+        // Record the height of the content now that the keyboard is open.
+        final contentHeightWithKeyboardOpen = tester.getSize(find.byKey(_chatPageKey)).height;
+
+        // Ensure that the content is pushed up above the keyboard + toolbar.
+        expect(
+          contentHeightWithNoKeyboard - contentHeightWithKeyboardOpen,
+          _toolbarHeight + _expandedPhoneKeyboardHeight,
+        );
+      });
+
+      testWidgetsOnMobilePhone('makes room for keyboard panel (with multiple scopes)', (tester) async {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -562,7 +591,7 @@ void main() {
         final softwareKeyboardController = SoftwareKeyboardController();
         final controller = KeyboardPanelController(softwareKeyboardController);
 
-        await _pumpTestAppWithTabs(
+        await _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
           tester,
           controller: controller,
           softwareKeyboardController: softwareKeyboardController,
@@ -647,10 +676,13 @@ void main() {
 /// used to verify what happens when navigating from an open editor to another
 /// tab.
 ///
+/// The pumped widget tree includes multiple keyboard safe area scopes, which helps
+/// to stress test their communication with each other in the widget tree.
+///
 /// Simulates the software keyboard appearance and disappearance by animating
 /// the `MediaQuery` view insets when the app communicates with the IME to show/hide
 /// the software keyboard.
-Future<void> _pumpTestAppWithTabs(
+Future<void> _pumpTestAppWithTabsAndMultipleSafeAreaScopes(
   WidgetTester tester, {
   KeyboardPanelController? controller,
   SoftwareKeyboardController? softwareKeyboardController,
@@ -674,7 +706,7 @@ Future<void> _pumpTestAppWithTabs(
         simulatedKeyboardHeight: simulatedKeyboardHeight,
       )
       .withCustomWidgetTreeBuilder(
-        (superEditor) => _TestAppScaffold(
+        (superEditor) => _TestAppWithTabsAndMultipleSafeAreaScopes(
           superEditor: superEditor,
           keyboardPanelController: keyboardPanelController,
           imeConnectionNotifier: imeConnectionNotifier,
@@ -690,8 +722,8 @@ Future<void> _pumpTestAppWithTabs(
 ///   |-- Column
 ///     |-- App bar with tabs
 ///     |-- Page (chat page or profile page)
-class _TestAppScaffold extends StatelessWidget {
-  const _TestAppScaffold({
+class _TestAppWithTabsAndMultipleSafeAreaScopes extends StatelessWidget {
+  const _TestAppWithTabsAndMultipleSafeAreaScopes({
     required this.superEditor,
     required this.keyboardPanelController,
     required this.imeConnectionNotifier,
@@ -841,6 +873,123 @@ class _AccountPage extends StatelessWidget {
       color: Colors.grey.shade100,
       child: const Center(
         child: Icon(Icons.account_circle),
+      ),
+    );
+  }
+}
+
+/// Pumps a tree that displays a page of content with an editor above it, at the bottom
+/// of the screen.
+///
+/// The pumped tree only includes a single safe area scope, which ensures that apps with
+/// only a single safe area work as expected.
+///
+/// Simulates the software keyboard appearance and disappearance by animating
+/// the `MediaQuery` view insets when the app communicates with the IME to show/hide
+/// the software keyboard.
+Future<void> _pumpTestAppWithSingleSafeAreaScope(
+  WidgetTester tester, {
+  KeyboardPanelController? keyboardPanelController,
+  SoftwareKeyboardController? softwareKeyboardController,
+  ValueNotifier<bool>? isImeConnected,
+  double simulatedKeyboardHeight = _expandedPhoneKeyboardHeight,
+  // (Optional) widget that's positioned below the chat editor, which pushes
+  // the chat editor up from the bottom of the screen.
+  Widget? widgetBelowEditor,
+}) async {
+  final keyboardController = softwareKeyboardController ?? SoftwareKeyboardController();
+  final panelController = keyboardPanelController ?? KeyboardPanelController(keyboardController);
+  final imeConnectionNotifier = isImeConnected ?? ValueNotifier<bool>(false);
+
+  await tester //
+      .createDocument()
+      .withLongDoc()
+      .withSoftwareKeyboardController(keyboardController)
+      .withImeConnectionNotifier(imeConnectionNotifier)
+      .simulateSoftwareKeyboardInsets(
+        true,
+        simulatedKeyboardHeight: simulatedKeyboardHeight,
+      )
+      .withCustomWidgetTreeBuilder(
+        (superEditor) => _TestAppWithSingleSafeAreaScope(
+          superEditor: superEditor,
+          keyboardPanelController: panelController,
+          imeConnectionNotifier: imeConnectionNotifier,
+          widgetBelowEditor: widgetBelowEditor,
+        ),
+      )
+      .pump();
+}
+
+class _TestAppWithSingleSafeAreaScope extends StatelessWidget {
+  const _TestAppWithSingleSafeAreaScope({
+    required this.superEditor,
+    required this.keyboardPanelController,
+    required this.imeConnectionNotifier,
+    this.widgetBelowEditor,
+  });
+
+  final Widget superEditor;
+
+  final KeyboardPanelController keyboardPanelController;
+  final ValueNotifier<bool> imeConnectionNotifier;
+  final Widget? widgetBelowEditor;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: KeyboardScaffoldSafeArea(
+          // ^ This is the one and only safe area scope in this tree.
+          debugLabel: "Root",
+          child: Column(
+            children: [
+              Expanded(
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: Container(
+                        key: _chatPageKey,
+                        color: Colors.blue,
+                      ),
+                    ),
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      child: Builder(builder: (context) {
+                        return KeyboardPanelScaffold(
+                          controller: keyboardPanelController,
+                          isImeConnected: imeConnectionNotifier,
+                          contentBuilder: (context, isKeyboardPanelVisible) => ConstrainedBox(
+                            constraints: const BoxConstraints(maxHeight: 250),
+                            child: ColoredBox(
+                              color: Colors.yellow,
+                              child: superEditor,
+                            ),
+                          ),
+                          toolbarBuilder: (context, isKeyboardPanelVisible) => Container(
+                            key: _aboveKeyboardToolbarKey,
+                            height: 54,
+                            color: Colors.green,
+                          ),
+                          fallbackPanelHeight: _keyboardPanelHeight,
+                          keyboardPanelBuilder: (context, panel) => const SizedBox.expand(
+                            child: ColoredBox(
+                              key: _keyboardPanelKey,
+                              color: Colors.red,
+                            ),
+                          ),
+                        );
+                      }),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
[Super Editor] - Fix KeyboardScaffoldSafeArea so that when there's only a single scope, that scope is used instead of MediaQuery (Resolves #2502)

The `KeyboardScaffoldSafeArea` and `KeyboardScaffoldSafeAreaScope` talk to each other in the widget tree so that they respect their ancestors. However, I focused so much on that intercommunication that I screwed up the case of a single safe area scope. This PR fixes that issue by applying the safe area insets from the singular safe area scope, when there's no ancestor.