### PR TITLE
[SuperEditor] Add more specific SelectionChangeTypes (Resolves #2367)

### DIFF
--- a/super_editor/lib/src/core/document_composer.dart
+++ b/super_editor/lib/src/core/document_composer.dart
@@ -255,8 +255,8 @@ class PushCaretRequest extends ChangeSelectionRequest {
   PushCaretRequest(
     DocumentPosition newPosition,
     this.direction,
-  ) : super(DocumentSelection.collapsed(position: newPosition), SelectionChangeType.pushCaret,
-            SelectionReason.userInteraction);
+    SelectionChangeType changeType,
+  ) : super(DocumentSelection.collapsed(position: newPosition), changeType, SelectionReason.userInteraction);
 
   final TextAffinity direction;
 
@@ -483,12 +483,33 @@ enum SelectionChangeType {
   /// dragging with the mouse.
   placeExtent,
 
-  /// Place the caret based on a desire to move the previous caret position upstream or downstream.
-  pushCaret,
+  /// Place the caret based on a desire to move the previous caret position downstream.
+  pushCaretDownstream,
 
-  /// Expand/contract a selection by pushing the extent upstream or downstream, such as by pressing
+  /// Place the caret based on a desire to move the previous caret position upstream.
+  pushCaretUpstream,
+
+  /// Place the caret based on a desire to move the previous caret position down.
+  pushCaretDown,
+
+  /// Place the caret based on a desire to move the previous caret position up.
+  pushCaretUp,
+
+  /// Expand/contract a selection by pushing the extent downstream, such as by pressing
+  /// SHIFT + RIGHT ARROW.
+  pushExtentDownstream,
+
+  /// Expand/contract a selection by pushing the extent upstream, such as by pressing
   /// SHIFT + LEFT ARROW.
-  pushExtent,
+  pushExtentUpstream,
+
+  /// Expand/contract a selection by pushing the extent down, such as by pressing
+  /// SHIFT + DOWN ARROW.
+  pushExtentDown,
+
+  /// Expand/contract a selection by pushing the extent up, such as by pressing
+  /// SHIFT + UP ARROW.
+  pushExtentUp,
 
   /// Expand a caret to an expanded selection, or move the base or extent of an already expanded selection.
   expandSelection,

--- a/super_editor/lib/src/default_editor/common_editor_operations.dart
+++ b/super_editor/lib/src/default_editor/common_editor_operations.dart
@@ -346,7 +346,7 @@ class CommonEditorOperations {
           composer.selection!.expandTo(
             newExtent,
           ),
-          SelectionChangeType.pushExtent,
+          SelectionChangeType.pushExtentUpstream,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -357,7 +357,7 @@ class CommonEditorOperations {
           DocumentSelection.collapsed(
             position: newExtent,
           ),
-          SelectionChangeType.pushCaret,
+          SelectionChangeType.pushCaretUpstream,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -454,7 +454,7 @@ class CommonEditorOperations {
           composer.selection!.expandTo(
             newExtent,
           ),
-          SelectionChangeType.pushExtent,
+          SelectionChangeType.pushExtentDownstream,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -465,7 +465,7 @@ class CommonEditorOperations {
           DocumentSelection.collapsed(
             position: newExtent,
           ),
-          SelectionChangeType.pushCaret,
+          SelectionChangeType.pushCaretDownstream,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -513,6 +513,8 @@ class CommonEditorOperations {
 
     String newExtentNodeId = nodeId;
     NodePosition? newExtentNodePosition = extentComponent.movePositionUp(currentExtent.nodePosition);
+    SelectionChangeType selectionChangeType =
+        expand ? SelectionChangeType.pushExtentUp : SelectionChangeType.pushCaretUp;
 
     if (newExtentNodePosition == null) {
       // Move to next node
@@ -530,6 +532,7 @@ class CommonEditorOperations {
         // We're at the top of the document. Move the cursor to the
         // beginning of the current node.
         newExtentNodePosition = extentComponent.getBeginningPosition();
+        selectionChangeType = expand ? SelectionChangeType.pushExtentUpstream : SelectionChangeType.pushCaretUpstream;
       }
     }
 
@@ -538,7 +541,11 @@ class CommonEditorOperations {
       nodePosition: newExtentNodePosition,
     );
 
-    _updateSelectionExtent(position: newExtent, expandSelection: expand);
+    _updateSelectionExtent(
+      position: newExtent,
+      expandSelection: expand,
+      selectionChangeType: selectionChangeType,
+    );
 
     return true;
   }
@@ -582,6 +589,8 @@ class CommonEditorOperations {
 
     String newExtentNodeId = nodeId;
     NodePosition? newExtentNodePosition = extentComponent.movePositionDown(currentExtent.nodePosition);
+    SelectionChangeType selectionChangeType =
+        expand ? SelectionChangeType.pushExtentDown : SelectionChangeType.pushCaretDown;
 
     if (newExtentNodePosition == null) {
       // Move to next node
@@ -599,6 +608,8 @@ class CommonEditorOperations {
         // We're at the bottom of the document. Move the cursor to the
         // end of the current node.
         newExtentNodePosition = extentComponent.getEndPosition();
+        selectionChangeType =
+            expand ? SelectionChangeType.pushExtentDownstream : SelectionChangeType.pushCaretDownstream;
       }
     }
 
@@ -607,7 +618,11 @@ class CommonEditorOperations {
       nodePosition: newExtentNodePosition,
     );
 
-    _updateSelectionExtent(position: newExtent, expandSelection: expand);
+    _updateSelectionExtent(
+      position: newExtent,
+      expandSelection: expand,
+      selectionChangeType: selectionChangeType,
+    );
 
     return true;
   }
@@ -658,7 +673,11 @@ class CommonEditorOperations {
       nodeId: newNodeId,
       nodePosition: newPosition,
     );
-    _updateSelectionExtent(position: newExtent, expandSelection: expand);
+    _updateSelectionExtent(
+      position: newExtent,
+      expandSelection: expand,
+      selectionChangeType: SelectionChangeType.placeCaret,
+    );
 
     return true;
   }
@@ -794,13 +813,14 @@ class CommonEditorOperations {
   void _updateSelectionExtent({
     required DocumentPosition position,
     required bool expandSelection,
+    required SelectionChangeType selectionChangeType,
   }) {
     if (expandSelection) {
       // Selection should be expanded.
       editor.execute([
         ChangeSelectionRequest(
           composer.selection!.expandTo(position),
-          SelectionChangeType.expandSelection,
+          selectionChangeType,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -809,7 +829,7 @@ class CommonEditorOperations {
       editor.execute([
         ChangeSelectionRequest(
           DocumentSelection.collapsed(position: position),
-          SelectionChangeType.collapseSelection,
+          selectionChangeType,
           SelectionReason.userInteraction,
         ),
       ]);
@@ -967,7 +987,7 @@ class CommonEditorOperations {
             nodePosition: nodeAfter.beginningPosition,
           ),
         ),
-        SelectionChangeType.pushCaret,
+        SelectionChangeType.pushCaretDownstream,
         SelectionReason.userInteraction,
       ),
     ]);

--- a/super_editor/lib/src/default_editor/composer/composer_reactions.dart
+++ b/super_editor/lib/src/default_editor/composer/composer_reactions.dart
@@ -70,7 +70,10 @@ class UpdateComposerTextStylesReaction extends EditReaction {
 
     switch (lastSelectionChange.changeType) {
       case SelectionChangeType.placeCaret:
-      case SelectionChangeType.pushCaret:
+      case SelectionChangeType.pushCaretDownstream:
+      case SelectionChangeType.pushCaretUpstream:
+      case SelectionChangeType.pushCaretUp:
+      case SelectionChangeType.pushCaretDown:
       case SelectionChangeType.collapseSelection:
       case SelectionChangeType.deleteContent:
         _updateComposerStylesAtCaret(editContext);

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -849,7 +849,7 @@ class SuperEditorState extends State<SuperEditor> {
           getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
           selection: _composer.selectionNotifier,
           setSelection: (newSelection) => editContext.editor.execute([
-            ChangeSelectionRequest(newSelection, SelectionChangeType.pushCaret, SelectionReason.userInteraction),
+            ChangeSelectionRequest(newSelection, SelectionChangeType.placeCaret, SelectionReason.userInteraction),
           ]),
           scrollChangeSignal: _scrollChangeSignal,
           dragHandleAutoScroller: _dragHandleAutoScroller,

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -942,7 +942,7 @@ class SplitExistingTaskCommand extends EditCommand {
       SelectionChangeEvent(
         oldSelection: oldSelection,
         newSelection: newSelection,
-        changeType: SelectionChangeType.pushCaret,
+        changeType: SelectionChangeType.pushCaretDownstream,
         reason: SelectionReason.userInteraction,
       ),
       ComposingRegionChangeEvent(

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -19,128 +19,264 @@ void main() {
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 2, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 2,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 1));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
         });
 
         testAllInputsOnDesktop("left by one character and expands when SHIFT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 2, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 2,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 2, to: 1));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUpstream));
         });
 
         testAllInputsOnDesktop("right by one character when RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 2, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 2,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 3));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDownstream));
         });
 
         testAllInputsOnDesktop("right by one character and expands when SHIFT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 2, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 2,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 2, to: 3));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDownstream));
         });
 
         testAllInputsOnApple("to beginning of word when ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressAltLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 8));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
         });
 
         testAllInputsOnApple("to beginning of word and expands when SHIFT + ALT + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftAltLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 8));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUpstream));
+        });
+
+        testAllInputsOnDesktop("to beginning of word and collapses when LEFT_ARROW is pressed", (
+          tester, {
+          required TextInputSource inputSource,
+        }) async {
+          final collector = _EditorSelectionChangeEventsCollector();
+          // Pumps the editor with the word "second" selected.
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 45,
+            expandedSelection: true,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
+
+          await tester.pressLeftArrow();
+
+          expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 41));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.collapseSelection));
         });
 
         testAllInputsOnApple("to end of word when ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressAltRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDownstream));
         });
 
         testAllInputsOnApple("to end of word and expands when SHIFT + ALT + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftAltRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDownstream));
+        });
+
+        testAllInputsOnDesktop("to end of word and collapses when RIGHT_ARROW is pressed", (
+          tester, {
+          required TextInputSource inputSource,
+        }) async {
+          final collector = _EditorSelectionChangeEventsCollector();
+          // Pumps the editor with the word "second" selected.
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 45,
+            expandedSelection: true,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
+
+          await tester.pressRightArrow();
+
+          expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 47));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.collapseSelection));
         });
 
         testAllInputsOnApple("to beginning of line when CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressCmdLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 0));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
         });
 
         testAllInputsOnApple("to beginning of line and expands when SHIFT + CMD + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftCmdLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 0));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUpstream));
         });
 
         testAllInputsOnApple("to end of line when CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressCmdRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 26, TextAffinity.upstream));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDownstream));
         });
 
         testAllInputsOnApple("to end of line and expands when SHIFT + CMD + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftCmdRightArrow();
 
@@ -148,144 +284,290 @@ void main() {
             SuperEditorInspector.findDocumentSelection(),
             _selectionInParagraph(nodeId, from: 10, to: 26, toAffinity: TextAffinity.upstream),
           );
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDownstream));
         });
 
         testAllInputsOnWindowsAndLinux("to beginning of word when CTL + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressCtlLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 8));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
         });
 
         testAllInputsOnWindowsAndLinux("to beginning of word and expands when SHIFT + CTL + LEFT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftCtlLeftArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 8));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUpstream));
         });
 
         testAllInputsOnWindowsAndLinux("to end of word when CTL + Right_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressCtlRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDownstream));
         });
 
         testAllInputsOnWindowsAndLinux("to end of word and expands when SHIFT + CTL + RIGHT_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpSingleLineWithCaret(
+            tester,
+            offset: 10,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftCtlRightArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 10, to: 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDownstream));
         });
 
         testAllInputsOnDesktop("up one line when UP_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 41, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 41,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressUpArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUp));
         });
 
         testAllInputsOnDesktop("up one line and expands when SHIFT + UP_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 41, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 41,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftUpArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 41, to: 12));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUp));
+        });
+
+        testAllInputsOnDesktop("up one line and collapses when UP_ARROW is pressed", (
+          tester, {
+          required TextInputSource inputSource,
+        }) async {
+          final collector = _EditorSelectionChangeEventsCollector();
+          // Pumps the editor with the word "second" selected.
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 44,
+            expandedSelection: true,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
+
+          await tester.pressUpArrow();
+
+          expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 18));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUp));
         });
 
         testAllInputsOnDesktop("down one line when DOWN_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 12, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 12,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressDownArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 41));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDown));
         });
 
         testAllInputsOnDesktop("down one line and expands when SHIFT + DOWN_ARROW is pressed", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 12, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 12,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftDownArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 12, to: 41));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDown));
