### PR TITLE
[SuperEditor] Fix text duplicated when a placeholder is inserted in a text with attributions (Resolves #2595)

### DIFF
--- a/super_editor/lib/src/infrastructure/attributed_text_styles.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text_styles.dart
@@ -40,19 +40,18 @@ extension ComputeTextSpan on AttributedText {
 
       // A single span might be divided in multiple inline spans if there are placeholders.
       // Keep track of the start of the current inline span.
-      int startOfInlineSpan = span.start;
+      int startOfMostRecentTextRun = span.start;
 
       // Look for placeholders within the current span and split the span accordingly.
-      int characterIndex = span.start;
-      while (characterIndex <= span.end) {
-        if (placeholders[characterIndex] != null) {
+      for (int i = span.start; i <= span.end; i++) {
+        if (placeholders[i] != null) {
           // We found a placeholder. Build a widget for it.
 
-          if (characterIndex > startOfInlineSpan) {
-            // There is text before the placeholder.
+          if (i > startOfMostRecentTextRun) {
+            // There is text before the placeholder. Add the current text run to the span.
             inlineSpans.add(
               TextSpan(
-                text: substring(startOfInlineSpan, characterIndex),
+                text: substring(startOfMostRecentTextRun, i),
                 style: textStyle,
               ),
             );
@@ -60,7 +59,7 @@ extension ComputeTextSpan on AttributedText {
 
           Widget? inlineWidget;
           for (final builder in inlineWidgetBuilders) {
-            inlineWidget = builder(context, textStyle, placeholders[characterIndex]!);
+            inlineWidget = builder(context, textStyle, placeholders[i]!);
             if (inlineWidget != null) {
               break;
             }
@@ -76,17 +75,15 @@ extension ComputeTextSpan on AttributedText {
           }
 
           // Start another inline span after the placeholder.
-          startOfInlineSpan = characterIndex + 1;
+          startOfMostRecentTextRun = i + 1;
         }
-
-        characterIndex += 1;
       }
 
-      if (startOfInlineSpan <= span.end) {
+      if (startOfMostRecentTextRun <= span.end) {
         // There is text after the last placeholder or there is no placeholder at all.
         inlineSpans.add(
           TextSpan(
-            text: substring(startOfInlineSpan, span.end + 1),
+            text: substring(startOfMostRecentTextRun, span.end + 1),
             style: textStyle,
           ),
         );

--- a/super_editor/lib/src/infrastructure/attributed_text_styles.dart
+++ b/super_editor/lib/src/infrastructure/attributed_text_styles.dart
@@ -63,13 +63,26 @@ extension ComputeTextSpan on AttributedText {
         }
       } else {
         // This section is text. The end of this text is either the
-        // end of the AttributedText, or the index of the next placeholder.
+        // end of the current span, or the index of the next placeholder.
         contentEnd = span.end + 1;
+
+        final nextSpan = spanIndex + 1 < collapsedSpans.length //
+            ? collapsedSpans[spanIndex + 1]
+            : null;
         for (final entry in placeholders.entries) {
-          if (entry.key > start) {
-            contentEnd = entry.key;
+          if (entry.key <= start) {
+            // This placeholder is before the current span.
+            continue;
+          }
+
+          if (nextSpan != null && entry.key >= nextSpan.start) {
+            // This placeholder is beyond the next span.
             break;
           }
+
+          // This placeholder is within the current span.
+          contentEnd = entry.key;
+          break;
         }
 
         inlineSpans.add(

--- a/super_editor/test/infrastructure/inline_span_test.dart
+++ b/super_editor/test/infrastructure/inline_span_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/super_editor.dart';
+
+void main() {
+  group('SuperEditor > computeInlineSpan >', () {
+    testWidgets('does not modify text with attributions and a placeholder at the beginning', (tester) async {
+      // Pump a widget because we need a BuildContext to compute the InlineSpan.
+      await tester.pumpWidget(
+        const MaterialApp(),
+      );
+
+      // Create an AttributedText with the words "Welcome" and "SuperEditor" in bold and with a leading placeholder.
+      final text = AttributedText(
+        'Welcome to SuperEditor',
+        AttributedSpans(
+          attributions: [
+            const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 21, markerType: SpanMarkerType.end),
+          ],
+        ),
+        {0: const _ExamplePlaceholder()},
+      );
+
+      final inlineSpan = text.computeInlineSpan(
+        find.byType(MaterialApp).evaluate().first as BuildContext,
+        defaultStyleBuilder,
+        [_inlineWidgetBuilder],
+      );
+
+      // Ensure the text was not modified.
+      expect(
+        inlineSpan.toPlainText(includePlaceholders: false),
+        'Welcome to SuperEditor',
+      );
+    });
+
+    testWidgets('does not modify text with attributions and a placeholder at the middle', (tester) async {
+      // Pump a widget because we need a BuildContext to compute the InlineSpan.
+      await tester.pumpWidget(
+        const MaterialApp(),
+      );
+
+      // Create an AttributedText with the words "Welcome" and "SuperEditor" in bold and with a
+      // placeholder after the word "to".
+      final text = AttributedText(
+        'Welcome to SuperEditor',
+        AttributedSpans(
+          attributions: [
+            const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 21, markerType: SpanMarkerType.end),
+          ],
+        ),
+        {10: const _ExamplePlaceholder()},
+      );
+
+      final inlineSpan = text.computeInlineSpan(
+        find.byType(MaterialApp).evaluate().first as BuildContext,
+        defaultStyleBuilder,
+        [_inlineWidgetBuilder],
+      );
+
+      // Ensure the text was not modified.
+      expect(
+        inlineSpan.toPlainText(includePlaceholders: false),
+        'Welcome to SuperEditor',
+      );
+    });
+
+    testWidgets('does not modify text with attributions and a placeholder at the end', (tester) async {
+      // Pump a widget because we need a BuildContext to compute the InlineSpan.
+      await tester.pumpWidget(
+        const MaterialApp(),
+      );
+
+      // Create an AttributedText with the word "Welcome" in bold and with a trailing placeholder.
+      // Create an AttributedText with the words "Welcome" and "SuperEditor" in bold and with a
+      // placeholder after the word "to".
+      final text = AttributedText(
+        'Welcome to SuperEditor',
+        AttributedSpans(
+          attributions: [
+            const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 21, markerType: SpanMarkerType.end),
+          ],
+        ),
+        {22: const _ExamplePlaceholder()},
+      );
+
+      final inlineSpan = text.computeInlineSpan(
+        find.byType(MaterialApp).evaluate().first as BuildContext,
+        defaultStyleBuilder,
+        [_inlineWidgetBuilder],
+      );
+
+      // Ensure the text was not modified.
+      expect(
+        inlineSpan.toPlainText(includePlaceholders: false),
+        'Welcome to SuperEditor',
+      );
+    });
+  });
+}
+
+class _ExamplePlaceholder {
+  const _ExamplePlaceholder();
+}
+
+Widget? _inlineWidgetBuilder(BuildContext context, TextStyle textStyle, Object placeholder) {
+  return const SizedBox(width: 10);
+}

--- a/super_editor/test/infrastructure/inline_span_test.dart
+++ b/super_editor/test/infrastructure/inline_span_test.dart
@@ -77,9 +77,7 @@ void main() {
         const MaterialApp(),
       );
 
-      // Create an AttributedText with the word "Welcome" in bold and with a trailing placeholder.
-      // Create an AttributedText with the words "Welcome" and "SuperEditor" in bold and with a
-      // placeholder after the word "to".
+      // Create an AttributedText with the words "Welcome" and "SuperEditor" in bold and a trailing placeholder.
       final text = AttributedText(
         'Welcome to SuperEditor',
         AttributedSpans(

--- a/super_editor/test/infrastructure/inline_span_test.dart
+++ b/super_editor/test/infrastructure/inline_span_test.dart
@@ -4,7 +4,7 @@ import 'package:super_editor/super_editor.dart';
 
 void main() {
   group('SuperEditor > computeInlineSpan >', () {
-    testWidgets('does not modify text with attributions and a placeholder at the beginning', (tester) async {
+    testWidgets('computes inlineSpan for text with attributions and a placeholder at the beginning', (tester) async {
       // Pump a widget because we need a BuildContext to compute the InlineSpan.
       await tester.pumpWidget(
         const MaterialApp(),
@@ -15,10 +15,10 @@ void main() {
         'Welcome to SuperEditor',
         AttributedSpans(
           attributions: [
-            const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
-            const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: boldAttribution, offset: 21, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 1, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 7, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 12, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 22, markerType: SpanMarkerType.end),
           ],
         ),
         {0: const _ExamplePlaceholder()},
@@ -30,14 +30,34 @@ void main() {
         [_inlineWidgetBuilder],
       );
 
-      // Ensure the text was not modified.
-      expect(
-        inlineSpan.toPlainText(includePlaceholders: false),
-        'Welcome to SuperEditor',
-      );
+      final spanList = _flattenInlineSpan(inlineSpan);
+      expect(spanList.length, equals(5));
+
+      // Ensure that the first span is an empty TextSpan with the default fontWeight.
+      expect(spanList[0], isA<TextSpan>());
+      expect((spanList[0] as TextSpan).text, equals(''));
+      expect((spanList[0] as TextSpan).style!.fontWeight, isNull);
+
+      // Expect that the second span is the widget rendered using the placeholder.
+      expect(spanList[1], isA<WidgetSpan>());
+
+      // Ensure that the third span is a TextSpan with the text "Welcome" in bold.
+      expect(spanList[2], isA<TextSpan>());
+      expect((spanList[2] as TextSpan).text, equals('Welcome'));
+      expect((spanList[2] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
+
+      // Ensure that the fourth span is a TextSpan with the text " to " with the default fontWeight.
+      expect(spanList[3], isA<TextSpan>());
+      expect((spanList[3] as TextSpan).text, equals(' to '));
+      expect((spanList[3] as TextSpan).style!.fontWeight, isNull);
+
+      // Ensure that the fifth span is a TextSpan with the text "SuperEditor" in bold.
+      expect(spanList[4], isA<TextSpan>());
+      expect((spanList[4] as TextSpan).text, equals('SuperEditor'));
+      expect((spanList[4] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
     });
 
-    testWidgets('does not modify text with attributions and a placeholder at the middle', (tester) async {
+    testWidgets('computes inlineSpan for text with attributions and a placeholder at the middle', (tester) async {
       // Pump a widget because we need a BuildContext to compute the InlineSpan.
       await tester.pumpWidget(
         const MaterialApp(),
@@ -51,8 +71,8 @@ void main() {
           attributions: [
             const SpanMarker(attribution: boldAttribution, offset: 0, markerType: SpanMarkerType.start),
             const SpanMarker(attribution: boldAttribution, offset: 6, markerType: SpanMarkerType.end),
-            const SpanMarker(attribution: boldAttribution, offset: 11, markerType: SpanMarkerType.start),
-            const SpanMarker(attribution: boldAttribution, offset: 21, markerType: SpanMarkerType.end),
+            const SpanMarker(attribution: boldAttribution, offset: 12, markerType: SpanMarkerType.start),
+            const SpanMarker(attribution: boldAttribution, offset: 22, markerType: SpanMarkerType.end),
           ],
         ),
         {10: const _ExamplePlaceholder()},
@@ -64,14 +84,39 @@ void main() {
         [_inlineWidgetBuilder],
       );
 
-      // Ensure the text was not modified.
-      expect(
-        inlineSpan.toPlainText(includePlaceholders: false),
-        'Welcome to SuperEditor',
-      );
+      final spanList = _flattenInlineSpan(inlineSpan);
+      expect(spanList.length, equals(6));
+
+      // Ensure that the first span is an empty TextSpan with the default fontWeight.
+      expect(spanList[0], isA<TextSpan>());
+      expect((spanList[0] as TextSpan).text, equals(''));
+      expect((spanList[0] as TextSpan).style!.fontWeight, isNull);
+
+      // Expect that the second span is a TextSpan with the text "Welcome" in bold.
+      expect(spanList[1], isA<TextSpan>());
+      expect((spanList[1] as TextSpan).text, equals('Welcome'));
+      expect((spanList[1] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
+
+      // Ensure that the third span is a TextSpan with the text " to" with the default fontWeight.
+      expect(spanList[2], isA<TextSpan>());
+      expect((spanList[2] as TextSpan).text, equals(' to'));
+      expect((spanList[2] as TextSpan).style!.fontWeight, isNull);
+
+      // Expect that the fourth span is the widget rendered using the placeholder.
+      expect(spanList[3], isA<WidgetSpan>());
+
+      // Ensure that the fifth span is a TextSpan with the text " " with the default fontWeight.
+      expect(spanList[4], isA<TextSpan>());
+      expect((spanList[4] as TextSpan).text, equals(' '));
+      expect((spanList[4] as TextSpan).style!.fontWeight, isNull);
+
+      // Ensure that the sixth span is a TextSpan with the text "SuperEditor" in bold.
+      expect(spanList[5], isA<TextSpan>());
+      expect((spanList[5] as TextSpan).text, equals('SuperEditor'));
+      expect((spanList[5] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
     });
 
-    testWidgets('does not modify text with attributions and a placeholder at the end', (tester) async {
+    testWidgets('computes inlineSpan for text with attributions and a placeholder at the end', (tester) async {
       // Pump a widget because we need a BuildContext to compute the InlineSpan.
       await tester.pumpWidget(
         const MaterialApp(),
@@ -97,13 +142,44 @@ void main() {
         [_inlineWidgetBuilder],
       );
 
-      // Ensure the text was not modified.
-      expect(
-        inlineSpan.toPlainText(includePlaceholders: false),
-        'Welcome to SuperEditor',
-      );
+      final spanList = _flattenInlineSpan(inlineSpan);
+      expect(spanList.length, equals(5));
+
+      // Ensure that the first span is an empty TextSpan with the default fontWeight.
+      expect(spanList[0], isA<TextSpan>());
+      expect((spanList[0] as TextSpan).text, equals(''));
+      expect((spanList[0] as TextSpan).style!.fontWeight, isNull);
+
+      // Ensure that the second span is a TextSpan with the text "Welcome" in bold.
+      expect(spanList[1], isA<TextSpan>());
+      expect((spanList[1] as TextSpan).text, equals('Welcome'));
+      expect((spanList[1] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
+
+      // Ensure that the third span is a TextSpan with the text " to " with the default fontWeight.
+      expect(spanList[2], isA<TextSpan>());
+      expect((spanList[2] as TextSpan).text, equals(' to '));
+      expect((spanList[2] as TextSpan).style!.fontWeight, isNull);
+
+      // Ensure that the fourth span is a TextSpan with the text "SuperEditor" in bold.
+      expect(spanList[3], isA<TextSpan>());
+      expect((spanList[3] as TextSpan).text, equals('SuperEditor'));
+      expect((spanList[3] as TextSpan).style!.fontWeight, equals(FontWeight.bold));
+
+      // Expect that the fifth span is the widget rendered using the placeholder.
+      expect(spanList[4], isA<WidgetSpan>());
     });
   });
+}
+
+List<InlineSpan> _flattenInlineSpan(InlineSpan inlineSpan) {
+  final flatList = <InlineSpan>[];
+
+  inlineSpan.visitChildren((child) {
+    flatList.add(child);
+    return true;
+  });
+
+  return flatList;
 }
 
 class _ExamplePlaceholder {


### PR DESCRIPTION
[SuperEditor] Fix text duplicated when a placeholder is inserted in a text with attributions (Resolves #2595)

When inserting a placeholder after an attributed region, the editor duplicates the text:

https://github.com/user-attachments/assets/2a66b975-5a8a-4f00-b454-16adfe7595eb

The node's text itself isn't duplicated, the issue lives in the `InlineSpan` computation:

https://github.com/superlistapp/super_editor/blob/068aeb0114ca6ac5307217c26ae04906f65d9400/super_editor/lib/src/infrastructure/attributed_text_styles.dart#L64-L81

When there is a placeholder, we are assuming that the placeholder belongs in the current text span, which isn't always the case when there are attributions before the placeholder.

This PR fixes the issue by checking if the placeholder isn't part of a subsequent span.

I added tests for the `computeInlineSpan` extension method, but we could add tests using `SuperEditor` if needed.

I also found a separate issue when trying to insert a placeholder if the inline markdown plugin converter is used. I filed https://github.com/superlistapp/super_editor/issues/2604 for that.

