### PR TITLE
[SuperReader] Add support for rendering tasks (Resolves #2354)

### DIFF
--- a/super_editor/example/lib/demos/demo_animated_task_height.dart
+++ b/super_editor/example/lib/demos/demo_animated_task_height.dart
@@ -133,7 +133,7 @@ class _AnimatedTaskComponentState extends State<_AnimatedTaskComponent>
               child: Checkbox(
                 value: widget.viewModel.isComplete,
                 onChanged: (newValue) {
-                  widget.viewModel.setComplete(newValue!);
+                  widget.viewModel.setComplete?.call(newValue!);
                 },
               ),
             ),

--- a/super_editor/example/lib/demos/super_reader/demo_super_reader.dart
+++ b/super_editor/example/lib/demos/super_reader/demo_super_reader.dart
@@ -134,6 +134,11 @@ class _SuperReaderDemoState extends State<SuperReaderDemo> {
         selection: _selection,
         overlayController: _overlayController,
         selectionLayerLinks: _selectionLayerLinks,
+        stylesheet: defaultStylesheet.copyWith(
+          addRulesAfter: [
+            taskStyles,
+          ],
+        ),
         androidToolbarBuilder: (_) => AndroidTextEditingFloatingToolbar(
           onCopyPressed: _copy,
           onSelectAllPressed: _selectAll,

--- a/super_editor/example/lib/demos/super_reader/example_document.dart
+++ b/super_editor/example/lib/demos/super_reader/example_document.dart
@@ -88,6 +88,38 @@ Document createInitialDocument() {
       ),
       ParagraphNode(
         id: Editor.createNodeId(),
+        text: AttributedText('Quickstart 🚀'),
+        metadata: {
+          'blockType': header2Attribution,
+        },
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
+        text: AttributedText('To get started with your own editing experience, take the following steps:'),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: true,
+        text: AttributedText(
+          'Create and configure your document, for example, by creating a new MutableDocument.',
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: false,
+        text: AttributedText(
+          "If you want programmatic control over the user's selection and styles, create a DocumentComposer.",
+        ),
+      ),
+      TaskNode(
+        id: Editor.createNodeId(),
+        isComplete: false,
+        text: AttributedText(
+          "Build a SuperEditor widget in your widget tree, configured with your Document and (optionally) your DocumentComposer.",
+        ),
+      ),
+      ParagraphNode(
+        id: Editor.createNodeId(),
         text: AttributedText(
           "We hope you enjoy using Super Editor. Let us know what you're building, and please file issues for any bugs that you find.",
         ),

--- a/super_editor/example_perf/lib/demos/rebuild_demo.dart
+++ b/super_editor/example_perf/lib/demos/rebuild_demo.dart
@@ -139,7 +139,7 @@ class _AnimatedTaskComponentState extends State<_AnimatedTaskComponent>
               child: Checkbox(
                 value: widget.viewModel.isComplete,
                 onChanged: (newValue) {
-                  widget.viewModel.setComplete(newValue!);
+                  widget.viewModel.setComplete?.call(newValue!);
                 },
               ),
             ),

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -201,6 +201,50 @@ class TaskComponentBuilder implements ComponentBuilder {
   }
 }
 
+/// Builds [TaskComponentViewModel]s and [TaskComponent]s for every
+/// [TaskNode] in a document.
+///
+/// A [TaskComponent] built by this builder is read-only, meaning that
+/// the user cannot toggle it.
+class ReadOnlyTaskComponentBuilder implements ComponentBuilder {
+  const ReadOnlyTaskComponentBuilder();
+
+  @override
+  TaskComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! TaskNode) {
+      return null;
+    }
+
+    final textDirection = getParagraphDirection(node.text.toPlainText());
+
+    return TaskComponentViewModel(
+      nodeId: node.id,
+      padding: EdgeInsets.zero,
+      indent: node.indent,
+      isComplete: node.isComplete,
+      setComplete: null,
+      text: node.text,
+      textDirection: textDirection,
+      textAlignment: textDirection == TextDirection.ltr ? TextAlign.left : TextAlign.right,
+      textStyleBuilder: noStyleBuilder,
+      selectionColor: const Color(0x00000000),
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! TaskComponentViewModel) {
+      return null;
+    }
+
+    return TaskComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}
+
 /// View model that configures the appearance of a [TaskComponent].
 ///
 /// View models move through various style phases, which fill out
@@ -245,7 +289,7 @@ class TaskComponentViewModel extends SingleColumnLayoutComponentViewModel with T
   TextBlockIndentCalculator indentCalculator;
 
   bool isComplete;
-  void Function(bool) setComplete;
+  void Function(bool)? setComplete;
 
   @override
   AttributedText text;
@@ -398,9 +442,11 @@ class _TaskComponentState extends State<TaskComponent> with ProxyDocumentCompone
             child: Checkbox(
               visualDensity: Theme.of(context).visualDensity,
               value: widget.viewModel.isComplete,
-              onChanged: (newValue) {
-                widget.viewModel.setComplete(newValue!);
-              },
+              onChanged: widget.viewModel.setComplete != null
+                  ? (newValue) {
+                      widget.viewModel.setComplete!(newValue!);
+                    }
+                  : null,
             ),
           ),
           Expanded(

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -13,6 +13,7 @@ import 'package:super_editor/src/default_editor/blocks/indentation.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -13,7 +13,6 @@ import 'package:super_editor/src/default_editor/blocks/indentation.dart';
 import 'package:super_editor/src/default_editor/multi_node_editing.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
 import 'package:super_editor/src/default_editor/text.dart';
-import 'package:super_editor/src/default_editor/text_tools.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
@@ -179,50 +178,6 @@ class TaskComponentBuilder implements ComponentBuilder {
           ),
         ]);
       },
