### PR TITLE
fix: forward TextInputConnection.updateStyle for Flutter 3.44

### DIFF
--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -48,10 +48,9 @@ abstract class TextInputConnectionDecorator implements TextInputConnection {
           textDirection: textDirection,
           textAlign: textAlign);
 
-  // Flutter 3.44 moved the body of `setStyle` into `updateStyle`, so the
-  // decorator has to forward it too (see flutter/flutter#180436).
-  @override
-  void updateStyle(TextInputStyle style) => client?.updateStyle(style);
+  // Kept untyped and dynamic-forwarded to preserve compatibility with Flutter
+  // versions where updateStyle/TextInputStyle don't exist.
+  void updateStyle(dynamic style) => (client as dynamic)?.updateStyle(style);
 
   @override
   void requestAutofill() => client?.requestAutofill();

--- a/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
+++ b/super_editor/lib/src/default_editor/document_ime/ime_decoration.dart
@@ -48,6 +48,11 @@ abstract class TextInputConnectionDecorator implements TextInputConnection {
           textDirection: textDirection,
           textAlign: textAlign);
 
+  // Flutter 3.44 moved the body of `setStyle` into `updateStyle`, so the
+  // decorator has to forward it too (see flutter/flutter#180436).
+  @override
+  void updateStyle(TextInputStyle style) => client?.updateStyle(style);
+
   @override
   void requestAutofill() => client?.requestAutofill();
 


### PR DESCRIPTION
Required to build Superlist on Flutter 3.44 (superlist is upgrading 3.38.3 → 3.44.8).

## Problem

Flutter 3.44 moved the body of `TextInputConnection.setStyle` into a new `updateStyle(TextInputStyle)` method ([flutter/flutter#180436](https://github.com/flutter/flutter/pull/180436), the web IME style-syncing fix). `TextInputConnectionDecorator` implements `TextInputConnection` by forwarding every member, so it no longer satisfies the interface:

```
lib/src/default_editor/document_ime/document_ime_communication.dart:22:7:
Error: The non-abstract class 'DocumentImeInputClient' is missing implementations
for these members:
 - TextInputConnection.updateStyle
```

Every test and build touching the editor fails to compile.

## Fix

Forward `updateStyle` like the other members. `setStyle` is left as-is — the framework’s default implementation now delegates to `updateStyle`, so behaviour is unchanged on both old and new SDKs.

## Integration with current Superlist

The branch includes `feature/upgrade-to-latest` through `22722a4bcbb4a919dae92e967f554bbfb93d9593`, the editor revision currently pinned by Superlist main. This preserves the iOS context-menu, long-press selection, caret, and scrolling fixes added since this prerequisite was opened.

Relative to that base, the library change remains only the `updateStyle` forwarder. Its dynamic signature retains compatibility with older Flutter versions that do not define `TextInputStyle`.

The combined revision is `560458b6fa22c0a2ee4e8ecdf0bf8c480f577d13`; [Superlist #7477](https://github.com/superlistapp/superlist/pull/7477) will pin this revision. Do not drop these commits when merging the prerequisite. App integration validation is recorded in Superlist #7477.

## Verification on the combined revision

Using Superlist’s pinned Flutter revision `072fb02f538570144711be2f0b819ef0a8b74126`, **142 tests passed with one skip** across the iOS system-context-menu, iOS editor-selection, reader-scrolling, and editor-scrolling suites. These are host widget tests with platform emulation, not on-device validation.

An ancestry check confirms the combined revision includes app main’s editor revision. The library diff against that revision is only the four-line `updateStyle` forwarder.
