### PR TITLE
[SuperEditor][SuperTextField] Fix text layout invalidating when selection changes (Resolves #2611)

### DIFF
--- a/super_editor/lib/src/super_textfield/android/android_textfield.dart
+++ b/super_editor/lib/src/super_textfield/android/android_textfield.dart
@@ -1,4 +1,3 @@
-import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
@@ -573,14 +572,6 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
 
   @override
   Widget build(BuildContext context) {
-    return OverlayPortal(
-      controller: _popoverController,
-      overlayChildBuilder: _buildPopoverToolbar,
-      child: _buildTextField(),
-    );
-  }
-
-  Widget _buildTextField() {
     return TapRegion(
       groupId: widget.tapRegionGroupId,
       child: Focus(
@@ -688,13 +679,17 @@ class SuperAndroidTextFieldState extends State<SuperAndroidTextField>
             return const SizedBox();
           }
 
-          return TextLayoutCaret(
-            textLayout: textLayout,
-            style: widget.caretStyle,
-            position: _textEditingController.selection.isCollapsed //
-                ? _textEditingController.selection.extent
-                : null,
-            blinkController: _caretBlinkController,
+          return OverlayPortal(
+            controller: _popoverController,
+            overlayChildBuilder: _buildPopoverToolbar,
+            child: TextLayoutCaret(
+              textLayout: textLayout,
+              style: widget.caretStyle,
+              position: _textEditingController.selection.isCollapsed //
+                  ? _textEditingController.selection.extent
+                  : null,
+              blinkController: _caretBlinkController,
+            ),
           );
         },
       ),

--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -573,14 +573,6 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
 
   @override
   Widget build(BuildContext context) {
-    return OverlayPortal(
-      controller: _popoverController,
-      overlayChildBuilder: _buildOverlayIosControls,
-      child: _buildTextField(),
-    );
-  }
-
-  Widget _buildTextField() {
     return TapRegion(
       groupId: widget.tapRegionGroupId,
       child: Focus(
@@ -694,21 +686,25 @@ class SuperIOSTextFieldState extends State<SuperIOSTextField>
             return const SizedBox();
           }
 
-          return Stack(
-            clipBehavior: Clip.none,
-            children: [
-              TextLayoutCaret(
-                textLayout: textLayout,
-                style: widget.caretStyle,
-                position: _textEditingController.selection.isCollapsed //
-                    ? _textEditingController.selection.extent
-                    : null,
-                blinkController: _caretBlinkController,
-              ),
-              IOSFloatingCursor(
-                controller: _floatingCursorController,
-              ),
-            ],
+          return OverlayPortal(
+            controller: _popoverController,
+            overlayChildBuilder: _buildOverlayIosControls,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                TextLayoutCaret(
+                  textLayout: textLayout,
+                  style: widget.caretStyle,
+                  position: _textEditingController.selection.isCollapsed //
+                      ? _textEditingController.selection.extent
+                      : null,
+                  blinkController: _caretBlinkController,
+                ),
+                IOSFloatingCursor(
+                  controller: _floatingCursorController,
+                ),
+              ],
+            ),
           );
         },
       ),

--- a/super_editor/test/super_editor/supereditor_inline_widgets_test.dart
+++ b/super_editor/test/super_editor/supereditor_inline_widgets_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_runners/flutter_test_runners.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor/super_editor_test.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+import 'supereditor_test_tools.dart';
+
+void main() {
+  group('SuperEditor > inline widgets >', () {
+    testWidgetsOnAllPlatforms('does not invalidate layout when selection changes', (tester) async {
+      await tester
+          .createDocument()
+          .withCustomContent(
+            MutableDocument(
+              nodes: [
+                ParagraphNode(
+                  id: '1',
+                  text: AttributedText('Hello, world!', null, {
+                    7: const _NamedPlaceHolder('world'),
+                  }),
+                ),
+              ],
+            ),
+          )
+          .useStylesheet(
+            defaultStylesheet.copyWith(
+              inlineWidgetBuilders: [_boxPlaceHolderBuilder],
+            ),
+          )
+          .pump();
+
+      // Place the caret at the beginning of the paragraph.
+      await tester.placeCaretInParagraph('1', 0);
+
+      // Keep track of whether of not the layout was invalidated.
+      bool wasLayoutInvalidated = false;
+
+      final renderParagraph = find
+          .byType(LayoutAwareRichText) //
+          .evaluate()
+          .first
+          .findRenderObject() as RenderLayoutAwareParagraph;
+      renderParagraph.onMarkNeedsLayout = () {
+        wasLayoutInvalidated = true;
+      };
+
+      // Place the selection somewhere else.
+      await tester.placeCaretInParagraph('1', 2);
+
+      // Ensure the layout was not invalidated.
+      expect(wasLayoutInvalidated, isFalse);
+    });
+  });
+}
+
+/// A builder that renders a [ColoredBox] for a [_NamedPlaceHolder].
+Widget? _boxPlaceHolderBuilder(BuildContext context, TextStyle textStyle, Object placeholder) {
+  if (placeholder is! _NamedPlaceHolder) {
+    return null;
+  }
+
+  return KeyedSubtree(
+    key: ValueKey('placeholder-${placeholder.name}'),
+    child: LineHeight(
+      style: textStyle,
+      child: const SizedBox(
+        width: 24,
+        child: ColoredBox(
+          color: Colors.yellow,
+        ),
+      ),
+    ),
+  );
+}
+
+/// A placeholder that is identified by a name.
+class _NamedPlaceHolder {
+  const _NamedPlaceHolder(this.name);
+
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is _NamedPlaceHolder && runtimeType == other.runtimeType && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+}


### PR DESCRIPTION
[SuperEditor][SuperTextField] Fix text layout invalidating when selection changes (Resolves #2611)

In `SuperTextField` in iOS and Android, when there are placeholders present, double tapping causes the textfield to crash with the following exception:

```console
The following _TypeError was thrown building MultiListenableBuilder(dirty, state: _MultiListenableBuilderState#19999):
Null check operator used on a null value

When the exception was thrown, this was the stack: 
#0      SuperTextState.textLayout (package:super_text_layout/src/super_text.dart:70:89)
#1      _IOSEditingControlsState._textLayout (package:super_editor/src/super_textfield/ios/editing_controls.dart:148:74)
#2      _IOSEditingControlsState._buildDraggableOverlayHandles (package:super_editor/src/super_textfield/ios/editing_controls.dart:444:28)
#3      _IOSEditingControlsState.build.<anonymous closure> (package:super_editor/src/super_textfield/ios/editing_controls.dart:297:18)
#4      _MultiListenableBuilderState.build (package:super_editor/src/infrastructure/multi_listenable_builder.dart:66:26)
#5      StatefulElement.build (package:flutter/src/widgets/framework.dart:5743:27)
#6      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5631:15)
#7      StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:5794:11)
#8      Element.rebuild (package:flutter/src/widgets/framework.dart:5347:7)
and much more...
```

The root cause is that, when using `WidgetSpan`s in a `TextSpan`, each build is triggering a layout phase due to the child widget being compared with `==`, instead of relying on the build pipeline itself to mark the layout as dirty if needed.

The mobile textfields use the text layout to compute the position for drag handles, the magnifier, etc. Because of the layout invalidation, we were trying to access an invalid layout, which causes the crash.

This PR introduces a `_LayoutOptimizedWidgetSpan` (for the lack of a better name), that does not compare the child widget  to determine if a layout phase is needed. By using it, a layout phase is only requested if the child's layout changes.

This PR also moves the editing controls overlay for both Android and iOS to be placed in the `SuperText`'s layer above. That way, it will be built during layout, like when using the `ContentLayers` widget. This will prevent that do need to invalidate the text layout (like animating an inline widget) from crashing the textfield.

