### PR TITLE
[SuperEditor] Make iOS overlay controls test use iOS selection heuristics (Resolves #2470)

### DIFF
--- a/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart
@@ -26,15 +26,16 @@ void main() {
     testWidgetsOnIos("shows toolbar when tapping on caret", (tester) async {
       await _pumpSingleParagraphApp(tester);
 
-      // Place the caret.
-      await tester.tapInParagraph("1", 200);
+      // Place the caret at the end of a word, because iOS snaps the caret
+      // to word boundaries by default.
+      await tester.tapInParagraph("1", 207);
 
       // Ensure all controls are hidden.
       expect(SuperEditorInspector.isMobileMagnifierVisible(), isFalse);
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);
 
       // Tap again on the caret.
-      await tester.tapInParagraph("1", 200);
+      await tester.tapInParagraph("1", 207);
 
       // Ensure that the toolbar is visible.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
@@ -218,7 +219,7 @@ void main() {
     });
 
     testWidgetsOnIos("keeps current selection when tapping on caret", (tester) async {
-      await _pumpSingleParagraphApp(tester, useIosSelectionHeuristics: true);
+      await _pumpSingleParagraphApp(tester);
 
       // Tap at "consectetur|" to place the caret.
       await tester.tapInParagraph("1", 39);
@@ -373,15 +374,12 @@ void main() {
   });
 }
 
-Future<void> _pumpSingleParagraphApp(
-  WidgetTester tester, {
-  bool useIosSelectionHeuristics = false,
-}) async {
+Future<void> _pumpSingleParagraphApp(WidgetTester tester) async {
   await tester
       .createDocument()
       // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor...
       .withSingleParagraph()
       .simulateSoftwareKeyboardInsets(true)
-      .useIosSelectionHeuristics(useIosSelectionHeuristics)
+      .useIosSelectionHeuristics(true)
       .pump();
 }


### PR DESCRIPTION
[SuperEditor] Make iOS overlay controls test use iOS selection heuristics (Resolves #2470)

iOS has a specific behavior for placing the caret by tapping: it always places the caret at word boundaries. In `SuperEditor`, we call this behavior "iOS selection heuristics". This heuristics are enabled by default on `SuperEditor`, but disabled by default in tests. They are disable because, on most cases, we just want to place the caret at a specific position. 

While the heuristics being disabled makes sense for some tests, tests that care about interacting with the caret should use these heuristics. One example is https://github.com/superlistapp/super_editor/issues/2152, where we have a test to make sure the toolbar is displayed when tapping on the caret, but the test didn't catch the bug because it wasn't using the selection heuristics.

Although we could modify the tests to always use these heuristics by default, this will cause a lot of failures in tests that want to place the caret at an exact position. I modified the tests to enable it by default and 46 tests failed. This is the complete list:

```
SuperEditor > iOS > overlay controls > shows toolbar when tapping on caret
IME input types characters in the middle of existing text (on iOS)
Super Editor keyboard actions movement > Mac and iOS > jumps to end of word with ALT + RIGHT ARROW
SuperEditor action tags > composing > can start between words (on iOS)
SuperEditor action tags > composing > cancels when downstream selection collapses outside of tag (on iOS)
SuperEditor action tags > composing > does not continue when user expands the selection downstream (on iOS)
SuperEditor action tags > composing > does not re-apply a canceled tag (on iOS)
SuperEditor applies attributions when selecting by tapping and typing at the middle of the attributed text (on iOS)
SuperEditor gestures places the caret at the end of a wrapped line when tapping there (on iOS)
SuperEditor keyboard on any desktop moves caret to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed (IME)
SuperEditor keyboard on any desktop moves caret to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed (keyboard)
SuperEditor keyboard on any desktop moves caret to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed (IME)
SuperEditor keyboard on any desktop moves caret to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed (keyboard)
SuperEditor keyboard on any desktop moves caret to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed (IME)
SuperEditor keyboard on any desktop moves caret to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed (keyboard)
SuperEditor keyboard on any desktop moves caret to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed (IME)
SuperEditor keyboard on any desktop moves caret to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed (keyboard)
SuperEditor keyboard on any desktop moves caret to end of word when ALT + RIGHT_ARROW is pressed (IME)
SuperEditor keyboard on any desktop moves caret to end of word when ALT + RIGHT_ARROW is pressed (keyboard)
SuperEditor link editing > can insert characters in the middle of a link removing the attribution (on iOS)
SuperEditor link editing > can insert characters in the middle of a link updating the attribution (on iOS)
SuperEditor link editing > can insert characters in the middle of a link updating the attribution (on iOS) (variant: https://)
SuperEditor link editing > can insert characters in the middle of a link without updating the attribution (on iOS)
SuperEditor pattern tags > caret placement > doesn't prevent user from tapping to place caret in tag (on iOS)
SuperEditor pattern tags > caret placement > pushes expanding downstream selection into the tag (on iOS)
SuperEditor pattern tags > caret placement > pushes expanding upstream selection into the tag (on iOS)
SuperEditor pattern tags > composing > can start between words (on iOS)
SuperEditor pattern tags > composing > shrinks to wherever a period is added (on iOS)
SuperEditor pattern tags > editing > user can delete pieces of tags (on iOS)
SuperEditor phone rotation on iOS from landscape to portrait updates caret position
SuperEditor phone rotation on iOS from portrait to landscape updates caret position
SuperEditor robot taps to place caret at a non-linebreak offset with different affinities (on iOS)
SuperEditor selection places caret at the previous selection when re-focusing by next (on iOS)
SuperEditor selection places caret at the previous selection when re-focusing by requesting focus (on iOS)
SuperEditor selection places caret at the previous selection when re-focusing by tab (on iOS)
SuperEditor stable tags > commits > when downstream selection collapses outside of tag (on iOS)
SuperEditor stable tags > committed > pushes caret downstream around the tag (on iOS)
SuperEditor stable tags > committed > pushes caret upstream around the tag (on iOS)
SuperEditor stable tags > committed > pushes expanding downstream selection around the tag (on iOS)
SuperEditor stable tags > committed > pushes expanding upstream selection around the tag (on iOS)
SuperEditor stable tags > composing > can start between words (on iOS)
SuperEditor stable tags > composing > continues when user expands the selection downstream (on iOS)
SuperEditor text affinity upstream and downstream positions render differently at a line break (on iOS)
SuperEditor text affinity upstream and downstream positions render the same if not at a line break (on iOS)
SuperEditor throws away stale selection after re-focus with caret when content type changes (on iOS)
SuperEditor throws away stale selection after re-focus with caret when it no longer fits in text (on iOS)
```

It seems that only the first one is really a test that should use the heuristics by default. 

This PR modifies the tests in `test/super_editor/mobile/super_editor_ios_overlay_controls_test.dart` to use the iOS selection heuristics.

If we enable the heuristics for all tests, then we would need to add logic in all of those failing tests to drag the caret to the expected position when running for iOS, or make those tests explicitly opt-out of the selection heuristics. This might be a safer approach.