### PR TITLE
[SuperReader][Android] Fix crash when rotating the phone with an expanded selection (Resolves #2580)

### DIFF
--- a/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_android_touch_interactor.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -26,6 +27,7 @@ import 'package:super_editor/src/infrastructure/platforms/android/magnifier.dart
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/src/infrastructure/platforms/mobile_documents.dart';
 import 'package:super_editor/src/infrastructure/platforms/platform.dart';
+import 'package:super_editor/src/infrastructure/render_sliver_ext.dart';
 import 'package:super_editor/src/infrastructure/signal_notifier.dart';
 import 'package:super_editor/src/infrastructure/sliver_hybrid_stack.dart';
 import 'package:super_editor/src/infrastructure/toolbar_position_delegate.dart';
@@ -322,7 +324,7 @@ class _ReadOnlyAndroidDocumentTouchInteractorState extends State<ReadOnlyAndroid
     }
 
     // Determines the offset of the editor in the viewport coordinate
-    final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderBox;
+    final editorBox = widget.documentKey.currentContext!.findRenderObject() as RenderSliver;
     final editorInViewportOffset = viewportBox.localToGlobal(Offset.zero) - editorBox.localToGlobal(Offset.zero);
 
     // Determines the offset of the handle in the viewport coordinate

--- a/super_editor/test/super_reader/super_reader_phone_rotation_test.dart
+++ b/super_editor/test/super_reader/super_reader_phone_rotation_test.dart
@@ -1,0 +1,81 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor_test.dart';
+
+import 'reader_test_tools.dart';
+
+void main() {
+  group('SuperReader > phone rotation >', () {
+    const screenSizePortrait = Size(400.0, 1000.0);
+    const screenSizeLandscape = Size(1000.0, 400);
+
+    testWidgetsOnMobile('does not crash the app when there is no selection', (tester) async {
+      // Start the test in portrait mode.
+      tester.view
+        ..devicePixelRatio = 1.0
+        ..platformDispatcher.textScaleFactorTestValue = 1.0
+        ..physicalSize = screenSizePortrait;
+
+      addTearDown(() => tester.platformDispatcher.clearAllTestValues());
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .pump();
+
+      // Simulate a phone rotation.
+      tester.view.physicalSize = screenSizeLandscape;
+      await tester.pumpAndSettle();
+
+      // Reaching this point means the reader didn't crash.
+    });
+
+    testWidgetsOnMobile('does not crash the app when the selection is collapsed', (tester) async {
+      // Start the test in portrait mode.
+      tester.view
+        ..devicePixelRatio = 1.0
+        ..platformDispatcher.textScaleFactorTestValue = 1.0
+        ..physicalSize = screenSizePortrait;
+      addTearDown(() => tester.platformDispatcher.clearAllTestValues());
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .pump();
+
+      // Place the caret at the beginning of the document.
+      await tester.placeCaretInParagraph('1', 0);
+
+      // Simulate a phone rotation.
+      tester.view.physicalSize = screenSizeLandscape;
+      await tester.pumpAndSettle();
+
+      // Reaching this point means the reader didn't crash.
+    });
+
+    testWidgetsOnMobile('does not crash the app when the selection is expanded', (tester) async {
+      // Start the test in portrait mode.
+      tester.view
+        ..devicePixelRatio = 1.0
+        ..platformDispatcher.textScaleFactorTestValue = 1.0
+        ..physicalSize = screenSizePortrait;
+      addTearDown(() => tester.platformDispatcher.clearAllTestValues());
+
+      await tester //
+          .createDocument()
+          .withSingleParagraph()
+          .pump();
+
+      // Double tap to select the first word.
+      await tester.doubleTapInParagraph('1', 0);
+
+      // Simulate a phone rotation.
+      tester.view.physicalSize = screenSizeLandscape;
+      await tester.pumpAndSettle();
+
+      // Reaching this point means the reader didn't crash.
+    });
+  });
+}


### PR DESCRIPTION
[SuperReader][Android] Fix crash when rotating the phone with an expanded selection (Resolves #2580)

When rotating the phone the reader crashes if it has an expanded selection:

```console
════════ Exception caught by scheduler library ═════════════════════════════════
The following _TypeError was thrown during a scheduler callback:
type 'RenderSliverToBoxAdapter' is not a subtype of type 'RenderBox' in type cast

When the exception was thrown, this was the stack:
#0      _ReadOnlyAndroidDocumentTouchInteractorState._ensureSelectionExtentIsVisible (package:super_editor/src/super_reader/read_only_document_android_touch_interactor.dart:325:77)
read_only_document_android_touch_interactor.dart:325
#1      _ReadOnlyAndroidDocumentTouchInteractorState.didChangeMetrics.<anonymous closure> (package:super_editor/src/super_reader/read_only_document_android_touch_interactor.dart:292:7)
read_only_document_android_touch_interactor.dart:292
#2      Frames.onNextFrame.<anonymous closure> (package:super_editor/src/infrastructure/flutter/flutter_scheduler.dart:72:11)
flutter_scheduler.dart:72
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
binding.dart:1442
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1369:11)
binding.dart:1369
#5      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
binding.dart:1208
#6      _invoke (dart:ui/hooks.dart:316:13)
hooks.dart:316
#7      PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
platform_dispatcher.dart:428
#8      _drawFrame (dart:ui/hooks.dart:288:31)
hooks.dart:288
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by scheduler library ═════════════════════════════════
type 'RenderSliverToBoxAdapter' is not a subtype of type 'RenderBox' in type cast
```

The issue is that we are trying to access the document's `RenderObject` as a `RenderBox`, but it is a `RenderSliver` now.

This PR fixes this issue and adds tests for phone rotation.