### PR TITLE
[Quill][Bug] - Fix exception when serializing empty document (Resolves #2635)

### DIFF
--- a/super_editor_quill/lib/src/serializing/serializers.dart
+++ b/super_editor_quill/lib/src/serializing/serializers.dart
@@ -232,8 +232,8 @@ class TextBlockDeltaSerializer implements DeltaSerializer {
     // We didn't have a natural trailing newline. Insert a newline as per the
     // Delta spec.
     final newlineDelta = Operation.insert("\n", blockFormats.isNotEmpty ? blockFormats : null);
-    final previousDelta = deltas.operations[deltas.operations.length - 1];
-    if (newlineDelta.canMergeWith(previousDelta)) {
+    final previousDelta = deltas.operations.isNotEmpty ? deltas.operations[deltas.operations.length - 1] : null;
+    if (previousDelta != null && newlineDelta.canMergeWith(previousDelta)) {
       deltas.operations[deltas.operations.length - 1] = newlineDelta.mergeWith(previousDelta);
     } else {
       deltas.operations.add(newlineDelta);

--- a/super_editor_quill/test/serializing_test.dart
+++ b/super_editor_quill/test/serializing_test.dart
@@ -10,6 +10,23 @@ import 'test_documents.dart';
 
 void main() {
   group("Delta document serializing >", () {
+    test("empty document", () {
+      final deltas = MutableDocument(
+        nodes: [
+          ParagraphNode(
+            id: "1",
+            text: AttributedText(""),
+          ),
+        ],
+      ).toQuillDeltas();
+
+      final expectedDeltas = Delta.fromJson([
+        {"insert": "\n"},
+      ]);
+
+      expect(deltas, quillDocumentEquivalentTo(expectedDeltas));
+    });
+
     group("text >", () {
       test("multiline header", () {
         // Note: The official Quill editor doesn't seem to support multiline


### PR DESCRIPTION
[Quill][Bug] - Fix exception when serializing empty document (Resolves #2635)