### PR TITLE
[SuperEditor][SuperEditorClipboard] - Add support for rich text copying

### DIFF
--- a/super_editor/lib/src/infrastructure/serialization/html/document_to_html.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/document_to_html.dart
@@ -1,3 +1,5 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/serialization/html/html_blockquotes.dart';
 import 'package:super_editor/src/infrastructure/serialization/html/html_code.dart';
 import 'package:super_editor/src/infrastructure/serialization/html/html_headers.dart';
@@ -6,7 +8,6 @@ import 'package:super_editor/src/infrastructure/serialization/html/html_images.d
 import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
 import 'package:super_editor/src/infrastructure/serialization/html/html_list_items.dart';
 import 'package:super_editor/src/infrastructure/serialization/html/html_paragraphs.dart';
-import 'package:super_editor/super_editor.dart';
 
 extension HtmlSerialization on Document {
   /// Converts this [Document] to an HTML representation.

--- a/super_editor/lib/src/infrastructure/serialization/html/document_to_html.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/document_to_html.dart
@@ -1,0 +1,112 @@
+import 'package:super_editor/src/infrastructure/serialization/html/html_blockquotes.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_code.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_headers.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_horizontal_rules.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_images.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_list_items.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_paragraphs.dart';
+import 'package:super_editor/super_editor.dart';
+
+extension HtmlSerialization on Document {
+  /// Converts this [Document] to an HTML representation.
+  ///
+  /// When [selection] is `null`, the entire document is converted to HTML. When
+  /// [selection] is non-`null`, only the selected content is converted to HTML.
+  ///
+  /// When [skipUnknownNodes] is `true`, nodes that don't have an HTML serializer
+  /// will be ignored. When it's `false`, an exception will be thrown.
+  String toHtml({
+    DocumentSelection? selection,
+    NodeHtmlSerializerChain nodeSerializers = defaultNodeHtmlSerializerChain,
+    InlineHtmlSerializerChain inlineSerializers = defaultInlineHtmlSerializers,
+    bool skipUnknownNodes = true,
+  }) {
+    final htmlBuffer = StringBuffer();
+
+    if (selection != null && selection.isCollapsed) {
+      // The selection is collapsed to a single position, which by definition can't
+      // contain any content.
+      return "";
+    }
+
+    late final DocumentRange? selectedRange;
+    late final List<DocumentNode> selectedNodes;
+    if (selection != null) {
+      selectedRange = selection.normalize(this);
+      selectedNodes = getNodesInside(
+        selectedRange.start,
+        selectedRange.end,
+      );
+    } else {
+      selectedRange = null;
+      selectedNodes = toList(growable: false);
+    }
+
+    for (final node in selectedNodes) {
+      late final NodeSelection? nodeSelection;
+      if (selectedRange != null && node.id == selectedRange.start.nodeId && node.id == selectedRange.end.nodeId) {
+        // The entire copy selection is within this node.
+        nodeSelection = node.computeSelection(
+          base: selectedRange.start.nodePosition,
+          extent: selectedRange.end.nodePosition,
+        );
+      } else if (selectedRange != null && node.id == selectedRange.start.nodeId) {
+        // The selection starts somewhere in this node and goes to the end of the node.
+        nodeSelection = node.computeSelection(
+          base: selectedRange.start.nodePosition,
+          extent: node.endPosition,
+        );
+      } else if (selectedRange != null && node.id == selectedRange.end.nodeId) {
+        // The selection starts at the beginning of this node and ends somewhere within this node.
+        nodeSelection = node.computeSelection(
+          base: node.beginningPosition,
+          extent: selectedRange.end.nodePosition,
+        );
+      } else {
+        nodeSelection = null;
+      }
+
+      bool didSerializeNode = false;
+      for (final serializer in nodeSerializers) {
+        final html = serializer(this, node, nodeSelection, inlineSerializers);
+        if (html != null) {
+          htmlBuffer.write(html);
+          didSerializeNode = true;
+          break;
+        }
+      }
+      if (!didSerializeNode && !skipUnknownNodes) {
+        throw Exception("Tried to serialize node ($node) but couldn't find a compatible HTML serializer.");
+      }
+    }
+
+    return htmlBuffer.toString();
+  }
+}
+
+/// The standard HTML serializers for every type of [DocumentNode] in a [Document].
+///
+/// To customize how [Document]s are serialized to HTML, create a custom list of serializers
+/// as needed, and pass that chain into the HTML serializer.
+const NodeHtmlSerializerChain defaultNodeHtmlSerializerChain = [
+  defaultImageToHtmlSerializer,
+  defaultHorizontalRuleToHtmlSerializer,
+  defaultListItemToHtmlSerializer,
+  defaultHeaderToHtmlSerializer,
+  defaultBlockquoteToHtmlSerializer,
+  defaultCodeBlockToHtmlSerializer,
+  defaultParagraphToHtmlSerializer,
+];
+
+/// A priority-order list of [NodeHtmlSerializer]s, which can be used to serialize
+/// an entire [Document] of nodes.
+typedef NodeHtmlSerializerChain = List<NodeHtmlSerializer>;
+
+/// A function that (maybe) serializes the given [node] to HTML.
+typedef NodeHtmlSerializer = String? Function(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+);

--- a/super_editor/lib/src/infrastructure/serialization/html/html_blockquotes.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_blockquotes.dart
@@ -1,0 +1,36 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultBlockquoteToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ParagraphNode) {
+    return null;
+  }
+  if (node.getMetadataValue(NodeMetadata.blockType) != blockquoteAttribution) {
+    return null;
+  }
+  if (selection != null && selection is! TextNodeSelection) {
+    // We don't know how to handle this selection type.
+    return null;
+  }
+
+  final textSelection = selection as TextNodeSelection?;
+  if (true == textSelection?.isCollapsed) {
+    // Nothing is selected.
+    return "";
+  }
+
+  final content = node.text.toHtml(
+    serializers: inlineSerializers,
+    start: textSelection?.start,
+    end: textSelection?.end,
+  );
+  return '<blockquote>$content</blockquote>';
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_code.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_code.dart
@@ -1,0 +1,36 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultCodeBlockToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ParagraphNode) {
+    return null;
+  }
+  if (node.getMetadataValue(NodeMetadata.blockType) != codeAttribution) {
+    return null;
+  }
+  if (selection != null && selection is! TextNodeSelection) {
+    // We don't know how to handle this selection type.
+    return null;
+  }
+
+  final textSelection = selection as TextNodeSelection?;
+  if (true == textSelection?.isCollapsed) {
+    // Nothing is selected.
+    return "";
+  }
+
+  final content = node.text.toHtml(
+    serializers: inlineSerializers,
+    start: textSelection?.start,
+    end: textSelection?.end,
+  );
+  return '<pre><code>$content</code></pre>';
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_headers.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_headers.dart
@@ -1,0 +1,70 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultHeaderToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ParagraphNode) {
+    return null;
+  }
+
+  final headerType = node.getMetadataValue(NodeMetadata.blockType);
+  if (!const [
+    header1Attribution,
+    header2Attribution,
+    header3Attribution,
+    header4Attribution,
+    header5Attribution,
+    header6Attribution,
+  ].contains(headerType)) {
+    // Not a header.
+    return null;
+  }
+  if (selection != null && selection is! TextNodeSelection) {
+    // We don't know how to handle this selection type.
+    return null;
+  }
+
+  final textSelection = selection as TextNodeSelection?;
+  if (true == textSelection?.isCollapsed) {
+    // Nothing is selected.
+    return "";
+  }
+
+  final openTag = _openTag(headerType);
+  final closeTag = _closeTag(headerType);
+  final content = node.text.toHtml(
+    serializers: inlineSerializers,
+    start: textSelection?.start,
+    end: textSelection?.end,
+  );
+  return '$openTag$content$closeTag';
+}
+
+String _openTag(Attribution headerType) {
+  return _tag(headerType, isOpening: true);
+}
+
+String _closeTag(Attribution headerType) {
+  return _tag(headerType, isOpening: false);
+}
+
+String _tag(Attribution headerType, {required bool isOpening}) {
+  return switch (headerType) {
+    header1Attribution => isOpening ? "<h1>" : "</h1>",
+    header2Attribution => isOpening ? "<h2>" : "</h2>",
+    header3Attribution => isOpening ? "<h3>" : "</h3>",
+    header4Attribution => isOpening ? "<h4>" : "</h4>",
+    header5Attribution => isOpening ? "<h5>" : "</h5>",
+    header6Attribution => isOpening ? "<h6>" : "</h6>",
+    _ => throw Exception(
+        "Tried to create HTML tag for a header block, but we don't recognize this block type: $headerType"),
+  };
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_horizontal_rules.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_horizontal_rules.dart
@@ -1,0 +1,28 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/horizontal_rule.dart';
+import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultHorizontalRuleToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! HorizontalRuleNode) {
+    return null;
+  }
+  if (selection != null) {
+    if (selection is! UpstreamDownstreamNodeSelection) {
+      // We don't know how to handle this selection type.
+      return null;
+    }
+    if (selection.isCollapsed) {
+      // This selection doesn't include the HR - it's a collapsed selection
+      // either on the upstream or downstream edge.
+      return null;
+    }
+  }
+
+  return '<hr>';
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_images.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_images.dart
@@ -1,0 +1,28 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/image.dart';
+import 'package:super_editor/src/default_editor/selection_upstream_downstream.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultImageToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ImageNode) {
+    return null;
+  }
+  if (selection != null) {
+    if (selection is! UpstreamDownstreamNodeSelection) {
+      // We don't know how to handle this selection type.
+      return null;
+    }
+    if (selection.isCollapsed) {
+      // This selection doesn't include the image - it's a collapsed selection
+      // either on the upstream or downstream edge.
+      return null;
+    }
+  }
+
+  return '<img src="${node.imageUrl}">';
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_inline_text_styles.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_inline_text_styles.dart
@@ -1,0 +1,194 @@
+import 'package:attributed_text/attributed_text.dart';
+import 'package:collection/collection.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+
+extension AttributedTextToHtml on AttributedText {
+  String toHtml({
+    int? start,
+    int? end,
+    InlineHtmlSerializerChain serializers = defaultInlineHtmlSerializers,
+  }) {
+    // Pull out the part of this text that we want to encode.
+    final substring = start != null || end != null ? copyText(start ?? 0, end ?? length) : this;
+
+    // Write this attributed text to HTML.
+    final htmlBuffer = StringBuffer();
+    int textIndex = 0;
+
+    substring.visitAttributions(
+      CallbackAttributionVisitor(
+        visitAttributions: (
+          AttributedText fullText,
+          int index,
+          Set<Attribution> startingAttributions,
+          Set<Attribution> endingAttributions,
+        ) {
+          // Encode the content between the last set of tags and just before
+          // this offset.
+          if (index > 0) {
+            htmlBuffer.write(fullText.substring(textIndex, index));
+          }
+
+          // Encode opening tags before the character at this index.
+          if (startingAttributions.isNotEmpty) {
+            final tags = startingAttributions
+                .map((a) => _encodeTag(serializers, a, TagType.opening))
+                .nonNulls
+                .sorted(_sortOpeningTags);
+            if (tags.isNotEmpty) {
+              htmlBuffer.write(tags.join(""));
+            }
+          }
+
+          // Write the character at this index.
+          htmlBuffer.write(fullText[index]);
+
+          // Encode closing tags after the character at this index.
+          if (endingAttributions.isNotEmpty) {
+            final tags = endingAttributions
+                .map((a) => _encodeTag(serializers, a, TagType.closing))
+                .nonNulls
+                .sorted(_sortClosingTags);
+            if (tags.isNotEmpty) {
+              htmlBuffer.write(tags.join(""));
+            }
+          }
+
+          textIndex = index + 1;
+        },
+        onVisitEnd: () {
+          // TODO: consider changing this behavior in attributed_text because
+          //       it's unexpected that we wouldn't be passed all the
+          //       attributions that end at the end of the string. In other
+          //       words, `visitAttributions` stops one segment too soon.
+          // Append the final string segment.
+          if (textIndex < substring.length) {
+            htmlBuffer.write(substring.substring(textIndex));
+
+            // Encode final ending tags.
+            final endingAttributions = getAllAttributionsAt(length - 1);
+            if (endingAttributions.isNotEmpty) {
+              final tags = endingAttributions
+                  .map((a) => _encodeTag(serializers, a, TagType.closing))
+                  .nonNulls
+                  .sorted(_sortClosingTags);
+              if (tags.isNotEmpty) {
+                htmlBuffer.write(tags.join(""));
+              }
+            }
+          }
+        },
+      ),
+    );
+
+    return htmlBuffer.toString();
+  }
+
+  String? _encodeTag(InlineHtmlSerializerChain serializers, Attribution attribution, TagType tagType) {
+    for (final serializer in serializers) {
+      final tag = serializer(attribution, tagType);
+      if (tag != null) {
+        return tag;
+      }
+    }
+
+    return null;
+  }
+
+  int _sortOpeningTags(String tagA, String tagB) {
+    // Sort opening tags alphabetically, to give us a consistent ordering.
+    return tagA.compareTo(tagB);
+  }
+
+  int _sortClosingTags(String tagA, String tagB) {
+    // Sort in the opposite order as starting tags, so tags end from inside out.
+    return -_sortOpeningTags(tagA, tagB);
+  }
+}
+
+enum TagType {
+  opening,
+  closing;
+}
+
+const defaultInlineHtmlSerializers = [
+  defaultBoldHtmlSerializer,
+  defaultItalicsHtmlSerializer,
+  defaultUnderlineHtmlSerializer,
+  defaultStrikethroughHtmlSerializer,
+  defaultCodeHtmlSerializer,
+  defaultLinkHtmlSerializer,
+];
+
+/// A priority-order list of [InlineHtmlSerializer]s, which can be used to serialize
+/// text segments from a document to inline HTML.
+typedef InlineHtmlSerializerChain = List<InlineHtmlSerializer>;
+
+/// A function that (maybe) serializes the given [attribution] to an HTML tag.
+typedef InlineHtmlSerializer = String? Function(Attribution attribution, TagType tagType);
+
+String? defaultBoldHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution != boldAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<strong>',
+    TagType.closing => '</strong>',
+  };
+}
+
+String? defaultItalicsHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution != italicsAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<i>',
+    TagType.closing => '</i>',
+  };
+}
+
+String? defaultUnderlineHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution != underlineAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<u>',
+    TagType.closing => '</u>',
+  };
+}
+
+String? defaultStrikethroughHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution != strikethroughAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<s>',
+    TagType.closing => '</s>',
+  };
+}
+
+String? defaultCodeHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution != codeAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<code>',
+    TagType.closing => '</code>',
+  };
+}
+
+String? defaultLinkHtmlSerializer(Attribution attribution, TagType tagType) {
+  if (attribution is! LinkAttribution) {
+    return null;
+  }
+
+  return switch (tagType) {
+    TagType.opening => '<a href="${attribution.plainTextUri}">',
+    TagType.closing => '</a>',
+  };
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_list_items.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_list_items.dart
@@ -1,0 +1,63 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/list_items.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultListItemToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ListItemNode) {
+    return null;
+  }
+  if (selection != null && selection is! TextNodeSelection) {
+    // We don't know how to handle this selection type.
+    return null;
+  }
+  final textSelection = selection as TextNodeSelection?;
+
+  return node.toHtml(document, inlineSerializers, start: textSelection?.start, end: textSelection?.end);
+}
+
+extension ListItemNodeToHtml on ListItemNode {
+  String toHtml(Document document, InlineHtmlSerializerChain inlineSerializers, {int? start, int? end}) {
+    if (start != null && start == end) {
+      // Selection is collapsed. Nothing is selected for copy.
+      return "";
+    }
+
+    final content = text.toHtml(serializers: inlineSerializers, start: start, end: end);
+
+    final nodeBefore = document.getNodeBeforeById(id);
+    final isListStart = nodeBefore == null || nodeBefore is! ListItemNode || nodeBefore.type != type;
+
+    final nodeAfter = document.getNodeAfterById(id);
+    final isListEnd = nodeAfter == null || nodeAfter is! ListItemNode || nodeAfter.type != type;
+
+    final htmlBuffer = StringBuffer();
+
+    if (isListStart) {
+      switch (type) {
+        case ListItemType.ordered:
+          htmlBuffer.write('<ol>');
+        case ListItemType.unordered:
+          htmlBuffer.write('<ul>');
+      }
+    }
+
+    htmlBuffer.write('<li>$content</li>');
+
+    if (isListEnd) {
+      switch (type) {
+        case ListItemType.ordered:
+          htmlBuffer.write('</ol>');
+        case ListItemType.unordered:
+          htmlBuffer.write('</ul>');
+      }
+    }
+
+    return htmlBuffer.toString();
+  }
+}

