### PR TITLE
[Clones] Add Slack clone

### DIFF
--- a/super_clones/slack/lib/chat_thread.dart
+++ b/super_clones/slack/lib/chat_thread.dart
@@ -1,0 +1,329 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:slack/domain/message.dart';
+import 'package:slack/domain/user.dart';
+import 'package:slack/fake_data/fake_users.dart';
+import 'package:slack/styles.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// A vertical list of messages.
+///
+/// Each message contains a user avatar, the message content and the user name.
+class ChatThread extends StatelessWidget {
+  const ChatThread({
+    super.key,
+    required this.messages,
+    required this.backgroundColor,
+    this.scrollController,
+  });
+
+  /// The messages to display.
+  final List<Message> messages;
+
+  /// The background color of each message.
+  final Color backgroundColor;
+
+  /// The `ScrollController` that controls the list scrolling.
+  final ScrollController? scrollController;
+
+  String _formatDate(DateTime date) {
+    final today = DateTime.now();
+    if (date.day == today.day && date.month == today.month && date.year == today.year) {
+      return 'Today';
+    }
+
+    // Get the full month name
+    final month = DateFormat('MMMM').format(date);
+
+    final day = date.day;
+    final suffix = _getDaySuffix(day);
+
+    return '$month $day$suffix';
+  }
+
+  String _getDaySuffix(int day) {
+    if (day >= 11 && day <= 13) {
+      return 'th';
+    }
+    switch (day % 10) {
+      case 1:
+        return 'st';
+      case 2:
+        return 'nd';
+      case 3:
+        return 'rd';
+      default:
+        return 'th';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reversedList = messages.reversed.toList();
+    return ListView.separated(
+      controller: scrollController,
+      physics: const ClampingScrollPhysics(),
+      reverse: true,
+      itemBuilder: (context, index) => _buildMessage(reversedList, index),
+      separatorBuilder: (context, index) {
+        final message = reversedList[index];
+        final previousMessage = index < reversedList.length - 1 //
+            ? reversedList[index + 1]
+            : null;
+        return _buildSeparator(message, previousMessage);
+      },
+      itemCount: reversedList.length,
+    );
+  }
+
+  Widget _buildMessage(List<Message> messages, int index) {
+    if (index == messages.length - 1) {
+      // This is the oldest message in the list.
+      // Show the date above it.
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildDividerForDate(messages[index].sentAt),
+          _MessageTile(
+            messages: messages,
+            index: index,
+            backgroundColor: backgroundColor,
+          ),
+        ],
+      );
+    }
+
+    if (index == 0) {
+      // This is the newest message in the list.
+      // Add some space below it.
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 20.0),
+        child: _MessageTile(
+          messages: messages,
+          index: index,
+          backgroundColor: backgroundColor,
+        ),
+      );
+    }
+
+    return _MessageTile(
+      messages: messages,
+      index: index,
+      backgroundColor: backgroundColor,
+    );
+  }
+
+  Widget _buildSeparator(Message message, Message? nextMessage) {
+    if (nextMessage == null) {
+      // This is the last message in the list.
+      // Don't show the separator.
+      return const SizedBox(height: 0);
+    }
+    if (message.userId == nextMessage.userId && _isSameDate(message.sentAt, nextMessage.sentAt)) {
+      // The message is from the same user and date as the previous message.
+      // Don't show the separator and don't add more space between messages.
+      return const SizedBox(height: 0);
+    }
+    if (message.userId != nextMessage.userId && _isSameDate(message.sentAt, nextMessage.sentAt)) {
+      // The message is on the same day as the previous message.
+      // Don't show the separator.
+      return const SizedBox(height: 5);
+    }
+    return _buildDividerForDate(message.sentAt);
+  }
+
+  Widget _buildDividerForDate(DateTime date) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 15.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: const Divider(color: dividerColor),
+          ),
+          Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: dividerColor,
+                width: 1,
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 8.0,
+              vertical: 4.0,
+            ),
+            child: Text(_formatDate(date)),
+          ),
+          Expanded(
+            child: const Divider(color: dividerColor),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Displays a single message from a list.
+///
+/// Shows the user avatar, the message content and the user's name.
+class _MessageTile extends StatefulWidget {
+  const _MessageTile({
+    required this.messages,
+    required this.index,
+    required this.backgroundColor,
+  });
+
+  /// List containing all messages.
+  ///
+  /// We take the whole list instead of a single message because
+  /// render the message differently depending on the previous message.
+  final List<Message> messages;
+
+  /// The index of the message to be displayed.
+  final int index;
+
+  final Color backgroundColor;
+
+  @override
+  State<_MessageTile> createState() => _MessageTileState();
+}
+
+class _MessageTileState extends State<_MessageTile> {
+  final ValueNotifier<DocumentSelection?> _selection = ValueNotifier(null);
+  final GlobalKey _documentLayoutKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    final message = widget.messages[widget.index];
+    // The list is reversed, so the previous message is at index + 1.
+    final previousMessage = widget.index < widget.messages.length - 1 //
+        ? widget.messages[widget.index + 1]
+        : null;
+
+    final user = fakeUsers.where((e) => e.id == message.userId).first;
+    final sameUserAsLastMessage = previousMessage != null && previousMessage.userId == message.userId;
+    final isSameDate = _isSameDate(message.sentAt, previousMessage?.sentAt ?? DateTime.now());
+
+    final shouldDisplayAvatar = !sameUserAsLastMessage || !isSameDate;
+
+    return ColoredBox(
+      color: widget.backgroundColor,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 16.0, right: 8.0, top: 2, bottom: 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            shouldDisplayAvatar
+                ? _buildUserAvatar(user.avatarUrl)
+                : const SizedBox(
+                    width: 46,
+                    height: 0,
+                  ),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (shouldDisplayAvatar) _buildMessageHeader(message, user),
+                  _buildMessageContent(message),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUserAvatar(String avatarUrl) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8.0, right: 10),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: Image.network(
+          avatarUrl,
+          height: 36,
+          width: 36,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageHeader(Message message, User user) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 10.0, top: 5.0),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            user.displayName,
+            selectionColor: Colors.blue,
+            style: const TextStyle(
+              fontSize: 15,
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(width: 15),
+          _buildMessageTime(message.sentAt),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageContent(Message message) {
+    return IntrinsicWidth(
+      child: IgnorePointer(
+        child: SuperEditorDryLayout(
+          superEditor: SuperReader(
+            document: message.content,
+            selection: _selection,
+            documentLayoutKey: _documentLayoutKey,
+            stylesheet: defaultStylesheet.copyWith(
+              documentPadding: const EdgeInsets.symmetric(
+                horizontal: 10.0,
+                vertical: 0.0,
+              ),
+              selectedTextColorStrategy: makeSelectedTextBlack,
+              addRulesAfter: messageListStyles,
+              inlineTextStyler: _inlineStyler,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageTime(DateTime dateTime) {
+    return Text(
+      DateFormat('h:mm a').format(dateTime),
+      style: const TextStyle(
+        fontSize: 14,
+        color: Colors.white54,
+      ),
+    );
+  }
+
+  TextStyle _inlineStyler(Set<Attribution> attributions, TextStyle existingStyle) {
+    TextStyle style = defaultInlineTextStyler(attributions, existingStyle);
+
+    if (attributions.contains(stableTagComposingAttribution)) {
+      style = style.copyWith(
+        color: Colors.blue,
+      );
+    }
+
+    if (attributions.whereType<CommittedStableTagAttribution>().isNotEmpty) {
+      style = style.copyWith(
+        color: Colors.orange,
+      );
+    }
+
+    return style;
+  }
+}
+
+bool _isSameDate(DateTime date1, DateTime date2) {
+  return date1.year == date2.year && date1.month == date2.month && date1.day == date2.day;
+}

--- a/super_clones/slack/lib/domain/message.dart
+++ b/super_clones/slack/lib/domain/message.dart
@@ -1,0 +1,12 @@
+import 'package:super_editor/super_editor.dart';
+
+class Message {
+  Message({
+    required this.userId,
+    required this.sentAt,
+    required this.content,
+  });
+  final String userId;
+  final DateTime sentAt;
+  final Document content;
+}

--- a/super_clones/slack/lib/domain/user.dart
+++ b/super_clones/slack/lib/domain/user.dart
@@ -1,0 +1,10 @@
+class User {
+  const User({
+    required this.id,
+    required this.displayName,
+    required this.avatarUrl,
+  });
+  final String id;
+  final String displayName;
+  final String avatarUrl;
+}

--- a/super_clones/slack/lib/fake_data/fake_messages.dart
+++ b/super_clones/slack/lib/fake_data/fake_messages.dart
@@ -1,0 +1,79 @@
+import 'package:slack/domain/message.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+final fakeMessages = <Message>[
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 14, 16, 50),
+    message:
+        "**Hey** @DevDana! Have you had a chance to delve deep into the **Flutter** framework? I've found some interesting aspects about it.",
+  ),
+  _buildMessage(
+    from: "2",
+    dateTime: DateTime(2025, 5, 14, 16, 52),
+    message:
+        "Oh, hey @FlutterGuru! I've been dabbling a bit. It's fascinating how it manages to be so _versatile_. What caught your attention?",
+  ),
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 15, 16, 54),
+    message:
+        "Here are a few things that really stand out to me:\n\n- **Hot Reload**: Super useful during development.\n- **Single Codebase**: Write once and deploy everywhere.\n- **Dart Language**: Initially a curveball but it grew on me.\n\nWhat about you?",
+  ),
+  _buildMessage(
+    from: "2",
+    dateTime: DateTime(2025, 5, 15, 16, 56),
+    message:
+        "I'm particularly intrigued by the following:\n\n1. _Rich widget catalog_: Makes UI building a breeze.\n2. _Performance_: Apps run smoothly with native-like performance.\n3. _Community support_: The community is simply amazing.",
+  ),
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 15, 16, 58),
+    message:
+        "Speaking of community, have you seen the plethora of resources out there? Here are a few I recommend:\n\n-  [Flutter Docs](https://flutter.dev/docs)\n-  [Dart Packages](https://pub.dev/flutter)\n-  [Flutter YouTube Channel](https://www.youtube.com/flutterdev)",
+  ),
+  _buildMessage(
+    from: "2",
+    dateTime: DateTime(2025, 5, 16, 17, 01),
+    message:
+        "Oh, I've been on the YouTube channel! So many tutorials and demos. Also, here's a visual representation of Flutter's architecture I found useful:\n\n![Flutter Architecture](https://docs.flutter.dev/assets/images/docs/arch-overview/archdiagram.png)",
+  ),
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 16, 17, 03),
+    message:
+        "I've seen that! It's quite an insightful diagram. By the way, have you heard of the controversies around Flutter? Some say it might not be the best for every project.",
+  ),
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 16, 17, 05),
+    message:
+        "For example, while it's great for most apps, heavy 3D games or highly specialized native applications might face challenges. But then again, every tool has its pros and cons, right?",
+  ),
+  _buildMessage(
+    from: "2",
+    dateTime: DateTime(2025, 5, 16, 17, 08),
+    message:
+        "Absolutely! No tool is a one-size-fits-all solution. And it's always about picking the right tool for the right job. By the way, did you see the new updates in the latest version? They've introduced some ~~deprecated widgets~~ and replaced them with more efficient ones.",
+  ),
+  _buildMessage(
+    from: "1",
+    dateTime: DateTime(2025, 5, 16, 17, 10),
+    message:
+        "I did notice that! And it shows how dedicated they are to improving and evolving. It's one of the reasons I'm so bullish on Flutter. **Onward and upward!**",
+  ),
+];
+
+Message _buildMessage({
+  required String from,
+  required DateTime dateTime,
+  required String message,
+}) {
+  return Message(
+    userId: from,
+    sentAt: dateTime,
+    content: deserializeMarkdownToDocument(
+      message,
+    ),
+  );
+}

