### PR TITLE
[SuperEditor] - Fix add/remove attribution commands when using placeholders (Resolves #2776)

### DIFF
--- a/super_editor/lib/src/default_editor/text.dart
+++ b/super_editor/lib/src/default_editor/text.dart
@@ -1590,7 +1590,11 @@ class AddTextAttributionsCommand extends EditCommand {
           node.id,
           node.copyTextNodeWith(
             text: AttributedText(
-              node.text.toPlainText(),
+              node.text.toPlainText(
+                // Don't include placeholder characters, because we're providing
+                // actual placeholders down below.
+                includePlaceholders: false,
+              ),
               node.text.spans.copy()
                 ..addAttribution(
                   newAttribution: attribution,
@@ -1718,13 +1722,18 @@ class RemoveTextAttributionsCommand extends EditCommand {
         // see that we made a change, and re-renders the text in the document.
         node = node.copyTextNodeWith(
           text: AttributedText(
-            node.text.toPlainText(),
+            node.text.toPlainText(
+              // Don't include placeholder characters, because we're providing
+              // actual placeholders down below.
+              includePlaceholders: false,
+            ),
             node.text.spans.copy()
               ..removeAttribution(
                 attributionToRemove: attribution,
                 start: range.start,
                 end: range.end,
               ),
+            Map.from(node.text.placeholders),
           ),
         );
 


### PR DESCRIPTION
[SuperEditor] - Fix add/remove attribution commands when using placeholders (Resolves #2776)

There were bugs in both the add attributions, and remove attributions commands.

First, both commands were encoding the placeholder characters in the copied plain text. This means that something like "~" was being injected into every copy, and this problem compounds. As you run the command again and again you end up with "~~~~~~~~~~". I fixed this by explicitly excluding placeholders where we copy `AttributedText`.

Second, in the removal command, we forgot to copy the placeholder objects to the copied `AttributedText`. I updated the command to pass those through.

Added a test that covers all 3 issues.