### PR TITLE
[Attributed Text] - Fix: A few methods still (erroneously) using plain text length without accounting for placeholders (Resolves #2515)

### DIFF
--- a/attributed_text/lib/src/attributed_text.dart
+++ b/attributed_text/lib/src/attributed_text.dart
@@ -270,14 +270,14 @@ class AttributedText {
   /// Returns all spans in this [AttributedText] for the given [attributions].
   Set<AttributionSpan> getAttributionSpans(Set<Attribution> attributions) => getAttributionSpansInRange(
         attributionFilter: (a) => attributions.contains(a),
-        range: SpanRange(0, _text.length),
+        range: SpanRange(0, length),
       );
 
   /// Returns all spans in this [AttributedText], for attributions that are
   /// selected by the given [filter].
   Set<AttributionSpan> getAttributionSpansByFilter(AttributionFilter filter) => getAttributionSpansInRange(
         attributionFilter: filter,
-        range: SpanRange(0, _text.length),
+        range: SpanRange(0, length),
       );
 
   /// Returns spans for each attribution that (at least partially) appear
@@ -502,7 +502,7 @@ class AttributedText {
 
     return AttributedText(
       _text + other._text,
-      spans.copy()..addAt(other: other.spans, index: _text.length),
+      spans.copy()..addAt(other: other.spans, index: length),
       {
         ...placeholders,
         ...other.placeholders.map((offset, placeholder) => MapEntry(offset + length, placeholder)),
@@ -707,7 +707,7 @@ class AttributedText {
   ///
   /// Attribution groups are useful when computing all style variations for [AttributedText].
   Iterable<MultiAttributionSpan> computeAttributionSpans() {
-    return spans.collapseSpans(contentLength: _text.length);
+    return spans.collapseSpans(contentLength: length);
   }
 
   /// Returns a copy of this [AttributedText].

--- a/attributed_text/test/attributed_text_test.dart
+++ b/attributed_text/test/attributed_text_test.dart
@@ -21,7 +21,7 @@ void main() {
         applyAttributions: {ExpectedSpans.bold},
       );
 
-      expect(newText.text, 'aabcdefghij');
+      expect(newText.toPlainText(), 'aabcdefghij');
       expect(
         newText.hasAttributionsWithin(attributions: {ExpectedSpans.bold}, range: const SpanRange(0, 10)),
         true,
@@ -43,7 +43,7 @@ void main() {
         );
 
         final slice = text.copyTextInRange(const SpanRange(5, 9));
-        expect(slice.text, "that");
+        expect(slice.toPlainText(), "that");
         expect(slice.length, 4);
         expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), const SpanRange(0, 1));
         expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), const SpanRange(2, 3));
@@ -63,7 +63,7 @@ void main() {
         );
 
         final slice = text.copyText(5, 9);
-        expect(slice.text, "that");
+        expect(slice.toPlainText(), "that");
         expect(slice.length, 4);
         expect(slice.getAttributedRange({ExpectedSpans.bold}, 0), const SpanRange(0, 1));
         expect(slice.getAttributedRange({ExpectedSpans.italics}, 2), const SpanRange(2, 3));


### PR DESCRIPTION
[Attributed Text] - Fix: A few methods still (erroneously) using plain text length without accounting for placeholders (Resolves #2515)

Apparently I missed some uses of `_text.length` in `AttributedText` when I implemented placeholders. Except for special situations of internal accounting, we should never use `_text.length` anymore because it misses the placeholders.

I added a failing test for each effected method.