### PR TITLE
[SuperKeyboard] - Fix keyboard test simulator (Resolves #2692)

### DIFF
--- a/super_keyboard/lib/test/keyboard_simulator.dart
+++ b/super_keyboard/lib/test/keyboard_simulator.dart
@@ -280,21 +280,21 @@ class TestSuperKeyboard implements SuperKeyboard {
   void _onKeyboardAnimationStatusChange(AnimationStatus status) {
     switch (status) {
       case AnimationStatus.forward:
-        _geometry.value = const MobileWindowGeometry(
+        _geometry.value = MobileWindowGeometry(
           keyboardState: KeyboardState.opening,
-          keyboardHeight: 150,
+          keyboardHeight: fakeKeyboardHeight / 2,
           bottomPadding: 48,
         );
       case AnimationStatus.completed:
-        _geometry.value = const MobileWindowGeometry(
+        _geometry.value = MobileWindowGeometry(
           keyboardState: KeyboardState.open,
-          keyboardHeight: 300,
+          keyboardHeight: fakeKeyboardHeight,
           bottomPadding: 48,
         );
       case AnimationStatus.reverse:
-        _geometry.value = const MobileWindowGeometry(
+        _geometry.value = MobileWindowGeometry(
           keyboardState: KeyboardState.closing,
-          keyboardHeight: 150,
+          keyboardHeight: fakeKeyboardHeight / 2,
           bottomPadding: 48,
         );
       case AnimationStatus.dismissed:


### PR DESCRIPTION
[SuperKeyboard] - Fix keyboard test simulator (Resolves #2692)

This PR respects the desired simulation keyboard height which was overriden with hard coded values in the previous release by accident.