### PR TITLE
[SuperEditor][Android] Fix toolbar being hidden when releasing a long press (Resolves #2481)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -430,6 +430,7 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
     required this.selection,
     this.openKeyboardWhenTappingExistingSelection = true,
     required this.openSoftwareKeyboard,
+    required this.isImeConnected,
     required this.scrollController,
     required this.fillViewport,
     this.contentTapHandlers,
@@ -451,6 +452,10 @@ class AndroidDocumentTouchInteractor extends StatefulWidget {
 
   /// A callback that should open the software keyboard when invoked.
   final VoidCallback openSoftwareKeyboard;
+
+  /// A [ValueListenable] that should notify this widget when the IME connects
+  /// and disconnects.
+  final ValueListenable<bool> isImeConnected;
 
   /// Optional list of handlers that respond to taps on content, e.g., opening
   /// a link when the user taps on text with a link attribution.
@@ -671,6 +676,9 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   }
 
   void _onDocumentChange(_) {
+    // The user might start typing when the toolbar is visible. Hide it.
+    _controlsController!.hideToolbar();
+
     onNextFrame((_) {
       _ensureSelectionExtentIsVisible();
     });
@@ -751,7 +759,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
     if (_isLongPressInProgress) {
       _longPressStrategy = null;
       _magnifierGlobalOffset.value = null;
-      _showAndHideEditingControlsAfterTapSelection(didTapOnExistingSelection: false);
+      _onLongPressEnd();
       return;
     }
 
@@ -985,7 +993,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
         ..hideMagnifier()
         ..blinkCaret();
 
-      if (didTapOnExistingSelection && _isKeyboardOpen) {
+      if (didTapOnExistingSelection && widget.isImeConnected.value) {
         // Toggle the toolbar display when the user taps on the collapsed caret,
         // or on top of an existing selection.
         //
@@ -998,16 +1006,6 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
         _controlsController!.hideToolbar();
       }
     }
-  }
-
-  /// Returns `true` if we *think* the software keyboard is currently open, or
-  /// `false` otherwise.
-  ///
-  /// We say "think" because Flutter doesn't report this info to us. Instead, we
-  /// inspect the bottom insets on the window, and we assume any insets greater than
-  /// zero means a keyboard is visible.
-  bool get _isKeyboardOpen {
-    return MediaQuery.viewInsetsOf(context).bottom > 0;
   }
 
   void _onPanStart(DragStartDetails details) {
@@ -1168,7 +1166,7 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
   }
 
   void _onLongPressEnd() {
-    _longPressStrategy!.onLongPressEnd();
+    _longPressStrategy?.onLongPressEnd();
 
     // Cancel any on-going long-press.
     _longPressStrategy = null;
@@ -1178,10 +1176,12 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     _controlsController!.hideMagnifier();
     if (!widget.selection.value!.isCollapsed) {
-      _controlsController!
-        ..showExpandedHandles()
-        ..showToolbar();
+      _controlsController!.showExpandedHandles();
     }
+
+    // Show the toolbar even the selection is collapsed, because the user might
+    // be long-pressing on an empty paragraph or on a whitespace.
+    _controlsController!.showToolbar();
   }
 
   void _onCaretDragEnd() {

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -899,6 +899,7 @@ class SuperEditorState extends State<SuperEditor> {
           selection: editContext.composer.selectionNotifier,
           openKeyboardWhenTappingExistingSelection: widget.selectionPolicies.openKeyboardWhenTappingExistingSelection,
           openSoftwareKeyboard: _openSoftwareKeyboard,
+          isImeConnected: _isImeConnected,
           contentTapHandlers: [
             ..._contentTapHandlers ?? [],
             for (final plugin in widget.plugins) //

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -168,6 +168,36 @@ void main() {
       expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
     });
 
+    testWidgetsOnAndroid("shows toolbar when long pressing on an empty paragraph and hides it after typing",
+        (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+
+      // Ensure the toolbar is not visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Long press to show the toolbar.
+      final gesture = await tester.longPressDownInParagraph('1', 0);
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Release the finger.
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Ensure the toolbar is still visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Type a character to hide the toolbar.
+      await tester.typeImeText('a');
+
+      // Ensure the toolbar is not visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
     testWidgetsOnAndroid("shows magnifier when dragging expanded handle", (tester) async {
       await _pumpSingleParagraphApp(tester);
 

--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -132,6 +132,36 @@ void main() {
       expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
     });
 
+    testWidgetsOnIos("shows toolbar when long pressing on an empty paragraph and hides it after typing",
+        (tester) async {
+      await tester //
+          .createDocument()
+          .withSingleEmptyParagraph()
+          .pump();
+
+      // Ensure the toolbar is not visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Long press, this shouldn't show the toolbar.
+      final gesture = await tester.longPressDownInParagraph('1', 0);
+
+      // Ensure the toolbar is not visible yet.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+
+      // Release the finger.
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Ensure the toolbar is visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
+
+      // Type a character to hide the toolbar.
+      await tester.typeImeText('a');
+
+      // Ensure the toolbar is not visible.
+      expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
+    });
+
     testWidgetsOnIos("does not show toolbar upon first tap", (tester) async {
       await tester //
           .createDocument()


### PR DESCRIPTION
[SuperEditor][Android] Fix toolbar being hidden when releasing a long press (Resolves #2481).

On Android, long pressing and releasing the gesture on an empty paragraph, or on a whitespace, is closing the toolbar:

[before.webm](https://github.com/user-attachments/assets/b7e869cd-d778-4a5b-9384-863986cbdd1b)

This is caused because we are calling the same method that updates the overlay controls when the user just performs a single tap. That method hides the toolbar when the selection is collapsed.

This PR changes the tap up handling to call `_onLongPressEnd` if the user was performing a long press, and modify this method to show the toolbar. We also need to hide the toolbar when the document changes, so it hides after the user starts typing. This will be a breaking change if an app performs some document change when interacting the toolbar and expects it to remain open. However, we already do that on iOS, so it might not be a problem.

Also, this PR makes a change, that we already made in iOS, to avoid checking if the keyboard is open by looking for bottom inserts, because that is unreliable. Instead, we are now checking for an IME connection. This doesn't guarantee that the keyboard is visible,  but we don't have an ideal alternative yet.

[after.webm](https://github.com/user-attachments/assets/9675352f-529e-4a87-a9b9-435d9384251b)

On iOS, this seems to be already working as expected, so this PR adds a test for it.