### PR TITLE
[SuperEditor] Fix crash with selected color strategy in an empty paragraph (Resolves #2253)

### DIFF
--- a/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_styler_user_selection.dart
@@ -134,20 +134,22 @@ class SingleColumnLayoutSelectionStyler extends SingleColumnLayoutStylePhase {
       if (viewModel is TextComponentViewModel) {
         final componentTextColor = viewModel.textStyleBuilder({}).color;
 
-        final textWithSelectionAttributions =
-            textSelection != null && _selectedTextColorStrategy != null && componentTextColor != null
-                ? (viewModel.text.copyText(0)
-                  ..addAttribution(
-                    ColorAttribution(_selectedTextColorStrategy!(
-                      originalTextColor: componentTextColor,
-                      selectionHighlightColor: _selectionStyles.selectionColor,
-                    )),
-                    SpanRange(textSelection.start, textSelection.end - 1),
-                    // The selected range might already have a color attribution. We want to override it
-                    // with the selected text color.
-                    overwriteConflictingSpans: true,
-                  ))
-                : viewModel.text;
+        final textWithSelectionAttributions = textSelection != null &&
+                !textSelection.isCollapsed &&
+                _selectedTextColorStrategy != null &&
+                componentTextColor != null
+            ? (viewModel.text.copyText(0)
+              ..addAttribution(
+                ColorAttribution(_selectedTextColorStrategy!(
+                  originalTextColor: componentTextColor,
+                  selectionHighlightColor: _selectionStyles.selectionColor,
+                )),
+                SpanRange(textSelection.start, textSelection.end - 1),
+                // The selected range might already have a color attribution. We want to override it
+                // with the selected text color.
+                overwriteConflictingSpans: true,
+              ))
+            : viewModel.text;
 
         viewModel
           ..text = textWithSelectionAttributions

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -84,6 +84,27 @@ void main() {
         expect(richText.getSpanForPosition(const TextPosition(offset: 5))!.style!.color, Colors.green);
         expect(richText.getSpanForPosition(const TextPosition(offset: 16))!.style!.color, Colors.green);
       });
+
+      testWidgetsOnAllPlatforms("does not crash when placing the selection on an empty paragraph", (tester) async {
+        // This test is to ensure that the selection color strategy doesn't crash when the paragraph is empty.
+        // See https://github.com/superlistapp/super_editor/issues/2253 for more context.
+        final stylesheet = defaultStylesheet.copyWith(
+          selectedTextColorStrategy: ({required Color originalTextColor, required Color selectionHighlightColor}) {
+            return Colors.white;
+          },
+        );
+
+        await tester //
+            .createDocument()
+            .withSingleEmptyParagraph()
+            .useStylesheet(stylesheet)
+            .pump();
+
+        // Tripple tap on the empty paragraph.
+        await tester.tripleTapInParagraph("1", 0);
+
+        // Reaching this point means the editor didn't crash.
+      });
     });
 
     testWidgetsOnArbitraryDesktop("calculates upstream document selection within a single node", (tester) async {

--- a/super_editor/test/super_editor/supereditor_selection_test.dart
+++ b/super_editor/test/super_editor/supereditor_selection_test.dart
@@ -85,7 +85,7 @@ void main() {
         expect(richText.getSpanForPosition(const TextPosition(offset: 16))!.style!.color, Colors.green);
       });
 
-      testWidgetsOnAllPlatforms("does not crash when placing the selection on an empty paragraph", (tester) async {
+      testWidgetsOnAllPlatforms("does not crash when triple tapping on an empty paragraph", (tester) async {
         // This test is to ensure that the selection color strategy doesn't crash when the paragraph is empty.
         // See https://github.com/superlistapp/super_editor/issues/2253 for more context.
         final stylesheet = defaultStylesheet.copyWith(


### PR DESCRIPTION
[SuperEditor] Fix crash with selected color strategy in an empty paragraph (Resolves #2253)

When the editor has a `selectedTextColorStrategy` configured, triple tapping on an empty paragraph crashes the editor with the following exception:

```console
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: 'package:attributed_text/src/span_range.dart': Failed assertion: line 20 pos 16: 'end >= -1': is not true.
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:63:4)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:45:5)
#2      new SpanRange (package:attributed_text/src/span_range.dart:20:16)
#3      SingleColumnLayoutSelectionStyler._applySelection (package:super_editor/src/default_editor/layout_single_column/_styler_user_selection.dart:147:17)
#4      SingleColumnLayoutSelectionStyler.style (package:super_editor/src/default_editor/layout_single_column/_styler_user_selection.dart:79:11)
#5      SingleColumnLayoutPresenter._createNewViewModel (package:super_editor/src/default_editor/layout_single_column/_presenter.dart:189:35)
#6      SingleColumnLayoutPresenter.updateViewModel (package:super_editor/src/default_editor/layout_single_column/_presenter.dart:148:18)
#7      _SingleColumnDocumentLayoutState._onPresenterMarkedDirty (package:super_editor/src/default_editor/layout_single_column/_layout.dart:115:22)
#8      SingleColumnLayoutPresenterChangeListener.onPresenterMarkedDirty (package:super_editor/src/default_editor/layout_single_column/_presenter.dart:338:30)
#9      SingleColumnLayoutPresenter._assemblePipeline.<anonymous closure> (package:super_editor/src/default_editor/layout_single_column/_presenter.dart:125:22)
#10     SingleColumnLayoutStylePhase.markDirty (package:super_editor/src/default_editor/layout_single_column/_presenter.dart:407:21)
#11     ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:439:24)
#12     ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:564:5)
#13     PausableValueNotifier.resumeNotifications (package:super_editor/src/infrastructure/pausable_value_notifier.dart:49:11)
#14     MutableDocumentComposer.onTransactionEnd (package:super_editor/src/core/document_composer.dart:155:24)
#15     Editor._onTransactionEnd (package:super_editor/src/core/editor.dart:331:16)
#16     Editor.endTransaction (package:super_editor/src/core/editor.dart:231:5)
#17     Editor.execute (package:super_editor/src/core/editor.dart:283:7)
#18     _DocumentMouseInteractorState._selectParagraphAt (package:super_editor/src/default_editor/document_gestures_mouse.dart:499:21)
#19     _DocumentMouseInteractorState._onTripleTapDown (package:super_editor/src/default_editor/document_gestures_mouse.dart:479:34)
#20     TapSequenceGestureRecognizer.addAllowedPointer.<anonymous closure> (package:super_editor/src/infrastructure/multi_tap_gesture.dart:105:71)
#21     GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:357:24)
#22     TapSequenceGestureRecognizer.addAllowedPointer (package:super_editor/src/infrastructure/multi_tap_gesture.dart:105:9)
#23     GestureRecognizer.addPointer (package:flutter/src/gestures/recognizer.dart:254:7)
#24     RawGestureDetectorState._handlePointerDown (package:flutter/src/widgets/gesture_detector.dart:1550:18)
#25     RenderPointerListener.handleEvent (package:flutter/src/rendering/proxy_box.dart:3095:44)
#26     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:499:22)
#27     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:460:11)
#28     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:437:7)
#29     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:394:5)
#30     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:341:7)
#31     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:308:9)
#32     _invoke1 (dart:ui/hooks.dart:332:13)
#33     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:451:7)
#34     _dispatchPointerDataPacket (dart:ui/hooks.dart:267:31)
```

This PR fixes this issue by checking if the selection is not collapsed before trying to apply the attributions.