--- a/super_clones/slack/lib/fake_data/fake_users.dart
+++ b/super_clones/slack/lib/fake_data/fake_users.dart
@@ -1,0 +1,59 @@
+import 'package:slack/domain/user.dart';
+
+const fakeUsers = <User>[
+  User(
+    id: '1',
+    displayName: 'FlutterGuru',
+    avatarUrl: 'https://i.pravatar.cc/36?img=13',
+  ),
+  User(
+    id: '2',
+    displayName: 'DevDana',
+    avatarUrl: 'https://i.pravatar.cc/36?img=47',
+  ),
+  User(
+    id: '3',
+    displayName: 'QuantumJester',
+    avatarUrl: 'https://i.pravatar.cc/36?img=56',
+  ),
+  User(
+    id: '4',
+    displayName: 'SereneSpectre',
+    avatarUrl: 'https://i.pravatar.cc/36?img=26',
+  ),
+  User(
+    id: '5',
+    displayName: 'MysticWhisperer',
+    avatarUrl: 'https://i.pravatar.cc/36?img=58',
+  ),
+  User(
+    id: '6',
+    displayName: 'NebulaNomad',
+    avatarUrl: 'https://i.pravatar.cc/36?img=59',
+  ),
+  User(
+    id: '7',
+    displayName: 'VelvetVortex',
+    avatarUrl: 'https://i.pravatar.cc/36?img=60',
+  ),
+  User(
+    id: '8',
+    displayName: 'EchoEnigma',
+    avatarUrl: 'https://i.pravatar.cc/36?img=61',
+  ),
+  User(
+    id: '9',
+    displayName: 'ZephyrZenith',
+    avatarUrl: 'https://i.pravatar.cc/36?img=62',
+  ),
+  User(
+    id: '10',
+    displayName: 'LunarLabyrinth',
+    avatarUrl: 'https://i.pravatar.cc/36?img=63',
+  ),
+  User(
+    id: '9',
+    displayName: 'EmberEclipse',
+    avatarUrl: 'https://i.pravatar.cc/36?img=64',
+  ),
+];

