### PR TITLE
[SuperKeyboard] - Report all changes together, also add bottom padding (Resolves #2686)

### DIFF
--- a/super_keyboard/android/src/main/kotlin/com/flutterbountyhunters/superkeyboard/super_keyboard/SuperKeyboardPlugin.kt
+++ b/super_keyboard/android/src/main/kotlin/com/flutterbountyhunters/superkeyboard/super_keyboard/SuperKeyboardPlugin.kt
@@ -294,45 +294,34 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   }
 
   private fun sendMessageKeyboardOpened() {
-    channel.invokeMethod("keyboardOpened", mapOf(
-      "keyboardHeight" to imeHeightInDpi,
-      "bottomPadding" to bottomPaddingInDpi,
-    ))
+    channel.invokeMethod("keyboardOpened", createMetricsPayload())
   }
 
   private fun sendMessageKeyboardOpening() {
-    channel.invokeMethod("keyboardOpening", mapOf(
-      "keyboardHeight" to imeHeightInDpi,
-      "bottomPadding" to bottomPaddingInDpi,
-    ))
+    channel.invokeMethod("keyboardOpening", createMetricsPayload())
   }
 
   private fun sendMessageKeyboardProgress() {
-    channel.invokeMethod("onProgress", mapOf(
-      "keyboardHeight" to imeHeightInDpi,
-      "bottomPadding" to bottomPaddingInDpi,
-    ))
+    channel.invokeMethod("onProgress", createMetricsPayload())
   }
 
   private fun sendMessageKeyboardClosed() {
-    channel.invokeMethod("keyboardClosed", mapOf(
-      "keyboardHeight" to imeHeightInDpi,
-      "bottomPadding" to bottomPaddingInDpi,
-    ))
+    channel.invokeMethod("keyboardClosed", createMetricsPayload())
   }
 
   private fun sendMessageKeyboardClosing() {
-    channel.invokeMethod("keyboardClosing", mapOf(
-      "keyboardHeight" to imeHeightInDpi,
-      "bottomPadding" to bottomPaddingInDpi,
-    ))
+    channel.invokeMethod("keyboardClosing", createMetricsPayload())
   }
 
   private fun sendMessageMetricsUpdate() {
-    channel.invokeMethod("metricsUpdate", mapOf(
+    channel.invokeMethod("metricsUpdate", createMetricsPayload())
+  }
+
+  private fun createMetricsPayload(): Map<String, Any> {
+    return mapOf<String, Any>(
       "keyboardHeight" to imeHeightInDpi,
       "bottomPadding" to bottomPaddingInDpi,
-    ))
+    )
   }
 }
 

--- a/super_keyboard/android/src/main/kotlin/com/flutterbountyhunters/superkeyboard/super_keyboard/SuperKeyboardPlugin.kt
+++ b/super_keyboard/android/src/main/kotlin/com/flutterbountyhunters/superkeyboard/super_keyboard/SuperKeyboardPlugin.kt
@@ -1,7 +1,6 @@
 package com.flutterbountyhunters.superkeyboard.super_keyboard
 
 import android.app.Activity
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
@@ -17,6 +16,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter
 import io.flutter.plugin.common.MethodChannel
