### PR TITLE
[Spellcheck] Add tests for ignore rules (Resolves #2573)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -144,6 +144,26 @@ jobs:
       # Run all tests
       - run: flutter test
 
+  test_super_editor_spellcheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./super_editor_spellcheck
+    steps:
+      # Checkout the PR branch
+      - uses: actions/checkout@v3
+
+      # Setup Flutter environment
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "master"
+
+      # Download all the packages that the app uses
+      - run: flutter pub get
+
+      # Run all tests
+      - run: flutter test
+
   analyze_super_keyboard:
     runs-on: ubuntu-latest
     defaults:
@@ -183,7 +203,6 @@ jobs:
 
       # Run all tests
       - run: flutter test
-
 
   analyze_super_text_layout:
     runs-on: ubuntu-latest

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -38,8 +38,11 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
   ///   It can be used,  for example, to ignore links or text with specific attributions. See [SpellingIgnoreRules]
   ///   for a list of built-in rules.
   /// - [spellCheckService]: a spell check service to use for spell checking. If this is provided,
-  ///   the plugin will use this service instead of the default spell check service. This is intended to
-  ///   be used in tests.
+  ///   the plugin will use this service instead of the default spell check service. The default spell checker
+  ///   supports macOS, Android, and iOS.
+  /// - [grammarCheckService]: a grammar check service to use for grammar checking. If this is provided,
+  ///   the plugin will use this service instead of the default grammar check service. The default grammar checker
+  ///   supports macOS only.
   SpellingAndGrammarPlugin({
     bool isSpellingCheckEnabled = true,
     UnderlineStyle spellingErrorUnderlineStyle = defaultSpellingErrorUnderlineStyle,
@@ -51,6 +54,7 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     SuperEditorIosControlsController? iosControlsController,
     List<SpellingIgnoreRule> ignoreRules = const [],
     SpellCheckService? spellCheckService,
+    GrammarCheckService? grammarCheckService,
   })  : _isSpellCheckEnabled = isSpellingCheckEnabled,
         _isGrammarCheckEnabled = isGrammarCheckEnabled {
     assert(defaultTargetPlatform != TargetPlatform.android || androidControlsController != null,
@@ -59,7 +63,18 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     assert(defaultTargetPlatform != TargetPlatform.iOS || iosControlsController != null,
         'The iosControlsController must be provided when running on iOS.');
 
-    _spellCheckService = spellCheckService;
+    _spellCheckService = spellCheckService ??
+        switch (defaultTargetPlatform) {
+          TargetPlatform.macOS => MacSpellCheckService(),
+          TargetPlatform.android || TargetPlatform.iOS => DefaultSpellCheckService(),
+          _ => null,
+        };
+
+    _grammarCheckService = grammarCheckService ??
+        switch (defaultTargetPlatform) {
+          TargetPlatform.macOS => MacGrammarCheckService(),
+          _ => null,
+        };
 
     documentOverlayBuilders = <SuperEditorLayerBuilder>[
       SpellingErrorSuggestionOverlayBuilder(
@@ -95,11 +110,10 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
   }
 
   /// A service that provides spell checking functionality.
-  ///
-  /// If provided, the plugin uses this service instead of the default spell check
-  /// service. This is intended to be used in tests, or for platforms that
-  /// don't have a built-in spellcheck plugin.
   late final SpellCheckService? _spellCheckService;
+
+  /// A service that provides grammar checking functionality.
+  late final GrammarCheckService? _grammarCheckService;
 
   final _spellingErrorSuggestions = SpellingErrorSuggestions();
 
@@ -160,7 +174,8 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     editor.context.put(spellingErrorSuggestionsKey, _spellingErrorSuggestions);
     _contentTapHandler?.editor = editor;
 
-    _reaction = SpellingAndGrammarReaction(_spellingErrorSuggestions, _styler, _ignoreRules, _spellCheckService);
+    _reaction = SpellingAndGrammarReaction(
+        _spellingErrorSuggestions, _styler, _ignoreRules, _spellCheckService!, _grammarCheckService);
     editor.reactionPipeline.add(_reaction);
 
     // Do initial spelling and grammar analysis, in case the document already
@@ -267,7 +282,8 @@ extension SpellingAndGrammarEditorExtensions on Editor {
 /// An [EditReaction] that runs spelling and grammar checks on all [TextNode]s
 /// in a given [Document].
 class SpellingAndGrammarReaction implements EditReaction {
-  SpellingAndGrammarReaction(this._suggestions, this._styler, this._ignoreRules, this._spellCheckService);
+  SpellingAndGrammarReaction(
+      this._suggestions, this._styler, this._ignoreRules, this._spellCheckService, this._grammarCheckService);
 
   final SpellingErrorSuggestions _suggestions;
 
@@ -275,7 +291,9 @@ class SpellingAndGrammarReaction implements EditReaction {
 
   final List<SpellingIgnoreRule> _ignoreRules;
 
-  final SpellCheckService? _spellCheckService;
+  final SpellCheckService _spellCheckService;
+
+  final GrammarCheckService? _grammarCheckService;
 
   bool isSpellCheckEnabled = true;
 
@@ -293,9 +311,6 @@ class SpellingAndGrammarReaction implements EditReaction {
   /// boundary to the platform to run such checks, removing any guarantee about order
   /// of receipt.
   final _asyncRequestIds = <String, int>{};
-
-  final _mobileSpellChecker = DefaultSpellCheckService();
-  final _macSpellChecker = SuperEditorSpellCheckerPlugin().macSpellChecker;
 
   /// Checks every [TextNode] in the given document for spelling and grammar
   /// errors and stores them for visual styling.
@@ -382,19 +397,8 @@ class SpellingAndGrammarReaction implements EditReaction {
   }
 
   Future<void> _findSpellingAndGrammarErrors(TextNode textNode) async {
-    if (_spellCheckService != null) {
-      await _findSpellingAndGrammarErrorsWithSpellCheckService(_spellCheckService!, textNode);
-    } else if (defaultTargetPlatform == TargetPlatform.macOS) {
-      await _findSpellingAndGrammarErrorsOnMac(textNode);
-    } else if (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) {
-      await _findSpellingAndGrammarErrorsWithSpellCheckService(_mobileSpellChecker, textNode);
-    }
-  }
-
-  Future<void> _findSpellingAndGrammarErrorsOnMac(TextNode textNode) async {
-    // TODO: Investigate whether we can parallelize spelling and grammar checks
-    //       for a given node (and whether it's worth the complexity).
     final textErrors = <TextError>{};
+    final spellingSuggestions = <TextRange, SpellingError>{};
 
     // Track this spelling and grammar request to make sure we don't process
     // the response out of order with other requests.
@@ -404,130 +408,51 @@ class SpellingAndGrammarReaction implements EditReaction {
 
     final plainText = _filterIgnoredRanges(textNode);
 
-    int startingOffset = 0;
-    TextRange prevError = TextRange.empty;
-    final locale = PlatformDispatcher.instance.locale;
-    final language = _macSpellChecker.convertDartLocaleToMacLanguageCode(locale)!;
-    final spellingSuggestions = <TextRange, SpellingError>{};
     if (isSpellCheckEnabled) {
-      do {
-        prevError = await _macSpellChecker.checkSpelling(
-          stringToCheck: plainText,
-          startingOffset: startingOffset,
-          language: language,
-        );
-
-        if (prevError.isValid) {
-          final word = plainText.substring(prevError.start, prevError.end);
-
-          // Ask platform for spelling correction guesses.
-          final guesses = await _macSpellChecker.guesses(range: prevError, text: plainText);
-
+      final suggestions = await _spellCheckService.fetchSpellCheckSuggestions(
+        PlatformDispatcher.instance.locale,
+        plainText,
+      );
+      if (suggestions != null) {
+        for (final suggestion in suggestions) {
+          final misspelledWord = plainText.substring(suggestion.range.start, suggestion.range.end);
+          spellingSuggestions[suggestion.range] = SpellingError(
+            word: misspelledWord,
+            nodeId: textNode.id,
+            range: suggestion.range,
+            suggestions: suggestion.suggestions,
+          );
           textErrors.add(
             TextError.spelling(
               nodeId: textNode.id,
-              range: prevError,
-              value: word,
-              suggestions: guesses,
+              range: suggestion.range,
+              value: misspelledWord,
+              suggestions: suggestion.suggestions,
             ),
           );
+        }
+      }
+    }
 
-          spellingSuggestions[prevError] = SpellingError(
-            word: word,
-            nodeId: textNode.id,
-            range: prevError,
-            suggestions: guesses,
+    if (isGrammarCheckEnabled && _grammarCheckService != null) {
+      final grammarErrors = await _grammarCheckService!.checkGrammar(
+        PlatformDispatcher.instance.locale,
+        plainText,
+      );
+
+      if (grammarErrors != null) {
+        for (final grammarError in grammarErrors) {
+          final errorRange = grammarError.range;
+          final text = plainText.substring(errorRange.start, errorRange.end);
+          textErrors.add(
+            TextError.grammar(
+              nodeId: textNode.id,
+              range: errorRange,
+              value: text,
+            ),
           );
-
-          startingOffset = prevError.end;
         }
-      } while (prevError.isValid);
-    }
-
-    if (isGrammarCheckEnabled) {
-      startingOffset = 0;
-      prevError = TextRange.empty;
-      do {
-        final result = await _macSpellChecker.checkGrammar(
-          stringToCheck: plainText,
-          startingOffset: startingOffset,
-          language: language,
-        );
-        prevError = result.firstError ?? TextRange.empty;
-
-        if (prevError.isValid) {
-          for (final grammarError in result.details) {
-            final errorRange = grammarError.range;
-            final text = plainText.substring(errorRange.start, errorRange.end);
-            textErrors.add(
-              TextError.grammar(
-                nodeId: textNode.id,
-                range: errorRange,
-                value: text,
-              ),
-            );
-          }
-
-          startingOffset = prevError.end;
-        }
-      } while (prevError.isValid);
-    }
-
-    if (requestId != _asyncRequestIds[textNode.id]) {
-      // Another request was started for this node while we were running our
-      // request. Fizzle.
-      return;
-    }
-    // Reset the request ID counter to zero so that we avoid increasing infinitely.
-    _asyncRequestIds[textNode.id] = 0;
-
-    // Display underlines on spelling and grammar errors.
-    _styler
-      ..clearErrorsForNode(textNode.id)
-      ..addErrors(textNode.id, textErrors);
-
-    // Update the shared repository of spelling suggestions so that the user can
-    // see suggestions and select them.
-    _suggestions.putSuggestions(textNode.id, spellingSuggestions);
-  }
-
-  Future<void> _findSpellingAndGrammarErrorsWithSpellCheckService(
-      SpellCheckService spellCheckService, TextNode textNode) async {
-    final textErrors = <TextError>{};
-    final spellingSuggestions = <TextRange, SpellingError>{};
-
-    // Track this spelling and grammar request to make sure we don't process
-    // the response out of order with other requests.
-    _asyncRequestIds[textNode.id] ??= 0;
-    final requestId = _asyncRequestIds[textNode.id]! + 1;
-    _asyncRequestIds[textNode.id] = requestId;
-
-    final plainText = _filterIgnoredRanges(textNode);
-
-    final suggestions = await spellCheckService.fetchSpellCheckSuggestions(
-      PlatformDispatcher.instance.locale,
-      plainText,
-    );
-    if (suggestions == null) {
-      return;
-    }
-
-    for (final suggestion in suggestions) {
-      final misspelledWord = plainText.substring(suggestion.range.start, suggestion.range.end);
-      spellingSuggestions[suggestion.range] = SpellingError(
-        word: misspelledWord,
-        nodeId: textNode.id,
-        range: suggestion.range,
-        suggestions: suggestion.suggestions,
-      );
-      textErrors.add(
-        TextError.spelling(
-          nodeId: textNode.id,
-          range: suggestion.range,
-          value: misspelledWord,
-          suggestions: suggestion.suggestions,
-        ),
-      );
+      }
     }
 
     if (requestId != _asyncRequestIds[textNode.id]) {
@@ -929,4 +854,103 @@ class SpellingIgnoreRules {
           .toList();
     };
   }
+}
+
+/// A [SpellCheckService] that uses a macOS plugin to check spelling.
+class MacSpellCheckService implements SpellCheckService {
+  final _macSpellChecker = SuperEditorSpellCheckerPlugin().macSpellChecker;
+
+  @override
+  Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(Locale locale, String text) async {
+    // TODO: Investigate whether we can parallelize spelling and grammar checks
+    //       for a given node (and whether it's worth the complexity).
+
+    final suggestionSpans = <SuggestionSpan>[];
+
+    int startingOffset = 0;
+    TextRange prevError = TextRange.empty;
+    final locale = PlatformDispatcher.instance.locale;
+    final language = _macSpellChecker.convertDartLocaleToMacLanguageCode(locale)!;
+    do {
+      prevError = await _macSpellChecker.checkSpelling(
+        stringToCheck: text,
+        startingOffset: startingOffset,
+        language: language,
+      );
+
+      if (prevError.isValid) {
+        final guesses = await _macSpellChecker.guesses(range: prevError, text: text);
+        suggestionSpans.add(SuggestionSpan(prevError, guesses));
+        startingOffset = prevError.end;
+      }
+    } while (prevError.isValid);
+
+    return suggestionSpans;
+  }
+}
+
+/// A service that knows how to check grammar on a text.
+abstract class GrammarCheckService {
+  /// Checks the given [text] for grammar errors with the given [locale].
+  ///
+  /// Returns a list of [GrammarError]s where each item represents a sentence
+  /// that has a grammatical error, with details about the error.
+  ///
+  /// Returns an empty list if no grammar errors are found or if the [locale]
+  /// isn't supported by the grammar checker.
+  ///
+  /// Returns `null` if the check was unsucessful.
+  Future<List<GrammarError>?> checkGrammar(Locale locale, String text);
+}
+
+/// A [GrammarCheckService] that uses a macOS plugin to check grammar.
+class MacGrammarCheckService implements GrammarCheckService {
+  final _macSpellChecker = SuperEditorSpellCheckerPlugin().macSpellChecker;
+
+  @override
+  Future<List<GrammarError>?> checkGrammar(Locale locale, String text) async {
+    final errors = <GrammarError>[];
+
+    final language = _macSpellChecker.convertDartLocaleToMacLanguageCode(locale)!;
+
+    int startingOffset = 0;
+    TextRange prevError = TextRange.empty;
+    do {
+      final result = await _macSpellChecker.checkGrammar(
+        stringToCheck: text,
+        startingOffset: startingOffset,
+        language: language,
+      );
+      prevError = result.firstError ?? TextRange.empty;
+
+      if (prevError.isValid) {
+        errors.addAll(
+          result.details.map(
+            (detail) => GrammarError(
+              range: detail.range,
+              description: detail.userDescription,
+            ),
+          ),
+        );
+
+        startingOffset = prevError.end;
+      }
+    } while (prevError.isValid);
+
+    return errors;
+  }
+}
+
+/// A grammatical error found in a text at [range].
+class GrammarError {
+  GrammarError({
+    required this.range,
+    required this.description,
+  });
+
+  /// The range of text that has a grammatical error.
+  final TextRange range;
+
+  /// The description of the grammatical error.
+  final String description;
 }

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -37,7 +37,7 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
   /// - [ignoreRules]: a list of rules that determine ranges that should be ignored from spellchecking.
   ///   It can be used,  for example, to ignore links or text with specific attributions. See [SpellingIgnoreRules]
   ///   for a list of built-in rules.
-  /// - [spellCheckService]: a custom spell check service to use for spell checking. If this is provided,
+  /// - [spellCheckService]: a spell check service to use for spell checking. If this is provided,
   ///   the plugin will use this service instead of the default spell check service. This is intended to
   ///   be used in tests.
   SpellingAndGrammarPlugin({
@@ -94,6 +94,11 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     };
   }
 
+  /// A service that provides spell checking functionality.
+  ///
+  /// If provided, the plugin uses this service instead of the default spell check
+  /// service. This is intended to be used in tests, or for platforms that
+  /// don't have a built-in spellcheck plugin.
   late final SpellCheckService? _spellCheckService;
 
   final _spellingErrorSuggestions = SpellingErrorSuggestions();
@@ -262,7 +267,7 @@ extension SpellingAndGrammarEditorExtensions on Editor {
 /// An [EditReaction] that runs spelling and grammar checks on all [TextNode]s
 /// in a given [Document].
 class SpellingAndGrammarReaction implements EditReaction {
-  SpellingAndGrammarReaction(this._suggestions, this._styler, this._ignoreRules, this._customSpellCheckService);
+  SpellingAndGrammarReaction(this._suggestions, this._styler, this._ignoreRules, this._spellCheckService);
 
   final SpellingErrorSuggestions _suggestions;
 
@@ -270,7 +275,7 @@ class SpellingAndGrammarReaction implements EditReaction {
 
   final List<SpellingIgnoreRule> _ignoreRules;
 
-  final SpellCheckService? _customSpellCheckService;
+  final SpellCheckService? _spellCheckService;
 
   bool isSpellCheckEnabled = true;
 
@@ -377,8 +382,8 @@ class SpellingAndGrammarReaction implements EditReaction {
   }
 
   Future<void> _findSpellingAndGrammarErrors(TextNode textNode) async {
-    if (_customSpellCheckService != null) {
-      await _findSpellingAndGrammarErrorsWithSpellCheckService(_customSpellCheckService!, textNode);
+    if (_spellCheckService != null) {
+      await _findSpellingAndGrammarErrorsWithSpellCheckService(_spellCheckService!, textNode);
     } else if (defaultTargetPlatform == TargetPlatform.macOS) {
       await _findSpellingAndGrammarErrorsOnMac(textNode);
     } else if (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) {

--- a/super_editor_spellcheck/pubspec.yaml
+++ b/super_editor_spellcheck/pubspec.yaml
@@ -15,8 +15,6 @@ dependencies:
   overlord: ^0.0.3+5
   plugin_platform_interface: ^2.0.2
 
-#  collection: ^1.18.0
-#  follow_the_leader: ^0.0.4+8
   super_editor: ^0.3.0-dev.15
   super_text_layout: ^0.1.12
 
@@ -31,6 +29,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.0
   pigeon: ^21.1.0
+  flutter_test_runners: ^0.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/super_editor_spellcheck/test/spellcheck_ignore_rules_test.dart
+++ b/super_editor_spellcheck/test/spellcheck_ignore_rules_test.dart
@@ -1,0 +1,221 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_spellcheck/super_editor_spellcheck.dart';
+
+void main() {
+  group('SuperEditor spellcheck >', () {
+    group('ignore rules >', () {
+      testWidgetsOnArbitraryDesktop('ignores by pattern', (tester) async {
+        final spellCheckerService = _FakeSpellChecker();
+
+        await _pumpTestApp(
+          tester,
+          document: MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: Editor.createNodeId(),
+                text: AttributedText(
+                  'An user @mention and @another one',
+                ),
+              ),
+            ],
+          ),
+          ignoreRules: [
+            // Ignores user mentions, like "@mention".
+            SpellingIgnoreRules.byPattern(RegExp(r'@\w+')),
+          ],
+          spellCheckerService: spellCheckerService,
+        );
+
+        // Ensure the spell checker service was queried without the text
+        // that matches the pattern.
+        expect(spellCheckerService.queriedTexts, ['An user          and          one']);
+      });
+
+      testWidgetsOnArbitraryDesktop('ignores by attribution', (tester) async {
+        final spellCheckerService = _FakeSpellChecker();
+
+        await _pumpTestApp(
+          tester,
+          document: MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: Editor.createNodeId(),
+                text: AttributedText(
+                  'A bold text and another bold text',
+                  AttributedSpans(
+                    attributions: [
+                      // First "bold" word.
+                      const SpanMarker(
+                        attribution: boldAttribution,
+                        offset: 2,
+                        markerType: SpanMarkerType.start,
+                      ),
+                      const SpanMarker(
+                        attribution: boldAttribution,
+                        offset: 5,
+                        markerType: SpanMarkerType.end,
+                      ),
+                      // Second "bold" word.
+                      const SpanMarker(
+                        attribution: boldAttribution,
+                        offset: 24,
+                        markerType: SpanMarkerType.start,
+                      ),
+                      const SpanMarker(
+                        attribution: boldAttribution,
+                        offset: 27,
+                        markerType: SpanMarkerType.end,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          ignoreRules: [
+            SpellingIgnoreRules.byAttribution(boldAttribution),
+          ],
+          spellCheckerService: spellCheckerService,
+        );
+
+        // Ensure the spell checker service was queried without the text
+        // that contains the bold attribution.
+        expect(spellCheckerService.queriedTexts, ['A      text and another      text']);
+      });
+
+      testWidgetsOnArbitraryDesktop('ignores by attribution filter', (tester) async {
+        final spellCheckerService = _FakeSpellChecker();
+
+        await _pumpTestApp(
+          tester,
+          document: MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: Editor.createNodeId(),
+                text: AttributedText(
+                  'A link and another link',
+                  AttributedSpans(
+                    attributions: [
+                      // First link.
+                      const SpanMarker(
+                        attribution: LinkAttribution('https://www.google.com'),
+                        offset: 2,
+                        markerType: SpanMarkerType.start,
+                      ),
+                      const SpanMarker(
+                        attribution: LinkAttribution('https://www.google.com'),
+                        offset: 5,
+                        markerType: SpanMarkerType.end,
+                      ),
+                      // Second link.
+                      const SpanMarker(
+                        attribution: LinkAttribution('https://www.youtube.com'),
+                        offset: 19,
+                        markerType: SpanMarkerType.start,
+                      ),
+                      const SpanMarker(
+                        attribution: LinkAttribution('https://www.youtube.com'),
+                        offset: 22,
+                        markerType: SpanMarkerType.end,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          ignoreRules: [
+            SpellingIgnoreRules.byAttributionFilter((attribution) => attribution is LinkAttribution),
+          ],
+          spellCheckerService: spellCheckerService,
+        );
+
+        // Ensure the spell checker service was queried without the text
+        // that contains the link attribution.
+        expect(spellCheckerService.queriedTexts, ['A      and another     ']);
+      });
+
+      testWidgetsOnArbitraryDesktop('allows overlapping rules', (tester) async {
+        final spellCheckerService = _FakeSpellChecker();
+
+        await _pumpTestApp(
+          tester,
+          document: MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: Editor.createNodeId(),
+                text: AttributedText(
+                  'The first text and the second text',
+                ),
+              ),
+            ],
+          ),
+          ignoreRules: [
+            (TextNode node) {
+              // The first text and the second text
+              //          ^^^^^^^^
+              return const [TextRange(start: 10, end: 18)];
+            },
+            // The first text and the second text
+            //               ^^^^^^^^^^^^^^
+            (TextNode node) {
+              return const [TextRange(start: 15, end: 29)];
+            }
+          ],
+          spellCheckerService: spellCheckerService,
+        );
+
+        // Ensure the spell checker service was queried without the text
+        // of the overlapping ranges.
+        expect(spellCheckerService.queriedTexts, ['The first                     text']);
+      });
+    });
+  });
+}
+
+Future<void> _pumpTestApp(
+  WidgetTester tester, {
+  required MutableDocument document,
+  List<SpellingIgnoreRule> ignoreRules = const [],
+  SpellCheckService? spellCheckerService,
+}) async {
+  final editor = createDefaultDocumentEditor(
+    document: document,
+    composer: MutableDocumentComposer(),
+  );
+
+  final plugin = SpellingAndGrammarPlugin(
+    ignoreRules: ignoreRules,
+    spellCheckService: spellCheckerService,
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SuperEditor(
+          editor: editor,
+          plugins: {plugin},
+        ),
+      ),
+    ),
+  );
+}
+
+/// A [SpellCheckService] that records the texts that were queried and returns
+/// an empty list of suggestions for each query.
+class _FakeSpellChecker extends SpellCheckService {
+  List<String> get queriedTexts => UnmodifiableListView(_queriedTexts);
+  final List<String> _queriedTexts = [];
+
+  @override
+  Future<List<SuggestionSpan>?> fetchSpellCheckSuggestions(Locale locale, String text) async {
+    _queriedTexts.add(text);
+    return const [];
+  }
+}


### PR DESCRIPTION
[Spellcheck] Add tests for ignore rules (Resolves #2573)

This is a follow up PR for https://github.com/superlistapp/super_editor/pull/2567.

We added support for "ignore rules", to allow apps to ignore from spellcheck certain pieces of text, like mentions, tags, texts with specific attributions, etc.

This PR modifies the `SpellingAndGrammarPlugin` to take an optional `SpellCheckService` parameter. This allows us to provide a fake spellchecker in tests, to verify which portions of texts were queried.