--- a/super_editor/lib/src/infrastructure/serialization/html/html_paragraphs.dart
+++ b/super_editor/lib/src/infrastructure/serialization/html/html_paragraphs.dart
@@ -1,0 +1,36 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/default_editor/attributions.dart';
+import 'package:super_editor/src/default_editor/paragraph.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+
+String? defaultParagraphToHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! ParagraphNode) {
+    return null;
+  }
+  if (node.getMetadataValue(NodeMetadata.blockType) != paragraphAttribution) {
+    return null;
+  }
+  if (selection != null && selection is! TextNodeSelection) {
+    // We don't know how to handle this selection type.
+    return null;
+  }
+
+  final textSelection = selection as TextNodeSelection?;
+  if (true == textSelection?.isCollapsed) {
+    // Nothing is selected.
+    return "";
+  }
+
+  final content = node.text.toHtml(
+    serializers: inlineSerializers,
+    start: textSelection?.start,
+    end: textSelection?.end,
+  );
+  return '<p>$content</p>';
+}

--- a/super_editor/lib/src/infrastructure/serialization/plain_text/document_to_plain_text.dart
+++ b/super_editor/lib/src/infrastructure/serialization/plain_text/document_to_plain_text.dart
@@ -1,0 +1,43 @@
+import 'package:super_editor/src/core/document.dart';
+import 'package:super_editor/src/core/document_selection.dart';
+import 'package:super_editor/src/default_editor/text.dart';
+
+extension ToPlainText on Document {
+  /// Serializes this [Document] to a plain-text representation by writing the text
+  /// from every [TextNode] to a `String`.
+  ///
+  /// Non-[TextNode]s are skipped. All attributions within [TextNode]s are ignored.
+  /// Inline text placeholders are stripped out.
+  String toPlainText({DocumentSelection? selection}) {
+    final plainTextBuffer = StringBuffer();
+
+    selection = selection ??
+        DocumentSelection(
+          base: DocumentPosition(nodeId: first.id, nodePosition: first.beginningPosition),
+          extent: DocumentPosition(nodeId: last.id, nodePosition: last.endPosition),
+        );
+    final selectedRange = selection.normalize(this);
+    final selectedNodes = getNodesInside(
+      selectedRange.start,
+      selectedRange.end,
+    );
+
+    for (final node in selectedNodes) {
+      switch (node) {
+        case TextNode():
+          final textStart =
+              node.id == selectedRange.start.nodeId ? (selectedRange.start.nodePosition as TextNodePosition).offset : 0;
+          final textEnd = node.id == selectedRange.end.nodeId
+              ? (selectedRange.end.nodePosition as TextNodePosition).offset
+              : node.text.length;
+
+          plainTextBuffer.write(
+            "${node.text.copyText(textStart, textEnd).toPlainText(includePlaceholders: false)}\n",
+          );
+        default: // We don't know how to encode non-text nodes as plain text. Ignore.
+      }
+    }
+
+    return plainTextBuffer.toString();
+  }
+}

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -121,6 +121,7 @@ export 'src/infrastructure/serialization/html/html_images.dart';
 export 'src/infrastructure/serialization/html/html_inline_text_styles.dart';
 export 'src/infrastructure/serialization/html/html_list_items.dart';
 export 'src/infrastructure/serialization/html/html_paragraphs.dart';
