### PR TITLE
[super_editor_markdown] Fix deserialization of a list item followed by a task (Resolves #2714)

### DIFF
--- a/super_editor_markdown/test/super_editor_markdown_test.dart
+++ b/super_editor_markdown/test/super_editor_markdown_test.dart
@@ -1285,6 +1285,35 @@ This is some code
         expect((document.getNodeAt(2)! as ListItemNode).text.toPlainText(), 'list item 3');
       });
 
+      test('unordered list items mixed with task items', () {
+        const markdown = '''
+- list item node 
+- [ ] task node
+- [x] completed task node
+- second list item node 
+- [ ] another task node
+- third list item node
+- fourth list item node 
+''';
+
+        final document = deserializeMarkdownToDocument(markdown);
+
+        expect(document.nodeCount, 7);
+        expect(document.getNodeAt(0)!, isA<ListItemNode>());
+        expect(document.getNodeAt(1)!, isA<TaskNode>());
+        expect((document.getNodeAt(1) as TaskNode).text.toPlainText(), 'task node');
+        expect((document.getNodeAt(1) as TaskNode).isComplete, isFalse);
+        expect(document.getNodeAt(2)!, isA<TaskNode>());
+        expect((document.getNodeAt(2) as TaskNode).text.toPlainText(), 'completed task node');
+        expect((document.getNodeAt(2) as TaskNode).isComplete, isTrue);
+        expect(document.getNodeAt(3)!, isA<ListItemNode>());
+        expect(document.getNodeAt(4)!, isA<TaskNode>());
+        expect((document.getNodeAt(4) as TaskNode).text.toPlainText(), 'another task node');
+        expect((document.getNodeAt(4) as TaskNode).isComplete, isFalse);
+        expect(document.getNodeAt(5)!, isA<ListItemNode>());
+        expect(document.getNodeAt(6)!, isA<ListItemNode>());
+      });
+
       test('ordered list', () {
         const markdown = '''
  1. list item 1


### PR DESCRIPTION
[super_editor_markdown] Fix deserialization of a list item followed by a task (Resolves #2714)

Consider the following markdown, where we have a list item followed by a task:

```
- list item node 
- [ ] task node
```

This markdown produces a document with two list item nodes. 

The issue is that the list item parser consumes all contiguous items in a single call to `parse`. Since the list item syntax matches the task pattern, it considers the task as a list item.

I noticed that the markdown version that we use already supports tasks with the `UnorderedListWithCheckboxSyntax` (which just signals the base list item parser to handle tasks). With this syntax, we can correctly parse task items following list items.

I chose this approach because the other option is to copy the entire list item parser to modify it to allow us to break the list parsing when we find the task syntax. 

We already have some tests that parse tasks, which continue to pass after this change.