### PR TITLE
[Spellcheck] - Check for spelling errors on initial document content (Resolves #2526)

### DIFF
--- a/super_editor_spellcheck/.run/main.dart.run.xml
+++ b/super_editor_spellcheck/.run/main.dart.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="main.dart" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/lib/main_super_editor_spellcheck.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/super_editor_spellcheck/example/lib/main_super_editor_spellcheck.dart
+++ b/super_editor_spellcheck/example/lib/main_super_editor_spellcheck.dart
@@ -85,7 +85,14 @@ class _SuperEditorSpellcheckScreenState extends State<_SuperEditorSpellcheckScre
     );
 
     _editor = createDefaultDocumentEditor(
-      document: MutableDocument.empty(),
+      document: MutableDocument(
+        // Start the document with some misspelled content to ensure pre-existing
+        // content is analyzed and styled.
+        nodes: [
+          ParagraphNode(id: "1", text: AttributedText("Tihs is mipelled")),
+          ParagraphNode(id: "2", text: AttributedText()),
+        ],
+      ),
       composer: MutableDocumentComposer(),
     );
 
@@ -104,8 +111,8 @@ class _SuperEditorSpellcheckScreenState extends State<_SuperEditorSpellcheckScre
       _editor.execute([
         InsertTextRequest(
           documentPosition: DocumentPosition(
-            nodeId: _editor.context.document.first.id,
-            nodePosition: _editor.context.document.first.beginningPosition,
+            nodeId: _editor.context.document.last.id,
+            nodePosition: _editor.context.document.last.beginningPosition,
           ),
           textToInsert:
               'Flutter is a populr framework developd by Google for buildng natively compilid applications for mobil, web, and desktop from a single code base. Its hot reload featur allows developers to see the changes they make in real-time without havng to restart the app, which can greatly sped up the development proccess. With a rich set of widgets and a customizble UI, Flutter makes it easy to creat beautiful and performant apps quickly.',

--- a/super_editor_spellcheck/example/pubspec.lock
+++ b/super_editor_spellcheck/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: attributed_text
-      sha256: "38e14c70958d5066ec79ca1a2c1e28abee8422dd257715de06fe3e90d46205ff"
+      sha256: d16c10850371421a778474ac24c24b4ab8708e3e53f3796f8d9ea2a41a25a59a
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -160,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.24"
+  flutter_test_runners:
+    dependency: transitive
+    description:
+      name: flutter_test_runners
+      sha256: cc575117ed66a79185a26995399d7048341517a1bd21188cb43753739627832d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -283,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -490,7 +498,7 @@ packages:
       path: "../../super_editor"
       relative: true
     source: path
-    version: "0.3.0-dev.9"
+    version: "0.3.0-dev.15"
   super_editor_spellcheck:
     dependency: "direct main"
     description:
@@ -498,14 +506,22 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  super_keyboard:
+    dependency: transitive
+    description:
+      name: super_keyboard
+      sha256: c8e303cd7bc1fc62732213f0f2660273a078be23eae7a4219d0ab3dd0b0ccb9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   super_text_layout:
     dependency: transitive
     description:
       name: super_text_layout
-      sha256: b99c2326fe56a21463c24a41c4fd3f30e38942a4a67524bc3069b2b052cdb6a2
+      sha256: e25f01ceb809118da66fd095b3dcdc608a611bf45e364f303e7f9f0af0c5f8d1
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.14"
+    version: "0.1.18"
   sync_http:
     dependency: transitive
     description:
@@ -558,10 +574,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   url_launcher_android:
     dependency: transitive
     description:
@@ -622,10 +638,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -691,5 +707,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -140,6 +140,10 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
 
     _reaction = SpellingAndGrammarReaction(_spellingErrorSuggestions, _styler);
     editor.reactionPipeline.add(_reaction);
+
+    // Do initial spelling and grammar analysis, in case the document already
+    // contains some content.
+    _reaction.analyzeWholeDocument(editor.context);
   }
 
   @override
@@ -266,6 +270,16 @@ class SpellingAndGrammarReaction implements EditReaction {
 
   final _mobileSpellChecker = DefaultSpellCheckService();
   final _macSpellChecker = SuperEditorSpellCheckerPlugin().macSpellChecker;
+
+  void analyzeWholeDocument(EditContext editorContext) {
+    for (final node in editorContext.document) {
+      if (node is! TextNode) {
+        continue;
+      }
+
+      _findSpellingAndGrammarErrors(node);
+    }
+  }
 
   @override
   void modifyContent(EditContext editorContext, RequestDispatcher requestDispatcher, List<EditEvent> changeList) {

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -271,6 +271,8 @@ class SpellingAndGrammarReaction implements EditReaction {
   final _mobileSpellChecker = DefaultSpellCheckService();
   final _macSpellChecker = SuperEditorSpellCheckerPlugin().macSpellChecker;
 
+  /// Checks every [TextNode] in the given document for spelling and grammar
+  /// errors and stores them for visual styling.
   void analyzeWholeDocument(EditContext editorContext) {
     for (final node in editorContext.document) {
       if (node is! TextNode) {


### PR DESCRIPTION
[Spellcheck] - Check for spelling errors on initial document content (Resolves #2526)

Editors can begin with non-empty Documents. In that case, we need to find spelling errors in the initial content. This PR does that.