+export 'src/infrastructure/serialization/plain_text/document_to_plain_text.dart';
 
 // Export from super_text_layout so that downstream clients don't
 // have to add this package to get access to these classes.

--- a/super_editor/lib/super_editor.dart
+++ b/super_editor/lib/super_editor.dart
@@ -111,6 +111,17 @@ export 'src/super_reader/read_only_document_mouse_interactor.dart';
 export 'src/super_reader/reader_context.dart';
 export 'src/super_reader/super_reader.dart';
 
+// HTML Serialization
+export 'src/infrastructure/serialization/html/document_to_html.dart';
+export 'src/infrastructure/serialization/html/html_blockquotes.dart';
+export 'src/infrastructure/serialization/html/html_code.dart';
+export 'src/infrastructure/serialization/html/html_headers.dart';
+export 'src/infrastructure/serialization/html/html_horizontal_rules.dart';
+export 'src/infrastructure/serialization/html/html_images.dart';
+export 'src/infrastructure/serialization/html/html_inline_text_styles.dart';
+export 'src/infrastructure/serialization/html/html_list_items.dart';
+export 'src/infrastructure/serialization/html/html_paragraphs.dart';
+
 // Export from super_text_layout so that downstream clients don't
 // have to add this package to get access to these classes.
 export 'package:super_text_layout/super_text_layout.dart'

