### PR TITLE
[SuperEditor][SuperReader] - Custom underline style configuration (Resolves #2675)

### DIFF
--- a/doc/website/source/super-editor/guides/_data.yaml
+++ b/doc/website/source/super-editor/guides/_data.yaml
@@ -82,6 +82,8 @@ navigation:
           url: super-editor/guides/styling/dark-mode-and-light-mode
         - title: Style a Document
           url: super-editor/guides/styling/style-a-document
+        - title: Text Underlines
+          url: super-editor/guides/styling/text-underlines
 
     - title: Editing UI
       items:

--- a/doc/website/source/super-editor/guides/styling/text-underlines.md
+++ b/doc/website/source/super-editor/guides/styling/text-underlines.md
@@ -1,0 +1,167 @@
+---
+title: Text Underlines
+---
+Underlines in Flutter text don't support any styles. They're always the same
+thickness, the same distance from the text, the same color as the text, and
+have the same square end-caps. It should be possible to control these styles,
+but Flutter doesn't expose the lower level text layout controls.
+
+Editors require custom underline painting for styles and design languages that
+don't exactly match the standard text underline. Super Editor supports custom 
+painting of underlines by manually positioning the painted lines beneath the
+relevant spans of text.
+
+## Special Underlines
+Super Editor treats some underlines as special. These include:
+
+ * The user's composing region.
+ * Spelling errors.
+ * Grammar errors.
+
+For these special underlines, please see other guides and references to
+work with them.
+
+## Custom Underlines
+Super Editor supports painting custom text underlines.
+
+### Attribute the Text
+First, attribute the desired text with a `CustomUnderlineAttribution`, which
+specifies the visual type of underline. Super Editor includes some pre-defined
+type names, but you can use any name.
+
+```dart
+final underlineAttribution = CustomUnderlineAttribution(
+  CustomUnderlineAttribution.standard,
+);
+
+AttributedText(
+  "This text includes an underline.",
+  AttributedSpans(
+    attributions: [
+      SpanMarker(attribution: underlineAttribution, offset: 22, markerType: SpanMarkerType.start),
+      SpanMarker(attribution: underlineAttribution, offset: 30, markerType: SpanMarkerType.end),
+    ],
+  ),
+)
+```
+
+### Style the Underlines
+Add a style rule to your stylesheet, which specifies all underline styles.
+
+```dart
+final myStylesheet = defaultStylesheet.copyWith(
+  addRulesBefore: [
+    StyleRule(
+      BlockSelector.all,
+      (doc, docNode) {
+        return {
+          // The `underlineStyles` key is used to identify a collection of
+          // underline styles.
+          //
+          // Within the `CustomUnderlineStyles`, you should add an entry
+          // for every underline type name that your app uses, and then
+          // specify the `UnderlineStyle` to paint that underline.
+          UnderlineStyler.underlineStyles: CustomUnderlineStyles({
+            // In this example, we specify only one underline style. This
+            // style is for the `standard` underline type, and it paints
+            // a green squiggly underline.
+            CustomUnderlineAttribution.standard: SquiggleUnderlineStyle(
+              color: Colors.green,
+            ),
+            // You can add more types and styles here...
+          }),
+        };
+      },
+    ),
+  ],
+);
+```
+
+### Custom Styles
+Super Editor provides a few underline styles, which offer some configuration,
+including `StraightUnderlineStyle`, `DottedUnderlineStyle`, and `SquiggleUnderlineStyle`.
+However, these may not meet your needs.
+
+To paint your own underline, you need to create two classes: a subclass of `UnderlineStyle`
+and a `CustomPainter` that actually does the painting.
+
+The `UnderlineStyle` subclass is like a view-model, and the `CustomPainter` uses
+properties from the `UnderlineStyle` to decide how to paint the underline.
+
+For example, the following is the implementation of `StraightUnderlineStyle`.
+
+```dart
+class StraightUnderlineStyle implements UnderlineStyle {
+  const StraightUnderlineStyle({
+    this.color = const Color(0xFF000000),
+    this.thickness = 2,
+    this.capType = StrokeCap.square,
+  });
+
+  final Color color;
+  final double thickness;
+  final StrokeCap capType;
+
+  @override
+  CustomPainter createPainter(List<LineSegment> underlines) {
+    return StraightUnderlinePainter(underlines: underlines, color: color, thickness: thickness, capType: capType);
+  }
+}
+```
+
+The job of the `UnderlineStyle` is to take a collection of properties and
+pass them in some form to a `CustomPainter`. In the case of `StraightUnderlineStyle`,
+the properties are passed to a `StraightUnderlinePainter`. The `createPainter()`
+method is called by Super Editor at the appropriate time.
+
+To complete the example, the following is the implementation of `StraightUnderlinePainter`.
+
+```dart
+class StraightUnderlinePainter extends CustomPainter {
+  const StraightUnderlinePainter({
+    required List<LineSegment> underlines,
+    this.color = const Color(0xFF000000),
+    this.thickness = 2,
+    this.capType = StrokeCap.square,
+  }) : _underlines = underlines;
+
+  final List<LineSegment> _underlines;
+
+  final Color color;
+  final double thickness;
+  final StrokeCap capType;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (_underlines.isEmpty) {
+      return;
+    }
+
+    final linePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..color = color
+      ..strokeWidth = thickness
+      ..strokeCap = capType;
+    for (final underline in _underlines) {
+      canvas.drawLine(underline.start, underline.end, linePaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(StraightUnderlinePainter oldDelegate) {
+    return color != oldDelegate.color ||
+        thickness != oldDelegate.thickness ||
+        capType != oldDelegate.capType ||
+        !const DeepCollectionEquality().equals(_underlines, oldDelegate._underlines);
+  }
+}
+```
+
+By providing your own version of these two classes, you can paint any underline you desire.
+
+With your own `UnderlineStyle` defined, use it in your stylesheet as discussed previously.
+
+As you implement your own underline painting, you might be confused where some of these
+underline classes come from. Note that some of them are lower level than Super Editor - 
+they come from the `super_text_layout` package, which is another package in the
+Super Editor mono repo.

--- a/super_editor/example/lib/demos/in_the_lab/feature_custom_underlines.dart
+++ b/super_editor/example/lib/demos/in_the_lab/feature_custom_underlines.dart
@@ -1,0 +1,129 @@
+import 'package:example/demos/in_the_lab/in_the_lab_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+class CustomUnderlinesDemo extends StatefulWidget {
+  const CustomUnderlinesDemo({super.key});
+
+  @override
+  State<CustomUnderlinesDemo> createState() => _CustomUnderlinesDemoState();
+}
+
+class _CustomUnderlinesDemoState extends State<CustomUnderlinesDemo> {
+  late final Editor _editor;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _editor = createDefaultDocumentEditor(
+      document: _createDocument(),
+      composer: MutableDocumentComposer(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InTheLabScaffold(
+      content: SuperEditor(
+        editor: _editor,
+        stylesheet: defaultStylesheet.copyWith(
+          addRulesBefore: [
+            StyleRule(
+              BlockSelector.all,
+              (doc, docNode) {
+                return {
+                  Styles.customUnderlineStyles: CustomUnderlineStyles({
+                    _brandUnderline: StraightUnderlineStyle(
+                      color: Colors.red,
+                      thickness: 3,
+                      capType: StrokeCap.round,
+                      offset: -3,
+                    ),
+                    _dottedUnderline: DottedUnderlineStyle(
+                      color: Colors.blue,
+                    ),
+                    _squiggleUnderline: SquiggleUnderlineStyle(
+                      color: Colors.green,
+                    ),
+                  }),
+                };
+              },
+            ),
+          ],
+          addRulesAfter: [
+            ...darkModeStyles,
+          ],
+          selectedTextColorStrategy: ({
+            required Color originalTextColor,
+            required Color selectionHighlightColor,
+          }) =>
+              Colors.black,
+        ),
+        documentOverlayBuilders: [
+          DefaultCaretOverlayBuilder(
+            caretStyle: CaretStyle().copyWith(color: Colors.redAccent),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+MutableDocument _createDocument() {
+  return MutableDocument(
+    nodes: [
+      ParagraphNode(
+        id: "1",
+        text: AttributedText("Custom Underlines"),
+        metadata: {
+          NodeMetadata.blockType: header1Attribution,
+        },
+      ),
+      ParagraphNode(
+        id: "2",
+        text: AttributedText(
+          "Super Editor supports custom painted underlines across text spans.",
+          AttributedSpans(
+            attributions: [
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_brandUnderline),
+                offset: 0,
+                markerType: SpanMarkerType.start,
+              ),
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_brandUnderline),
+                offset: 11,
+                markerType: SpanMarkerType.end,
+              ),
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_dottedUnderline),
+                offset: 22,
+                markerType: SpanMarkerType.start,
+              ),
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_dottedUnderline),
+                offset: 35,
+                markerType: SpanMarkerType.end,
+              ),
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_squiggleUnderline),
+                offset: 48,
+                markerType: SpanMarkerType.start,
+              ),
+              SpanMarker(
+                attribution: CustomUnderlineAttribution(_squiggleUnderline),
+                offset: 64,
+                markerType: SpanMarkerType.end,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+const _brandUnderline = "brand";
+const _dottedUnderline = "dotted";
+const _squiggleUnderline = "squiggly";

--- a/super_editor/example/lib/main.dart
+++ b/super_editor/example/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:example/demos/flutter_features/demo_inline_widgets.dart';
 import 'package:example/demos/flutter_features/textinputclient/basic_text_input_client.dart';
 import 'package:example/demos/flutter_features/textinputclient/textfield.dart';
 import 'package:example/demos/in_the_lab/feature_action_tags.dart';
+import 'package:example/demos/in_the_lab/feature_custom_underlines.dart';
 import 'package:example/demos/in_the_lab/feature_ios_native_context_menu.dart';
 import 'package:example/demos/in_the_lab/feature_pattern_tags.dart';
 import 'package:example/demos/in_the_lab/feature_stable_tags.dart';
@@ -331,6 +332,13 @@ final _menu = <_MenuGroup>[
         title: 'Native iOS Toolbar',
         pageBuilder: (context) {
           return const NativeIosContextMenuFeatureDemo();
+        },
+      ),
+      _MenuItem(
+        icon: Icons.line_style,
+        title: 'Custom Underlines',
+        pageBuilder: (context) {
+          return const CustomUnderlinesDemo();
         },
       ),
     ],

--- a/super_editor/lib/src/core/styles.dart
+++ b/super_editor/lib/src/core/styles.dart
@@ -1,5 +1,6 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:flutter/painting.dart';
+import 'package:super_editor/src/default_editor/text/custom_underlines.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 
 import 'document.dart';
@@ -346,6 +347,12 @@ class Styles {
 
   /// Applies a [TextAlign] to a text node.
   static const String textAlign = 'textAlign';
+
+  /// Defines the visual style for all custom underlines rendered by all
+  /// text that matches the style rule selector.
+  ///
+  /// The value should be a [CustomUnderlineStyles].
+  static const String customUnderlineStyles = "customUnderlineStyles";
 
   /// Applies an [UnderlineStyle] to the composing region, e.g., the word
   /// the user is currently editing on mobile.

--- a/super_editor/lib/src/default_editor/attributions.dart
+++ b/super_editor/lib/src/default_editor/attributions.dart
@@ -106,7 +106,7 @@ class ColorAttribution implements Attribution {
 }
 
 /// Attribution to be used within [AttributedText] to
-/// represent an inline span of a backgrounnd color change.
+/// represent an inline span of a background color change.
 ///
 /// Every [BackgroundColorAttribution] is considered equivalent so
 /// that [AttributedText] prevents multiple [BackgroundColorAttribution]s
@@ -135,6 +135,74 @@ class BackgroundColorAttribution implements Attribution {
   @override
   String toString() {
     return '[BackgroundColorAttribution]: $color';
+  }
+}
+
+/// Attribution to be used within [AttributedText] to mark text that should be painted
+/// with a custom underline.
+///
+/// A custom underline is an underline that's painted by Super Editor, rather than
+/// painted by the text layout package, inside of the Flutter engine. Flutter's standard
+/// text underline doesn't allow for any stylistic configuration. It always has the
+/// same thickness, the same end-caps, sits the same distance from the text, and has
+/// the same color as the text. This is insufficient for real world document editing
+/// use-cases.
+///
+/// A [CustomUnderlineAttribution] tells Super Editor that a user wants to paint a
+/// custom underline beneath a span of text. From there, various pieces of the Super Editor
+/// styling system process the attribution, and paint the desired underline.
+///
+/// ## Other Approaches to Underlines
+/// [CustomUnderlineAttribution]s refer to visual style choices, similar to bold, italics,
+/// and strikethrough. In other words, this attribution is for painting underlines in situations
+/// where the spans of text don't represent some other semantic meaning.
+///
+/// Super Editor includes other underlined content that does include semantic meaning.
+/// Therefore, those underlines don't use [CustomUnderlineAttribution]s.
+///
+/// One example is the user's composing region. Super Editor underlines the composing region,
+/// but that region doesn't have a [CustomUnderlineAttribution] applied to it. Instead,
+/// Super Editor explicitly tracks the user's composing region in a variable.
+///
+/// Another example is spelling and grammar errors. These, too, display underlines.
+/// However, the placement of spelling and grammar error spans is managed by the
+/// spelling and grammar check system. These spans don't simply represent a stylistic
+/// underline, they carry semantic meaning. In this case that meaning is a misspelled
+/// word, or a grammatically incorrect structure.
+///
+/// [CustomUnderlineAttribution] is provided for situations where the underline doesn't
+/// mean anything more than an underline.
+class CustomUnderlineAttribution implements Attribution {
+  static const standard = "standard";
+
+  const CustomUnderlineAttribution([this.type = standard]);
+
+  @override
+  String get id => 'custom_underline';
+
+  /// The type of underline that should be applied to the attributed text.
+  ///
+  /// The type can be anything. The meaning of the term is enforced by the developer's
+  /// styling system. Super Editor ships with some pre-defined terms for obvious
+  /// use-cases, e.g., [standard].
+  final String type;
+
+  @override
+  bool canMergeWith(Attribution other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CustomUnderlineAttribution && runtimeType == other.runtimeType && type == other.type;
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  String toString() {
+    return '[CustomUnderlineAttribution]: $type';
   }
 }
 

--- a/super_editor/lib/src/default_editor/blockquote.dart
+++ b/super_editor/lib/src/default_editor/blockquote.dart
@@ -1,15 +1,11 @@
 import 'package:attributed_text/attributed_text.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:super_editor/src/core/edit_context.dart';
-import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
 import 'package:super_editor/src/default_editor/blocks/indentation.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
-import 'package:super_editor/src/infrastructure/keyboard.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import '../core/document.dart';
@@ -155,29 +151,29 @@ class BlockquoteComponentViewModel extends SingleColumnLayoutComponentViewModel 
 
   @override
   BlockquoteComponentViewModel copy() {
-    return BlockquoteComponentViewModel(
-      nodeId: nodeId,
-      maxWidth: maxWidth,
-      padding: padding,
-      text: text,
-      textStyleBuilder: textStyleBuilder,
-      inlineWidgetBuilders: inlineWidgetBuilders,
-      textDirection: textDirection,
-      textAlignment: textAlignment,
-      indent: indent,
-      indentCalculator: indentCalculator,
-      backgroundColor: backgroundColor,
-      borderRadius: borderRadius,
-      selection: selection,
-      selectionColor: selectionColor,
-      highlightWhenEmpty: highlightWhenEmpty,
-      spellingErrorUnderlineStyle: spellingErrorUnderlineStyle,
-      spellingErrors: List.from(spellingErrors),
-      grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
-      grammarErrors: List.from(grammarErrors),
-      composingRegion: composingRegion,
-      showComposingRegionUnderline: showComposingRegionUnderline,
+    return internalCopy(
+      BlockquoteComponentViewModel(
+        nodeId: nodeId,
+        text: text,
+        textStyleBuilder: textStyleBuilder,
+        selectionColor: selectionColor,
+        backgroundColor: backgroundColor,
+        borderRadius: borderRadius,
+      ),
     );
+  }
+
+  @override
+  BlockquoteComponentViewModel internalCopy(BlockquoteComponentViewModel viewModel) {
+    final copy = super.internalCopy(viewModel) as BlockquoteComponentViewModel;
+
+    copy
+      ..indent = indent
+      ..indentCalculator = indentCalculator
+      ..backgroundColor = backgroundColor
+      ..borderRadius = borderRadius;
+
+    return copy;
   }
 
   @override
@@ -186,42 +182,14 @@ class BlockquoteComponentViewModel extends SingleColumnLayoutComponentViewModel 
       super == other &&
           other is BlockquoteComponentViewModel &&
           runtimeType == other.runtimeType &&
-          nodeId == other.nodeId &&
-          text == other.text &&
-          textDirection == other.textDirection &&
-          textAlignment == other.textAlignment &&
+          textViewModelEquals(other) &&
           indent == other.indent &&
           backgroundColor == other.backgroundColor &&
-          borderRadius == other.borderRadius &&
-          selection == other.selection &&
-          selectionColor == other.selectionColor &&
-          highlightWhenEmpty == other.highlightWhenEmpty &&
-          spellingErrorUnderlineStyle == other.spellingErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(spellingErrors, other.spellingErrors) &&
-          grammarErrorUnderlineStyle == other.grammarErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(grammarErrors, other.grammarErrors) &&
-          composingRegion == other.composingRegion &&
-          showComposingRegionUnderline == other.showComposingRegionUnderline;
+          borderRadius == other.borderRadius;
 
   @override
   int get hashCode =>
-      super.hashCode ^
-      nodeId.hashCode ^
-      text.hashCode ^
-      textDirection.hashCode ^
-      textAlignment.hashCode ^
-      indent.hashCode ^
-      backgroundColor.hashCode ^
-      borderRadius.hashCode ^
-      selection.hashCode ^
-      selectionColor.hashCode ^
-      highlightWhenEmpty.hashCode ^
-      spellingErrorUnderlineStyle.hashCode ^
-      spellingErrors.hashCode ^
-      grammarErrorUnderlineStyle.hashCode ^
-      grammarErrors.hashCode ^
-      composingRegion.hashCode ^
-      showComposingRegionUnderline.hashCode;
+      super.hashCode ^ textViewModelHashCode ^ indent.hashCode ^ backgroundColor.hashCode ^ borderRadius.hashCode;
 }
 
 /// Displays a blockquote in a document.

--- a/super_editor/lib/src/default_editor/document_layers/attributed_text_bounds_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_layers/attributed_text_bounds_overlay.dart
@@ -4,6 +4,9 @@ import 'package:super_editor/src/default_editor/super_editor.dart';
 import 'package:super_editor/src/infrastructure/attribution_layout_bounds.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
 
+/// A [SuperEditorLayerBuilder] that makes [AttributionBounds] usable by a `SuperEditor`.
+///
+/// See [AttributionBounds] for the real implementation.
 class AttributedTextBoundsOverlay implements SuperEditorLayerBuilder {
   const AttributedTextBoundsOverlay({
     required this.selector,

--- a/super_editor/lib/src/default_editor/list_items.dart
+++ b/super_editor/lib/src/default_editor/list_items.dart
@@ -1,5 +1,4 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document_composer.dart';
@@ -286,43 +285,25 @@ abstract class ListItemComponentViewModel extends SingleColumnLayoutComponentVie
   bool highlightWhenEmpty;
 
   @override
+  ListItemComponentViewModel internalCopy(ListItemComponentViewModel viewModel) {
+    final copy = super.internalCopy(viewModel) as ListItemComponentViewModel;
+
+    copy.indent = indent;
+
+    return copy;
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       super == other &&
           other is ListItemComponentViewModel &&
           runtimeType == other.runtimeType &&
-          nodeId == other.nodeId &&
-          indent == other.indent &&
-          text == other.text &&
-          textDirection == other.textDirection &&
-          textAlignment == other.textAlignment &&
-          selection == other.selection &&
-          selectionColor == other.selectionColor &&
-          highlightWhenEmpty == other.highlightWhenEmpty &&
-          spellingErrorUnderlineStyle == other.spellingErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(spellingErrors, spellingErrors) &&
-          grammarErrorUnderlineStyle == other.grammarErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(grammarErrors, grammarErrors) &&
-          composingRegion == other.composingRegion &&
-          showComposingRegionUnderline == other.showComposingRegionUnderline;
+          textViewModelEquals(other) &&
+          indent == other.indent;
 
   @override
-  int get hashCode =>
-      super.hashCode ^
-      nodeId.hashCode ^
-      indent.hashCode ^
-      text.hashCode ^
-      textDirection.hashCode ^
-      textAlignment.hashCode ^
-      selection.hashCode ^
-      selectionColor.hashCode ^
-      highlightWhenEmpty.hashCode ^
-      spellingErrorUnderlineStyle.hashCode ^
-      spellingErrors.hashCode ^
-      grammarErrorUnderlineStyle.hashCode ^
-      grammarErrors.hashCode ^
-      composingRegion.hashCode ^
-      showComposingRegionUnderline.hashCode;
+  int get hashCode => super.hashCode ^ textViewModelHashCode ^ indent.hashCode;
 }
 
 class UnorderedListItemComponentViewModel extends ListItemComponentViewModel {
@@ -362,26 +343,26 @@ class UnorderedListItemComponentViewModel extends ListItemComponentViewModel {
 
   @override
   UnorderedListItemComponentViewModel copy() {
-    return UnorderedListItemComponentViewModel(
-      nodeId: nodeId,
-      maxWidth: maxWidth,
-      padding: padding,
-      indent: indent,
-      text: text,
-      textStyleBuilder: textStyleBuilder,
-      dotStyle: dotStyle,
-      textDirection: textDirection,
-      textAlignment: textAlignment,
-      selection: selection,
-      selectionColor: selectionColor,
-      composingRegion: composingRegion,
-      showComposingRegionUnderline: showComposingRegionUnderline,
-      spellingErrorUnderlineStyle: spellingErrorUnderlineStyle,
-      spellingErrors: List.from(spellingErrors),
-      grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
-      grammarErrors: List.from(grammarErrors),
-      inlineWidgetBuilders: inlineWidgetBuilders,
+    return internalCopy(
+      UnorderedListItemComponentViewModel(
+        nodeId: nodeId,
+        text: text,
+        textStyleBuilder: textStyleBuilder,
+        selectionColor: selectionColor,
+        indent: indent,
+      ),
     );
+  }
+
+  @override
+  UnorderedListItemComponentViewModel internalCopy(UnorderedListItemComponentViewModel viewModel) {
+    final copy = super.internalCopy(viewModel) as UnorderedListItemComponentViewModel;
+
+    copy
+      ..indent = indent
+      ..dotStyle = dotStyle.copyWith();
+
+    return copy;
   }
 
   @override
@@ -420,7 +401,7 @@ class OrderedListItemComponentViewModel extends ListItemComponentViewModel {
     super.grammarErrors,
   });
 
-  final int? ordinalValue;
+  int? ordinalValue;
   OrderedListNumeralStyle numeralStyle;
 
   @override
@@ -431,27 +412,27 @@ class OrderedListItemComponentViewModel extends ListItemComponentViewModel {
 
   @override
   OrderedListItemComponentViewModel copy() {
-    return OrderedListItemComponentViewModel(
-      nodeId: nodeId,
-      maxWidth: maxWidth,
-      padding: padding,
-      indent: indent,
-      ordinalValue: ordinalValue,
-      numeralStyle: numeralStyle,
-      text: text,
-      textStyleBuilder: textStyleBuilder,
-      textDirection: textDirection,
-      textAlignment: textAlignment,
-      selection: selection,
-      selectionColor: selectionColor,
-      composingRegion: composingRegion,
-      showComposingRegionUnderline: showComposingRegionUnderline,
-      spellingErrorUnderlineStyle: spellingErrorUnderlineStyle,
-      spellingErrors: List.from(spellingErrors),
-      grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
-      grammarErrors: List.from(grammarErrors),
-      inlineWidgetBuilders: inlineWidgetBuilders,
+    return internalCopy(
+      OrderedListItemComponentViewModel(
+        nodeId: nodeId,
+        text: text,
+        textStyleBuilder: textStyleBuilder,
+        selectionColor: selectionColor,
+        indent: indent,
+      ),
     );
+  }
+
+  @override
+  OrderedListItemComponentViewModel internalCopy(OrderedListItemComponentViewModel viewModel) {
+    final copy = super.internalCopy(viewModel) as OrderedListItemComponentViewModel;
+
+    copy
+      ..indent = indent
+      ..ordinalValue = ordinalValue
+      ..numeralStyle = numeralStyle;
+
+    return copy;
   }
 
   @override

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -380,6 +380,7 @@ class SuperEditorState extends State<SuperEditor> {
   SingleColumnLayoutPresenter? _docLayoutPresenter;
   late SingleColumnStylesheetStyler _docStylesheetStyler;
   late SingleColumnLayoutCustomComponentStyler _docLayoutPerComponentBlockStyler;
+  final _customUnderlineStyler = CustomUnderlineStyler();
   late SingleColumnLayoutSelectionStyler _docLayoutSelectionStyler;
 
   @visibleForTesting
@@ -610,7 +611,7 @@ class SuperEditorState extends State<SuperEditor> {
       pipeline: [
         _docStylesheetStyler,
         _docLayoutPerComponentBlockStyler,
-        CustomUnderlineStyler(),
+        _customUnderlineStyler,
         ...widget.customStylePhases,
         if (showComposingUnderline)
           SingleColumnLayoutComposingRegionStyler(

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -22,6 +22,7 @@ import 'package:super_editor/src/default_editor/layout_single_column/_styler_com
 import 'package:super_editor/src/default_editor/list_items.dart';
 import 'package:super_editor/src/default_editor/tap_handlers/tap_handlers.dart';
 import 'package:super_editor/src/default_editor/tasks.dart';
+import 'package:super_editor/src/default_editor/text/custom_underlines.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scaffold.dart';
 import 'package:super_editor/src/infrastructure/documents/document_scroller.dart';
@@ -609,6 +610,7 @@ class SuperEditorState extends State<SuperEditor> {
       pipeline: [
         _docStylesheetStyler,
         _docLayoutPerComponentBlockStyler,
+        CustomUnderlineStyler(),
         ...widget.customStylePhases,
         if (showComposingUnderline)
           SingleColumnLayoutComposingRegionStyler(

--- a/super_editor/lib/src/default_editor/tasks.dart
+++ b/super_editor/lib/src/default_editor/tasks.dart
@@ -1,5 +1,4 @@
 import 'package:attributed_text/attributed_text.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:super_editor/src/core/document.dart';
@@ -266,29 +265,30 @@ class TaskComponentViewModel extends SingleColumnLayoutComponentViewModel with T
 
   @override
   TaskComponentViewModel copy() {
-    return TaskComponentViewModel(
-      nodeId: nodeId,
-      maxWidth: maxWidth,
-      padding: padding,
-      indent: indent,
-      indentCalculator: indentCalculator,
-      isComplete: isComplete,
-      setComplete: setComplete,
-      text: text,
-      textStyleBuilder: textStyleBuilder,
-      inlineWidgetBuilders: inlineWidgetBuilders,
-      textDirection: textDirection,
-      textAlignment: textAlignment,
-      selection: selection,
-      selectionColor: selectionColor,
-      highlightWhenEmpty: highlightWhenEmpty,
-      spellingErrorUnderlineStyle: spellingErrorUnderlineStyle,
-      spellingErrors: List.from(spellingErrors),
-      grammarErrorUnderlineStyle: grammarErrorUnderlineStyle,
-      grammarErrors: List.from(grammarErrors),
-      composingRegion: composingRegion,
-      showComposingRegionUnderline: showComposingRegionUnderline,
+    return internalCopy(
+      TaskComponentViewModel(
+        nodeId: nodeId,
+        padding: padding,
+        text: text,
+        textStyleBuilder: textStyleBuilder,
+        selectionColor: selectionColor,
+        indent: indent,
+        isComplete: isComplete,
+        setComplete: setComplete,
+      ),
     );
+  }
+
+  @override
+  TaskComponentViewModel internalCopy(TaskComponentViewModel viewModel) {
+    final copy = super.internalCopy(viewModel) as TaskComponentViewModel;
+
+    copy
+      ..indent = indent
+      ..isComplete = isComplete
+      ..setComplete = setComplete;
+
+    return copy;
   }
 
   @override
@@ -297,38 +297,12 @@ class TaskComponentViewModel extends SingleColumnLayoutComponentViewModel with T
       super == other &&
           other is TaskComponentViewModel &&
           runtimeType == other.runtimeType &&
+          textViewModelEquals(other) &&
           indent == other.indent &&
-          isComplete == other.isComplete &&
-          text == other.text &&
-          textDirection == other.textDirection &&
-          textAlignment == other.textAlignment &&
-          selection == other.selection &&
-          selectionColor == other.selectionColor &&
-          highlightWhenEmpty == other.highlightWhenEmpty &&
-          spellingErrorUnderlineStyle == other.spellingErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(spellingErrors, other.spellingErrors) &&
-          grammarErrorUnderlineStyle == other.grammarErrorUnderlineStyle &&
-          const DeepCollectionEquality().equals(grammarErrors, other.grammarErrors) &&
-          composingRegion == other.composingRegion &&
-          showComposingRegionUnderline == other.showComposingRegionUnderline;
+          isComplete == other.isComplete;
 
   @override
-  int get hashCode =>
-      super.hashCode ^
-      indent.hashCode ^
-      isComplete.hashCode ^
-      text.hashCode ^
-      textDirection.hashCode ^
-      textAlignment.hashCode ^
-      selection.hashCode ^
-      selectionColor.hashCode ^
-      highlightWhenEmpty.hashCode ^
-      spellingErrorUnderlineStyle.hashCode ^
-      spellingErrors.hashCode ^
-      grammarErrorUnderlineStyle.hashCode ^
-      grammarErrors.hashCode ^
-      composingRegion.hashCode ^
-      showComposingRegionUnderline.hashCode;
+  int get hashCode => super.hashCode ^ textViewModelHashCode ^ indent.hashCode ^ isComplete.hashCode;
 }
 
 /// The standard [TextBlockIndentCalculator] used by tasks in `SuperEditor`.

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -607,11 +607,9 @@ mixin TextComponentViewModel on SingleColumnLayoutComponentViewModel {
   }
 
   List<Underlines> createUnderlines() {
-    print("Creating underlines for view model - ${customUnderlines.length} custom underlines");
     return [
       for (final underline in customUnderlines)
         Underlines(
-          // TODO: lookup the actual desired style
           style: customUnderlineStyles?.stylesByType[underline.type] ?? const StraightUnderlineStyle(),
           underlines: [underline.textRange],
         ),

--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -15,6 +15,7 @@ import 'package:super_editor/src/core/edit_context.dart';
 import 'package:super_editor/src/core/editor.dart';
 import 'package:super_editor/src/core/styles.dart';
 import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/text/custom_underlines.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
 import 'package:super_editor/src/infrastructure/attributed_text_styles.dart';
 import 'package:super_editor/src/infrastructure/composable_text.dart';
@@ -25,7 +26,6 @@ import 'package:super_editor/src/infrastructure/strings.dart';
 import 'package:super_text_layout/super_text_layout.dart';
 
 import 'layout_single_column/layout_single_column.dart';
-import 'list_items.dart';
 import 'multi_node_editing.dart';
 import 'paragraph.dart';
 import 'selection_upstream_downstream.dart';
@@ -530,6 +530,9 @@ mixin TextComponentViewModel on SingleColumnLayoutComponentViewModel {
   TextRange? composingRegion;
   UnderlineStyle composingRegionUnderlineStyle = const StraightUnderlineStyle();
 
+  Set<CustomUnderline> customUnderlines = {};
+  CustomUnderlineStyles? customUnderlineStyles;
+
   /// Whether to underline the [composingRegion].
   ///
   /// Showing the underline is optional because the behavior differs between
@@ -542,8 +545,76 @@ mixin TextComponentViewModel on SingleColumnLayoutComponentViewModel {
   List<TextRange> grammarErrors = [];
   UnderlineStyle grammarErrorUnderlineStyle = const SquiggleUnderlineStyle(color: Colors.blue);
 
+  /// Given a [subclassInstance] of [TextComponentViewModel], copies all base-level text
+  /// properties from this [TextComponentViewModel] into the given [subclassInstance].
+  ///
+  /// Every view model must implement the ability to copy. Without this method, every subclass
+  /// would have to repeat the same mapping of properties between the original view model to
+  /// the copied view model. Originally, that's what Super Editor did, but it became very
+  /// tedious, and it was error prone because it was easy to accidentally miss a property.
+  ///
+  /// From a copy perspective, mutability of view models is important because [TextComponentViewModel]
+  /// doesn't have a constructor, and because every subclass has different constructors. Therefore,
+  /// the one approach to consistently support copy is to mutate the parts of a view model
+  /// that a given class knows about, such as what you see in the implementation of this method.
+  @protected
+  TextComponentViewModel internalCopy(covariant TextComponentViewModel subclassInstance) {
+    subclassInstance
+      ..maxWidth = maxWidth
+      ..padding = padding
+      ..text = text
+      ..textStyleBuilder = textStyleBuilder
+      ..inlineWidgetBuilders = inlineWidgetBuilders
+      ..textDirection = textDirection
+      ..textAlignment = textAlignment
+      ..selection = selection
+      ..selectionColor = selectionColor
+      ..highlightWhenEmpty = highlightWhenEmpty
+      ..customUnderlines = Set.from(customUnderlines)
+      ..customUnderlineStyles = customUnderlineStyles?.copy()
+      ..spellingErrorUnderlineStyle = spellingErrorUnderlineStyle
+      ..spellingErrors = List.from(spellingErrors)
+      ..grammarErrorUnderlineStyle = grammarErrorUnderlineStyle
+      ..grammarErrors = List.from(grammarErrors)
+      ..composingRegion = composingRegion
+      ..showComposingRegionUnderline = showComposingRegionUnderline;
+
+    return subclassInstance;
+  }
+
+  @override
+  void applyStyles(Map<String, dynamic> styles) {
+    super.applyStyles(styles);
+
+    textAlignment = styles[Styles.textAlign] ?? textAlignment;
+
+    textStyleBuilder = (attributions) {
+      final baseStyle = styles[Styles.textStyle] ?? noStyleBuilder({});
+      final inlineTextStyler = styles[Styles.inlineTextStyler] as AttributionStyleAdjuster;
+
+      return inlineTextStyler(attributions, baseStyle);
+    };
+
+    inlineWidgetBuilders = styles[Styles.inlineWidgetBuilders] ?? [];
+
+    customUnderlineStyles = styles[Styles.customUnderlineStyles];
+
+    composingRegionUnderlineStyle = styles[Styles.composingRegionUnderlineStyle] ?? composingRegionUnderlineStyle;
+    showComposingRegionUnderline = styles[Styles.showComposingRegionUnderline] ?? showComposingRegionUnderline;
+
+    spellingErrorUnderlineStyle = styles[Styles.spellingErrorUnderlineStyle] ?? spellingErrorUnderlineStyle;
+    grammarErrorUnderlineStyle = styles[Styles.grammarErrorUnderlineStyle] ?? grammarErrorUnderlineStyle;
+  }
+
   List<Underlines> createUnderlines() {
+    print("Creating underlines for view model - ${customUnderlines.length} custom underlines");
     return [
+      for (final underline in customUnderlines)
+        Underlines(
+          // TODO: lookup the actual desired style
+          style: customUnderlineStyles?.stylesByType[underline.type] ?? const StraightUnderlineStyle(),
+          underlines: [underline.textRange],
+        ),
       if (composingRegion != null && showComposingRegionUnderline)
         Underlines(
           style: composingRegionUnderlineStyle,
@@ -562,27 +633,48 @@ mixin TextComponentViewModel on SingleColumnLayoutComponentViewModel {
     ];
   }
 
-  @override
-  void applyStyles(Map<String, dynamic> styles) {
-    super.applyStyles(styles);
+  bool textViewModelEquals(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is TextComponentViewModel &&
+          runtimeType == other.runtimeType &&
+          nodeId == other.nodeId &&
+          maxWidth == other.maxWidth &&
+          padding == other.padding &&
+          text == other.text &&
+          textDirection == other.textDirection &&
+          textAlignment == other.textAlignment &&
+          selection == other.selection &&
+          selectionColor == other.selectionColor &&
+          highlightWhenEmpty == other.highlightWhenEmpty &&
+          customUnderlineStyles == other.customUnderlineStyles &&
+          spellingErrorUnderlineStyle == other.spellingErrorUnderlineStyle &&
+          grammarErrorUnderlineStyle == other.grammarErrorUnderlineStyle &&
+          composingRegion == other.composingRegion &&
+          showComposingRegionUnderline == other.showComposingRegionUnderline &&
+          const DeepCollectionEquality().equals(customUnderlines, other.customUnderlines) &&
+          const DeepCollectionEquality().equals(spellingErrors, other.spellingErrors) &&
+          const DeepCollectionEquality().equals(grammarErrors, other.grammarErrors);
 
-    textAlignment = styles[Styles.textAlign] ?? textAlignment;
-
-    textStyleBuilder = (attributions) {
-      final baseStyle = styles[Styles.textStyle] ?? noStyleBuilder({});
-      final inlineTextStyler = styles[Styles.inlineTextStyler] as AttributionStyleAdjuster;
-
-      return inlineTextStyler(attributions, baseStyle);
-    };
-
-    inlineWidgetBuilders = styles[Styles.inlineWidgetBuilders] ?? [];
-
-    composingRegionUnderlineStyle = styles[Styles.composingRegionUnderlineStyle] ?? composingRegionUnderlineStyle;
-    showComposingRegionUnderline = styles[Styles.showComposingRegionUnderline] ?? showComposingRegionUnderline;
-
-    spellingErrorUnderlineStyle = styles[Styles.spellingErrorUnderlineStyle] ?? spellingErrorUnderlineStyle;
-    grammarErrorUnderlineStyle = styles[Styles.grammarErrorUnderlineStyle] ?? grammarErrorUnderlineStyle;
-  }
+  int get textViewModelHashCode =>
+      super.hashCode ^
+      nodeId.hashCode ^
+      maxWidth.hashCode ^
+      padding.hashCode ^
+      text.hashCode ^
+      textDirection.hashCode ^
+      textAlignment.hashCode ^
+      selection.hashCode ^
+      selectionColor.hashCode ^
+      highlightWhenEmpty.hashCode ^
+      customUnderlines.hashCode ^
+      customUnderlineStyles.hashCode ^
+      spellingErrorUnderlineStyle.hashCode ^
+      spellingErrors.hashCode ^
+      grammarErrorUnderlineStyle.hashCode ^
+      grammarErrors.hashCode ^
+      composingRegion.hashCode ^
+      showComposingRegionUnderline.hashCode;
 }
 
 /// Document component that displays hint text when its content text

--- a/super_editor/lib/src/default_editor/text/custom_underlines.dart
+++ b/super_editor/lib/src/default_editor/text/custom_underlines.dart
@@ -1,0 +1,102 @@
+import 'dart:ui';
+
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/styles.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/layout_single_column/_presenter.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_text_layout/super_text_layout.dart';
+
+/// A style phase that inspects [TextComponentViewModel]s, finds text with
+/// [CustomUnderlineAttribution]s and adds underline configurations to that
+/// view model for each such attribution span.
+///
+/// The [TextComponentViewModel]s then configure some kind of `TextComponent`,
+/// which finally paints the desired underline.
+///
+/// To associate an underline type with a visual style, see [CustomUnderlineStyles].
+class CustomUnderlineStyler extends SingleColumnLayoutStylePhase {
+  @override
+  SingleColumnLayoutViewModel style(Document document, SingleColumnLayoutViewModel viewModel) {
+    final updatedViewModel = SingleColumnLayoutViewModel(
+      padding: viewModel.padding,
+      componentViewModels: [
+        for (final previousViewModel in viewModel.componentViewModels) //
+          _applyUnderlines(previousViewModel.copy()),
+      ],
+    );
+
+    return updatedViewModel;
+  }
+
+  SingleColumnLayoutComponentViewModel _applyUnderlines(SingleColumnLayoutComponentViewModel viewModel) {
+    if (viewModel is! TextComponentViewModel) {
+      return viewModel;
+    }
+
+    final underlineSpans = viewModel.text.getAttributionSpansByFilter((a) => a is CustomUnderlineAttribution);
+    if (underlineSpans.isEmpty) {
+      return viewModel;
+    }
+
+    // Add each attributed underline to the text view model.
+    viewModel.customUnderlines.clear();
+    for (final span in underlineSpans) {
+      final underlineAttribution = span.attribution as CustomUnderlineAttribution;
+
+      viewModel.customUnderlines.add(
+        CustomUnderline(
+          underlineAttribution.type,
+          TextRange(start: span.start, end: span.end + 1),
+          // ^ +1 because SpanRange is inclusive and TextRange is exclusive.
+        ),
+      );
+    }
+
+    return viewModel;
+  }
+}
+
+/// A data structure that describes how various custom underline styles should
+/// be painted.
+///
+/// This data structure is a glorified map, which maps from underline names,
+/// such as "squiggle", to an underline style, such as `SquiggleUnderlineStyle`.
+///
+/// A [CustomUnderlineStyles] can be placed in a document stylesheet in a style
+/// rule with a key of [Styles.customUnderlineStyles].
+class CustomUnderlineStyles {
+  const CustomUnderlineStyles(this.stylesByType);
+
+  /// Map from a custom underline type to its painter.
+  final Map<String, UnderlineStyle> stylesByType;
+
+  CustomUnderlineStyles copy() {
+    return CustomUnderlineStyles(Map.from(stylesByType));
+  }
+
+  CustomUnderlineStyles addStyles(Map<String, UnderlineStyle> newStyles) {
+    return CustomUnderlineStyles({
+      ...stylesByType,
+      ...newStyles,
+    });
+  }
+}
+
+/// Data structure, which describes a [type] of underline, which should be painted
+/// across the given [textRange].
+///
+/// A [CustomUnderline] applies to a given piece of text - it does not encode any
+/// particular document node/position.
+class CustomUnderline {
+  const CustomUnderline(this.type, this.textRange);
+
+  /// A name that represents the type of underline, which maps to some painting
+  /// style, e.g., "straight", "squiggle".
+  ///
+  /// The [type] can be anything - it's meaning is determined by the style system.
+  final String type;
+
+  /// The range of text within some text block to which this underline applies.
+  final TextRange textRange;
+}

--- a/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
+++ b/super_editor/lib/src/infrastructure/attribution_layout_bounds.dart
@@ -6,12 +6,15 @@ import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/default_editor/text.dart';
 import 'package:super_editor/src/infrastructure/content_layers.dart';
 
-/// Positions invisible widgets around runs of attributed text.
+/// Places invisible widgets around runs of attributed text.
 ///
 /// The attributions that are bounded are selected with a given [selector].
 ///
-/// The bounding widget is build with a given [builder], so that any number
-/// of use-cases can be implemented with this widget.
+/// The bounding widget is built with a given [builder], so that any number
+/// of use-cases can be implemented with this widget. This widget is sized
+/// as wide and tall as the attributed text run. If text is laid out across
+/// multiple lines, the [builder] widget is made as wide and as tall as the
+/// bounding box which includes all lines of that text.
 class AttributionBounds extends ContentLayerStatefulWidget {
   const AttributionBounds({
     Key? key,
@@ -128,6 +131,6 @@ class AttributionBoundsLayout {
 /// should have a widget boundary placed around it.
 typedef AttributionBoundsSelector = bool Function(Attribution attribution);
 
-/// Builder that (optionally) returns a widget that positioned at the size
+/// Builder that (optionally) returns a widget that is positioned at the size
 /// and location of attributed text.
 typedef AttributionBoundsBuilder = Widget? Function(BuildContext context, Attribution attribution);

--- a/super_editor/lib/src/super_reader/super_reader.dart
+++ b/super_editor/lib/src/super_reader/super_reader.dart
@@ -37,6 +37,7 @@ import 'package:super_editor/src/infrastructure/platforms/ios/toolbar.dart';
 import 'package:super_editor/src/infrastructure/platforms/platform.dart';
 import 'package:super_editor/src/super_reader/tasks.dart';
 
+import '../default_editor/text/custom_underlines.dart';
 import '../infrastructure/platforms/mobile_documents.dart';
 import '../infrastructure/text_input.dart';
 import 'read_only_document_android_touch_interactor.dart';
@@ -230,6 +231,7 @@ class SuperReaderState extends State<SuperReader> {
   final _documentLayoutLink = LayerLink();
   SingleColumnLayoutPresenter? _docLayoutPresenter;
   late SingleColumnStylesheetStyler _docStylesheetStyler;
+  final _customUnderlineStyler = CustomUnderlineStyler();
   late SingleColumnLayoutCustomComponentStyler _docLayoutPerComponentBlockStyler;
   late SingleColumnLayoutSelectionStyler _docLayoutSelectionStyler;
 
@@ -351,6 +353,7 @@ class SuperReaderState extends State<SuperReader> {
       pipeline: [
         _docStylesheetStyler,
         _docLayoutPerComponentBlockStyler,
+        _customUnderlineStyler,
         ...widget.customStylePhases,
         // Selection changes are very volatile. Put that phase last
         // to minimize view model recalculations.

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -51,6 +51,7 @@ export 'src/default_editor/super_editor.dart';
 export 'src/default_editor/tasks.dart';
 export 'src/default_editor/text.dart';
 export 'src/default_editor/text_tools.dart';
+export 'src/default_editor/text/custom_underlines.dart';
 export 'src/default_editor/text_tokenizing/action_tags.dart';
 export 'src/default_editor/text_tokenizing/pattern_tags.dart';
 export 'src/default_editor/text_tokenizing/tags.dart';

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -48,13 +48,13 @@ dependencies:
   flutter_test_robots: ^0.0.24
   clock: ^1.1.1
 
-#dependency_overrides:
+dependency_overrides:
 #  # Override to local mono-repo path so devs can test this repo
 #  # against changes that they're making to other mono-repo packages
 #  attributed_text:
 #    path: ../attributed_text
-#  super_text_layout:
-#    path: ../super_text_layout
+  super_text_layout:
+    path: ../super_text_layout
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
[SuperEditor][SuperReader] - Custom underline style configuration (Resolves #2675)

Text can now be attributed for a custom underline, and that custom underline is painted by `SuperEditor` and `SuperReader`.

The first step is to attribute some text with a `CustomUnderlineAttribution`. This attribution includes a `type` which is a `String` that can be anything. The `type` is interpreted by the style system, so as long as the `type` maps to an underline style, it will be honored. An unknown type will paint a straight black underline.

Each `TextComponentViewModel` has the stylesheet applied to it in `applyStyles()`. Each text view model now looks for a collection of underline styles: `customUnderlineStyles = styles[Styles.customUnderlineStyles];`. Each `TextComponentViewModel` holds on to those styles.

A new style phase called `CustomUnderlineStyler` inspects each `TextComponentViewModel` and looks for `CustomUnderlineAttribution`s in the text. If it finds any, then the `CustomUnderlineStyler` adds underlines to the `TextComponentViewModel` for each attribution.

After each view model runs `applyStyles()` and after the `CustomUnderlineStyler` parses the underlines out of the text, each `TextComponentViewModel` has enough information to create a list of underline styles for the text in the node. The method for this already existed before this PR - it's called `createUnderlines()`. That method now also creates these new custom underlines in addition to the existing composing region, spelling, and grammar underlines. The `createUnderlines()` method is called when the component is configured with the view model, e.g., when `ParagraphComponent` is created from the view model.

This PR also adds an `offset` property to the existing underline styles so that the underlines can be pushed up/down from their natural position.

## Unrelated Changes
As I tried to add a new property to all text component view models, it became clear that it's tedious and error prone to maintain our approach to mixing in `TextComponentViewModel` and implementing `copy()`, `==`, and `hashCode`. This requires replicating many lines per implementation and it's easy to miss one.

I refactored these relationships to significantly reduce tedious boilerplate.

Previously a call to `copy()` would create a new view model by passing every relevant property into its constructor. This required every text component to repeat all of these properties in the call to their constructors. The new approach in this PR is to leverage mutability, and let the mixin mutate all the properties that it wants. In other words, classes like `ParagraphComponentViewModel` and `ListItemComponentViewModel` now delegate to `TextComponentViewModel` to copy all the properties from `TextComponentViewModel`. As a result, we can implement new properties on `TextComponentViewModel` without altering any class that mixes in `TextComponentViewModel`.

A similar change was made to help with implementing `==` and `hashCode` via delegation to `TextComponentViewModel`.

## Demo
<img width="687" alt="Screenshot 2025-05-18 at 10 52 29 PM" src="https://github.com/user-attachments/assets/f355cfcf-0baa-4261-8587-e8829aa88218" />