+        });
+
+        testAllInputsOnDesktop("down one line and collapses when DOWN_ARROW is pressed", (
+          tester, {
+          required TextInputSource inputSource,
+        }) async {
+          final collector = _EditorSelectionChangeEventsCollector();
+          // Pumps the editor with the word "first" selected.
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 15,
+            expandedSelection: true,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
+
+          await tester.pressDownArrow();
+
+          expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 46));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDown));
         });
 
         testAllInputsOnDesktop("to beginning of line when UP_ARROW is pressed at top of document", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 12, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 12,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressUpArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 0));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
         });
 
         testAllInputsOnDesktop("to beginning of line and expands when SHIFT + UP_ARROW is pressed at top of document", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 12, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 12,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftUpArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 12, to: 0));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentUpstream));
         });
 
         testAllInputsOnDesktop("to end of line when DOWN_ARROW is pressed at end of document", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 41, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 41,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressDownArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _caretInParagraph(nodeId, 58));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretDownstream));
         });
 
         testAllInputsOnDesktop("end of line and expands when SHIFT + DOWN_ARROW is pressed at end of document", (
           tester, {
           required TextInputSource inputSource,
         }) async {
-          final nodeId = await _pumpDoubleLineWithCaret(tester, offset: 41, inputSource: inputSource);
+          final collector = _EditorSelectionChangeEventsCollector();
+          final nodeId = await _pumpDoubleLineWithCaret(
+            tester,
+            offset: 41,
+            inputSource: inputSource,
+            selectionChangeCollector: collector,
+          );
 
           await tester.pressShiftDownArrow();
 
           expect(SuperEditorInspector.findDocumentSelection(), _selectionInParagraph(nodeId, from: 41, to: 58));
+          expect(collector.events.length, equals(1));
+          expect(collector.events.first.changeType, equals(SelectionChangeType.pushExtentDownstream));
         });
       });
     });
 
