### PR TITLE
[Spellcheck] - Temporary workaround to fix dark mode toolbar color, and toolbar appearance behind software keyboard, on Android (Resolves #2719)

### DIFF
--- a/super_editor_spellcheck/example/pubspec.yaml
+++ b/super_editor_spellcheck/example/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 dependency_overrides:
   super_editor:
     path: ../../super_editor
+  url_launcher_android: 6.3.16
 
 dev_dependencies:
   integration_test:

--- a/super_editor_spellcheck/lib/src/super_editor/spell_checker_popover_controller.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spell_checker_popover_controller.dart
@@ -6,7 +6,11 @@ import 'package:super_editor_spellcheck/src/super_editor/spelling_error_suggesti
 /// A [SpellCheckerPopoverController] must be attached to a [SpellCheckerPopoverDelegate],
 /// which will effectively show/hide the popover.
 class SpellCheckerPopoverController {
+  SpellCheckerPopoverController();
+
   SpellCheckerPopoverDelegate? _delegate;
+
+  var _orientation = SpellcheckToolbarOrientation.auto;
 
   /// Whether or not the popover is currently showing.
   bool get isShowing => _isShowing;
@@ -22,6 +26,7 @@ class SpellCheckerPopoverController {
     detach();
 
     _delegate = delegate;
+    _delegate!.setOrientation(_orientation);
   }
 
   /// Detaches this controller from the delegate.
@@ -55,6 +60,12 @@ class SpellCheckerPopoverController {
     _isShowing = true;
   }
 
+  @Deprecated("This is a temporary behavior until we generalize the control (June 19, 2025)")
+  void setOrientation(SpellcheckToolbarOrientation orientation) {
+    _orientation = orientation;
+    _delegate?.setOrientation(orientation);
+  }
+
   /// Hides the spelling suggestions popover if it's visible.
   void hide() {
     _delegate?.hideSuggestionsPopover();
@@ -67,6 +78,15 @@ class SpellCheckerPopoverController {
   SpellingError? findSuggestionsForWordAt(DocumentRange wordRange) {
     return _delegate?.findSuggestionsForWordAt(wordRange);
   }
+}
+
+enum SpellcheckToolbarOrientation {
+  // Use whatever the standard is.
+  auto,
+  // Display toolbar above the misspelled word.
+  above,
+  // Display toolbar below the misspelled word.
+  below,
 }
 
 /// Delegate that's attached to a [SpellCheckerPopoverController], to show/hide
@@ -108,6 +128,9 @@ abstract class SpellCheckerPopoverDelegate {
     SpellingError suggestions, {
     VoidCallback? onDismiss,
   }) {}
+
+  @Deprecated("This is a temporary behavior until we generalize the control (June 19, 2025)")
+  void setOrientation(SpellcheckToolbarOrientation orientation);
 
   /// Hides the spelling suggestions popover if it's visible.
   void hideSuggestionsPopover() {}

--- a/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
+++ b/super_editor_spellcheck/lib/src/super_editor/spelling_and_grammar_plugin.dart
@@ -177,6 +177,11 @@ class SpellingAndGrammarPlugin extends SuperEditorPlugin {
 
   final _popoverController = SpellCheckerPopoverController();
 
+  @Deprecated("This is a temporary behavior until we generalize the control (June 19, 2025)")
+  void setToolbarOrientation(SpellcheckToolbarOrientation orientation) => _popoverController.setOrientation(
+        orientation,
+      );
+
   @override
   List<SingleColumnLayoutStylePhase> get appendedStylePhases => [_styler];
 


### PR DESCRIPTION
[Spellcheck] - Temporary workaround to fix dark mode toolbar color, and toolbar appearance behind software keyboard, on Android (Resolves #2719)

This is a temporary change to quickly ship solutions to two client problems:
 * Spellcheck toolbar on Android has a white background in dark mode, when the text is white, so you can't see the text.
 * Spellcheck toolbar can sit behind the software keyboard.

We have tickets for better solutions to this:
 * https://github.com/superlistapp/super_editor/issues/2717
 * https://github.com/superlistapp/super_editor/issues/2718

I also did a dep override for `url_launcher_android` in the spellcheck example app. This is because the current version of `url_launcher`, which includes `url_launcher_android` seems to be out of date and doesn't compile against the latest Flutter on Android, due to not upgrading from embedding v1 to v2.