--- a/super_editor/test/infrastructure/serialization/html/document_to_html_test.dart
+++ b/super_editor/test/infrastructure/serialization/html/document_to_html_test.dart
@@ -1,0 +1,508 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/document_to_html.dart';
+import 'package:super_editor/src/infrastructure/serialization/html/html_inline_text_styles.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_markdown/super_editor_markdown.dart';
+
+void main() {
+  group("Super Editor > HTML serialization >", () {
+    test("whole document", () {
+      expect(
+        _createDiverseDocument().toHtml(),
+        _getDiverseDocumentHtmlGolden(),
+      );
+    });
+
+    test("partial document from middle to end", () {
+      expect(
+        _createDiverseDocument().toHtml(
+          selection: const DocumentSelection(
+            base: DocumentPosition(
+              nodeId: "8",
+              nodePosition: TextNodePosition(offset: 15),
+            ),
+            extent: DocumentPosition(
+              nodeId: "14",
+              nodePosition: TextNodePosition(offset: 28),
+            ),
+          ),
+        ),
+        [
+          '<p>separates an unordered list from an ordered list.</p>',
+          '<ol>',
+          '<li>This is ordered list item 1</li>',
+          '<li>This is ordered list item 2</li>',
+          '<li>This is ordered list item 3</li>',
+          '</ol>',
+          '<blockquote>This is a blockquote</blockquote>',
+          '<pre><code>This is a code block</code></pre>',
+          '<p>This is the final paragraph.</p>',
+        ].join(),
+      );
+    });
+
+    test("partial document from beginning to middle", () {
+      expect(
+        _createDiverseDocument().toHtml(
+          selection: const DocumentSelection(
+            base: DocumentPosition(
+              nodeId: "1",
+              nodePosition: TextNodePosition(offset: 0),
+            ),
+            extent: DocumentPosition(
+              nodeId: "8",
+              nodePosition: TextNodePosition(offset: 15),
+            ),
+          ),
+        ),
+        [
+          '<h1>This is a header 1</h1>',
+          '<p>This is a regular paragraph of text.</p>',
+          '<img src="https://doesnotexist.com/image.png">',
+          '<p>This is another regular paragraph.</p>',
+          '<ul>',
+          '<li>This is unordered list item 1</li>',
+          '<li>This is unordered list item 2</li>',
+          '<li>This is unordered list item 3</li>',
+          '</ul>',
+          '<p>This paragraph </p>',
+        ].join(),
+      );
+    });
+
+    test("partial document from middle to middle", () {
+      expect(
+        _createDiverseDocument().toHtml(
+          selection: const DocumentSelection(
+            base: DocumentPosition(
+              nodeId: "6",
+              nodePosition: TextNodePosition(offset: 8),
+            ),
+            extent: DocumentPosition(
+              nodeId: "13",
+              nodePosition: TextNodePosition(offset: 14),
+            ),
+          ),
+        ),
+        [
+          '<li>unordered list item 2</li>',
+          '<li>This is unordered list item 3</li>',
+          '</ul>',
+          '<p>This paragraph separates an unordered list from an ordered list.</p>',
+          '<ol>',
+          '<li>This is ordered list item 1</li>',
+          '<li>This is ordered list item 2</li>',
+          '<li>This is ordered list item 3</li>',
+          '</ol>',
+          '<blockquote>This is a blockquote</blockquote>',
+          '<pre><code>This is a code</code></pre>',
+        ].join(),
+      );
+    });
+
+    group("start or end of block >", () {
+      test("starting at end of paragraph", () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText("This is paragraph 1")),
+            ParagraphNode(id: "2", text: AttributedText("This is paragraph 2")),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 19),
+              ),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 19),
+              ),
+            ),
+          ),
+          "<p>This is paragraph 2</p>",
+        );
+      });
+
+      test("ending at beginning of paragraph", () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText("This is paragraph 1")),
+            ParagraphNode(id: "2", text: AttributedText("This is paragraph 2")),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+          "<p>This is paragraph 1</p>",
+        );
+      });
+
+      test("from caret on downstream edge of image to paragraph", () {
+        final document = MutableDocument(
+          nodes: [
+            ImageNode(id: "1", imageUrl: "https://doesnotexist.com/image.png"),
+            ParagraphNode(id: "2", text: AttributedText("This is paragraph 1")),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: "1",
+                nodePosition: UpstreamDownstreamNodePosition.downstream(),
+              ),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 19),
+              ),
+            ),
+          ),
+          "<p>This is paragraph 1</p>",
+        );
+      });
+
+      test("from paragraph to caret on upstream edge of image", () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText("This is paragraph 1")),
+            ImageNode(id: "2", imageUrl: "https://doesnotexist.com/image.png"),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+          ),
+          "<p>This is paragraph 1</p>",
+        );
+      });
+    });
+
+    group("collapsed selections >", () {
+      test("end of paragraph to beginning of paragraph", () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText("This is a paragraph 1")),
+            ParagraphNode(id: "2", text: AttributedText("This is a paragraph 2")),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection(
+              base: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 21),
+              ),
+              extent: DocumentPosition(
+                nodeId: "2",
+                nodePosition: TextNodePosition(offset: 0),
+              ),
+            ),
+          ),
+          "",
+        );
+      });
+
+      test("caret in paragraph", () {
+        final document = MutableDocument(
+          nodes: [
+            ParagraphNode(id: "1", text: AttributedText("This is a paragraph of text")),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: TextNodePosition(offset: 3),
+              ),
+            ),
+          ),
+          "",
+        );
+      });
+
+      test("caret in image", () {
+        final document = MutableDocument(
+          nodes: [
+            ImageNode(id: "1", imageUrl: "https://doesnotexist.com/image.png"),
+          ],
+        );
+
+        expect(
+          document.toHtml(
+            selection: const DocumentSelection.collapsed(
+              position: DocumentPosition(
+                nodeId: "1",
+                nodePosition: UpstreamDownstreamNodePosition.upstream(),
+              ),
+            ),
+          ),
+          "",
+        );
+      });
+    });
+
+    test("inline text styles", () {
+      expect(
+        deserializeMarkdownToDocument(
+          "This paragraph contains many inline styles: **bold**, *italics*, ¬underline¬, ~strikethrough~, [link](https://someplace.com).",
+        ).toHtml(),
+        '<p>This paragraph contains many inline styles: <strong>bold</strong>, <i>italics</i>, <u>underline</u>, <s>strikethrough</s>, <a href="https://someplace.com">link</a>.</p>',
+      );
+    });
+
+    group("custom serialization >", () {
+      test("custom node type", () {
+        expect(
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText("Custom Nodes"),
+                metadata: const {
+                  NodeMetadata.blockType: header1Attribution,
+                },
+              ),
+              ParagraphNode(
+                id: "2",
+                text: AttributedText("Below this is a custom table node serialization."),
+              ),
+              _TableNode(id: "3"),
+            ],
+          ).toHtml(
+            nodeSerializers: [
+              _tableHtmlSerializer,
+              ...defaultNodeHtmlSerializerChain,
+            ],
+          ),
+          [
+            '<h1>Custom Nodes</h1>',
+            '<p>Below this is a custom table node serialization.</p>',
+            '<table>',
+            '<tr>',
+            '<th>Column 1</th>',
+            '<th>Column 2</th>',
+            '</tr>',
+            '<tr>',
+            '<th>Value 1</th>',
+            '<td>Value 2</td>',
+            '</tr>',
+            '</table>',
+          ].join(''),
+        );
+      });
+
+      test("custom inline text style", () {
+        expect(
+          MutableDocument(
+            nodes: [
+              ParagraphNode(
+                id: "1",
+                text: AttributedText(
+                  "This paragraph contains custom styling.",
+                  AttributedSpans(
+                    attributions: [
+                      const SpanMarker(attribution: _customStyle, offset: 24, markerType: SpanMarkerType.start),
+                      const SpanMarker(attribution: _customStyle, offset: 37, markerType: SpanMarkerType.end),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ).toHtml(
+            inlineSerializers: [
+              (Attribution attribution, TagType tagType) {
+                if (attribution != _customStyle) {
+                  return null;
+                }
+
+                return switch (tagType) {
+                  TagType.opening => '<mytag>',
+                  TagType.closing => '</mytag>',
+                };
+              },
+              ...defaultInlineHtmlSerializers,
+            ],
+          ),
+          "<p>This paragraph contains <mytag>custom styling</mytag>.</p>",
+        );
+      });
+    });
+  });
+}
+
+Document _createDiverseDocument() => MutableDocument(
+      nodes: [
+        ParagraphNode(
+          id: "1",
+          text: AttributedText("This is a header 1"),
+          metadata: const {
+            NodeMetadata.blockType: header1Attribution,
+          },
+        ),
+        ParagraphNode(
+          id: "2",
+          text: AttributedText("This is a regular paragraph of text."),
+        ),
+        ImageNode(id: "3", imageUrl: "https://doesnotexist.com/image.png"),
+        ParagraphNode(
+          id: "4",
+          text: AttributedText("This is another regular paragraph."),
+        ),
+        ListItemNode.unordered(
+          id: "5",
+          text: AttributedText("This is unordered list item 1"),
+        ),
+        ListItemNode.unordered(
+          id: "6",
+          text: AttributedText("This is unordered list item 2"),
+        ),
+        ListItemNode.unordered(
+          id: "7",
+          text: AttributedText("This is unordered list item 3"),
+        ),
+        ParagraphNode(
+          id: "8",
+          text: AttributedText("This paragraph separates an unordered list from an ordered list."),
+        ),
+        ListItemNode.ordered(
+          id: "9",
+          text: AttributedText("This is ordered list item 1"),
+        ),
+        ListItemNode.ordered(
+          id: "10",
+          text: AttributedText("This is ordered list item 2"),
+        ),
+        ListItemNode.ordered(
+          id: "11",
+          text: AttributedText("This is ordered list item 3"),
+        ),
+        ParagraphNode(
+          id: "12",
+          text: AttributedText("This is a blockquote"),
+          metadata: const {
+            NodeMetadata.blockType: blockquoteAttribution,
+          },
+        ),
+        ParagraphNode(
+          id: "13",
+          text: AttributedText("This is a code block"),
+          metadata: const {
+            NodeMetadata.blockType: codeAttribution,
+          },
+        ),
+        ParagraphNode(
+          id: "14",
+          text: AttributedText("This is the final paragraph."),
+        ),
+      ],
+    );
+
+String _getDiverseDocumentHtmlGolden() => [
+      '<h1>This is a header 1</h1>',
+      '<p>This is a regular paragraph of text.</p>',
+      '<img src="https://doesnotexist.com/image.png">',
+      '<p>This is another regular paragraph.</p>',
+      '<ul>',
+      '<li>This is unordered list item 1</li>',
+      '<li>This is unordered list item 2</li>',
+      '<li>This is unordered list item 3</li>',
+      '</ul>',
+      '<p>This paragraph separates an unordered list from an ordered list.</p>',
+      '<ol>',
+      '<li>This is ordered list item 1</li>',
+      '<li>This is ordered list item 2</li>',
+      '<li>This is ordered list item 3</li>',
+      '</ol>',
+      '<blockquote>This is a blockquote</blockquote>',
+      '<pre><code>This is a code block</code></pre>',
+      '<p>This is the final paragraph.</p>',
+    ].join();
+
+const _customStyle = NamedAttribution("custom_style");
+
+String? _tableHtmlSerializer(
+  Document document,
+  DocumentNode node,
+  NodeSelection? selection,
+  InlineHtmlSerializerChain inlineSerializers,
+) {
+  if (node is! _TableNode) {
+    return null;
+  }
+  if (selection != null) {
+    if (selection is! UpstreamDownstreamNodeSelection) {
+      // We don't know how to handle this selection type.
+      return null;
+    }
+    if (selection.isCollapsed) {
+      // This selection doesn't include the image - it's a collapsed selection
+      // either on the upstream or downstream edge.
+      return null;
+    }
+  }
+
+  return [
+    '<table>',
+    '<tr>',
+    '<th>Column 1</th>',
+    '<th>Column 2</th>',
+    '</tr>',
+    '<tr>',
+    '<th>Value 1</th>',
+    '<td>Value 2</td>',
+    '</tr>',
+    '</table>',
+  ].join('');
+}
+
+class _TableNode extends BlockNode {
+  _TableNode({
+    required this.id,
+  });
+
+  @override
+  final String id;
+
+  @override
+  DocumentNode copyWithAddedMetadata(Map<String, dynamic> newProperties) {
+    throw UnimplementedError();
+  }
+
+  @override
+  DocumentNode copyAndReplaceMetadata(Map<String, dynamic> newMetadata) {
+    throw UnimplementedError();
+  }
+
+  @override
+  String? copyContent(NodeSelection selection) {
+    throw UnimplementedError();
+  }
+}

