### PR TITLE
[SuperEditor] Fix Structured Content Paste Edge Case (Resolves #2626)

### DIFF
--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -164,7 +164,11 @@ class PasteStructuredContentEditorCommand extends EditCommand {
       // We've pasted the first new node. Remove it from the nodes to insert.
       nodesToInsert.removeAt(0);
     }
-    if (currentNodeWithSelection.text.length == 0) {
+
+    // Get the initial node with selection again, as it may have been modified.
+    final latestCurrentNodeWithSelection = document.getNodeById(currentNodeWithSelection.id);
+
+    if (latestCurrentNodeWithSelection is TextNode && latestCurrentNodeWithSelection.text.length == 0) {
       // The node with the selection is an empty text node. After we use that node's
       // position to insert other nodes, we want to delete that first node, as if the
       // pasted content replaced it.


### PR DESCRIPTION
Previously, when pasting mergable multi-paragraph content at the beginning of an empty document, the first paragraph would get dropped. This was because the code was merging the content of the initial paragraph with the blank initial ParagraphNode. The code would then check if the _original_ node was empty to determine if it should be removed but at that point it had been replaced in the document with the content of the initial pasted paragraph.

This pr just refetches the selection node by the supplied node id and uses that to determine if the initial paragraph needs to be removed.

#2626 

## Tests

  - [x] existing paste tests pass
  - [x] added new test for this case