### PR TITLE
[Spellcheck] - Ignore entire text blocks, add configurable delay after edit before running spellcheck (Resolves #2651)

### DIFF
--- a/super_editor_spellcheck/example/lib/main_super_editor_spellcheck.dart
+++ b/super_editor_spellcheck/example/lib/main_super_editor_spellcheck.dart
@@ -82,8 +82,9 @@ class _SuperEditorSpellcheckScreenState extends State<_SuperEditorSpellcheckScre
     _spellingAndGrammarPlugin = SpellingAndGrammarPlugin(
       iosControlsController: _iosControlsController,
       androidControlsController: _androidControlsController,
+      spellCheckDelayAfterEdit: const Duration(seconds: 1),
       ignoreRules: [
-        SpellingIgnoreRules.byAttribution(boldAttribution),
+        SpellingIgnoreRules.byAttribution(codeAttribution),
         SpellingIgnoreRules.byAttributionFilter((attr) => attr is LinkAttribution),
         SpellingIgnoreRules.byPattern(RegExp(r'#\w+')),
       ],

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -48,6 +48,7 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     UnderlineStyle spellingErrorUnderlineStyle = defaultSpellingErrorUnderlineStyle,
     bool isGrammarCheckEnabled = true,
     UnderlineStyle grammarErrorUnderlineStyle = defaultGrammarErrorUnderlineStyle,
+    Duration spellCheckDelayAfterEdit = Duration.zero,
     SpellingErrorSuggestionToolbarBuilder toolbarBuilder = defaultSpellingSuggestionToolbarBuilder,
     Color? selectedWordHighlightColor,
     SuperEditorAndroidControlsController? androidControlsController,
@@ -56,7 +57,8 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     SpellCheckService? spellCheckService,
     GrammarCheckService? grammarCheckService,
   })  : _isSpellCheckEnabled = isSpellingCheckEnabled,
