### PR TITLE
fix(super_textfield): guard iOS system context menu against non-finite anchor

### DIFF
--- a/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
+++ b/super_editor/lib/src/super_textfield/ios/ios_textfield.dart
@@ -850,15 +850,17 @@ class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSy
     // The size reported by the controller's toolbarFocalPoint is one frame behind. Query the information
     // overlayController instead.
     final topAnchor = widget.controller.overlayController.toolbarTopAnchor;
-    final bottomAnchor = widget.controller.overlayController.toolbarTopAnchor;
+    final bottomAnchor = widget.controller.overlayController.toolbarBottomAnchor;
 
-    if (topAnchor == null || bottomAnchor == null) {
-      // We don't expect the toolbar builder to be called without having the anchors
-      // defined. But, since these properties are nullable, we account for that.
+    final menuRect = sanitizeSystemContextMenuAnchor(topAnchor, bottomAnchor);
+    if (menuRect == null) {
+      // Either the anchors aren't defined yet, or they resolved to non-finite
+      // values. We can't show the system menu without a valid anchor rect, so
+      // bail out for this frame. See [sanitizeSystemContextMenuAnchor].
       return;
     }
 
-    _systemContextMenuController.show(Rect.fromLTRB(topAnchor.dx, topAnchor.dy, bottomAnchor.dx, bottomAnchor.dy));
+    _systemContextMenuController.show(menuRect);
   }
 
   @override
@@ -866,4 +868,33 @@ class _IOSSuperTextFieldSystemContextMenuState extends State<IOSSuperTextFieldSy
     assert(IOSSystemContextMenu.isSupported(context));
     return const SizedBox.shrink();
   }
+}
+
+/// Builds the anchor [Rect] for the iOS system context menu from the toolbar's
+/// top and bottom anchor offsets, or returns `null` when no menu should be
+/// shown.
+///
+/// Returns `null` when either anchor is `null` (the toolbar hasn't been
+/// positioned yet) or when the resulting rect is not finite.
+///
+/// The anchors originate from text-layout geometry that is mapped through
+/// ancestor render transforms via `RenderBox.localToGlobal`/`globalToLocal`.
+/// During overlay or keyboard transitions an ancestor transform can be
+/// momentarily singular (zero determinant), which makes those mappings produce
+/// `NaN`/`Infinity`. Forwarding a non-finite rect to
+/// [SystemContextMenuController.show] sends it across the platform channel,
+/// where `NaN` fails to JSON-encode and throws `JsonUnsupportedObjectError`.
+/// Returning `null` lets the caller skip showing the menu for that frame.
+@visibleForTesting
+Rect? sanitizeSystemContextMenuAnchor(Offset? topAnchor, Offset? bottomAnchor) {
+  if (topAnchor == null || bottomAnchor == null) {
+    return null;
+  }
+
+  final rect = Rect.fromLTRB(topAnchor.dx, topAnchor.dy, bottomAnchor.dx, bottomAnchor.dy);
+  if (!rect.isFinite) {
+    return null;
+  }
+
+  return rect;
 }

--- a/super_editor/test/super_textfield/ios/super_textfield_ios_system_context_menu_test.dart
+++ b/super_editor/test/super_textfield/ios/super_textfield_ios_system_context_menu_test.dart
@@ -1,0 +1,41 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_editor/src/super_textfield/ios/ios_textfield.dart';
+
+void main() {
+  group('SuperTextField iOS', () {
+    group('system context menu anchor', () {
+      test('builds a rect from finite anchors', () {
+        final rect = sanitizeSystemContextMenuAnchor(
+          const Offset(10, 20),
+          const Offset(10, 40),
+        );
+
+        expect(rect, const Rect.fromLTRB(10, 20, 10, 40));
+      });
+
+      test('returns null when an anchor is null', () {
+        expect(sanitizeSystemContextMenuAnchor(null, const Offset(10, 40)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(10, 20), null), isNull);
+        expect(sanitizeSystemContextMenuAnchor(null, null), isNull);
+      });
+
+      // Regression test for SUPERLIST-FRONTEND-2BBX: a singular ancestor render
+      // transform during an overlay/keyboard transition can make the anchor
+      // offsets NaN/Infinity. Such a rect must not reach the platform channel,
+      // where NaN throws JsonUnsupportedObjectError when JSON-encoded.
+      test('returns null when an anchor component is not finite', () {
+        const nan = double.nan;
+        const inf = double.infinity;
+
+        expect(sanitizeSystemContextMenuAnchor(const Offset(nan, 20), const Offset(10, 40)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(10, nan), const Offset(10, 40)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(10, 20), const Offset(nan, 40)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(10, 20), const Offset(10, nan)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(inf, 20), const Offset(10, 40)), isNull);
+        expect(sanitizeSystemContextMenuAnchor(const Offset(10, -inf), const Offset(10, 40)), isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Sentry `SUPERLIST-FRONTEND-2BBX` (release 1.55.6, iOS, 77 events from one user):

```
JsonUnsupportedObjectError: Converting object to an encodable object failed: NaN
  at _IOSSuperTextFieldSystemContextMenuState._positionSystemMenu (ios_textfield.dart)
```

`_positionSystemMenu()` builds a `Rect` from the toolbar's top/bottom anchor offsets and passes it to `SystemContextMenuController.show()`, which serializes the rect to JSON over the platform channel to iOS. The anchors are derived from text-layout geometry mapped through ancestor render transforms (`RenderBox.localToGlobal`/`globalToLocal`). During overlay/keyboard transitions an ancestor transform can be momentarily singular (zero determinant), which makes those mappings return `NaN`/`Infinity`. A `NaN` then fails to JSON-encode and throws.

## Fix

- Extract `sanitizeSystemContextMenuAnchor(topAnchor, bottomAnchor)` (marked `@visibleForTesting`) which returns `null` when either anchor is `null` **or** the resulting `Rect` is not finite (`!rect.isFinite`). `_positionSystemMenu()` bails out for the frame when it gets `null` instead of forwarding a poisoned rect across the channel.
- Fix a copy-paste bug: `bottomAnchor` was reading `toolbarTopAnchor` instead of `toolbarBottomAnchor`, which made the system-menu anchor rect always zero-height.

## Tests

New `test/super_textfield/ios/super_textfield_ios_system_context_menu_test.dart` covers the finite, null, and non-finite (NaN/Infinity) cases. All pass; `flutter analyze` introduces no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)