+import kotlin.math.roundToInt
 
 
 /**
@@ -45,6 +45,15 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   // The most recent known state of the software keyboard.
   private var keyboardState: KeyboardState = KeyboardState.Closed
 
+  // The device's DPI, used to map to logical pixels before sending the
+  // keyboard height to Flutter.
+  private var dpi: Float = 1.0f
+
+  // The most recent measurement of the keyboard height.
+  private var imeHeightInDpi: Float = 0f
+  // The most recent measurement of the gesture area at the bottom of the screen.
+  private var bottomPaddingInDpi: Float = 0f
+
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     SuperKeyboardLog.d("super_keyboard", "Attached to Flutter engine")
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "super_keyboard_android")
@@ -67,6 +76,7 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     SuperKeyboardLog.d("super_keyboard", "Attached to Flutter Activity")
     this.binding = binding
+    this.dpi = binding.activity.resources.displayMetrics.density;
     startListeningToActivityLifecycle()
   }
 
@@ -74,13 +84,24 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
     SuperKeyboardLog.d("super_keyboard", "Activity Resumed - keyboard state: $keyboardState")
     startListeningForKeyboardChanges(binding!!)
 
-    // Specifically in the case of an app resuming, it's possible that the keyboard
-    // went from open to closed without us getting a chance to report it. Check if we're
-    // closed and if we are, tell the app.
-    val insets = ViewCompat.getRootWindowInsets(mainView!!) ?: return
-    if (insets.getInsets(WindowInsetsCompat.Type.ime()).bottom == 0 && keyboardState != KeyboardState.Closed) {
+    // It's possible that, while paused, the keyboard went from closed to open, or open to closed.
+    // In practice, it's far more common to go from open to closed. However, while debugging some
+    // buggy lifecycle fluctuations on Android API 35 on a Pixel 9 Pro, it was found that it's also
+    // possible to pause while closed, and resume with the keyboard open.
+    measureInsets()
+
+    SuperKeyboardLog.v("super_keyboard", "Insets at time of resume are - Keyboard: $imeHeightInDpi, Bottom Padding: $bottomPaddingInDpi")
+    if (imeHeightInDpi.roundToInt() == 0 && keyboardState != KeyboardState.Closed) {
+      SuperKeyboardLog.d("super_keyboard", "Keyboard closed while paused - sending keyboardClosed message to Flutter.");
       keyboardState = KeyboardState.Closed
-      channel.invokeMethod("keyboardClosed", null)
+      sendMessageKeyboardClosed()
+    } else if (imeHeightInDpi > 0 && keyboardState != KeyboardState.Open) {
+      SuperKeyboardLog.d("super_keyboard", "Keyboard opened while paused - sending keyboardOpened message to Flutter.");
+      keyboardState = KeyboardState.Open
+      sendMessageKeyboardOpened()
+    } else {
+      SuperKeyboardLog.d("super_keyboard", "Reporting latest metrics to Flutter, just in case they got out of sync.");
+      sendMessageMetricsUpdate()
     }
   }
 
@@ -90,11 +111,13 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
+    SuperKeyboardLog.v("super_keyboard", "Detaching from Activity for config changes")
     stopListeningToActivityLifecycle()
     this.binding = null
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    SuperKeyboardLog.v("super_keyboard", "Re-attaching to Activity for config changes")
     startListeningToActivityLifecycle()
     this.binding = binding
   }
@@ -111,15 +134,18 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   }
 
   private fun startListeningToActivityLifecycle() {
+    SuperKeyboardLog.v("super_keyboard", "Starting to listen to Activity lifecycle")
     lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(binding!!)
     lifecycle!!.addObserver(this)
   }
 
   private fun stopListeningToActivityLifecycle() {
+    SuperKeyboardLog.v("super_keyboard", "Stopping listening to Activity lifecycle")
     lifecycle!!.removeObserver(this);
   }
 
   private fun startListeningForKeyboardChanges(binding: ActivityPluginBinding) {
+    SuperKeyboardLog.v("super_keyboard", "Starting to listen for keyboard changes")
     val activity = binding.activity
 
     mainView = activity.findViewById<ViewGroup>(android.R.id.content)
@@ -140,6 +166,7 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
           animation: WindowInsetsAnimationCompat
         ) {
           // no-op
+          SuperKeyboardLog.v("super_keyboard", "Insets animation callback - onPrepare() - current keyboard state: $keyboardState")
         }
 
         override fun onStart(
@@ -147,6 +174,7 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
           bounds: WindowInsetsAnimationCompat.BoundsCompat
         ): WindowInsetsAnimationCompat.BoundsCompat {
           // no-op
+          SuperKeyboardLog.v("super_keyboard", "Insets animation callback - onStart() - current keyboard state: $keyboardState")
           return bounds
         }
 
@@ -154,11 +182,15 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
           insets: WindowInsetsCompat,
           runningAnimations: MutableList<WindowInsetsAnimationCompat>
         ): WindowInsetsCompat {
-          val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+          SuperKeyboardLog.v("super_keyboard", "Insets animation callback - onProgress() - current keyboard state: $keyboardState")
 
-          channel.invokeMethod("onProgress", mapOf(
-            "keyboardHeight" to imeHeight,
-          ))
+          // Update our cached measurements.
+          imeHeightInDpi = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom / dpi
+          bottomPaddingInDpi = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom / dpi
+          SuperKeyboardLog.v("super_keyboard", "On progress keyboard height: $imeHeightInDpi, is IME visible: ${insets.isVisible(WindowInsetsCompat.Type.ime())}")
+
+          // Report our newly cached measurements to Flutter.
+          sendMessageKeyboardProgress()
 
           return insets
         }
@@ -167,12 +199,13 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
           animation: WindowInsetsAnimationCompat
         ) {
           // Report whether the keyboard has fully opened or fully closed.
+          SuperKeyboardLog.v("super_keyboard", "Insets animation callback - onEnd - current keyboard state: $keyboardState")
           if (keyboardState == KeyboardState.Opening) {
             keyboardState = KeyboardState.Open
-            channel.invokeMethod("keyboardOpened", null)
+            sendMessageKeyboardOpened()
           } else if (keyboardState == KeyboardState.Closing) {
             keyboardState = KeyboardState.Closed
-            channel.invokeMethod("keyboardClosed", null)
+            sendMessageKeyboardClosed()
           }
         }
       }
@@ -180,7 +213,7 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   }
 
   override fun onApplyWindowInsets(v: View, insets: WindowInsetsCompat): WindowInsetsCompat {
-    SuperKeyboardLog.d("super_keyboard", "onApplyWindowInsets()")
+    SuperKeyboardLog.d("super_keyboard", "onApplyWindowInsets() - current keyboard state: $keyboardState")
     if (lifecycle!!.currentState == Lifecycle.State.CREATED) {
       // For at least Android API 34, we receive conflicting reports about IME visibility
       // when the app is being backgrounded. First we're told the IME isn't visible, then
@@ -189,7 +222,7 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
       if (keyboardState != KeyboardState.Closed) {
         SuperKeyboardLog.d("super_keyboard", "Activity is in CREATED state - telling app that keyboard is closed")
         keyboardState = KeyboardState.Closed
-        channel.invokeMethod("keyboardClosed", null)
+        sendMessageKeyboardClosed()
       }
 
       return insets
@@ -208,16 +241,24 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
     //       to "closed". We catch that situation by looking for a `0` bottom inset.
     if (imeVisible && keyboardState != KeyboardState.Opening && keyboardState != KeyboardState.Open) {
       SuperKeyboardLog.d("super_keyboard", "Setting keyboard state to Opening")
-      channel.invokeMethod("keyboardOpening", null)
+      sendMessageKeyboardOpening()
       keyboardState = KeyboardState.Opening
     } else if (!imeVisible && keyboardState != KeyboardState.Closing && keyboardState != KeyboardState.Closed) {
       if (insets.getInsets(WindowInsetsCompat.Type.ime()).bottom == 0) {
         SuperKeyboardLog.d("super_keyboard", "Setting keyboard state to Closed")
-        channel.invokeMethod("keyboardClosed", null)
+
+        // The keyboard height should be zero at this point. But just in case something got messed
+        // up with Android timing, we set the height to zero explicitly.
+        if (imeHeightInDpi.roundToInt() != 0) {
+          SuperKeyboardLog.w("super_keyboard", "Setting keyboard state to Closed, but our most recent measured keyboard height is: $imeHeightInDpi")
+        }
+        imeHeightInDpi = 0f;
+
+        sendMessageKeyboardClosed()
         keyboardState = KeyboardState.Closed
       } else {
         SuperKeyboardLog.d("super_keyboard", "Setting keyboard state to Closing")
-        channel.invokeMethod("keyboardClosing", null)
+        sendMessageKeyboardClosing()
         keyboardState = KeyboardState.Closing
       }
     }
@@ -226,7 +267,9 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
   }
 
   private fun stopListeningForKeyboardChanges() {
+    SuperKeyboardLog.v("super_keyboard", "Stopping listening for keyboard changes")
     if (mainView == null) {
+      SuperKeyboardLog.w("super_keyboard", "Our mainView is null in onPause. This isn't expected.")
       return;
     }
 
@@ -234,6 +277,62 @@ class SuperKeyboardPlugin: FlutterPlugin, ActivityAware, DefaultLifecycleObserve
     ViewCompat.setWindowInsetsAnimationCallback(mainView!!, null)
 
     mainView = null
+  }
+
+  // Queries the current IME and gesture insets and updates our local record of those
+  // values.
+  //
+  // This method can be used to synchronize our understanding of these insets at times
+  // when Android's lifecycle might screw up. However, it's recommended that we measure
+  // these values in response to Android hooks as much as possible, rather than query
+  // directly. For example, we should prefer to update these values within a
+  // WindowsInsetsAnimationCallback.
+  private fun measureInsets() {
+    val insets = ViewCompat.getRootWindowInsets(mainView!!) ?: return
+    imeHeightInDpi = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom / dpi
+    bottomPaddingInDpi = insets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom / dpi
+  }
+
+  private fun sendMessageKeyboardOpened() {
+    channel.invokeMethod("keyboardOpened", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
+  }
+
+  private fun sendMessageKeyboardOpening() {
+    channel.invokeMethod("keyboardOpening", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
+  }
+
+  private fun sendMessageKeyboardProgress() {
+    channel.invokeMethod("onProgress", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
+  }
+
+  private fun sendMessageKeyboardClosed() {
+    channel.invokeMethod("keyboardClosed", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
+  }
+
+  private fun sendMessageKeyboardClosing() {
+    channel.invokeMethod("keyboardClosing", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
+  }
+
+  private fun sendMessageMetricsUpdate() {
+    channel.invokeMethod("metricsUpdate", mapOf(
+      "keyboardHeight" to imeHeightInDpi,
+      "bottomPadding" to bottomPaddingInDpi,
+    ))
   }
 }
 

--- a/super_keyboard/example/android/.gitignore
+++ b/super_keyboard/example/android/.gitignore
@@ -1,3 +1,5 @@
+app/.cxx/
+
 gradle-wrapper.jar
 /.gradle
 /captures/

--- a/super_keyboard/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/super_keyboard/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/super_keyboard/example/lib/main.dart
+++ b/super_keyboard/example/lib/main.dart
@@ -53,7 +53,7 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
                 ),
                 const SizedBox(height: 12),
                 ValueListenableBuilder(
-                  valueListenable: SuperKeyboard.instance.geometry,
+                  valueListenable: SuperKeyboard.instance.mobileGeometry,
                   builder: (context, value, child) {
                     return Text(
                         "Keyboard height: ${value.keyboardHeight != null ? "${value.keyboardHeight!.toInt()}" : "???"}");
@@ -75,7 +75,7 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
                 _buildFlutterLoggingOption(),
                 _buildPlatformLoggingOption(),
                 ValueListenableBuilder(
-                  valueListenable: SuperKeyboard.instance.geometry,
+                  valueListenable: SuperKeyboard.instance.mobileGeometry,
                   builder: (context, value, child) {
                     if (value.keyboardHeight == null) {
                       return const SizedBox();
@@ -94,17 +94,14 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
 
   Widget _buildKeyboardStateIcon() {
     return ValueListenableBuilder(
-      valueListenable: SuperKeyboard.instance.geometry,
+      valueListenable: SuperKeyboard.instance.mobileGeometry,
       builder: (context, value, child) {
-        if (value.keyboardState == null) {
-          return const SizedBox();
-        }
-
-        final icon = switch (value.keyboardState!) {
+        final icon = switch (value.keyboardState) {
           KeyboardState.closed => Icons.border_bottom,
           KeyboardState.opening => Icons.upload_sharp,
           KeyboardState.open => Icons.border_top,
           KeyboardState.closing => Icons.download_sharp,
+          null => Icons.question_mark,
         };
 
         return Icon(
@@ -116,7 +113,7 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
   }
 
   String? get _keyboardState {
-    return switch (SuperKeyboard.instance.geometry.value.keyboardState) {
+    return switch (SuperKeyboard.instance.mobileGeometry.value.keyboardState) {
       KeyboardState.closed => "Closed",
       KeyboardState.opening => "Opening",
       KeyboardState.open => "Open",

--- a/super_keyboard/example/lib/main.dart
+++ b/super_keyboard/example/lib/main.dart
@@ -53,9 +53,10 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
                 ),
                 const SizedBox(height: 12),
                 ValueListenableBuilder(
-                  valueListenable: SuperKeyboard.instance.keyboardHeight,
+                  valueListenable: SuperKeyboard.instance.geometry,
                   builder: (context, value, child) {
-                    return Text("Keyboard height: ${value != null ? "${value.toInt()}" : "???"}");
+                    return Text(
+                        "Keyboard height: ${value.keyboardHeight != null ? "${value.keyboardHeight!.toInt()}" : "???"}");
                   },
                 ),
                 const SizedBox(height: 48),
@@ -74,13 +75,13 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
                 _buildFlutterLoggingOption(),
                 _buildPlatformLoggingOption(),
                 ValueListenableBuilder(
-                  valueListenable: SuperKeyboard.instance.keyboardHeight,
+                  valueListenable: SuperKeyboard.instance.geometry,
                   builder: (context, value, child) {
-                    if (value == null) {
+                    if (value.keyboardHeight == null) {
                       return const SizedBox();
                     }
 
-                    return SizedBox(height: value / MediaQuery.of(context).devicePixelRatio);
+                    return SizedBox(height: value.keyboardHeight! / MediaQuery.of(context).devicePixelRatio);
                   },
                 ),
               ],
@@ -93,9 +94,13 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
 
   Widget _buildKeyboardStateIcon() {
     return ValueListenableBuilder(
-      valueListenable: SuperKeyboard.instance.state,
+      valueListenable: SuperKeyboard.instance.geometry,
       builder: (context, value, child) {
-        final icon = switch (value) {
+        if (value.keyboardState == null) {
+          return const SizedBox();
+        }
+
+        final icon = switch (value.keyboardState!) {
           KeyboardState.closed => Icons.border_bottom,
           KeyboardState.opening => Icons.upload_sharp,
           KeyboardState.open => Icons.border_top,
@@ -110,12 +115,13 @@ class _SuperKeyboardDemoAppState extends State<SuperKeyboardDemoApp> {
     );
   }
 
-  String get _keyboardState {
-    return switch (SuperKeyboard.instance.state.value) {
+  String? get _keyboardState {
+    return switch (SuperKeyboard.instance.geometry.value.keyboardState) {
       KeyboardState.closed => "Closed",
       KeyboardState.opening => "Opening",
       KeyboardState.open => "Open",
       KeyboardState.closing => "Closing",
+      _ => null,
     };
   }
 

--- a/super_keyboard/example/pubspec.lock
+++ b/super_keyboard/example/pubspec.lock
@@ -5,42 +5,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -118,18 +118,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -174,26 +174,26 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -219,41 +219,41 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   super_keyboard:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   sync_http:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -290,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   webdriver:
     dependency: transitive
     description:
@@ -303,5 +303,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/super_keyboard/ios/Classes/SuperKeyboardPlugin.swift
+++ b/super_keyboard/ios/Classes/SuperKeyboardPlugin.swift
@@ -53,7 +53,7 @@ public class SuperKeyboardPlugin: NSObject, FlutterPlugin {
     let keyboardHeight = max(0, screenHeight - keyboardFrame.origin.y)
     
     channel!.invokeMethod("keyboardDidShow", arguments: [
-      "keyboard_height": keyboardHeight
+      "keyboardHeight": keyboardHeight
     ])
   }
   
@@ -161,7 +161,9 @@ public class SuperKeyboardPlugin: NSObject, FlutterPlugin {
   }
   
   @objc private func keyboardDidHide(_ notification: Notification) {
-    channel!.invokeMethod("keyboardDidHide", arguments: nil)
+    channel!.invokeMethod("keyboardDidHide", arguments: [
+      "keyboardHeight": 0
+    ])
 //    stopTrackingKeyboard()
   }
 }

--- a/super_keyboard/lib/src/keyboard.dart
+++ b/super_keyboard/lib/src/keyboard.dart
@@ -1,3 +1,72 @@
+/// Mobile application window geometry as reported by the `super_keyboard` plugin.
+///
+/// This geometry includes values that are deemed relevant to keyboard behavior, but excludes
+/// geometry that's unrelated to keyboards, such as gesture areas on the left/right/top of the
+/// screen, and the space taken up by the camera at the top of the screen.
+class MobileWindowGeometry {
+  const MobileWindowGeometry({
+    this.keyboardState,
+    this.keyboardHeight,
+    this.bottomPadding,
+  });
+
+  /// The current state of the software keyboard, e.g., open, opening, closed, closing.
+  final KeyboardState? keyboardState;
+
+  /// The current height of the software keyboard.
+  ///
+  /// This height might reflect a keyboard that's completely open, completely closed,
+  /// in the process of opening, or in the process of closing.
+  final double? keyboardHeight;
+
+  /// Bottom padding that the OS expects apps to respect when the keyboard is closed.
+  ///
+  /// This gap might represent, for example, an OS draggable area at the bottom of the screen,
+  /// which is used to open the app switcher.
+  final double? bottomPadding;
+
+  /// Returns a copy of this [MobileWindowGeometry] with the [newValues] applied
+  /// on top, i.e., replaces values in this [MobileWindowGeometry] with values from
+  /// the given [newValues].
+  MobileWindowGeometry updateWith(MobileWindowGeometry newValues) {
+    return copyWith(
+      keyboardState: newValues.keyboardState,
+      keyboardHeight: newValues.keyboardHeight,
+      bottomPadding: newValues.bottomPadding,
+    );
+  }
+
+  /// Returns a copy of [baseValues] with values from this [MobileWindowGeometry] applied on top, i.e.,
+  /// the values in this [MobileWindowGeometry] replace values in [baseValues].
+  MobileWindowGeometry applyTo(MobileWindowGeometry baseValues) {
+    return baseValues.updateWith(this);
+  }
+
+  MobileWindowGeometry copyWith({
+    KeyboardState? keyboardState,
+    double? keyboardHeight,
+    double? bottomPadding,
+  }) {
+    return MobileWindowGeometry(
+      keyboardState: keyboardState ?? this.keyboardState,
+      keyboardHeight: keyboardHeight ?? this.keyboardHeight,
+      bottomPadding: bottomPadding ?? this.bottomPadding,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MobileWindowGeometry &&
+          runtimeType == other.runtimeType &&
+          keyboardState == other.keyboardState &&
+          keyboardHeight == other.keyboardHeight &&
+          bottomPadding == other.bottomPadding;
+
+  @override
+  int get hashCode => keyboardState.hashCode ^ keyboardHeight.hashCode ^ bottomPadding.hashCode;
+}
+
 enum KeyboardState {
   closed,
   opening,

--- a/super_keyboard/lib/src/super_keyboard_android.dart
+++ b/super_keyboard/lib/src/super_keyboard_android.dart
@@ -10,7 +10,7 @@ class SuperKeyboardAndroidBuilder extends StatefulWidget {
     required this.builder,
   });
 
-  final Widget Function(BuildContext, MobileWindowGeometry?) builder;
+  final Widget Function(BuildContext, MobileWindowGeometry) builder;
 
   @override
   State<SuperKeyboardAndroidBuilder> createState() => _SuperKeyboardAndroidBuilderState();
@@ -93,7 +93,6 @@ class SuperKeyboardAndroid {
 
   Future<void> _onPlatformMessage(MethodCall message) async {
     log.fine("Android platform message: '${message.method}', args: ${message.arguments}");
-    print("Android platform message: '${message.method}', args: ${message.arguments}");
     switch (message.method) {
       case "keyboardOpening":
         _geometry.value = _geometry.value.updateWith(

--- a/super_keyboard/lib/src/super_keyboard_ios.dart
+++ b/super_keyboard/lib/src/super_keyboard_ios.dart
@@ -10,7 +10,7 @@ class SuperKeyboardIOSBuilder extends StatefulWidget {
     required this.builder,
   });
 
-  final Widget Function(BuildContext, KeyboardState) builder;
+  final Widget Function(BuildContext, MobileWindowGeometry) builder;
 
   @override
   State<SuperKeyboardIOSBuilder> createState() => _SuperKeyboardIOSBuilderState();
@@ -53,7 +53,7 @@ class _SuperKeyboardIOSBuilderState extends State<SuperKeyboardIOSBuilder> imple
   Widget build(BuildContext context) {
     return widget.builder(
       context,
-      SuperKeyboardIOS.instance.keyboardState.value,
+      SuperKeyboardIOS.instance.geometry.value,
     );
   }
 }
@@ -78,8 +78,8 @@ class SuperKeyboardIOS {
 
   final _methodChannel = const MethodChannel('super_keyboard_ios');
 
-  ValueListenable<KeyboardState> get keyboardState => _keyboardState;
-  final _keyboardState = ValueNotifier(KeyboardState.closed);
+  ValueListenable<MobileWindowGeometry> get geometry => _geometry;
+  final _geometry = ValueNotifier<MobileWindowGeometry>(const MobileWindowGeometry());
 
   final _listeners = <SuperKeyboardIOSListener>{};
   void addListener(SuperKeyboardIOSListener listener) => _listeners.add(listener);
@@ -94,7 +94,13 @@ class SuperKeyboardIOS {
     switch (message.method) {
       case "keyboardWillShow":
         log.info("keyboardWillShow");
-        _keyboardState.value = KeyboardState.opening;
+        _geometry.value = _geometry.value.updateWith(
+          MobileWindowGeometry(
+            keyboardState: KeyboardState.opening,
+            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+          ),
+        );
 
         for (final listener in _listeners) {
           listener.onKeyboardWillShow();
@@ -102,7 +108,13 @@ class SuperKeyboardIOS {
         break;
       case "keyboardDidShow":
         log.info("keyboardDidShow");
-        _keyboardState.value = KeyboardState.open;
+        _geometry.value = _geometry.value.updateWith(
+          MobileWindowGeometry(
+            keyboardState: KeyboardState.open,
+            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+          ),
+        );
 
         for (final listener in _listeners) {
           listener.onKeyboardDidShow();
@@ -113,7 +125,13 @@ class SuperKeyboardIOS {
         break;
       case "keyboardWillHide":
         log.info("keyboardWillHide");
-        _keyboardState.value = KeyboardState.closing;
+        _geometry.value = _geometry.value.updateWith(
+          MobileWindowGeometry(
+            keyboardState: KeyboardState.closing,
+            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+          ),
+        );
 
         for (final listener in _listeners) {
           listener.onKeyboardWillHide();
@@ -121,7 +139,13 @@ class SuperKeyboardIOS {
         break;
       case "keyboardDidHide":
         log.info("keyboardDidHide");
-        _keyboardState.value = KeyboardState.closed;
+        _geometry.value = _geometry.value.updateWith(
+          MobileWindowGeometry(
+            keyboardState: KeyboardState.closed,
+            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+          ),
+        );
 
         for (final listener in _listeners) {
           listener.onKeyboardDidHide();

--- a/super_keyboard/lib/src/super_keyboard_ios.dart
+++ b/super_keyboard/lib/src/super_keyboard_ios.dart
@@ -31,21 +31,25 @@ class _SuperKeyboardIOSBuilderState extends State<SuperKeyboardIOSBuilder> imple
 
   @override
   void onKeyboardWillShow() {
+    print("iOS keyboard builder - will show");
     setState(() {});
   }
 
   @override
   void onKeyboardDidShow() {
+    print("iOS keyboard builder - did show");
     setState(() {});
   }
 
   @override
   void onKeyboardWillHide() {
+    print("iOS keyboard builder - will hide");
     setState(() {});
   }
 
   @override
   void onKeyboardDidHide() {
+    print("iOS keyboard builder - did hide");
     setState(() {});
   }
 
@@ -97,11 +101,12 @@ class SuperKeyboardIOS {
         _geometry.value = _geometry.value.updateWith(
           MobileWindowGeometry(
             keyboardState: KeyboardState.opening,
-            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
-            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+            keyboardHeight: (message.arguments?["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments?["bottomPadding"] as num?)?.toDouble(),
           ),
         );
 
+        print("Reporting onKeyboardWillShow()");
         for (final listener in _listeners) {
           listener.onKeyboardWillShow();
         }
@@ -111,11 +116,12 @@ class SuperKeyboardIOS {
         _geometry.value = _geometry.value.updateWith(
           MobileWindowGeometry(
             keyboardState: KeyboardState.open,
-            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
-            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+            keyboardHeight: (message.arguments?["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments?["bottomPadding"] as num?)?.toDouble(),
           ),
         );
 
+        print("Reporting onkeyboardDidShow()");
         for (final listener in _listeners) {
           listener.onKeyboardDidShow();
         }
@@ -128,11 +134,12 @@ class SuperKeyboardIOS {
         _geometry.value = _geometry.value.updateWith(
           MobileWindowGeometry(
             keyboardState: KeyboardState.closing,
-            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
-            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+            keyboardHeight: (message.arguments?["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments?["bottomPadding"] as num?)?.toDouble(),
           ),
         );
 
+        print("Reporting onKeyboardWillHide()");
         for (final listener in _listeners) {
           listener.onKeyboardWillHide();
         }
@@ -142,11 +149,12 @@ class SuperKeyboardIOS {
         _geometry.value = _geometry.value.updateWith(
           MobileWindowGeometry(
             keyboardState: KeyboardState.closed,
-            keyboardHeight: (message.arguments["keyboardHeight"] as num?)?.toDouble(),
-            bottomPadding: (message.arguments["bottomPadding"] as num?)?.toDouble(),
+            keyboardHeight: (message.arguments?["keyboardHeight"] as num?)?.toDouble(),
+            bottomPadding: (message.arguments?["bottomPadding"] as num?)?.toDouble(),
           ),
         );
 
+        print("Reporting onKeyboardDidHide()");
         for (final listener in _listeners) {
           listener.onKeyboardDidHide();
         }

--- a/super_keyboard/lib/src/super_keyboard_ios.dart
+++ b/super_keyboard/lib/src/super_keyboard_ios.dart
@@ -31,25 +31,21 @@ class _SuperKeyboardIOSBuilderState extends State<SuperKeyboardIOSBuilder> imple
 
   @override
   void onKeyboardWillShow() {
-    print("iOS keyboard builder - will show");
     setState(() {});
   }
 
   @override
   void onKeyboardDidShow() {
-    print("iOS keyboard builder - did show");
     setState(() {});
   }
 
   @override
   void onKeyboardWillHide() {
-    print("iOS keyboard builder - will hide");
     setState(() {});
   }
 
   @override
   void onKeyboardDidHide() {
-    print("iOS keyboard builder - did hide");
     setState(() {});
   }
 
@@ -106,7 +102,6 @@ class SuperKeyboardIOS {
           ),
         );
 
-        print("Reporting onKeyboardWillShow()");
         for (final listener in _listeners) {
           listener.onKeyboardWillShow();
         }
@@ -121,7 +116,6 @@ class SuperKeyboardIOS {
           ),
         );
 
-        print("Reporting onkeyboardDidShow()");
         for (final listener in _listeners) {
           listener.onKeyboardDidShow();
         }
@@ -139,7 +133,6 @@ class SuperKeyboardIOS {
           ),
         );
 
-        print("Reporting onKeyboardWillHide()");
         for (final listener in _listeners) {
           listener.onKeyboardWillHide();
         }
@@ -154,7 +147,6 @@ class SuperKeyboardIOS {
           ),
         );
 
-        print("Reporting onKeyboardDidHide()");
         for (final listener in _listeners) {
           listener.onKeyboardDidHide();
         }

--- a/super_keyboard/lib/src/super_keyboard_unified.dart
+++ b/super_keyboard/lib/src/super_keyboard_unified.dart
@@ -23,12 +23,12 @@ class _SuperKeyboardBuilderState extends State<SuperKeyboardBuilder> {
   @override
   void initState() {
     super.initState();
-    SuperKeyboard.instance.geometry.addListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.mobileGeometry.addListener(_onKeyboardStateChange);
   }
 
   @override
   void dispose() {
-    SuperKeyboard.instance.geometry.removeListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.mobileGeometry.removeListener(_onKeyboardStateChange);
     super.dispose();
   }
 
@@ -42,7 +42,7 @@ class _SuperKeyboardBuilderState extends State<SuperKeyboardBuilder> {
   Widget build(BuildContext context) {
     return widget.builder(
       context,
-      SuperKeyboard.instance.geometry.value,
+      SuperKeyboard.instance.mobileGeometry.value,
     );
   }
 }
@@ -101,15 +101,15 @@ class SuperKeyboard {
     }
   }
 
-  ValueListenable<MobileWindowGeometry> get geometry => _geometry;
-  final _geometry = ValueNotifier<MobileWindowGeometry>(const MobileWindowGeometry());
+  ValueListenable<MobileWindowGeometry> get mobileGeometry => _mobileGeometry;
+  final _mobileGeometry = ValueNotifier<MobileWindowGeometry>(const MobileWindowGeometry());
 
   void _onIOSWindowGeometryChange() {
-    _geometry.value = SuperKeyboardIOS.instance.geometry.value;
+    _mobileGeometry.value = SuperKeyboardIOS.instance.geometry.value;
   }
 
   void _onAndroidWindowGeometryChange() {
-    _geometry.value = SuperKeyboardAndroid.instance.geometry.value;
+    _mobileGeometry.value = SuperKeyboardAndroid.instance.geometry.value;
   }
 }
 

--- a/super_keyboard/lib/src/super_keyboard_unified.dart
+++ b/super_keyboard/lib/src/super_keyboard_unified.dart
@@ -5,13 +5,15 @@ import 'package:super_keyboard/src/keyboard.dart';
 import 'package:super_keyboard/src/super_keyboard_android.dart';
 import 'package:super_keyboard/src/super_keyboard_ios.dart';
 
+/// A widget that rebuilds whenever the window geometry changes in a way that's
+/// relevant to the software keyboard.
 class SuperKeyboardBuilder extends StatefulWidget {
   const SuperKeyboardBuilder({
     super.key,
     required this.builder,
   });
 
-  final Widget Function(BuildContext, KeyboardState) builder;
+  final Widget Function(BuildContext, MobileWindowGeometry) builder;
 
   @override
   State<SuperKeyboardBuilder> createState() => _SuperKeyboardBuilderState();
@@ -21,12 +23,12 @@ class _SuperKeyboardBuilderState extends State<SuperKeyboardBuilder> {
   @override
   void initState() {
     super.initState();
-    SuperKeyboard.instance.state.addListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.geometry.addListener(_onKeyboardStateChange);
   }
 
   @override
   void dispose() {
-    SuperKeyboard.instance.state.removeListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.geometry.removeListener(_onKeyboardStateChange);
     super.dispose();
   }
 
@@ -40,13 +42,12 @@ class _SuperKeyboardBuilderState extends State<SuperKeyboardBuilder> {
   Widget build(BuildContext context) {
     return widget.builder(
       context,
-      SuperKeyboard.instance.state.value,
+      SuperKeyboard.instance.geometry.value,
     );
   }
 }
 
-/// A unified API for tracking the software keyboard status, regardless
-/// of platform.
+/// A unified API for tracking the software keyboard status, regardless of platform.
 class SuperKeyboard {
   static SuperKeyboard? _instance;
   static SuperKeyboard get instance {
@@ -80,11 +81,10 @@ class SuperKeyboard {
     log.info("Initializing SuperKeyboard");
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       log.fine("SuperKeyboard - Initializing for iOS");
-      SuperKeyboardIOS.instance.keyboardState.addListener(_onIOSKeyboardChange);
+      SuperKeyboardIOS.instance.geometry.addListener(_onIOSWindowGeometryChange);
     } else if (defaultTargetPlatform == TargetPlatform.android) {
       log.fine("SuperKeyboard - Initializing for Android");
-      SuperKeyboardAndroid.instance.keyboardState.addListener(_onAndroidKeyboardChange);
-      SuperKeyboardAndroid.instance.keyboardHeight.addListener(_onAndroidKeyboardHeightChange);
+      SuperKeyboardAndroid.instance.geometry.addListener(_onAndroidWindowGeometryChange);
     }
   }
 
@@ -101,22 +101,15 @@ class SuperKeyboard {
     }
   }
 
-  ValueListenable<KeyboardState> get state => _state;
-  final _state = ValueNotifier(KeyboardState.closed);
+  ValueListenable<MobileWindowGeometry> get geometry => _geometry;
+  final _geometry = ValueNotifier<MobileWindowGeometry>(const MobileWindowGeometry());
 
-  ValueListenable<double?> get keyboardHeight => _keyboardHeight;
-  final _keyboardHeight = ValueNotifier<double?>(null);
-
-  void _onIOSKeyboardChange() {
-    _state.value = SuperKeyboardIOS.instance.keyboardState.value;
+  void _onIOSWindowGeometryChange() {
+    _geometry.value = SuperKeyboardIOS.instance.geometry.value;
   }
 
-  void _onAndroidKeyboardChange() {
-    _state.value = SuperKeyboardAndroid.instance.keyboardState.value;
-  }
-
-  void _onAndroidKeyboardHeightChange() {
-    _keyboardHeight.value = SuperKeyboardAndroid.instance.keyboardHeight.value;
+  void _onAndroidWindowGeometryChange() {
+    _geometry.value = SuperKeyboardAndroid.instance.geometry.value;
   }
 }
 

--- a/super_keyboard/lib/test/keyboard_simulator.dart
+++ b/super_keyboard/lib/test/keyboard_simulator.dart
@@ -23,6 +23,7 @@ class SoftwareKeyboardHeightSimulator extends StatefulWidget {
     required this.tester,
     this.isEnabled = true,
     this.enableForAllPlatforms = false,
+    this.initialKeyboardState = KeyboardState.closed,
     this.keyboardHeight = _defaultKeyboardHeight,
     this.animateKeyboard = false,
     required this.child,
@@ -44,6 +45,9 @@ class SoftwareKeyboardHeightSimulator extends StatefulWidget {
   /// The value for this property should remain constant within a single test. Don't
   /// attempt to enable and then disable keyboard simulation. That behavior is undefined.
   final bool enableForAllPlatforms;
+
+  /// The state of the keyboard, e.g., open, opening, closed, closing.
+  final KeyboardState initialKeyboardState;
 
   /// The vertical space, in logical pixels, to occupy at the bottom of the screen to simulate the appearance
   /// of a keyboard.
@@ -72,6 +76,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
     if (widget.isEnabled) {
       TestSuperKeyboard.install(
         widget.tester,
+        initialKeyboardState: widget.initialKeyboardState,
         fakeKeyboardHeight: widget.keyboardHeight,
         keyboardAnimationTime: widget.animateKeyboard ? const Duration(milliseconds: 600) : Duration.zero,
       );
@@ -87,6 +92,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
 
       TestSuperKeyboard.install(
         widget.tester,
+        initialKeyboardState: widget.initialKeyboardState,
         fakeKeyboardHeight: widget.keyboardHeight,
         keyboardAnimationTime: widget.animateKeyboard ? const Duration(milliseconds: 600) : Duration.zero,
       );
@@ -110,8 +116,8 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: SuperKeyboard.instance.keyboardHeight,
-      builder: (context, keyboardHeight, child) {
+      valueListenable: SuperKeyboard.instance.geometry,
+      builder: (context, geometry, child) {
         final realMediaQuery = MediaQuery.of(context);
         final isRelevantPlatform = widget.enableForAllPlatforms ||
             (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS);
@@ -129,7 +135,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
                 child: MediaQuery(
                   data: realMediaQuery.copyWith(
                     viewInsets: realMediaQuery.viewInsets.copyWith(
-                      bottom: keyboardHeight ?? 0.0,
+                      bottom: geometry.keyboardHeight ?? 0.0,
                     ),
                   ),
                   child: widget.child,
@@ -141,7 +147,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
                 left: 0,
                 right: 0,
                 bottom: 0,
-                height: keyboardHeight,
+                height: geometry.keyboardHeight,
                 child: const Placeholder(),
               ),
             ],
@@ -155,6 +161,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
 class TestSuperKeyboard implements SuperKeyboard {
   static void install(
     WidgetTester tester, {
+    KeyboardState initialKeyboardState = KeyboardState.closed,
     double fakeKeyboardHeight = _defaultKeyboardHeight,
     Duration keyboardAnimationTime = const Duration(milliseconds: 600),
   }) {
@@ -164,6 +171,7 @@ class TestSuperKeyboard implements SuperKeyboard {
 
     _instance = TestSuperKeyboard(
       tester,
+      initialKeyboardState: initialKeyboardState,
       fakeKeyboardHeight: fakeKeyboardHeight,
       keyboardAnimationTime: keyboardAnimationTime,
     );
@@ -186,17 +194,26 @@ class TestSuperKeyboard implements SuperKeyboard {
 
   TestSuperKeyboard(
     this.tester, {
+    KeyboardState initialKeyboardState = KeyboardState.closed,
     this.fakeKeyboardHeight = 400.0,
     Duration keyboardAnimationTime = const Duration(milliseconds: 600),
   }) {
     _interceptPlatformChannel();
+
+    _geometry.value = MobileWindowGeometry(
+      keyboardState: initialKeyboardState,
+    );
 
     _keyboardHeightController = AnimationController(
       duration: keyboardAnimationTime,
       vsync: tester,
     )
       ..addListener(() {
-        _keyboardHeight.value = _keyboardHeightController.value * fakeKeyboardHeight;
+        _geometry.value = _geometry.value.updateWith(
+          MobileWindowGeometry(
+            keyboardHeight: _keyboardHeightController.value * fakeKeyboardHeight,
+          ),
+        );
       })
       ..addStatusListener(_onKeyboardAnimationStatusChange);
   }
@@ -249,12 +266,8 @@ class TestSuperKeyboard implements SuperKeyboard {
   late final AnimationController _keyboardHeightController;
 
   @override
-  ValueListenable<double?> get keyboardHeight => _keyboardHeight;
-  final _keyboardHeight = ValueNotifier(0.0);
-
-  @override
-  ValueListenable<KeyboardState> get state => _state;
-  final _state = ValueNotifier(KeyboardState.closed);
+  ValueListenable<MobileWindowGeometry> get geometry => _geometry;
+  final _geometry = ValueNotifier(const MobileWindowGeometry());
 
   void _simulatePlatformOpeningKeyboard() {
     _keyboardHeightController.forward();
@@ -267,13 +280,29 @@ class TestSuperKeyboard implements SuperKeyboard {
   void _onKeyboardAnimationStatusChange(AnimationStatus status) {
     switch (status) {
       case AnimationStatus.forward:
-        _state.value = KeyboardState.opening;
+        _geometry.value = const MobileWindowGeometry(
+          keyboardState: KeyboardState.opening,
+          keyboardHeight: 150,
+          bottomPadding: 48,
+        );
       case AnimationStatus.completed:
-        _state.value = KeyboardState.open;
+        _geometry.value = const MobileWindowGeometry(
+          keyboardState: KeyboardState.open,
+          keyboardHeight: 300,
+          bottomPadding: 48,
+        );
       case AnimationStatus.reverse:
-        _state.value = KeyboardState.closing;
+        _geometry.value = const MobileWindowGeometry(
+          keyboardState: KeyboardState.closing,
+          keyboardHeight: 150,
+          bottomPadding: 48,
+        );
       case AnimationStatus.dismissed:
-        _state.value = KeyboardState.closed;
+        _geometry.value = const MobileWindowGeometry(
+          keyboardState: KeyboardState.closed,
+          keyboardHeight: 0,
+          bottomPadding: 48,
+        );
     }
   }
 }

--- a/super_keyboard/lib/test/keyboard_simulator.dart
+++ b/super_keyboard/lib/test/keyboard_simulator.dart
@@ -116,7 +116,7 @@ class _SoftwareKeyboardHeightSimulatorState extends State<SoftwareKeyboardHeight
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: SuperKeyboard.instance.geometry,
+      valueListenable: SuperKeyboard.instance.mobileGeometry,
       builder: (context, geometry, child) {
         final realMediaQuery = MediaQuery.of(context);
         final isRelevantPlatform = widget.enableForAllPlatforms ||
@@ -266,7 +266,7 @@ class TestSuperKeyboard implements SuperKeyboard {
   late final AnimationController _keyboardHeightController;
 
   @override
-  ValueListenable<MobileWindowGeometry> get geometry => _geometry;
+  ValueListenable<MobileWindowGeometry> get mobileGeometry => _geometry;
   final _geometry = ValueNotifier(const MobileWindowGeometry());
 
   void _simulatePlatformOpeningKeyboard() {

--- a/super_keyboard/test/keyboard_simulation_test.dart
+++ b/super_keyboard/test/keyboard_simulation_test.dart
@@ -17,7 +17,7 @@ void main() {
       );
 
       // Ensure the keyboard is closed, initially.
-      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closed);
+      expect(SuperKeyboard.instance.mobileGeometry.value.keyboardState, KeyboardState.closed);
       expect(_calculateKeyboardHeight(screenKey, contentKey), 0.0);
 
       // Focus the text field to open the keyboard.
@@ -28,7 +28,7 @@ void main() {
       //       move forward. I don't know why.
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.opening);
+      expect(SuperKeyboard.instance.mobileGeometry.value.keyboardState, KeyboardState.opening);
       expect(_calculateKeyboardHeight(screenKey, contentKey), lessThan(_keyboardHeight));
       expect(_calculateKeyboardHeight(screenKey, contentKey), greaterThan(0));
 
@@ -36,7 +36,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Ensure that the keyboard is fully open.
-      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.open);
+      expect(SuperKeyboard.instance.mobileGeometry.value.keyboardState, KeyboardState.open);
       expect(_calculateKeyboardHeight(screenKey, contentKey), _keyboardHeight);
 
       // Tap outside the text field to unfocus it.
@@ -47,7 +47,7 @@ void main() {
       //       move forward. I don't know why.
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closing);
+      expect(SuperKeyboard.instance.mobileGeometry.value.keyboardState, KeyboardState.closing);
       expect(_calculateKeyboardHeight(screenKey, contentKey), lessThan(_keyboardHeight));
       expect(_calculateKeyboardHeight(screenKey, contentKey), greaterThan(0));
 
@@ -55,7 +55,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Ensure that the keyboard is fully closed.
-      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closed);
+      expect(SuperKeyboard.instance.mobileGeometry.value.keyboardState, KeyboardState.closed);
       expect(_calculateKeyboardHeight(screenKey, contentKey), 0.0);
     });
 

--- a/super_keyboard/test/keyboard_simulation_test.dart
+++ b/super_keyboard/test/keyboard_simulation_test.dart
@@ -17,7 +17,7 @@ void main() {
       );
 
       // Ensure the keyboard is closed, initially.
-      expect(SuperKeyboard.instance.state.value, KeyboardState.closed);
+      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closed);
       expect(_calculateKeyboardHeight(screenKey, contentKey), 0.0);
 
       // Focus the text field to open the keyboard.
@@ -28,7 +28,7 @@ void main() {
       //       move forward. I don't know why.
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(SuperKeyboard.instance.state.value, KeyboardState.opening);
+      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.opening);
       expect(_calculateKeyboardHeight(screenKey, contentKey), lessThan(_keyboardHeight));
       expect(_calculateKeyboardHeight(screenKey, contentKey), greaterThan(0));
 
@@ -36,7 +36,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Ensure that the keyboard is fully open.
-      expect(SuperKeyboard.instance.state.value, KeyboardState.open);
+      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.open);
       expect(_calculateKeyboardHeight(screenKey, contentKey), _keyboardHeight);
 
       // Tap outside the text field to unfocus it.
@@ -47,7 +47,7 @@ void main() {
       //       move forward. I don't know why.
       await tester.pump(const Duration(milliseconds: 16));
       await tester.pump(const Duration(milliseconds: 16));
-      expect(SuperKeyboard.instance.state.value, KeyboardState.closing);
+      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closing);
       expect(_calculateKeyboardHeight(screenKey, contentKey), lessThan(_keyboardHeight));
       expect(_calculateKeyboardHeight(screenKey, contentKey), greaterThan(0));
 
@@ -55,7 +55,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Ensure that the keyboard is fully closed.
-      expect(SuperKeyboard.instance.state.value, KeyboardState.closed);
+      expect(SuperKeyboard.instance.geometry.value.keyboardState, KeyboardState.closed);
       expect(_calculateKeyboardHeight(screenKey, contentKey), 0.0);
     });
 


### PR DESCRIPTION
[SuperKeyboard] - Report all changes together, also add bottom insets (Resolves #2686)

This PR reports changes to the keyboard state and keyboard height at the same time in a new geometry data structure. This was done to prevent issues that might come from order of operations where the keyboard state change is reported and THEN the keyboard height change is reported, or vis-a-versa. 

This PR also adds reporting of bottom padding on Android as a way to work around a buggy lifecycle on Android.

The buggy lifecycle on Android was found to be caused by incorrect handling of permissions in a client app. However, that lifecycle issue also demonstrated that when it happens, Flutter loses synchronization with the bottom insets and bottom padding, reporting it incorrectly for the remainder of the app run. By reporting the bottom padding ourselves, we ensure that we use the correct value.