### PR TITLE
[SuperEditor][web] Fix double tap closing the IME connection on Safari/Firefox (Resolves #2513)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_mouse.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_mouse.dart
@@ -364,10 +364,10 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
     }
 
     _selectionType = SelectionType.word;
-    _clearSelection();
+    bool didSelectContent = false;
 
     if (docPosition != null) {
-      bool didSelectContent = _selectWordAt(
+      didSelectContent = _selectWordAt(
         docPosition: docPosition,
         docLayout: _docLayout,
       );
@@ -387,6 +387,15 @@ class _DocumentMouseInteractorState extends State<DocumentMouseInteractor> with 
         // user tapped.
         _selectPosition(docPosition);
       }
+    }
+
+    // Only clear the existing selection if we were not able to place a new selection,
+    // because clearing the selection might close the IME connection, depending
+    // on the `SuperEditorImePolicies` used. If we cleared the selection and then
+    // placed a new selection, the IME connection would be closed and then immediately
+    // reopened, and this doesn't seem to work on Safari and Firefox.
+    if (!didSelectContent) {
+      _clearSelection();
     }
 
     _focusNode.requestFocus();


### PR DESCRIPTION
[SuperEditor][web] Fix double tap closing the IME connection on Safari/Firefox. Resolves #2513

On Safari/Firefox, double tapping to select a word and then pressing backspace, delete, or any letter does nothing and stops the editor from responding to key presses.

I noticed this only happens when the selection is expanded by double tapping. When expanding by dragging, or pressing SHIFT + ARROW key it works correctly. What's happening is that we are closing the IME connection and then immediately reopening it, and it doesn't seem to work correctly on Safari/Firefox. This is the sequence of events:

- The user double taps
- We clear the existing selection
- Because the default value of `SuperEditorImePolicies.closeKeyboardOnSelectionLost` is `true`, we close the IME connection
- We place the new selection
- We try to open the IME selection again (which doesn't seem to work)

This PR modifies the double tap handler to only clear the existing selection if we weren't able to place a new selection. I tried with both Safari and Firefox and this seems to fix the issue.