### PR TITLE
[SuperEditor][Android][Web] Fix ENTER not correctly splitting list items and tasks (Resolves #2600)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -124,10 +124,10 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine('Old text: "${delta.oldText}"');
 
     if (delta.textInserted == "\n") {
-      // On iOS, newlines are reported here and also to performAction().
-      // On Android, newlines are only reported here. So, on Android,
+      // On iOS and Android Web, newlines are reported here and also to performAction().
+      // On Android native, newlines are only reported here. So, on Android native,
       // we forward the newline action to performAction.
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (defaultTargetPlatform == TargetPlatform.android && !CurrentPlatform.isWeb) {
         editorImeLog.fine("Received a newline insertion on Android. Forwarding to newline input action.");
         onPerformAction(TextInputAction.newline);
       } else {
@@ -197,10 +197,10 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine('Old text: "${delta.oldText}"');
 
     if (delta.replacementText == "\n") {
-      // On iOS, newlines are reported here and also to performAction().
-      // On Android, newlines are only reported here. So, on Android,
+      // On iOS and Android Web, newlines are reported here and also to performAction().
+      // On Android native, newlines are only reported here. So, on Android native,
       // we forward the newline action to performAction.
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (defaultTargetPlatform == TargetPlatform.android && !CurrentPlatform.isWeb) {
         editorImeLog.fine("Received a newline replacement on Android. Forwarding to newline input action.");
         onPerformAction(TextInputAction.newline);
       } else {

--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -124,7 +124,7 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine('Old text: "${delta.oldText}"');
 
     if (delta.textInserted == "\n") {
-      // On iOS and Android Web, newlines are reported here and also to performAction().
+      // On iOS native and Android Web, newlines are reported here and also to performAction().
       // On Android native, newlines are only reported here. So, on Android native,
       // we forward the newline action to performAction.
       if (defaultTargetPlatform == TargetPlatform.android && !CurrentPlatform.isWeb) {
@@ -197,7 +197,7 @@ class TextDeltasDocumentEditor {
     editorImeLog.fine('Old text: "${delta.oldText}"');
 
     if (delta.replacementText == "\n") {
-      // On iOS and Android Web, newlines are reported here and also to performAction().
+      // On iOS native and Android Web, newlines are reported here and also to performAction().
       // On Android native, newlines are only reported here. So, on Android native,
       // we forward the newline action to performAction.
       if (defaultTargetPlatform == TargetPlatform.android && !CurrentPlatform.isWeb) {

--- a/super_editor/test/super_editor/components/list_items_test.dart
+++ b/super_editor/test/super_editor/components/list_items_test.dart
@@ -443,6 +443,54 @@ void main() {
         );
       });
 
+      testWidgetsOnWebAndroid("inserts new item upon new line insertion at end of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* Item 1')
+            .pump();
+
+        final document = context.findEditContext().document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.first.id, 6);
+
+        // Type at the end of the list item to generate a composing region,
+        // simulating the Samsung keyboard.
+        await tester.typeImeText('2');
+        await tester.ime.sendDeltas(const [
+          TextEditingDeltaNonTextUpdate(
+            oldText: '. Item 12',
+            selection: TextSelection.collapsed(offset: 9),
+            composing: TextRange.collapsed(9),
+          ),
+        ], getter: imeClientGetter);
+
+        // On Android Web, pressing ENTER generates both a "\n" insertion and a newline input action.
+        await tester.pressEnterWithIme(getter: imeClientGetter);
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodeCount, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.toPlainText(), "Item 12");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.toPlainText(), "");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
       testWidgetsOnMobile("inserts new item upon new line input action at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
@@ -538,6 +586,40 @@ void main() {
 
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.toPlainText(), "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.toPlainText(), "Item");
+        expect((document.last as ListItemNode).type, ListItemType.unordered);
+        expect((document.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnWebAndroid("splits list item into two upon new line insertion in middle of existing item",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('* List Item')
+            .pump();
+
+        final document = context.findEditContext().document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.first.id, 5);
+
+        // On Android Web, pressing ENTER generates both a "\n" insertion and a newline input action.
+        await tester.pressEnterWithIme(getter: imeClientGetter);
 
         // Ensure that a new item was created with part of the previous item.
         expect(document.nodeCount, 2);
@@ -939,6 +1021,43 @@ A paragraph
         );
       });
 
+      testWidgetsOnWebAndroid("inserts new item upon new line insertion at end of existing item", (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. Item 1')
+            .pump();
+
+        final document = context.findEditContext().document;
+
+        // Place the caret at the end of the list item.
+        await tester.placeCaretInParagraph(document.first.id, 6);
+
+        // On Android Web, pressing ENTER generates both a "\n" insertion and a newline input action.
+        await tester.pressEnterWithIme(getter: imeClientGetter);
+
+        // Ensure that a new, empty list item was created.
+        expect(document.nodeCount, 2);
+
+        // Ensure the existing item remains the same.
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.toPlainText(), "Item 1");
+
+        // Ensure the new item has the correct list item type and indentation.
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.toPlainText(), "");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
       testWidgetsOnMobile("inserts new item upon new line input action at end of existing item", (tester) async {
         final context = await tester //
             .createDocument()
@@ -1023,6 +1142,40 @@ A paragraph
 
         // On Android, pressing ENTER generates a "\n" insertion.
         await tester.typeImeText("\n");
+
+        // Ensure that a new item was created with part of the previous item.
+        expect(document.nodeCount, 2);
+        expect(document.first, isA<ListItemNode>());
+        expect((document.first as ListItemNode).text.toPlainText(), "List ");
+        expect(document.last, isA<ListItemNode>());
+        expect((document.last as ListItemNode).text.toPlainText(), "Item");
+        expect((document.last as ListItemNode).type, ListItemType.ordered);
+        expect((document.last as ListItemNode).indent, 0);
+        expect(
+          SuperEditorInspector.findDocumentSelection(),
+          DocumentSelection.collapsed(
+            position: DocumentPosition(
+              nodeId: document.last.id,
+              nodePosition: const TextNodePosition(offset: 0),
+            ),
+          ),
+        );
+      });
+
+      testWidgetsOnWebAndroid("splits list item into two upon new line insertion in middle of existing item",
+          (tester) async {
+        final context = await tester //
+            .createDocument()
+            .fromMarkdown('1. List Item')
+            .pump();
+
+        final document = context.findEditContext().document;
+
+        // Place the caret at "List |Item"
+        await tester.placeCaretInParagraph(document.first.id, 5);
+
+        // On Android Web, pressing ENTER generates both a "\n" insertion and a newline input action.
+        await tester.pressEnterWithIme(getter: imeClientGetter);
 
         // Ensure that a new item was created with part of the previous item.
         expect(document.nodeCount, 2);


### PR DESCRIPTION
[SuperEditor][Android][Web] Fix ENTER not correctly splitting list items and tasks (Resolves #2600)

On Android, pressing ENTER on a list item or task does not correctly splits the list item:

https://github.com/user-attachments/assets/2c9137a4-3c04-4f50-a31e-b1bd770ad5c2

On Android native, pressing ENTER generates only a new line insertion delta. Because of that, when receive a new line insertion, we call `onPerformAction` to notify that the `TextInputAction.newline` happened.

The issue is that, on Android Web, pressing ENTER generates both an `onPerformAction` call and a new line insertion delta. So we end up with `onPerformAction` being called twice. This causes a new list item to be inserted and being immediately converted to a paragraph.

This PR modifies the IME code to avoid calling `onPerformAction` for a new line insertion on Android Web, because the `onPerformAction` will already be called automatically.

We have tests for Android native, where we are only reporting the new line insertion deltas (as expected for Android native). I duplicated those tests to report the new line insertion and the `onPerformAction` call. 

The `pressEnterWithIme` method from `flutter_test_robots` always report both signals:

```dart
Future<void> pressEnterWithIme({
    Finder? finder,
    GetDeltaTextInputClient? getter,
}) async {
  if (!testTextInput.hasAnyClients) {
    // There isn't any IME connections.
    return;
  }

  await ime.typeText('\n', finder: finder, getter: getter);
  await pump();
  await testTextInput.receiveAction(TextInputAction.newline);
  await pump();
}
```

We should call the `receiveAction` on Android only if it's running on Web. The issue is that `flutter_test_robots` doesn't have `WebPlatformOverride` as we have in `SuperEditor`, so we can't simulate a web test here. We should find a way to make it easy to use `pressEnterWithIme` in both native and web tests without needing to modify each test that uses it.