### PR TITLE
[Infrastructure] Add test platform suffixed by default (Resolves #2274)

### DIFF
--- a/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_swipe_to_pop_test.dart
@@ -9,8 +9,7 @@ import '../supereditor_test_tools.dart';
 
 void main() {
   group('SuperEditor', () {
-    testWidgetsOnIos('keeps current selection and does not show mobile controls when swipping to pop (on iOS)',
-        (tester) async {
+    testWidgetsOnIos('keeps current selection and does not show mobile controls when swipping to pop', (tester) async {
       // Run the test with a fixed size so we know how much we need to swipe
       // to pop the page.
       tester.view

--- a/super_editor/test/super_editor/supereditor_content_insertion_test.dart
+++ b/super_editor/test/super_editor/supereditor_content_insertion_test.dart
@@ -491,8 +491,7 @@ Second paragraph"""). //
         );
       });
 
-      testWidgetsOnAndroid(
-          'when the user presses the newline button on the software keyboard at the end of an image (on Android)',
+      testWidgetsOnAndroid('when the user presses the newline button on the software keyboard at the end of an image',
           (tester) async {
         final testContext = await tester
             .createDocument()

--- a/super_editor/test/super_editor/supereditor_gestures_test.dart
+++ b/super_editor/test/super_editor/supereditor_gestures_test.dart
@@ -458,7 +458,7 @@ spans multiple lines.''',
       );
     });
 
-    testWidgetsOnAndroid('configures default gesture mode (on Android)', (tester) async {
+    testWidgetsOnAndroid('configures default gesture mode', (tester) async {
       await tester //
           .createDocument()
           .withSingleParagraph()

--- a/super_editor/test/super_editor/supereditor_scrolling_test.dart
+++ b/super_editor/test/super_editor/supereditor_scrolling_test.dart
@@ -292,7 +292,7 @@ void main() {
       );
     });
 
-    testWidgetsOnAndroid("auto-scrolls to caret position when dragging the spacebar (on Android)", (tester) async {
+    testWidgetsOnAndroid("auto-scrolls to caret position when dragging the spacebar", (tester) async {
       // Pump an editor with a size that will cause it to be scrollable.
       const windowSize = Size(800, 400);
       tester.view.physicalSize = windowSize;

--- a/super_editor/test/super_editor/text_entry/links_test.dart
+++ b/super_editor/test/super_editor/text_entry/links_test.dart
@@ -155,8 +155,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the end of a paragraph (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the end of a paragraph',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -207,8 +206,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the middle of a paragraph (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the middle of a paragraph',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -261,7 +259,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a paragraph (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a paragraph',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -313,8 +311,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ParagraphNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnIos(
-          'when pressing the newline button on the software keyboard at the middle of a paragraph (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a paragraph',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -470,8 +467,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ListItemNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the end of a list item (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the end of a list item',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -524,8 +520,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ListItemNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the middle of a list item (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the middle of a list item',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -578,7 +573,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ListItemNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a list item (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a list item',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -632,8 +627,7 @@ void main() {
         expect((textContext.document.getNodeAt(1)! as ListItemNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnIos(
-          'when pressing the newline button on the software keyboard at the middle of a list item (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a list item',
           (tester) async {
         final textContext = await tester //
             .createDocument()
@@ -815,8 +809,7 @@ void main() {
         expect((document.getNodeAt(1)! as TaskNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the end of a task (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the end of a task',
           (tester) async {
         final document = MutableDocument(
           nodes: [
@@ -882,8 +875,7 @@ void main() {
         expect((document.getNodeAt(1)! as TaskNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnAndroid(
-          'when pressing the newline button on the software keyboard at the middle of a task (on Android)',
+      testWidgetsOnAndroid('when pressing the newline button on the software keyboard at the middle of a task',
           (tester) async {
         final document = MutableDocument(
           nodes: [
@@ -949,7 +941,7 @@ void main() {
         expect((document.getNodeAt(1)! as TaskNode).text.toPlainText(), "after link");
       });
 
-      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a task (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the end of a task',
           (tester) async {
         final document = MutableDocument(
           nodes: [
@@ -1016,7 +1008,7 @@ void main() {
         expect((document.getNodeAt(1)! as TaskNode).text.toPlainText(), "");
       });
 
-      testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a task (on iOS)',
+      testWidgetsOnIos('when pressing the newline button on the software keyboard at the middle of a task',
           (tester) async {
         final document = MutableDocument(
           nodes: [

--- a/super_editor/test/super_textfield/super_textfield_emoji_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_emoji_test.dart
@@ -445,7 +445,7 @@ void main() {
         );
       });
 
-      testWidgetsOnAndroid('deletes emojis with BACKSPACE (on Android)', (tester) async {
+      testWidgetsOnAndroid('deletes emojis with BACKSPACE', (tester) async {
         await _pumpSuperTextFieldEmojiTest(
           tester,
           configuration: SuperTextFieldPlatformConfiguration.android,

--- a/super_editor/test/super_textfield/super_textfield_ime_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_ime_test.dart
@@ -291,7 +291,7 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 9));
         });
 
-        testWidgetsOnMac('when NUMPAD ENTER is pressed in middle of text (on MAC)', (tester) async {
+        testWidgetsOnMac('when NUMPAD ENTER is pressed in middle of tex', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
@@ -322,7 +322,7 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 1));
         });
 
-        testWidgetsOnMac('when NUMPAD ENTER is pressed at beginning of text (on MAC)', (tester) async {
+        testWidgetsOnMac('when NUMPAD ENTER is pressed at beginning of text', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
@@ -353,7 +353,7 @@ void main() {
           expect(SuperTextFieldInspector.findSelection(), const TextSelection.collapsed(offset: 18));
         });
 
-        testWidgetsOnMac('when NUMPAD ENTER is pressed at end of text (on MAC)', (tester) async {
+        testWidgetsOnMac('when NUMPAD ENTER is pressed at end of text', (tester) async {
           await _pumpSuperTextField(
             tester,
             AttributedTextEditingController(
@@ -812,8 +812,7 @@ void main() {
   });
 
   group('SuperTextField on some bad Android software keyboards', () {
-    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a collapsed selection (on Android)',
-        (tester) async {
+    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a collapsed selection', (tester) async {
       final controller = AttributedTextEditingController(
         text: AttributedText('This is a text'),
       );
@@ -835,8 +834,7 @@ void main() {
       expect(controller.text.toPlainText(), 'Thi is a text');
     });
 
-    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a expanded selection (on Android)',
-        (tester) async {
+    testWidgetsOnAndroid('handles BACKSPACE key event instead of deletion for a expanded selection', (tester) async {
       final controller = AttributedTextEditingController(
         text: AttributedText('This is a text'),
       );

--- a/super_editor/test/super_textfield/super_textfield_theme_test.dart
+++ b/super_editor/test/super_textfield/super_textfield_theme_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(popoverBrightness, Brightness.light);
     });
 
-    testWidgetsOnAndroid('applies app theme to the popover toolbar (on Android)', (tester) async {
+    testWidgetsOnAndroid('applies app theme to the popover toolbar', (tester) async {
       final controller = ImeAttributedTextEditingController(
         controller: AttributedTextEditingController(
           text: AttributedText('A single line textfield'),

--- a/super_editor/test/test_runners.dart
+++ b/super_editor/test/test_runners.dart
@@ -38,9 +38,9 @@ void testWidgetsOnWebDesktop(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgetsOnMacWeb("$description (on MAC Web)", test, skip: skip, variant: variant);
-  testWidgetsOnWindowsWeb("$description (on Windows Web)", test, skip: skip, variant: variant);
-  testWidgetsOnLinuxWeb("$description (on Linux Web)", test, skip: skip, variant: variant);
+  testWidgetsOnMacWeb(description, test, skip: skip, variant: variant);
+  testWidgetsOnWindowsWeb(description, test, skip: skip, variant: variant);
+  testWidgetsOnLinuxWeb(description, test, skip: skip, variant: variant);
 }
 
 /// A widget test that runs a variant for every mobile platform on web, e.g.,
@@ -52,8 +52,8 @@ void testWidgetsOnWebMobile(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgetsOnWebIos("$description (on iOS Web)", test, skip: skip, variant: variant);
-  testWidgetsOnWebAndroid("$description (on Android Web)", test, skip: skip, variant: variant);
+  testWidgetsOnWebIos(description, test, skip: skip, variant: variant);
+  testWidgetsOnWebAndroid(description, test, skip: skip, variant: variant);
 }
 
 @isTestGroup
@@ -63,8 +63,8 @@ void testWidgetsOnMacDesktopAndWeb(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgetsOnMac("$description (on MAC)", test, skip: skip, variant: variant);
-  testWidgetsOnMacWeb("$description (on MAC Web)", test, skip: skip, variant: variant);
+  testWidgetsOnMac(description, test, skip: skip, variant: variant);
+  testWidgetsOnMacWeb(description, test, skip: skip, variant: variant);
 }
 
 @isTestGroup
@@ -74,7 +74,7 @@ void testWidgetsOnMacWeb(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgets(description, (tester) async {
+  testWidgets("$description (on MAC Web)", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
     debugIsWebOverride = WebPlatformOverride.web;
 
@@ -121,7 +121,7 @@ void testWidgetsOnWebIos(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgets(description, (tester) async {
+  testWidgets("$description (on iOS Web)", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     debugIsWebOverride = WebPlatformOverride.web;
 
@@ -152,7 +152,7 @@ void testWidgetsOnWebAndroid(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgets(description, (tester) async {
+  testWidgets("$description (on Android Web)", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
     debugIsWebOverride = WebPlatformOverride.web;
 
@@ -172,7 +172,7 @@ void testWidgetsOnWindowsWeb(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgets(description, (tester) async {
+  testWidgets("$description (on Windows Web)", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
     debugIsWebOverride = WebPlatformOverride.web;
 
@@ -196,7 +196,7 @@ void testWidgetsOnLinuxWeb(
   bool skip = false,
   TestVariant<Object?> variant = const DefaultTestVariant(),
 }) {
-  testWidgets(description, (tester) async {
+  testWidgets("$description (on Linux Web)", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.linux;
     debugIsWebOverride = WebPlatformOverride.web;
 


### PR DESCRIPTION
[Infrastructure] Add test platform suffixed by default (Resolves #2274)

In some of the tests that are specific to a single platform, we are adding the platform suffixes manually. For example: `testWidgetsOnAndroid("test something", (tester) async{});`

We already made the change to include the platform suffix to the test methods from the `flutter_test_runners` package a while ago (https://github.com/Flutter-Bounty-Hunters/testing/pull/1), but we did not release a new version since, so we should release a new version.

This PR removes the manually added suffixes and also modify some test runners declared directly in this repo.