### PR TITLE
[SuperEditor][iOS] Update spellcheck popover suggestions dimensions (Resolves #2577)

### DIFF
--- a/super_editor_spellcheck/lib/src/super_editor/spelling_error_suggestion_overlay.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_error_suggestion_overlay.dart
@@ -994,10 +994,10 @@ class _IosSpellingSuggestionToolbarState extends State<IosSpellingSuggestionTool
         foregroundColor: _getTextColor(brightness),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12.0),
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
         child: Text(
           title,
-          style: const TextStyle(fontSize: 12),
+          style: const TextStyle(fontSize: 14),
         ),
       ),
     );


### PR DESCRIPTION
[SuperEditor][iOS] Update spellcheck popover suggestions dimensions (Resolves #2577)

It was reported that the buttons in the spell check suggestions popover don't have the same dimensions that the native toolbar has.

I measured the dimensions from Apple Notes, and it seems the only thing we need is to increase the horizontal padding and the font size:

Apple Notes:

![image](https://github.com/user-attachments/assets/291aa0e0-6fd4-4493-9807-8872529af20e)

SuperEditor (currently):

![image](https://github.com/user-attachments/assets/dbb42fe9-a6b8-41cf-85f5-5fb051697c87)


SuperEditor (This PR):

![image](https://github.com/user-attachments/assets/bf313e99-d3b7-45ab-869d-8ed4fae20175)