--- a/super_clones/slack/lib/main.dart
+++ b/super_clones/slack/lib/main.dart
@@ -1,125 +1,289 @@
 import 'package:flutter/material.dart';
+import 'package:slack/domain/message.dart';
+import 'package:slack/domain/user.dart';
+import 'package:slack/fake_data/fake_messages.dart';
+import 'package:slack/fake_data/fake_users.dart';
+import 'package:slack/chat_thread.dart';
+import 'package:slack/mobile_message_editor.dart';
+import 'package:slack/styles.dart';
+import 'package:super_editor/super_editor.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    const MaterialApp(
+      home: SlackChatPage(),
+    ),
+  );
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+/// A Slack-like UI containing a list of messages and a message editor.
+///
+/// Messages are loaded from markdown and can contain rich content, like list items,
+/// headers, images, user mentions, etc.
+class SlackChatPage extends StatefulWidget {
+  const SlackChatPage({super.key});
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
+  State<SlackChatPage> createState() => _SlackChatPageState();
+}
+
+class _SlackChatPageState extends State<SlackChatPage> {
+  final ScrollController _messageListScrollController = ScrollController();
+  final GlobalKey _scaffoldKey = GlobalKey();
+
+  final User _user = fakeUsers[1];
+  final List<Message> _messages = [...fakeMessages];
+
+  @override
+  void dispose() {
+    _messageListScrollController.dispose();
+    super.dispose();
   }
-}
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  void _onSendMessage(Document document) {
+    if (document.length == 1 &&
+        document.first is ParagraphNode &&
+        (document.first as ParagraphNode).text.toPlainText().trim().isEmpty) {
+      // The message editor is empty. Fizzle.
+      return;
+    }
 
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _messages.add(Message(
+        userId: '1',
+        sentAt: DateTime.now(),
+        content: document,
+      ));
+    });
+
+    // Scroll the message list to display the newly added message.
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      if (!mounted) {
+        return;
+      }
+
+      _messageListScrollController.animateTo(
+        _messageListScrollController.position.minScrollExtent,
+        // ^ minScrollExtent because the list is reversed.
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+      );
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+      key: _scaffoldKey,
+      backgroundColor: backgroundColor,
+      resizeToAvoidBottomInset: false,
+      body: SafeArea(
+        bottom: false,
+        // ^ Don't add padding at the bottom of the screen because
+        // we handle it ourselves.
+        child: DefaultTextStyle(
+          style: const TextStyle(color: Colors.white),
+          child: _buildBody(),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+
+  Widget _buildBody() {
+    // TODO: implement desktop screen.
+    return _SlackChatMobile(
+      scaffoldKey: _scaffoldKey,
+      onSendMessage: _onSendMessage,
+      user: _user,
+      messages: _messages,
+      scrollController: _messageListScrollController,
+    );
+  }
+}
+
+class _SlackChatMobile extends StatefulWidget {
+  const _SlackChatMobile({
+    required this.scaffoldKey,
+    required this.onSendMessage,
+    required this.user,
+    required this.messages,
+    required this.scrollController,
+  });
+
+  final GlobalKey scaffoldKey;
+  final OnSendMessage onSendMessage;
+  final User user;
+  final List<Message> messages;
+  final ScrollController scrollController;
+
+  @override
+  State<_SlackChatMobile> createState() => _SlackChatMobileState();
+}
+
+class _SlackChatMobileState extends State<_SlackChatMobile> {
+  final _messagePageController = MessagePageController();
+
+  @override
+  Widget build(BuildContext context) {
+    return MessagePageScaffold(
+      controller: _messagePageController,
+      bottomSheetMinimumTopGap: 150,
+      bottomSheetMinimumHeight: 120,
+      contentBuilder: (contentContext, bottomSpacing) {
+        return MediaQuery.removePadding(
+          context: contentContext,
+          removeBottom: true,
+          // ^ Remove bottom padding because if we don't, when the keyboard
+          //   opens to edit the bottom sheet, this content behind the bottom
+          //   sheet adds some phantom space at the bottom, slightly pushing
+          //   it up for no reason.
+          child: Stack(
+            children: [
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: bottomSpacing,
+                child: _buildChatThread(),
+              ),
+            ],
+          ),
+        );
+      },
+      bottomSheetBuilder: (messageContext) {
+        return _buildBottomSheet();
+      },
+    );
+  }
+
+  Widget _buildChatThread() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildTopSection(),
+        Divider(color: dividerColor),
+        Expanded(
+          child: ChatThread(
+            messages: widget.messages,
+            backgroundColor: backgroundColor,
+            scrollController: widget.scrollController,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Builds the top section of the chat, containing the back button, the user avatar with the
+  /// user's name, and the headphones icon.
+  Widget _buildTopSection() {
+    return SizedBox(
+      height: 60,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            icon: const Icon(
+              Icons.arrow_back,
+              color: Colors.white,
+            ),
+            onPressed: () {},
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20.0),
+              child: Container(
+                height: 50,
+                padding: EdgeInsets.all(2.0),
+                decoration: BoxDecoration(
+                  color: Color(0xFF21252A),
+                  borderRadius: BorderRadius.all(Radius.circular(12)),
+                ),
+                child: Row(
+                  children: [
+                    Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.network(
+                            widget.user.avatarUrl,
+                            fit: BoxFit.cover,
+                            height: 50,
+                          ),
+                        ),
+                        Positioned(
+                          bottom: -1,
+                          right: -4,
+                          child: Container(
+                            height: 18,
+                            width: 18,
+                            padding: EdgeInsets.all(3.0),
+                            decoration: BoxDecoration(
+                              color: Color(0xFF21252A),
+                              shape: BoxShape.circle,
+                            ),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: Color(0xFF3CAA7B),
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
+                    SizedBox(width: 8),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      spacing: 2,
+                      children: [
+                        Text(
+                          widget.user.displayName,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                          ),
+                        ),
+                        Row(
+                          children: [
+                            Text(
+                              '3 tabs',
+                              style: TextStyle(color: Colors.white),
+                            ),
+                            Transform.rotate(
+                              angle: 270 * 3.14 / 180,
+                              child: Icon(
+                                Icons.chevron_left,
+                                size: 19,
+                                color: Colors.white,
+                              ),
+                            )
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.headphones_outlined),
+            color: Colors.white,
+            onPressed: () {},
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBottomSheet() {
+    return MobileMessageEditor(
+      hintText: 'Message ${widget.user.displayName}',
+      messagePageController: _messagePageController,
+      onSendMessage: widget.onSendMessage,
     );
   }
 }

--- a/super_clones/slack/lib/mobile_message_editor.dart
+++ b/super_clones/slack/lib/mobile_message_editor.dart
@@ -1,0 +1,458 @@
+import 'package:flutter/material.dart';
+import 'package:slack/styles.dart';
+import 'package:super_editor/super_editor.dart';
+
+/// An input field where users can compose rich text messages.
+class MobileMessageEditor extends StatefulWidget {
+  const MobileMessageEditor({
+    super.key,
+    required this.hintText,
+    required this.messagePageController,
+    required this.onSendMessage,
+  });
+
+  final String hintText;
+  final MessagePageController messagePageController;
+  final OnSendMessage onSendMessage;
+
+  @override
+  State<MobileMessageEditor> createState() => _MobileMessageEditorState();
+}
+
+class _MobileMessageEditorState extends State<MobileMessageEditor> {
+  final _dragIndicatorKey = GlobalKey();
+  final _panelFocusNode = FocusNode();
+  final _editorFocusNode = FocusNode();
+
+  final _scrollController = ScrollController();
+
+  final _editorSheetKey = GlobalKey();
+  late Editor _editor;
+
+  /// The message being composed.
+  late MutableDocument _document;
+
+  double _dragTouchOffsetFromIndicator = 0;
+
+  // FIXME: Keyboard keeps closing without a bunch of global keys. Either
+  //        document why, or figure out how to operate without all the keys.
+  final _editorKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _panelFocusNode.addListener(_onFocusChange);
+    _createDocument();
+  }
+
+  @override
+  void dispose() {
+    _panelFocusNode.removeListener(_onFocusChange);
+    _panelFocusNode.dispose();
+
+    _editorFocusNode.dispose();
+
+    _document.removeListener(_onDocumentChange);
+    super.dispose();
+  }
+
+  void _onDocumentChange(DocumentChangeLog changeLog) {
+    setState(() {});
+  }
+
+  void _onFocusChange() {
+    // Reflow the layout to show the editor when the panel is focused.
+    setState(() {});
+
+    // Request focus on the editor when the panel is focused.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_panelFocusNode.hasFocus) {
+        _editorFocusNode.requestFocus();
+      }
+    });
+  }
+
+  /// Create a document with an empty paragraph.
+  ///
+  /// If [withSelection] is `true`, selection is placed at the beginning of the document,
+  /// and the caret is displayed.
+  void _createDocument({bool withSelection = false}) {
+    _document = MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: Editor.createNodeId(),
+          text: AttributedText(''),
+        ),
+      ],
+    );
+
+    _document.addListener(_onDocumentChange);
+
+    final composer = MutableDocumentComposer(
+      initialSelection: withSelection
+          ? DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: _document.first.id,
+                nodePosition: const TextNodePosition(offset: 0),
+              ),
+            )
+          : null,
+    );
+
+    _editor = Editor(
+      editables: {Editor.documentKey: _document, Editor.composerKey: composer},
+      requestHandlers: [...defaultRequestHandlers],
+      reactionPipeline: List.from(defaultEditorReactions),
+    );
+  }
+
+  void _onVerticalDragStart(DragStartDetails details) {
+    _dragTouchOffsetFromIndicator = _dragFingerOffsetFromIndicator(details.globalPosition);
+
+    widget.messagePageController.onDragStart(
+      details.globalPosition.dy - _dragIndicatorOffsetFromTop + _dragTouchOffsetFromIndicator,
+    );
+  }
+
+  void _onVerticalDragUpdate(DragUpdateDetails details) {
+    widget.messagePageController.onDragUpdate(
+      details.globalPosition.dy - _dragIndicatorOffsetFromTop + _dragTouchOffsetFromIndicator,
+    );
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    widget.messagePageController.onDragEnd();
+  }
+
+  void _onVerticalDragCancel() {
+    widget.messagePageController.onDragEnd();
+  }
+
+  double get _dragIndicatorOffsetFromTop {
+    final editorSheetBox = _editorSheetKey.currentContext!.findRenderObject();
+    final dragIndicatorBox = _dragIndicatorKey.currentContext!.findRenderObject()! as RenderBox;
+
+    return dragIndicatorBox.localToGlobal(Offset.zero, ancestor: editorSheetBox).dy;
+  }
+
+  double _dragFingerOffsetFromIndicator(Offset globalDragOffset) {
+    final dragIndicatorBox = _dragIndicatorKey.currentContext!.findRenderObject()! as RenderBox;
+
+    return dragIndicatorBox.localToGlobal(Offset.zero).dy - globalDragOffset.dy;
+  }
+
+  void _sendMessage() {
+    widget.onSendMessage(_document);
+
+    // Reset the editor to an empty state.
+    _createDocument(withSelection: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      key: _editorSheetKey,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(32),
+          topRight: Radius.circular(32),
+        ),
+        border: Border(
+          top: BorderSide(width: 1, color: borderColor),
+        ),
+      ),
+      child: KeyboardScaffoldSafeArea(
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.paddingOf(context).bottom,
+            // ^ Avoid the bottom notch when the keyboard is closed.
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (_panelFocusNode.hasFocus) //
+                _buildDragHandle()
+              else
+                const SizedBox(height: 10),
+              Flexible(
+                child: _buildSheetContent(),
+              ),
+              if (_panelFocusNode.hasFocus)
+                _SlackMobileEditorToolbar(
+                  onSendMessage: _document.isEmpty ||
+                          (_document.nodeCount == 1 &&
+                              _document.first is TextNode &&
+                              (_document.first as TextNode).text.isEmpty)
+                      ? null
+                      : _sendMessage,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDragHandle() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        GestureDetector(
+          onVerticalDragStart: _onVerticalDragStart,
+          onVerticalDragUpdate: _onVerticalDragUpdate,
+          onVerticalDragEnd: _onVerticalDragEnd,
+          onVerticalDragCancel: _onVerticalDragCancel,
+          behavior: HitTestBehavior.opaque,
+          // ^ Opaque to handle touch events in our invisible padding.
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            // ^ Expand the hit area with invisible padding.
+            child: Container(
+              key: _dragIndicatorKey,
+              width: 48,
+              height: 3,
+              decoration: BoxDecoration(
+                color: Colors.grey,
+                borderRadius: BorderRadius.circular(3),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSheetContent() {
+    return Focus(
+      focusNode: _panelFocusNode,
+      child: BottomSheetEditorHeight(
+        previewHeight: 42,
+        child: _panelFocusNode.hasFocus //
+            ? _buildChatEditor()
+            : _buildNonFocusedBottomPanel(),
+      ),
+    );
+  }
+
+  Widget _buildChatEditor() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0),
+      child: _ChatEditor(
+        key: _editorKey,
+        editor: _editor,
+        editorFocusNode: _editorFocusNode,
+        hintText: widget.hintText,
+        messagePageController: widget.messagePageController,
+        scrollController: _scrollController,
+        onSendMessage: _sendMessage,
+      ),
+    );
+  }
+
+  /// A bottom panel that is shown when the editor is not focused.
+  ///
+  /// This panel contains a hint text, an add button and the microphone button.
+  Widget _buildNonFocusedBottomPanel() {
+    return GestureDetector(
+      onTap: () => _panelFocusNode.requestFocus(),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 5.0),
+        child: Row(
+          children: [
+            _AddButton(),
+            Expanded(
+              child: Text(
+                widget.hintText,
+                style: _hintTextStyleBuilder(context),
+              ),
+            ),
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(
+                Icons.mic_none_outlined,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// An editor for composing chat messages.
+class _ChatEditor extends StatefulWidget {
+  const _ChatEditor({
+    super.key,
+    required this.editor,
+    required this.hintText,
+    required this.editorFocusNode,
+    required this.messagePageController,
+    required this.scrollController,
+    required this.onSendMessage,
+  });
+
+  final Editor editor;
+  final String hintText;
+  final FocusNode editorFocusNode;
+  final MessagePageController messagePageController;
+  final ScrollController scrollController;
+  final VoidCallback onSendMessage;
+
+  @override
+  State<_ChatEditor> createState() => _ChatEditorState();
+}
+
+class _ChatEditorState extends State<_ChatEditor> {
+  final _editorKey = GlobalKey();
+
+  final _isImeConnected = ValueNotifier(false);
+
+  @override
+  void initState() {
+    super.initState();
+
+    widget.messagePageController.addListener(_onMessagePageControllerChange);
+    _isImeConnected.addListener(_onImeConnectionChange);
+  }
+
+  @override
+  void didUpdateWidget(_ChatEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.messagePageController != oldWidget.messagePageController) {
+      oldWidget.messagePageController.removeListener(_onMessagePageControllerChange);
+      widget.messagePageController.addListener(_onMessagePageControllerChange);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.messagePageController.removeListener(_onMessagePageControllerChange);
+    widget.scrollController.dispose();
+    _isImeConnected.dispose();
+
+    super.dispose();
+  }
+
+  void _onImeConnectionChange() {
+    widget.messagePageController.collapsedMode = _isImeConnected.value //
+        ? MessagePageSheetCollapsedMode.intrinsic
+        : MessagePageSheetCollapsedMode.preview;
+  }
+
+  void _onMessagePageControllerChange() {
+    if (widget.messagePageController.isPreview) {
+      // Always scroll the editor to the top when in preview mode.
+      widget.scrollController.position.jumpTo(0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperEditorDryLayout(
+      controller: widget.scrollController,
+      superEditor: SuperEditor(
+        key: _editorKey,
+        focusNode: widget.editorFocusNode,
+        editor: widget.editor,
+        isImeConnected: _isImeConnected,
+        imePolicies: SuperEditorImePolicies(),
+        selectionPolicies: SuperEditorSelectionPolicies(),
+        shrinkWrap: false,
+        stylesheet: messageEditorStylesheet,
+        componentBuilders: [
+          HintComponentBuilder(
+            widget.hintText,
+            _hintTextStyleBuilder,
+          ),
+          ...defaultComponentBuilders,
+        ],
+      ),
+    );
+  }
+}
+
+TextStyle _hintTextStyleBuilder(context) => TextStyle(
+      fontSize: 14,
+      color: Colors.grey,
+    );
+
+class _SlackMobileEditorToolbar extends StatefulWidget {
+  const _SlackMobileEditorToolbar({
+    required this.onSendMessage,
+  });
+
+  final VoidCallback? onSendMessage;
+
+  @override
+  State<_SlackMobileEditorToolbar> createState() => _SlackMobileEditorToolbarState();
+}
+
+class _SlackMobileEditorToolbarState extends State<_SlackMobileEditorToolbar> {
+  @override
+  Widget build(BuildContext context) {
+    return IconButtonTheme(
+      data: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          foregroundColor: Colors.white,
+          disabledForegroundColor: Colors.white.withValues(alpha: 0.5),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6.0)),
+        ),
+      ),
+      child: Material(
+        child: Container(
+          width: double.infinity,
+          color: backgroundColor,
+          child: Row(
+            children: [
+              _AddButton(),
+              IconButton(onPressed: () {}, icon: const Icon(Icons.format_size)),
+              IconButton(onPressed: () {}, icon: const Icon(Icons.emoji_emotions_outlined)),
+              IconButton(onPressed: () {}, icon: const Icon(Icons.alternate_email)),
+              Spacer(),
+              widget.onSendMessage != null
+                  ? CircleAvatar(
+                      backgroundColor: Colors.green,
+                      child: IconButton(
+                        onPressed: widget.onSendMessage,
+                        icon: const Icon(Icons.send),
+                      ),
+                    )
+                  : IconButton(
+                      onPressed: null,
+                      icon: const Icon(Icons.send),
+                    ),
+              const SizedBox(width: 10),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddButton extends StatelessWidget {
+  const _AddButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {},
+      style: ElevatedButton.styleFrom(
+        shape: CircleBorder(),
+        padding: EdgeInsets.all(6),
+        backgroundColor: Color(0xFF22242A),
+      ),
+      child: Icon(
+        Icons.add,
+        size: 24,
+        color: Colors.white.withValues(alpha: 0.5),
+      ),
+    );
+  }
+}
+
+typedef OnSendMessage = void Function(Document document);

--- a/super_clones/slack/lib/styles.dart
+++ b/super_clones/slack/lib/styles.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:super_editor/super_editor.dart';
+
+const backgroundColor = Color(0xFF191E22);
+const dividerColor = Color(0xFF292D32);
+const borderColor = Color(0xFF36383E);
+
+final messageListStyles = [
+  StyleRule(
+    BlockSelector.all,
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFFCCCCCC),
+          fontSize: 14,
+        ),
+        Styles.padding: const CascadingPadding.symmetric(
+          horizontal: 0,
+          vertical: 0,
+        ),
+      };
+    },
+  ),
+  StyleRule(
+    const BlockSelector("header1"),
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFF888888),
+          fontSize: 16,
+        ),
+        Styles.padding: const CascadingPadding.symmetric(
+          horizontal: 0,
+          vertical: 0,
+        ),
+      };
+    },
+  ),
+  StyleRule(
+    const BlockSelector("header2"),
+    (doc, docNode) {
+      return {
+        Styles.textStyle: const TextStyle(
+          color: Color(0xFF888888),
+        ),
+      };
+    },
+  ),
+];
+
+final messageEditorStylesheet = defaultStylesheet.copyWith(
+  addRulesAfter: [
+    ...messageListStyles,
+    StyleRule(
+      BlockSelector.all.last(),
+      (doc, docNode) {
+        return {
+          Styles.padding: const CascadingPadding.only(bottom: 22),
+        };
+      },
+    ),
+  ],
+  documentPadding: const EdgeInsets.symmetric(horizontal: 10),
+  inlineTextStyler: (attributions, existingStyle) {
+    TextStyle style = defaultInlineTextStyler(attributions, existingStyle);
+
+    if (attributions.contains(stableTagComposingAttribution)) {
+      // Style an user tag being composed.
+      style = style.copyWith(color: Colors.blue);
+    }
+
+    if (attributions.whereType<CommittedStableTagAttribution>().isNotEmpty) {
+      // Style an already composed user tag.
+      style = style.copyWith(color: Colors.orange);
+    }
+
+    return style;
+  },
+);
+
+Color makeSelectedTextBlack({required Color originalTextColor, required Color selectionHighlightColor}) {
+  return Colors.black;
+}

--- a/super_clones/slack/pubspec.yaml
+++ b/super_clones/slack/pubspec.yaml
@@ -1,17 +1,41 @@
 name: slack
 description: "A Flutter clone of Slack."
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.6.0
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^1.0.8
+  super_editor:
+    git:
+      url: https://github.com/superlistapp/super_editor.git
+      path: super_editor
+  super_editor_markdown:
+    git:
+      url: https://github.com/superlistapp/super_editor.git
+      path: super_editor_markdown
+  follow_the_leader: ^0.0.4+2
+  overlord: ^0.0.3+2
+  markdown: ^7.2.1
+
+  # The following adds the Cupertino Icons font to your application.
+  # Use with the CupertinoIcons class for iOS style icons.
+  cupertino_icons: ^1.0.2
+  flutter_svg: ^2.1.0
+  intl: ^0.20.2
+
+dependency_overrides:
+  super_editor:
+    path: ../../super_editor
+  super_text_layout:
+    path: ../../super_text_layout
+  attributed_text:
+    path: ../../attributed_text
 
 dev_dependencies:
   flutter_test:
@@ -20,7 +44,6 @@ dev_dependencies:
   flutter_lints: ^5.0.0
 
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -28,7 +51,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   # assets:
-  #   - images/a_dot_burr.jpeg
+  #   - assets/styles.svg
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
[Clones] Add Slack clone.

This PR adds a clone of Slack's message page. The implementation is based on the `example_chat` project, which uses the newly introduced `MessagePageScaffold` widget.

Each message tile uses a separate `SuperReader` to render the message. The message editor uses a `SuperEditor`.

The dimensions don't match perfectly Slack's dimensions and, at the moment, we have only the mobile UI.

[slack.webm](https://github.com/user-attachments/assets/3bef62f3-0fd8-4a30-b40d-c217c8d09a17)