-        _isGrammarCheckEnabled = isGrammarCheckEnabled {
+        _isGrammarCheckEnabled = isGrammarCheckEnabled,
+        _spellCheckDelayAfterEdit = spellCheckDelayAfterEdit {
     assert(defaultTargetPlatform != TargetPlatform.android || androidControlsController != null,
         'The androidControlsController must be provided when running on Android.');
 
@@ -114,6 +116,9 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
 
   /// A service that provides grammar checking functionality.
   late final GrammarCheckService? _grammarCheckService;
+
+  /// The time to wait after a user edit before running the spelling and grammar check.
+  late final Duration _spellCheckDelayAfterEdit;
 
   final _spellingErrorSuggestions = SpellingErrorSuggestions();
 
@@ -175,7 +180,13 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
     _contentTapHandler?.editor = editor;
 
     _reaction = SpellingAndGrammarReaction(
-        _spellingErrorSuggestions, _styler, _ignoreRules, _spellCheckService!, _grammarCheckService);
+      _spellingErrorSuggestions,
+      _styler,
+      _ignoreRules,
+      _spellCheckService!,
+      _grammarCheckService,
+      spellCheckDelayAfterEdit: _spellCheckDelayAfterEdit,
+    );
     editor.reactionPipeline.add(_reaction);
 
     // Do initial spelling and grammar analysis, in case the document already
@@ -283,7 +294,13 @@ extension SpellingAndGrammarEditorExtensions on Editor {
 /// in a given [Document].
 class SpellingAndGrammarReaction implements EditReaction {
   SpellingAndGrammarReaction(
-      this._suggestions, this._styler, this._ignoreRules, this._spellCheckService, this._grammarCheckService);
+    this._suggestions,
+    this._styler,
+    this._ignoreRules,
+    this._spellCheckService,
+    this._grammarCheckService, {
+    Duration spellCheckDelayAfterEdit = Duration.zero,
+  }) : _spellCheckDelayAfterEdit = spellCheckDelayAfterEdit;
 
   final SpellingErrorSuggestions _suggestions;
 
@@ -302,6 +319,24 @@ class SpellingAndGrammarReaction implements EditReaction {
   bool isGrammarCheckEnabled = true;
 
   set grammarErrorUnderlineStyle(UnderlineStyle style) => _styler.grammarErrorUnderlineStyle = style;
+
+  /// An amount of time to wait after a content edit, before running a spell check.
+  ///
+  /// For example, with a delay of 500ms, as the user types, spell check doesn't run
+  /// until the user stops typing for 500ms.
+  final Duration _spellCheckDelayAfterEdit;
+
+  /// The time at which various nodes should be checked for spelling and grammar.
+  ///
+  /// This map is used to orchestrate delayed spelling and grammar checks.
+  final _delayedChecks = <String, (DateTime, TextNode)>{};
+
+  /// A [Timer] that's scheduled when a spelling and grammar check is desired, which
+  /// then runs the actual spelling and grammar check after [_spellCheckDelayAfterEdit].
+  ///
+  /// There may be many waiting checks, each with a different desired check time. This timer
+  /// is scheduled for the nearest desired check time.
+  Timer? _delayedChecksTimer;
 
   /// A map from a document node to the ID of the most recent spelling and grammar
   /// check request ID.
@@ -392,8 +427,67 @@ class SpellingAndGrammarReaction implements EditReaction {
         continue;
       }
 
+      _scheduleSpellingAndGrammarCheck(textNode);
+    }
+  }
+
+  void _scheduleSpellingAndGrammarCheck(TextNode textNode) {
+    if (_spellCheckDelayAfterEdit == Duration.zero) {
+      // The user doesn't want any delay. Run spell and grammar check immediately.
+      _findSpellingAndGrammarErrors(textNode);
+      return;
+    }
+
+    // The user wants a delay before running spelling and grammar checks. Schedule
+    // this node for a check after a delay.
+    _delayedChecks[textNode.id] = (DateTime.now().add(_spellCheckDelayAfterEdit), textNode);
+
+    // Schedule a timer for the next delayed check.
+    _delayedChecksTimer ??= Timer(_spellCheckDelayAfterEdit, _runCheckAfterDelay);
+  }
+
+  void _runCheckAfterDelay() {
+    // Find all nodes that haven't changed in the delayed amount of time.
+    final now = DateTime.now();
+    final waitingNodes = _delayedChecks.keys.toList(growable: false);
+    final nodesToCheck = <TextNode>{};
+    for (final nodeId in waitingNodes) {
+      if (now.isAfter(_delayedChecks[nodeId]!.$1)) {
+        nodesToCheck.add(_delayedChecks[nodeId]!.$2);
+      }
+    }
+
+    // Check each node that has exceeded the delay.
+    for (final textNode in nodesToCheck) {
+      _delayedChecks.remove(textNode.id);
       _findSpellingAndGrammarErrors(textNode);
     }
+
+    // Schedule the next timer if there are still nodes waiting to be checked.
+    if (_delayedChecks.isNotEmpty) {
+      _delayedChecksTimer = Timer(_findNextDelayedCheckDuration(), _runCheckAfterDelay);
+    } else {
+      _delayedChecksTimer = null;
+    }
+  }
+
+  Duration _findNextDelayedCheckDuration() {
+    var nearest = _delayedChecks.entries.first.value.$1;
+    for (final entry in _delayedChecks.entries) {
+      if (entry.value.$1.isBefore(nearest)) {
+        nearest = entry.value.$1;
+      }
+    }
+
+    final timeDifference = nearest.difference(DateTime.now());
+    if (timeDifference <= Duration.zero) {
+      // This shouldn't happen, but the clock has already passed
+      // at least one desired check time. Schedule an immediate
+      // timer.
+      return Duration.zero;
+    }
+
+    return timeDifference;
   }
 
   Future<void> _findSpellingAndGrammarErrors(TextNode textNode) async {
@@ -505,6 +599,10 @@ class SpellingAndGrammarReaction implements EditReaction {
     if (ranges.isEmpty) {
       // We don't have any ranges to remove, short circuit.
       return text;
+    }
+    if (ranges.length == 1 && ranges.first.start == 0 && ranges.first.end >= text.length) {
+      // We want to ignore all of the text in this node.
+      return "";
     }
 
     final buffer = StringBuffer();
@@ -843,6 +941,19 @@ typedef SpellingIgnoreRule = List<TextRange> Function(TextNode node);
 
 /// A collection of built-in rules for ignoring spans of text from spellchecking.
 class SpellingIgnoreRules {
+  /// Creates a rule that ignores an entire text block of the given [blockType].
+  ///
+  /// For example, a rule might ignore a code block or a blockquote.
+  static SpellingIgnoreRule byBlockType(Attribution blockType) {
+    return (TextNode node) {
+      if (node.metadata[NodeMetadata.blockType] == blockType) {
+        return [TextRange(start: 0, end: node.text.length)];
+      }
+
+      return [];
+    };
+  }
+
   /// Creates a rule that ignores text spans that match the given [pattern].
   static SpellingIgnoreRule byPattern(Pattern pattern) {
     return (TextNode node) {

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -198,6 +198,7 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
   void detach(Editor editor) {
     _styler.clearAllErrors();
     editor.reactionPipeline.remove(_reaction);
+    _reaction.dispose();
     _contentTapHandler?.editor = null;
 
     editor.context.remove(spellingErrorSuggestionsKey);
@@ -301,6 +302,13 @@ class SpellingAndGrammarReaction implements EditReaction {
     this._grammarCheckService, {
     Duration spellCheckDelayAfterEdit = Duration.zero,
   }) : _spellCheckDelayAfterEdit = spellCheckDelayAfterEdit;
+
+  void dispose() {
+    _delayedChecks.clear();
+
+    _delayedChecksTimer?.cancel();
+    _delayedChecksTimer = null;
+  }
 
   final SpellingErrorSuggestions _suggestions;
 

--- a/super_editor_spellcheck/test/spellcheck_ignore_rules_test.dart
+++ b/super_editor_spellcheck/test/spellcheck_ignore_rules_test.dart
@@ -10,6 +10,60 @@ import 'package:super_editor_spellcheck/super_editor_spellcheck.dart';
 void main() {
   group('SuperEditor spellcheck >', () {
     group('ignore rules >', () {
+      testWidgetsOnArbitraryDesktop('ignores by block type', (tester) async {
+        final spellCheckerService = _FakeSpellChecker();
+
+        await _pumpTestApp(
+          tester,
+          document: MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText(
+                  'This is a paragraph',
+                ),
+              ),
+              ParagraphNode(
+                id: "2",
+                text: AttributedText(
+                  'This is a code block',
+                ),
+                metadata: const {
+                  NodeMetadata.blockType: codeAttribution,
+                },
+              ),
+              ParagraphNode(
+                id: "3",
+                text: AttributedText(
+                  'This is another paragraph',
+                ),
+              ),
+              ParagraphNode(
+                id: "4",
+                text: AttributedText(
+                  'This is a blockquote',
+                ),
+                metadata: const {
+                  NodeMetadata.blockType: blockquoteAttribution,
+                },
+              ),
+            ],
+          ),
+          ignoreRules: [
+            SpellingIgnoreRules.byBlockType(codeAttribution),
+            SpellingIgnoreRules.byBlockType(blockquoteAttribution),
+          ],
+          spellCheckerService: spellCheckerService,
+        );
+
+        // Ensure the spell checker service was queried for the paragraphs but
+        // not for the code block or blockquote.
+        expect(spellCheckerService.queriedTexts, [
+          'This is a paragraph',
+          'This is another paragraph',
+        ]);
+      });
+
       testWidgetsOnArbitraryDesktop('ignores by pattern', (tester) async {
         final spellCheckerService = _FakeSpellChecker();
 


### PR DESCRIPTION
[Spellcheck] - Ignore entire text blocks, add configurable delay after edit before running spellcheck (Resolves #2651)