### PR TITLE
[FEATURE] - inline widgets in List Item Component #2608

### DIFF
--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -209,6 +209,7 @@ class ListItemComponentBuilder implements ComponentBuilder {
         selectionColor: componentViewModel.selectionColor,
         highlightWhenEmpty: componentViewModel.highlightWhenEmpty,
         underlines: componentViewModel.createUnderlines(),
+        inlineWidgetBuilders: componentViewModel.inlineWidgetBuilders,
       );
     } else if (componentViewModel is OrderedListItemComponentViewModel) {
       return OrderedListItemComponent(
@@ -224,6 +225,7 @@ class ListItemComponentBuilder implements ComponentBuilder {
         selectionColor: componentViewModel.selectionColor,
         highlightWhenEmpty: componentViewModel.highlightWhenEmpty,
         underlines: componentViewModel.createUnderlines(),
+        inlineWidgetBuilders: componentViewModel.inlineWidgetBuilders,
       );
     }
 
@@ -378,6 +380,7 @@ class UnorderedListItemComponentViewModel extends ListItemComponentViewModel {
       spellingErrors: List.from(spellingErrors),
       grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
       grammarErrors: List.from(grammarErrors),
+      inlineWidgetBuilders: inlineWidgetBuilders,
     );
   }
 
@@ -447,6 +450,7 @@ class OrderedListItemComponentViewModel extends ListItemComponentViewModel {
       spellingErrors: List.from(spellingErrors),
       grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
       grammarErrors: List.from(grammarErrors),
+      inlineWidgetBuilders: inlineWidgetBuilders,
     );
   }
 


### PR DESCRIPTION
[FEATURE] - inline widgets in List Item Component (https://github.com/superlistapp/super_editor/issues/2608)

Inline widget builders passed from componentViewModel to List Item Components. Inline widget builders preserved in UnorderedListItemComponentViewModel and OrderedListItemComponentViewModel copy methods.