--- a/super_editor_clipboard/.gitignore
+++ b/super_editor_clipboard/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/super_editor_clipboard/.metadata
+++ b/super_editor_clipboard/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "8defaa71a77c16e8547abdbfad2053ce3a6e2d5b"
+  channel: "stable"
+
+project_type: package

--- a/super_editor_clipboard/CHANGELOG.md
+++ b/super_editor_clipboard/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/super_editor_clipboard/LICENSE
+++ b/super_editor_clipboard/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2025 Declarative, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/super_editor_clipboard/README.md
+++ b/super_editor_clipboard/README.md
@@ -1,0 +1,6 @@
+# Super Editor Clipboard
+Rich text copy/paste extensions on `super_editor`.
+
+This behavior is delivered as its own package so that `super_editor` users
+aren't forced to depend upon another package (`super_clipboard`), which auto
+downloads rust binaries.

--- a/super_editor_clipboard/analysis_options.yaml
+++ b/super_editor_clipboard/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options
+
+linter:
+  rules:
+    always_use_package_imports: true

--- a/super_editor_clipboard/lib/src/document_copy.dart
+++ b/super_editor_clipboard/lib/src/document_copy.dart
@@ -1,0 +1,43 @@
+import 'package:super_clipboard/super_clipboard.dart';
+import 'package:super_editor/super_editor.dart';
+
+extension RichTextCopy on Document {
+  Future<void> copyAsRichText({
+    DocumentSelection? selection,
+  }) async {
+    final clipboard = SystemClipboard.instance;
+    if (clipboard == null) {
+      return; // Clipboard API is not supported on this platform.
+    }
+
+    final item = DataWriterItem();
+
+    // Serialize to HTML as the most common representation of rich text
+    // across apps.
+    item.add(Formats.htmlText(toHtml(
+      selection: selection,
+      nodeSerializers: SuperEditorClipboardConfig.nodeHtmlSerializers,
+      inlineSerializers: SuperEditorClipboardConfig.inlineHtmlSerializers,
+    )));
+
+    // Serialize a backup copy in plain text so that this clipboard content
+    // can be pasted into plain-text apps, too.
+    item.add(Formats.plainText(toPlainText(selection: selection)));
+
+    // Write the document to the clipboard.
+    await clipboard.write([item]);
+  }
+}
+
+/// A global configuration for rich text serializers, which can be globally customized
+/// within an app to add or change the serializers used by [Document.copyAsRichText].
+abstract class SuperEditorClipboardConfig {
+  static NodeHtmlSerializerChain get nodeHtmlSerializers => _nodeHtmlSerializers;
+  static NodeHtmlSerializerChain _nodeHtmlSerializers = defaultNodeHtmlSerializerChain;
+  static void setNodeHtmlSerializers(NodeHtmlSerializerChain nodeSerializers) => _nodeHtmlSerializers = nodeSerializers;
+
+  static InlineHtmlSerializerChain get inlineHtmlSerializers => _inlineHtmlSerializers;
+  static InlineHtmlSerializerChain _inlineHtmlSerializers = defaultInlineHtmlSerializers;
+  static void setInlineHtmlSerializers(InlineHtmlSerializerChain inlineSerializers) =>
+      _inlineHtmlSerializers = inlineSerializers;
+}

