### PR TITLE
[SuperReader][Adjustment] - Change shortcuts to operate on 'down' instead of 'up' (Resolves #2738)

### DIFF
--- a/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_keyboard_interactor.dart
@@ -482,8 +482,8 @@ ReadOnlyDocumentKeyboardAction createShortcut(
   bool? isCmdPressed,
   bool? isCtlPressed,
   bool? isAltPressed,
-  bool onKeyUp = true,
-  bool onKeyDown = false,
+  bool onKeyUp = false,
+  bool onKeyDown = true,
   Set<TargetPlatform>? platforms,
 }) {
   if (onKeyUp == false && onKeyDown == false) {


### PR DESCRIPTION
[SuperReader][Adjustment] - Change shortcuts to operate on 'down' instead of 'up' (Resolves #2738)

In a client app, we had complaints that sometimes users would attempt to copy content, but the content wouldn't be copied.

My hypothesis is that the failure is due to users inadvertently releasing CMD before releasing C. Because SuperReader looks for "up" events instead of "down" events, this causes the key event to look like the user is pressing C, and nothing else.

For this ticket, change the defaults so that the shortcuts recognize "down" events instead of "up" events.