### PR TITLE
[SuperEditor][Chat] - Add option for KeyboardPanelScaffold to bypass MediaQuery (Resolves #2689)

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
     git:
       url: https://github.com/superlistapp/super_editor.git
       path: super_text_layout
-  super_keyboard: ^0.1.0
+  super_keyboard: ^0.2.0
   follow_the_leader: ^0.0.4+7
   overlord: ^0.0.3+5
 

--- a/super_editor/example_chat/lib/message_page_scaffold_demo/demo_super_editor_message_page.dart
+++ b/super_editor/example_chat/lib/message_page_scaffold_demo/demo_super_editor_message_page.dart
@@ -15,6 +15,20 @@ class _SuperEditorMessagePageDemoState extends State<SuperEditorMessagePageDemo>
   final _messagePageController = MessagePageController();
 
   @override
+  void initState() {
+    super.initState();
+
+    SuperKeyboard.startLogging();
+  }
+
+  @override
+  void dispose() {
+    SuperKeyboard.stopLogging();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return MessagePageScaffold(
       controller: _messagePageController,
@@ -328,7 +342,7 @@ class _ChatEditorState extends State<_ChatEditor> {
 
     _isImeConnected.addListener(_onImeConnectionChange);
 
-    SuperKeyboardAndroid.instance.keyboardState.addListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.mobileGeometry.addListener(_onKeyboardChange);
   }
 
   @override
@@ -343,7 +357,7 @@ class _ChatEditorState extends State<_ChatEditor> {
 
   @override
   void dispose() {
-    SuperKeyboardAndroid.instance.keyboardState.removeListener(_onKeyboardStateChange);
+    SuperKeyboard.instance.mobileGeometry.removeListener(_onKeyboardChange);
 
     widget.messagePageController.removeListener(_onMessagePageControllerChange);
 
@@ -355,7 +369,7 @@ class _ChatEditorState extends State<_ChatEditor> {
     super.dispose();
   }
 
-  void _onKeyboardStateChange() {
+  void _onKeyboardChange() {
     // On Android, we've found that when swiping to go back, the keyboard often
     // closes without Flutter reporting the closure of the IME connection.
     // Therefore, the keyboard closes, but editors and text fields retain focus,
@@ -366,7 +380,7 @@ class _ChatEditorState extends State<_ChatEditor> {
     // To hack around this bug in Flutter, when super_keyboard reports keyboard
     // closure, and this controller thinks the keyboard is open, we give up
     // focus so that our app state synchronizes with the closed IME connection.
-    final keyboardState = SuperKeyboardAndroid.instance.keyboardState.value;
+    final keyboardState = SuperKeyboard.instance.mobileGeometry.value.keyboardState;
     if (_isImeConnected.value && (keyboardState == KeyboardState.closing || keyboardState == KeyboardState.closed)) {
       _editorFocusNode.unfocus();
     }

--- a/super_editor/example_chat/pubspec.lock
+++ b/super_editor/example_chat/pubspec.lock
@@ -34,10 +34,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   attributed_text:
     dependency: transitive
     description:
@@ -50,34 +50,34 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -114,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
@@ -147,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -241,18 +249,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -297,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -313,10 +321,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -353,10 +361,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -438,10 +446,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -454,41 +462,41 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   super_editor:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0-dev.19"
+    version: "0.3.0-dev.23"
   super_keyboard:
     dependency: "direct main"
     description:
       name: super_keyboard
-      sha256: c8e303cd7bc1fc62732213f0f2660273a078be23eae7a4219d0ab3dd0b0ccb9a
+      sha256: "708827e7a744996a2723854cfe7a7e10ce8e2effee863138963f9fb8ef3452d7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   super_text_layout:
     dependency: transitive
     description:
@@ -501,34 +509,34 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: transitive
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.8"
   typed_data:
     dependency: transitive
     description:
@@ -621,10 +629,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -674,5 +682,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/super_editor/example_chat/pubspec.yaml
+++ b/super_editor/example_chat/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
   super_editor:
     path: ../
-  super_keyboard: ^0.1.0
+  super_keyboard: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/super_editor/lib/src/chat/message_page_scaffold.dart
+++ b/super_editor/lib/src/chat/message_page_scaffold.dart
@@ -941,8 +941,6 @@ class RenderMessagePageScaffold extends RenderBox {
       MessagePageSheetCollapsedMode.preview => _previewHeight,
       MessagePageSheetCollapsedMode.intrinsic => _intrinsicHeight,
     };
-    print(
-        "Collapsed mode: ${_controller.collapsedMode}, preview height: $_previewHeight, intrinsic height: $_intrinsicHeight");
 
     final bottomSheetConstraints = constraints.copyWith(
       minHeight: minimizedHeight,
@@ -1023,8 +1021,6 @@ class RenderMessagePageScaffold extends RenderBox {
     // Now that we know the size of the message editor, build the content based
     // on the bottom spacing needed to push above the editor.
     final bottomSpacing = _bottomSheet!.size.height;
-    print(
-        "Bottom sheet. Constraints - min: $minimizedHeight, max: $_bottomSheetMaximumHeight, chosen height: ${_bottomSheet!.size.height}");
     messagePageLayoutLog.info('');
     messagePageLayoutLog.info('Building chat scaffold content');
     invokeLayoutCallback((constraints) {
@@ -1118,7 +1114,6 @@ class RenderMessagePageScaffold extends RenderBox {
       messagePagePaintLog.info(
         'Painting message editor - y-offset: ${size.height - _bottomSheet!.size.height}',
       );
-      print('Painting message editor - y-offset: ${size.height - _bottomSheet!.size.height}');
       context.paintChild(
         _bottomSheet!,
         offset + (_bottomSheet!.parentData! as BoxParentData).offset,

--- a/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
@@ -43,6 +43,7 @@ class KeyboardPanelScaffold<PanelType> extends StatefulWidget {
     required this.keyboardPanelBuilder,
     this.fallbackPanelHeight = 250,
     required this.contentBuilder,
+    this.bypassMediaQuery = false,
   });
 
   /// Controls the visibility of the keyboard toolbar, keyboard panel, and software keyboard.
@@ -71,6 +72,16 @@ class KeyboardPanelScaffold<PanelType> extends StatefulWidget {
   /// a whole screen of content, or other times this content might be a single widget
   /// like a text field or an editor.
   final Widget Function(BuildContext context, PanelType? openPanel) contentBuilder;
+
+  /// When determining the height of the keyboard, whether to bypass Flutter's `MediaQuery`
+  /// and solely rely on `SuperKeyboard` reporting, or whether the scaffold should use a
+  /// combination of both.
+  ///
+  /// This option was added after a client app had an Android lifecycle bug, which caused
+  /// Flutter's `MediaQuery` to report the wrong bottom insets. Apps should start with this
+  /// value as `false` and only change it to `true` if the app runs into problems with
+  /// `MediaQuery`.
+  final bool bypassMediaQuery;
 
   @override
   State<KeyboardPanelScaffold<PanelType>> createState() => _KeyboardPanelScaffoldState<PanelType>();
@@ -226,7 +237,7 @@ class _KeyboardPanelScaffoldState<PanelType> extends State<KeyboardPanelScaffold
   }
 
   double _getCurrentKeyboardHeight() {
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (widget.bypassMediaQuery) {
       return SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? MediaQuery.viewInsetsOf(context).bottom;
     }
 
@@ -919,12 +930,23 @@ class KeyboardScaffoldSafeAreaScope extends StatefulWidget {
   const KeyboardScaffoldSafeAreaScope({
     super.key,
     this.debugLabel = "UNNAMED",
+    this.bypassMediaQuery = false,
     required this.child,
   });
 
   /// A label associated with this widget that can be helpful when debugging
   /// unexpected safe areas throughout a scope.
   final String debugLabel;
+
+  /// When determining the height of the keyboard, whether to bypass Flutter's `MediaQuery`
+  /// and solely rely on `SuperKeyboard` reporting, or whether the scaffold should use a
+  /// combination of both.
+  ///
+  /// This option was added after a client app had an Android lifecycle bug, which caused
+  /// Flutter's `MediaQuery` to report the wrong bottom insets. Apps should start with this
+  /// value as `false` and only change it to `true` if the app runs into problems with
+  /// `MediaQuery`.
+  final bool bypassMediaQuery;
 
   final Widget child;
 
@@ -1022,7 +1044,7 @@ class _KeyboardScaffoldSafeAreaScopeState extends State<KeyboardScaffoldSafeArea
   }
 
   double _getCurrentKeyboardHeight() {
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (widget.bypassMediaQuery) {
       return SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? MediaQuery.viewInsetsOf(context).bottom;
     }
 

--- a/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
+++ b/super_editor/lib/src/infrastructure/keyboard_panel_scaffold.dart
@@ -236,20 +236,6 @@ class _KeyboardPanelScaffoldState<PanelType> extends State<KeyboardPanelScaffold
     super.dispose();
   }
 
-  double _getCurrentKeyboardHeight() {
-    if (widget.bypassMediaQuery) {
-      return SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? MediaQuery.viewInsetsOf(context).bottom;
-    }
-
-    // Note: One reason that it's still important to use MediaQuery bottom insets on iOS instead
-    // of deferring to SuperKeyboard is that, at the time of writing this (May, 2025), SuperKeyboard
-    // hasn't implemented any heuristics to estimate keyboard transition insets, nor does iOS report
-    // those insets.
-    // TODO: We should lookup how Flutter's MediaQuery estimates the keyboard insets when the keyboard
-    //       is closing, and replicate that in SuperKeyboard so we can defer to SuperKeyboard all the time.
-    return MediaQuery.viewInsetsOf(context).bottom;
-  }
-
   void _onKeyboardGeometryChange() {
     // Note: The following post frame callback shouldn't be necessary.
     // We should be able to look up our ancestor MediaQuery immediately.
@@ -592,7 +578,7 @@ class _KeyboardPanelScaffoldState<PanelType> extends State<KeyboardPanelScaffold
         ? 0.0
         : _wantsToShowSoftwareKeyboard //
             ? 0.0
-            : MediaQuery.paddingOf(context).bottom;
+            : _getCurrentBottomPadding();
 
     final toolbarSize = (_toolbarKey.currentContext?.findRenderObject() as RenderBox?)?.size;
     final bottomInsets = _currentBottomSpacing.value + (toolbarSize?.height ?? 0);
@@ -601,6 +587,28 @@ class _KeyboardPanelScaffoldState<PanelType> extends State<KeyboardPanelScaffold
       bottomInsets: bottomInsets,
       bottomPadding: bottomPadding,
     );
+  }
+
+  double _getCurrentKeyboardHeight() {
+    if (widget.bypassMediaQuery) {
+      return SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? MediaQuery.viewInsetsOf(context).bottom;
+    }
+
+    // Note: One reason that it's still important to use MediaQuery bottom insets on iOS instead
+    // of deferring to SuperKeyboard is that, at the time of writing this (May, 2025), SuperKeyboard
+    // hasn't implemented any heuristics to estimate keyboard transition insets, nor does iOS report
+    // those insets.
+    // TODO: We should lookup how Flutter's MediaQuery estimates the keyboard insets when the keyboard
+    //       is closing, and replicate that in SuperKeyboard so we can defer to SuperKeyboard all the time.
+    return MediaQuery.viewInsetsOf(context).bottom;
+  }
+
+  double _getCurrentBottomPadding() {
+    if (widget.bypassMediaQuery) {
+      return SuperKeyboard.instance.mobileGeometry.value.bottomPadding ?? MediaQuery.paddingOf(context).bottom;
+    }
+
+    return MediaQuery.paddingOf(context).bottom;
   }
 
   @override
@@ -1004,7 +1012,7 @@ class _KeyboardScaffoldSafeAreaScopeState extends State<KeyboardScaffoldSafeArea
       // we want to continue blindly honoring the MediaQuery.
       _keyboardSafeAreaData = KeyboardSafeAreaGeometry(
         bottomInsets: _getCurrentKeyboardHeight(),
-        bottomPadding: MediaQuery.paddingOf(context).bottom,
+        bottomPadding: _getCurrentBottomPadding(),
       );
     } else if (_isSafeAreaFromAncestor) {
       if (_ancestorSafeArea != null) {
@@ -1015,9 +1023,8 @@ class _KeyboardScaffoldSafeAreaScopeState extends State<KeyboardScaffoldSafeArea
         // Our previous safe area was inherited from an ancestor scope, but now that
         // scope is gone. Reset back to the regular MediaQuery safe area.
         _keyboardSafeAreaData = KeyboardSafeAreaGeometry(
-          bottomInsets:
-              SuperKeyboard.instance.mobileGeometry.value.keyboardHeight ?? MediaQuery.viewInsetsOf(context).bottom,
-          bottomPadding: MediaQuery.paddingOf(context).bottom,
+          bottomInsets: _getCurrentKeyboardHeight(),
+          bottomPadding: _getCurrentBottomPadding(),
         );
         _isSafeAreaFromMediaQuery = true;
         _isSafeAreaFromAncestor = false;
@@ -1049,6 +1056,14 @@ class _KeyboardScaffoldSafeAreaScopeState extends State<KeyboardScaffoldSafeArea
     }
 
     return MediaQuery.viewInsetsOf(context).bottom;
+  }
+
+  double _getCurrentBottomPadding() {
+    if (widget.bypassMediaQuery) {
+      return SuperKeyboard.instance.mobileGeometry.value.bottomPadding ?? MediaQuery.paddingOf(context).bottom;
+    }
+
+    return MediaQuery.paddingOf(context).bottom;
   }
 
   @override

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   linkify: ^5.0.0
   logging: ^1.3.0
   super_text_layout: ^0.1.18
-  super_keyboard: ^0.1.1
+  super_keyboard: ^0.2.0
   url_launcher: ^6.3.1
   uuid: ^4.5.1
   overlord: ^0.0.3+5

--- a/super_keyboard/README.md
+++ b/super_keyboard/README.md
@@ -14,8 +14,8 @@ Build a widget subtree based on the keyboard state:
 @override
 Widget build(BuildContext context) {
   return SuperKeyboardBuilder(
-    builder: (context, keyboardState) {
-      // TODO: do something with the keyboard state.
+    builder: (context, keyboardGeometry) {
+      // TODO: do something with the keyboard state and size.
       return const SizedBox();
     }
   );
@@ -25,21 +25,27 @@ Widget build(BuildContext context) {
 Directly listen for changes to the keyboard state:
 ```dart
 void startListeningToKeyboardState() {
-  SuperKeyboard.instance.state.addListener(_onKeyboardStateChange);
+  SuperKeyboard.instance.geometry.addListener(_onKeyboardChange);
 }
 
 void stopListeningToKeyboardState() {
-  SuperKeyboard.instance.state.removeListener(_onKeyboardStateChange);
+  SuperKeyboard.instance.geometry.removeListener(_onKeyboardChange);
 }
 
-void _onKeyboardStateChange(KeyboardState newState) {
-  // TODO: do something with the new keyboard state.
+void _onKeyboardChange(MobileWindowGeometry geometry) {
+  // TODO: do something with the new keyboard state and size.
 }
 ```
 
+**Note:** This plugin is limited by the APIs of the underlying platform. For example,
+iOS does not provide any direct means of querying the keyboard height as it opens and
+closes. Therefore, on iOS, while this plugin does notify clients about the keyboard
+opening and closing, the reported keyboard height during those transitions won't match
+the visual keyboard on screen.
+
 Activate logs:
 ```dart
-SuperKeyboard.initLogs();
+SuperKeyboard.startLogging();
 ```
 
 ## iOS and Android


### PR DESCRIPTION
[SuperEditor][Chat] - Add option for KeyboardPanelScaffold to bypass MediaQuery (Resolves #2689)

Apps can now explicitly request that `KeyboardPanelScaffold` pull the keyboard height from `SuperKeyboard` instead of `MediaQuery`. See the original issue for an explanation why.