--- a/super_editor_clipboard/lib/src/super_editor_copy.dart
+++ b/super_editor_clipboard/lib/src/super_editor_copy.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/services.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_clipboard/src/document_copy.dart';
+
+/// [SuperEditor] shortcut to copy the document as rich text when
+/// `CMD + C` (Mac) or `CTRL + C` (Windows/Linux) is pressed.
+ExecutionInstruction copyAsRichTextWhenCmdCOrCtrlCIsPressed({
+  required SuperEditorContext editContext,
+  required KeyEvent keyEvent,
+}) {
+  if (keyEvent is! KeyDownEvent && keyEvent is! KeyRepeatEvent) {
+    return ExecutionInstruction.continueExecution;
+  }
+
+  if (!keyEvent.isPrimaryShortcutKeyPressed || keyEvent.logicalKey != LogicalKeyboardKey.keyC) {
+    return ExecutionInstruction.continueExecution;
+  }
+  if (editContext.composer.selection == null) {
+    return ExecutionInstruction.continueExecution;
+  }
+  if (editContext.composer.selection!.isCollapsed) {
+    // Nothing to copy, but we technically handled the task.
+    return ExecutionInstruction.haltExecution;
+  }
+
+  editContext.document.copyAsRichText(
+    selection: editContext.composer.selection!,
+  );
+
+  return ExecutionInstruction.haltExecution;
+}

