### PR TITLE
[Infrastructure] Update actions/upload-artifact to v4 (Resolves #2585)

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -94,7 +94,7 @@ jobs:
       - run: flutter test test_goldens
 
       # Archive golden failures
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: golden-failures
@@ -267,7 +267,7 @@ jobs:
       - run: flutter test test_goldens
 
       # Archive golden failures
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: golden-failures


### PR DESCRIPTION
[Infrastructure] Update actions/upload-artifact to v4 (Resolves #2585)

Our golden tests are failing with the following message:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

This is the action we use to upload the golden images in case of failures.

This PR simply bumps the version to v4.