### PR TITLE
[Spellcheck] - Upgrade super_editor dependency from 0.3.0-dev.3 to ^0.3.0-dev.15.

### DIFF
--- a/super_editor_spellcheck/pubspec.yaml
+++ b/super_editor_spellcheck/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 #  collection: ^1.18.0
 #  follow_the_leader: ^0.0.4+8
-  super_editor: 0.3.0-dev.3
+  super_editor: ^0.3.0-dev.3
   super_text_layout: ^0.1.12
 
 dependency_overrides:

--- a/super_editor_spellcheck/pubspec.yaml
+++ b/super_editor_spellcheck/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 #  collection: ^1.18.0
 #  follow_the_leader: ^0.0.4+8
-  super_editor: ^0.3.0-dev.3
+  super_editor: ^0.3.0-dev.15
   super_text_layout: ^0.1.12
 
 dependency_overrides:


### PR DESCRIPTION
[Spellcheck] - Upgrade `super_editor` dependency from 0.3.0-dev.3 to ^0.3.0-dev.15 to get access to new APIs that otherwise create a compilation error.
