### PR TITLE
[SuperEditor] Fix immutability violation in spellchecking styler (Resolves #2560)

### DIFF
--- a/super_editor/lib/src/default_editor/spelling_and_grammar/spelling_and_grammar_styler.dart
+++ b/super_editor/lib/src/default_editor/spelling_and_grammar/spelling_and_grammar_styler.dart
@@ -120,11 +120,7 @@ class SpellingAndGrammarStyler extends SingleColumnLayoutStylePhase {
       // Apply it.
       viewModel.spellingErrorUnderlineStyle = _spellingErrorUnderlineStyle!;
     }
-    viewModel.spellingErrors
-      ..clear()
-      ..addAll([
-        for (final spellingError in spellingErrors) spellingError.range,
-      ]);
+    viewModel.spellingErrors = spellingErrors.map((error) => error.range).toList();
 
     if (_overrideSelectionColor && selectionHighlightColor != null) {
       viewModel.selectionColor = selectionHighlightColor!;
@@ -136,11 +132,7 @@ class SpellingAndGrammarStyler extends SingleColumnLayoutStylePhase {
       // Apply it.
       viewModel.grammarErrorUnderlineStyle = _grammarErrorUnderlineStyle!;
     }
-    viewModel.grammarErrors
-      ..clear()
-      ..addAll([
-        for (final grammarError in grammarErrors) grammarError.range,
-      ]);
+    viewModel.grammarErrors = grammarErrors.map((error) => error.range).toList();
 
     return viewModel;
   }


### PR DESCRIPTION
[SuperEditor] Fix immutability violation in spellchecking styler (Resolves #2560)

A crash was reported within `spelling_and_grammar.dart` within `_applyErrors()` where we try to do the following:

```dart
viewModel.grammarErrors
  ..clear()
  ..addAll([
    //....
  ]);
```

I didn't find any places where we return an unmodifiable list from the the `grammarErrors`, but I think it's safer to replace  the list instead of modifying it, because apps can add custom view models, that might return an unmodifiable list for `grammarErrors`.

This PR changes the `SpellingAndGrammarStyler` to override the viewmodel's `spellingErrors` and `grammarErrors`.

