### PR TITLE
[SuperEditor] - Fix: Don't hide toolbar when user presses 'select all' on toolbar (Resolves #2679)

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -316,13 +316,22 @@ class SuperEditorAndroidControlsController {
   final _shouldShowToolbar = ValueNotifier<bool>(false);
 
   /// Shows the toolbar by setting [shouldShowToolbar] to `true`.
-  void showToolbar() => _shouldShowToolbar.value = true;
+  // void showToolbar() => _shouldShowToolbar.value = true;
+  void showToolbar() {
+    _shouldShowToolbar.value = true;
+  }
 
   /// Hides the toolbar by setting [shouldShowToolbar] to `false`.
-  void hideToolbar() => _shouldShowToolbar.value = false;
+  // void hideToolbar() => _shouldShowToolbar.value = false;
+  void hideToolbar() {
+    _shouldShowToolbar.value = false;
+  }
 
   /// Toggles [shouldShowToolbar].
-  void toggleToolbar() => _shouldShowToolbar.value = !_shouldShowToolbar.value;
+  // void toggleToolbar() => _shouldShowToolbar.value = !_shouldShowToolbar.value;
+  void toggleToolbar() {
+    _shouldShowToolbar.value = !_shouldShowToolbar.value;
+  }
 
   /// Link to a location where a toolbar should be focused.
   ///

--- a/super_editor/lib/src/default_editor/super_editor.dart
+++ b/super_editor/lib/src/default_editor/super_editor.dart
@@ -1097,7 +1097,6 @@ class DefaultAndroidEditorToolbar extends StatelessWidget {
 
   void _selectAll() {
     editorOps.selectAll();
-    editorControlsController.hideToolbar();
   }
 }
 

--- a/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_android_overlay_controls_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_test_robots/flutter_test_robots.dart';
 import 'package:flutter_test_runners/flutter_test_runners.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:super_editor/src/infrastructure/platforms/android/selection_handles.dart';
 import 'package:super_editor/super_editor.dart';
 import 'package:super_editor/super_editor_test.dart';
@@ -109,8 +111,12 @@ void main() {
       // Ensure the toolbar is visible.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isTrue);
 
-      // Place the caret at "Lorem |ipsum".
-      await tester.placeCaretInParagraph("1", 6);
+      // Place the caret somewhere else in the paragraph.
+      //
+      // WARNING: We choose a position way beyond the start of the paragraph so that
+      // it's down multiple lines, below the toolbar. Otherwise, this type might accidentally
+      // activate a toolbar button instead of moving the selection.
+      await tester.placeCaretInParagraph("1", 200);
 
       // Ensure the toolbar isn't visible.
       expect(SuperEditorInspector.isMobileToolbarVisible(), isFalse);

--- a/super_editor/test/super_editor/supereditor_keyboard_test.dart
+++ b/super_editor/test/super_editor/supereditor_keyboard_test.dart
@@ -655,12 +655,18 @@ void main() {
         expect(keyboardController.isConnectedToIme, isFalse);
 
         // Select a word
-        await tester.doubleTapInParagraph(nodeId, 10);
+        //
+        // WARNING: To avoid accidentally tapping on the popover toolbar, we tap down a few
+        // lines. The specific text offset isn't important in this case.
+        await tester.doubleTapInParagraph(nodeId, 100);
         // Ensure the keyboard is still closed.
         expect(keyboardController.isConnectedToIme, isFalse);
 
-        // Select a paragraph
-        await tester.tripleTapInParagraph(nodeId, 15);
+        // Select a paragraph.
+        //
+        // WARNING: To avoid accidentally tapping on the popover toolbar, we tap down a few
+        // lines. The specific text offset isn't important in this case.
+        await tester.tripleTapInParagraph(nodeId, 100);
         // Ensure the keyboard is still closed.
         expect(keyboardController.isConnectedToIme, isFalse);
       });


### PR DESCRIPTION
[SuperEditor] - Fix: Don't hide toolbar when user presses 'select all' on toolbar (Resolves #2679)

Previously, for some reason, we were hiding the toolbar when the user presses "Select All" on the toolbar. And once the toolbar disappears, there's no way to get it back (tapping on the selection just places the caret).

This PR keeps the toolbar open after the user taps "Select All" so that the user can then copy or paste using the toolbar.

## Related Changes
This feature change broke a couple tests because in those tests, the toolbar became visible, and then blocked a tap position that was previously working. It's actually possible that these tests weren't testing what we thought up to this point, but now that they've failed by accidentally pressing a button on the toolbar, I verified with golden checks that those tests are not testing what we think.