-    testWidgetsOnMacWeb("on web moves caret to beginning of line when CMD + LEFT_ARROW is pressed", (tester) async {
-      final nodeId = await _pumpSingleLineWithCaret(tester, offset: 10, inputSource: TextInputSource.ime);
+    testWidgetsOnMacWeb("moves caret to beginning of line when CMD + LEFT_ARROW is pressed", (tester) async {
+      final collector = _EditorSelectionChangeEventsCollector();
+      final nodeId = await _pumpSingleLineWithCaret(
+        tester,
+        offset: 10,
+        inputSource: TextInputSource.ime,
+        selectionChangeCollector: collector,
+      );
 
       // Simulate the user pressing CMD + LEFT ARROW, which generates a delta moving
       // the selection to the beginning of the line.
@@ -314,6 +596,8 @@ void main() {
           end: DocumentPosition(nodeId: nodeId, nodePosition: const TextNodePosition(offset: 0)),
         ),
       );
+      expect(collector.events.length, equals(1));
+      expect(collector.events.first.changeType, equals(SelectionChangeType.pushCaretUpstream));
     });
 
     testAllInputsOnAllPlatforms('does nothing without primary focus', (
@@ -872,6 +1156,7 @@ Future<String> _pumpSingleLineWithCaret(
   WidgetTester tester, {
   required int offset,
   required TextInputSource inputSource,
+  _EditorSelectionChangeEventsCollector? selectionChangeCollector,
 }) async {
   final testContext = await tester //
       .createDocument()
@@ -883,11 +1168,20 @@ Future<String> _pumpSingleLineWithCaret(
 
   await tester.placeCaretInParagraph(nodeId, offset);
 
+  if (selectionChangeCollector != null) {
+    testContext.editor.addListener(selectionChangeCollector);
+  }
+
   return nodeId;
 }
 
-Future<String> _pumpDoubleLineWithCaret(WidgetTester tester,
-    {required int offset, required TextInputSource inputSource}) async {
+Future<String> _pumpDoubleLineWithCaret(
+  WidgetTester tester, {
+  required int offset,
+  bool expandedSelection = false,
+  required TextInputSource inputSource,
+  _EditorSelectionChangeEventsCollector? selectionChangeCollector,
+}) async {
   final testContext = await tester //
       .createDocument()
       // Text indices:
@@ -896,10 +1190,17 @@ Future<String> _pumpDoubleLineWithCaret(WidgetTester tester,
       // - second line: [30, 58]
       .fromMarkdown("This is the first paragraph.\nThis is the second paragraph.")
       .pump();
-
   final nodeId = testContext.findEditContext().document.first.id;
 
-  await tester.placeCaretInParagraph(nodeId, offset);
+  if (expandedSelection) {
+    await tester.doubleTapInParagraph(nodeId, offset);
+  } else {
+    await tester.placeCaretInParagraph(nodeId, offset);
+  }
+
+  if (selectionChangeCollector != null) {
+    testContext.editor.addListener(selectionChangeCollector);
+  }
 
   return nodeId;
 }
@@ -970,5 +1271,15 @@ class _CloseKeyboardOnDisposeState extends State<_CloseKeyboardOnDispose> {
   @override
   Widget build(BuildContext context) {
     return widget.child;
+  }
+}
+
+/// An [EditListener] that collects all [SelectionChangeEvent]s reported.
+class _EditorSelectionChangeEventsCollector implements EditListener {
+  final List<SelectionChangeEvent> events = [];
+
+  @override
+  void onEdit(List<EditEvent> changeList) {
+    events.addAll(changeList.whereType<SelectionChangeEvent>());
   }
 }


### PR DESCRIPTION
[SuperEditor] Add more specific SelectionChangeTypes (Resolves #2367)

Currently, when moving the caret using up or down arrow, the editor generates a selection change event with the type `SelectionChangeType.collapseSelection`.  This makes it difficult for reactions to determine if the selection moved up or down.

Also, our `SelectionChangeType`s for pushing the caret or extent don't carry the direction of the selection change.

This PR removes `SelectionChangeType.pushCaret` and `SelectionChangeType.pushExtent` in favor of more specific types:

- `SelectionChangeType.pushDownstream`
- `SelectionChangeType.pushCaretUpstream`
- `SelectionChangeType.pushCaretDown`
- `SelectionChangeType.pushCaretUp`
- `SelectionChangeType.pushExtentDownstream`
- `SelectionChangeType.pushExtentUpstream`
- `SelectionChangeType.pushExtentDown`
- `SelectionChangeType.pushExtentUp`

This is a breaking change, but I think it's much more safer to generate a compilation error instead of keeping `SelectionChangeType.pushCaretUp` and possibly silently failing at runtime.

The upgrade should be straightforward: 

Before

```dart
if (selectionChangeType == SelectionChangeType.pushCaret) {

}

switch (selectionChangeType) {
  case SelectionChangeType.pushCaret:         
    break;
}
```

After:

```dart
if (const [
  SelectionChangeType.pushCaretDownstream,
  SelectionChangeType.pushCaretUpstream,
  SelectionChangeType.pushCaretDown,
  SelectionChangeType.pushCaretUp
].contains(selectionChangeType)) {

}

switch (selectionChangeType) {
  case SelectionChangeType.pushCaretDownstream:
  case SelectionChangeType.pushCaretUpstream:
  case SelectionChangeType.pushCaretDown:
  case SelectionChangeType.pushCaretUp:
    break;
}

// The same for pushExtent.
```

On Android, we are always generating a selection change type of `SelectionChangeType.pushCaret`. This PR changes it to `SelectionChangeType.placeCaret`, but it might be better to let that decision to the touch interactor instead.

On web, things are a bit trickier. We handle selection changes by IME deltas, so we don't have information about the intent of the selection change. Should we compare the new selection, with the selection that is expected when the user presses up/down/left/right arrow to determine what is the correct selection change type?

