### PR TITLE
[Super Editor] - Delete selected content when user enters text with IME (Resolves #2747)

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
+++ b/super_editor/lib/src/default_editor/document_ime/document_delta_editing.dart
@@ -389,6 +389,7 @@ class TextDeltasDocumentEditor {
   }
 
   void replace(TextRange replacedRange, String replacementText) {
+    editorImeLog.fine("Replacing content in IME range: $replacedRange, with new text: '$replacementText'");
     final replacementSelection = _serializedDoc.imeToDocumentSelection(TextSelection(
       baseOffset: replacedRange.start,
       // TODO: the delta API is wrong for TextRange.end, it should be exclusive,

--- a/super_editor/lib/src/default_editor/multi_node_editing.dart
+++ b/super_editor/lib/src/default_editor/multi_node_editing.dart
@@ -1221,7 +1221,7 @@ class DeleteSelectionCommand extends EditCommand {
 
         if (affinity == TextAffinity.upstream) {
           // The user is trying to delete using backspace (we assume this because the deletion is in
-          // downstream direction). Do nothing.
+          // upstream direction). Do nothing.
           return;
         }
 


### PR DESCRIPTION
[Super Editor] - Delete selected content when user enters text with IME (Resolves #2747)

Root cause was that `InsertPlainTextAtCaretCommand` would immediately bail out if the `start` node for text insertion wasn't a text node. This was being triggered in the case that the user drags up from text over an image and then tries to insert a character.

I change the command to delete whatever the selection is. After deleting the selection, if we're still not in a text node, we insert a text node.

I tried writing a test for this but no matter what I tried I wasn't able to get the IME simulation to work. Something within the test structure always broke. So I gave up. I tested this manually in the Mac desktop app.