--- a/super_editor_clipboard/lib/src/super_reader_copy.dart
+++ b/super_editor_clipboard/lib/src/super_reader_copy.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/services.dart';
+import 'package:super_editor/super_editor.dart';
+import 'package:super_editor_clipboard/src/document_copy.dart';
+
+/// [SuperReader] shortcut to copy the selected content within the document
+/// as rich text, on Mac.
+final copyAsRichTextWhenCmdCIsPressedOnMac = createShortcut(
+  ({required SuperReaderContext documentContext, required KeyEvent keyEvent}) {
+    if (documentContext.composer.selection == null) {
+      return ExecutionInstruction.continueExecution;
+    }
+    if (documentContext.composer.selection!.isCollapsed) {
+      // Nothing to copy, but we technically handled the task.
+      return ExecutionInstruction.haltExecution;
+    }
+
+    documentContext.document.copyAsRichText(
+      selection: documentContext.composer.selection!,
+    );
+
+    return ExecutionInstruction.haltExecution;
+  },
+  keyPressedOrReleased: LogicalKeyboardKey.keyC,
+  isCmdPressed: true,
+  platforms: {TargetPlatform.macOS, TargetPlatform.iOS},
+);
+
+/// [SuperReader] shortcut to copy the selected content within the document
+/// as rich text, on Windows and Linux.
+final copyAsRichTextWhenCtrlCIsPressedOnWindowsAndLinux = createShortcut(
+  ({required SuperReaderContext documentContext, required KeyEvent keyEvent}) {
+    if (documentContext.composer.selection == null) {
+      return ExecutionInstruction.continueExecution;
+    }
+    if (documentContext.composer.selection!.isCollapsed) {
+      // Nothing to copy, but we technically handled the task.
+      return ExecutionInstruction.haltExecution;
+    }
+
+    documentContext.document.copyAsRichText(
+      selection: documentContext.composer.selection!,
+    );
+
+    return ExecutionInstruction.haltExecution;
+  },
+  keyPressedOrReleased: LogicalKeyboardKey.keyC,
+  isCtlPressed: true,
+  platforms: {
+    TargetPlatform.windows,
+    TargetPlatform.linux,
+    TargetPlatform.fuchsia,
+    TargetPlatform.android,
+  },
+);

