### PR TITLE
[SuperEditor][iOS] Fix selecting all document when using the native toolbar (Resolves #2579)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -261,46 +261,58 @@ class TextDeltasDocumentEditor {
       // where the user can swipe over the spacebar to change the selection. This also happens
       // when the app uses the native iOS text selection toolbar and the user presses "Select all".
 
-      final extentNode = document.getNodeById(docSelection.extent.nodeId)!;
-      final isWholeNodeSelected = docSelection.start.nodeId == docSelection.end.nodeId &&
-          docSelection.start.nodePosition == extentNode.beginningPosition &&
-          docSelection.end.nodePosition == extentNode.endPosition;
-      if (defaultTargetPlatform == TargetPlatform.iOS && isWholeNodeSelected) {
-        // On iOS, when the app uses the native text selection toolbar and the user presses "Select all",
-        // Flutter sends us a non-text delta with the selection change. However, since we only send to the IME the text
-        // of the currently selected nodes, the delta reports the node being selected, not the entire
-        // document. To workaroud this, whenever iOS reports a selection change that selects an entire node,
-        // we select the entire document instead.
-        editor.execute([
-          ChangeSelectionRequest(
-            DocumentSelection(
-              base: DocumentPosition(
-                nodeId: document.first.id,
-                nodePosition: document.first.beginningPosition,
-              ),
-              extent: DocumentPosition(
-                nodeId: document.last.id,
-                nodePosition: document.last.endPosition,
-              ),
-            ),
-            SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          ),
-        ]);
-      } else {
-        editor.execute([
-          ChangeSelectionRequest(
-            docSelection,
-            docSelection.isCollapsed ? SelectionChangeType.placeCaret : SelectionChangeType.expandSelection,
-            SelectionReason.userInteraction,
-          ),
-          ChangeComposingRegionRequest(docComposingRegion),
-        ]);
-      }
+      docSelection = _ajustWholeDocumentSelectionOnIos(docSelection);
+
+      editor.execute([
+        ChangeSelectionRequest(
+          docSelection,
+          docSelection.isCollapsed ? SelectionChangeType.placeCaret : SelectionChangeType.expandSelection,
+          SelectionReason.userInteraction,
+        ),
+        ChangeComposingRegionRequest(docComposingRegion),
+      ]);
     }
 
     // Update the local IME value that changes with each delta.
     _previousImeValue = delta.apply(_previousImeValue);
+  }
+
+  /// Performs a workaround to select all text in the document on iOS when the user presses "Select all".
+  ///
+  /// On iOS, when the app uses the native text selection toolbar and the user presses "Select all",
+  /// Flutter sends us a non-text delta with the selection change. However, since we only send to the IME the text
+  /// of the currently selected nodes, the delta reports the node being selected, not the entire
+  /// document.
+  ///
+  /// To workaroud this, whenever iOS reports a selection change that selects an entire node,
+  /// we select the entire document instead.
+  DocumentSelection _ajustWholeDocumentSelectionOnIos(DocumentSelection documentSelection) {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return documentSelection;
+    }
+
+    final extentNode = document.getNodeById(documentSelection.extent.nodeId)!;
+    final isWholeNodeSelected = documentSelection.start.nodeId == documentSelection.end.nodeId &&
+        documentSelection.start.nodePosition == extentNode.beginningPosition &&
+        documentSelection.end.nodePosition == extentNode.endPosition;
+
+    if (!isWholeNodeSelected) {
+      // The selection is either across multiple nodes or not the entire node.
+      // The user didn't press "Select all".
+      return documentSelection;
+    }
+
+    // The IME reported a selection that selects an entire node. Select the entire document instead.
+    return DocumentSelection(
+      base: DocumentPosition(
+        nodeId: document.first.id,
+        nodePosition: document.first.beginningPosition,
+      ),
+      extent: DocumentPosition(
+        nodeId: document.last.id,
+        nodePosition: document.last.endPosition,
+      ),
+    );
   }
 
   void insert(DocumentSelection insertionSelection, String textInserted) {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -261,7 +261,7 @@ class TextDeltasDocumentEditor {
       // where the user can swipe over the spacebar to change the selection. This also happens
       // when the app uses the native iOS text selection toolbar and the user presses "Select all".
 
-      docSelection = _ajustWholeDocumentSelectionOnIos(docSelection);
+      docSelection = _maybeSelectAllOnIos(docSelection);
 
       editor.execute([
         ChangeSelectionRequest(
@@ -286,7 +286,7 @@ class TextDeltasDocumentEditor {
   ///
   /// To workaroud this, whenever iOS reports a selection change that selects an entire node,
   /// we select the entire document instead.
-  DocumentSelection _ajustWholeDocumentSelectionOnIos(DocumentSelection documentSelection) {
+  DocumentSelection _maybeSelectAllOnIos(DocumentSelection documentSelection) {
     if (defaultTargetPlatform != TargetPlatform.iOS) {
       return documentSelection;
     }


### PR DESCRIPTION
[SuperEditor][iOS] Fix selecting all document when using the native toolbar (Resolves #2579).

When using the iOS native toolbar, "select all" only selects the paragraph with the caret:

https://github.com/user-attachments/assets/02e1344a-9038-4cf4-8ce2-6a1cbcc07fe8

This happens because we only send to the IME the text of the currently selected nodes. So the IME "thinks" that this is the entire text.

Ideally, Flutter should report an action for us to handle that, but I'm not sure if this is possible.

To workaround this, whenever we receive a non-text delta selecting an entire node, on iOS, we select then entire document instead:

https://github.com/user-attachments/assets/230786d5-b756-4aa2-8cf8-7444c4fbe5ba