-      text: node.text,
-      textDirection: textDirection,
-      textAlignment: textDirection == TextDirection.ltr ? TextAlign.left : TextAlign.right,
-      textStyleBuilder: noStyleBuilder,
-      selectionColor: const Color(0x00000000),
-    );
-  }
-
-  @override
-  Widget? createComponent(
-      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
-    if (componentViewModel is! TaskComponentViewModel) {
-      return null;
-    }
-
-    return TaskComponent(
-      key: componentContext.componentKey,
-      viewModel: componentViewModel,
-    );
-  }
-}
-
-/// Builds [TaskComponentViewModel]s and [TaskComponent]s for every
-/// [TaskNode] in a document.
-///
-/// A [TaskComponent] built by this builder is read-only, meaning that
-/// the user cannot toggle it.
-class ReadOnlyTaskComponentBuilder implements ComponentBuilder {
-  const ReadOnlyTaskComponentBuilder();
-
-  @override
-  TaskComponentViewModel? createViewModel(Document document, DocumentNode node) {
-    if (node is! TaskNode) {
-      return null;
-    }
-
-    final textDirection = getParagraphDirection(node.text.toPlainText());
-
-    return TaskComponentViewModel(
-      nodeId: node.id,
-      padding: EdgeInsets.zero,
-      indent: node.indent,
-      isComplete: node.isComplete,
-      setComplete: null,
       text: node.text,
       textDirection: textDirection,
       textAlignment: textDirection == TextDirection.ltr ? TextAlign.left : TextAlign.right,

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -20,6 +20,7 @@ import 'package:super_editor/src/default_editor/layout_single_column/_styler_shy
 import 'package:super_editor/src/default_editor/layout_single_column/_styler_user_selection.dart';
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/default_editor/unknown_component.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
@@ -745,6 +746,7 @@ final readOnlyDefaultComponentBuilders = <ComponentBuilder>[
   const ListItemComponentBuilder(),
   const ImageComponentBuilder(),
   const HorizontalRuleComponentBuilder(),
+  const ReadOnlyTaskComponentBuilder(),
 ];
 
 /// Stylesheet applied to all [SuperReader]s by default.

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -35,6 +35,7 @@ import 'package:super_editor/src/infrastructure/links.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/ios_document_controls.dart';
 import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/platform.dart';
+import 'package:super_editor/src/super_reader/tasks.dart';
 
 import '../infrastructure/platforms/mobile_documents.dart';
 import '../infrastructure/text_input.dart';

--- a/super_editor/lib/src/super_reader/tasks.dart
+++ b/super_editor/lib/src/super_reader/tasks.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/layout_single_column.dart';
+import 'package:super_editor/src/default_editor/tasks.dart';
+import 'package:super_editor/src/default_editor/text_tools.dart';
+
+/// Builds [TaskComponentViewModel]s and [TaskComponent]s for every
+/// [TaskNode] in a document.
+///
+/// A [TaskComponent] built by this builder is read-only, meaning that
+/// the user cannot toggle it.
+class ReadOnlyTaskComponentBuilder implements ComponentBuilder {
+  const ReadOnlyTaskComponentBuilder();
+
+  @override
+  TaskComponentViewModel? createViewModel(Document document, DocumentNode node) {
+    if (node is! TaskNode) {
+      return null;
+    }
+
+    final textDirection = getParagraphDirection(node.text.toPlainText());
+
+    return TaskComponentViewModel(
+      nodeId: node.id,
+      padding: EdgeInsets.zero,
+      indent: node.indent,
+      isComplete: node.isComplete,
+      setComplete: null,
+      text: node.text,
+      textDirection: textDirection,
+      textAlignment: textDirection == TextDirection.ltr ? TextAlign.left : TextAlign.right,
+      textStyleBuilder: noStyleBuilder,
+      selectionColor: const Color(0x00000000),
+    );
+  }
+
+  @override
+  Widget? createComponent(
+      SingleColumnDocumentComponentContext componentContext, SingleColumnLayoutComponentViewModel componentViewModel) {
+    if (componentViewModel is! TaskComponentViewModel) {
+      return null;
+    }
+
+    return TaskComponent(
+      key: componentContext.componentKey,
+      viewModel: componentViewModel,
+    );
+  }
+}

--- a/super_editor/test/super_reader/components/task_test.dart
+++ b/super_editor/test/super_reader/components/task_test.dart
@@ -6,8 +6,8 @@ import 'package:super_editor/super_editor.dart';
 import '../reader_test_tools.dart';
 
 void main() {
-  group('SuperReader tasks', () {
-    testWidgetsOnAllPlatforms("are rendered without explicit configuration", (tester) async {
+  group('SuperReader tasks >', () {
+    testWidgetsOnAllPlatforms("are displayed in a read-only document", (tester) async {
       await tester //
           .createDocument()
           .withCustomContent(

--- a/super_editor/test/super_reader/components/task_test.dart
+++ b/super_editor/test/super_reader/components/task_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/src/test/super_editor_test/tasks_test_tools.dart';
+import 'package:super_editor/super_editor.dart';
+
+import '../reader_test_tools.dart';
+
+void main() {
+  group('SuperReader tasks', () {
+    testWidgetsOnAllPlatforms("are rendered without explicit configuration", (tester) async {
+      await tester //
+          .createDocument()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                TaskNode(id: "1", text: AttributedText(), isComplete: false),
+                TaskNode(id: "2", text: AttributedText(), isComplete: true),
+              ],
+            ),
+          )
+          .pump();
+
+      // Ensure the default task component is rendered.
+      expect(find.byType(TaskComponent), findsNWidgets(2));
+    });
+
+    testWidgetsOnAllPlatforms("cannot be toggled by the user", (tester) async {
+      await tester //
+          .createDocument()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                TaskNode(id: '1', text: AttributedText(), isComplete: false),
+                TaskNode(id: '2', text: AttributedText(), isComplete: true),
+              ],
+            ),
+          )
+          .pump();
+
+      // Tap on the first task's checkbox.
+      await tester.tapOnCheckbox('1');
+
+      // Ensure that the task's checkbox didn't change from unchecked to checked.
+      expect(TaskInspector.isChecked('1'), isFalse);
+
+      // Tap on the second task's checkbox.
+      await tester.tapOnCheckbox('2');
+
+      // Ensure that the task's checkbox didn't change from checked to unchecked.
+      expect(TaskInspector.isChecked('1'), isFalse);
+    });
+  });
+}

--- a/super_editor/test/super_reader/reader_test_tools.dart
+++ b/super_editor/test/super_reader/reader_test_tools.dart
@@ -287,7 +287,7 @@ class TestDocumentConfigurator {
             stylesheet: _stylesheet,
             componentBuilders: [
               ..._addedComponents,
-              ...(_componentBuilders ?? defaultComponentBuilders),
+              ...(_componentBuilders ?? readOnlyDefaultComponentBuilders),
             ],
             scrollController: _scrollController,
             androidToolbarBuilder: _androidToolbarBuilder,


### PR DESCRIPTION
[SuperReader] Add support for rendering tasks (Resolves #2354)

Currently, render a read-only document that contains a task node results in the reader rendering an unknown component:

<img width="733" alt="Снимок экрана 2024-09-27 в 19 32 21" src="https://github.com/user-attachments/assets/61ac62ca-e750-49f3-8c3f-5d6ecf1a3176">

This PR adds support for rendering read-only tasks in `SuperReader`. 

I modified the `TaskComponentViewModel.setComplete` to be nullable, but I can changed it to add an additional `readOnly` property, if preferable.

https://github.com/user-attachments/assets/1694e5af-dd8f-46e2-a522-0bff6aec30db