--- a/super_editor_clipboard/lib/super_editor_clipboard.dart
+++ b/super_editor_clipboard/lib/super_editor_clipboard.dart
@@ -1,0 +1,3 @@
+export 'src/document_copy.dart';
+export 'src/super_editor_copy.dart';
+export 'src/super_reader_copy.dart';

--- a/super_editor_clipboard/pubspec.yaml
+++ b/super_editor_clipboard/pubspec.yaml
@@ -1,0 +1,24 @@
+name: super_editor_clipboard
+description: "Rich text copy/paste extensions on super_editor."
+version: 0.1.0
+repository: https://github.com/superlistapp/super_editor/
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  collection: ^1.19.1
+  flutter:
+    sdk: flutter
+  super_clipboard: ^0.9.1
+  super_editor: 0.3.0-dev.28
+
+dependency_overrides:
+  super_editor:
+    path: ../super_editor
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0


### PR DESCRIPTION
This PR adds support to copy rich text from a `Document`.

To tell the system clipboard about the rich text, we use `super_clipboard`, which is a package that knows how to talk to the OS clipboard via Rust. To avoid adding a dependency on a Rust/binary package for all `super_editor` users, the use of `super_clipboard` is done in a new package called `super_editor_clipboard`, which is introduced in this PR.

Even with `super_clipboard`, it's still the responsibility of `super_editor` to report its document content in a way that interoperates with other apps. A very common interchange format is HTML. Therefore, this PR adds HTML serialization behavior for `Document`s. The rich text copy behavior in the `super_editor_clipboard` package uses the new HTML serialization from the `super_editor` package.

You'll notice that this PR packages serialization differently than perviously. For example, we have a package called `super_editor_markdown` which holds all the Markdown serialization behavior for `super_editor`. After a few years, we have yet to find any benefit from separating that serialization behavior, so I put HTML serialization directly into `super_editor`. Sometime soon, I'll move the Markdown serialization into `super_editor`, too, and deprecate the package.