### PR TITLE
Export src/infrastructure/platforms/platform.dart

### DIFF
--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -83,7 +83,6 @@ export 'src/infrastructure/platforms/ios/magnifier.dart';
 export 'src/infrastructure/platforms/ios/selection_heuristics.dart';
 export 'src/infrastructure/platforms/mac/mac_ime.dart';
 export 'src/infrastructure/platforms/mobile_documents.dart';
-export 'src/infrastructure/platforms/platform.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';
 export 'src/infrastructure/signal_notifier.dart';
 export 'src/infrastructure/strings.dart';

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -83,6 +83,7 @@ export 'src/infrastructure/platforms/ios/magnifier.dart';
 export 'src/infrastructure/platforms/ios/selection_heuristics.dart';
 export 'src/infrastructure/platforms/mac/mac_ime.dart';
 export 'src/infrastructure/platforms/mobile_documents.dart';
+export 'src/infrastructure/platforms/platform.dart';
 export 'src/infrastructure/scrolling_diagnostics/scrolling_diagnostics.dart';
 export 'src/infrastructure/signal_notifier.dart';
 export 'src/infrastructure/strings.dart';

--- a/super_editor/lib/super_editor_test.dart
+++ b/super_editor/lib/super_editor_test.dart
@@ -1,5 +1,6 @@
 library super_editor_test;
 
+export 'src/infrastructure/platforms/platform.dart';
 export 'src/test/ime.dart';
 export 'src/test/super_editor_test/supereditor_inspector.dart';
 export 'src/test/super_editor_test/supereditor_robot.dart';


### PR DESCRIPTION
Exports `src/infrastructure/platforms/platform.dart` that it's possible to access `debugIsWebOverride` in tests.