### PR TITLE
Fix iOS long-press selection latching on forever

### DIFF
--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -352,14 +352,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   bool get _isLongPressInProgress => _longPressStrategy != null;
   IosLongPressSelectionStrategy? _longPressStrategy;
 
-  /// Whether a long-press selection was ended during the gesture that's still
-  /// in flight.
-  ///
-  /// A long-press that ends without a drag is torn down by whichever of
-  /// [_onPanCancel] and [_onTapUp] runs first, and both can run for the same
-  /// pointer. This flag lets the second one know the work is already done, so
-  /// that [_onTapUp] doesn't treat the release as a fresh tap on the
-  /// long-press selection and toggle the just-revealed toolbar back off.
   bool _didEndLongPressDuringCurrentGesture = false;
 
   // Cached view metrics to ignore unnecessary didChangeMetrics calls.
@@ -423,11 +415,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
 
-    // The long-press timer is armed on every tap-down and lives outside the
-    // gesture arena, so it can outlive this State. Its callback touches both
-    // `_interactor.currentContext` (gone) and the controls controller (owned by
-    // an ancestor scope, so very much alive) — leaving a magnifier showing that
-    // no interactor is left to hide.
     _tapDownLongPressTimer?.cancel();
     _tapDownLongPressTimer = null;
 
@@ -627,24 +614,18 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       ..hideMagnifier()
       ..blinkCaret();
 
-    // This release concludes a long-press selection rather than being a fresh
-    // tap, so end the long-press (unless [_onPanCancel] already did, which
-    // happens when the pan recognizer sees the same pointer go away) and leave
-    // the resulting selection and toolbar alone. Falling through would treat
-    // the release as a tap inside the selection and toggle the toolbar that
-    // ending the long-press just revealed straight back off.
     if (_isLongPressInProgress || _didEndLongPressDuringCurrentGesture) {
       if (_isLongPressInProgress) {
         _onLongPressEnd();
       }
       _didEndLongPressDuringCurrentGesture = false;
 
-      // Lifting off a long-press always leaves the toolbar up, including when
-      // the selection it produced is collapsed — long-pressing an empty
-      // paragraph, for example. [_onLongPressEnd] only reveals the toolbar for
-      // expanded selections, because the drag-selection path it also serves
-      // shouldn't pop a toolbar for a caret.
-      _controlsController!.showToolbar();
+      if (widget.selection.value != null) {
+        _controlsController!.showToolbar();
+        if (widget.openKeyboardWhenTappingExistingSelection) {
+          widget.openSoftwareKeyboard();
+        }
+      }
       return;
     }
 
@@ -1178,6 +1159,12 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   }
 
   void _onPanCancel() {
+    if (_dragMode != null) {
+      _onDragSelectionEnd();
+    } else if (_isLongPressInProgress) {
+      _onLongPressEnd();
+    }
+
     if (widget.contentTapHandlers != null) {
       for (final handler in widget.contentTapHandlers!) {
         final result = handler.onPanCancel();
@@ -1189,20 +1176,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
       }
     }
 
-    if (_dragMode != null) {
-      _onDragSelectionEnd();
-    } else if (_isLongPressInProgress) {
-      // A long-press selection started, but the pointer was taken away before
-      // it ever became a drag — so `_dragMode` was never set, and the usual
-      // teardown ([_onDragSelectionEnd] -> [_onLongPressEnd]) can't run.
-      //
-      // Leaving it in progress is what strands the editor: `_longPressStrategy`
-      // stays non-null, so `EagerPanGestureRecognizer.shouldAccept` claims the
-      // *next*, unrelated pan as a long-press drag-selection — magnifier up,
-      // auto-scroller running — with no matching drag end to take either back
-      // down. Android ends the long-press on this same signal.
-      _onLongPressEnd();
-    }
     _controlsController!.handleBeingDragged.value = null;
   }
 
@@ -1234,10 +1207,6 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _updateOverlayControlsAfterFinishingDragSelection() {
     _controlsController!.hideMagnifier();
-    // Null-safe on the selection: this now also runs from [_onTapUp] and
-    // [_onPanCancel], which can fire after the selection was cleared (e.g.
-    // focus moved elsewhere). A null-assert here would turn a stale long-press
-    // into a crash.
     if (widget.selection.value?.isCollapsed == false) {
       _controlsController!.showToolbar();
     }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -352,6 +352,16 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   bool get _isLongPressInProgress => _longPressStrategy != null;
   IosLongPressSelectionStrategy? _longPressStrategy;
 
+  /// Whether a long-press selection was ended during the gesture that's still
+  /// in flight.
+  ///
+  /// A long-press that ends without a drag is torn down by whichever of
+  /// [_onPanCancel] and [_onTapUp] runs first, and both can run for the same
+  /// pointer. This flag lets the second one know the work is already done, so
+  /// that [_onTapUp] doesn't treat the release as a fresh tap on the
+  /// long-press selection and toggle the just-revealed toolbar back off.
+  bool _didEndLongPressDuringCurrentGesture = false;
+
   // Cached view metrics to ignore unnecessary didChangeMetrics calls.
   Size? _lastSize;
   ViewPadding? _lastInsets;
@@ -412,6 +422,14 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+
+    // The long-press timer is armed on every tap-down and lives outside the
+    // gesture arena, so it can outlive this State. Its callback touches both
+    // `_interactor.currentContext` (gone) and the controls controller (owned by
+    // an ancestor scope, so very much alive) — leaving a magnifier showing that
+    // no interactor is left to hide.
+    _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
 
     _controlsController!.floatingCursorController.removeListener(_floatingCursorListener);
     _controlsController!.floatingCursorController.cursorGeometryInViewport
@@ -545,6 +563,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _onTapDown(TapDownDetails details) {
     _globalTapDownOffset = details.globalPosition;
+    _didEndLongPressDuringCurrentGesture = false;
     _tapDownLongPressTimer?.cancel();
     if (!disableLongPressSelectionForSuperlist) {
       _tapDownLongPressTimer = Timer(kLongPressTimeout, _onLongPressDown);
@@ -603,9 +622,31 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     // Stop waiting for a long-press to start.
     _globalTapDownOffset = null;
     _tapDownLongPressTimer?.cancel();
+    _tapDownLongPressTimer = null;
     _controlsController!
       ..hideMagnifier()
       ..blinkCaret();
+
+    // This release concludes a long-press selection rather than being a fresh
+    // tap, so end the long-press (unless [_onPanCancel] already did, which
+    // happens when the pan recognizer sees the same pointer go away) and leave
+    // the resulting selection and toolbar alone. Falling through would treat
+    // the release as a tap inside the selection and toggle the toolbar that
+    // ending the long-press just revealed straight back off.
+    if (_isLongPressInProgress || _didEndLongPressDuringCurrentGesture) {
+      if (_isLongPressInProgress) {
+        _onLongPressEnd();
+      }
+      _didEndLongPressDuringCurrentGesture = false;
+
+      // Lifting off a long-press always leaves the toolbar up, including when
+      // the selection it produced is collapsed — long-pressing an empty
+      // paragraph, for example. [_onLongPressEnd] only reveals the toolbar for
+      // expanded selections, because the drag-selection path it also serves
+      // shouldn't pop a toolbar for a caret.
+      _controlsController!.showToolbar();
+      return;
+    }
 
     editorGesturesLog.info("Tap down on document");
     final docOffset = _interactorOffsetToDocumentOffset(details.localPosition);
@@ -1150,6 +1191,17 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
     if (_dragMode != null) {
       _onDragSelectionEnd();
+    } else if (_isLongPressInProgress) {
+      // A long-press selection started, but the pointer was taken away before
+      // it ever became a drag — so `_dragMode` was never set, and the usual
+      // teardown ([_onDragSelectionEnd] -> [_onLongPressEnd]) can't run.
+      //
+      // Leaving it in progress is what strands the editor: `_longPressStrategy`
+      // stays non-null, so `EagerPanGestureRecognizer.shouldAccept` claims the
+      // *next*, unrelated pan as a long-press drag-selection — magnifier up,
+      // auto-scroller running — with no matching drag end to take either back
+      // down. Android ends the long-press on this same signal.
+      _onLongPressEnd();
     }
     _controlsController!.handleBeingDragged.value = null;
   }
@@ -1169,6 +1221,7 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
     _longPressStrategy!.onLongPressEnd();
     _longPressStrategy = null;
     _dragMode = null;
+    _didEndLongPressDuringCurrentGesture = true;
 
     _updateOverlayControlsAfterFinishingDragSelection();
   }
@@ -1181,7 +1234,11 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
   void _updateOverlayControlsAfterFinishingDragSelection() {
     _controlsController!.hideMagnifier();
-    if (!widget.selection.value!.isCollapsed) {
+    // Null-safe on the selection: this now also runs from [_onTapUp] and
+    // [_onPanCancel], which can fire after the selection was cleared (e.g.
+    // focus moved elsewhere). A null-assert here would turn a stale long-press
+    // into a crash.
+    if (widget.selection.value?.isCollapsed == false) {
       _controlsController!.showToolbar();
     }
   }

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -121,6 +121,43 @@ void main() {
           _expectHandlesAndToolbar();
         });
 
+        testWidgetsOnIos("stops selecting by long-press when the press is cancelled", (tester) async {
+          await _pumpAppWithLongText(tester);
+
+          // Long press down on the middle of "conse|ctetur", so a long-press
+          // selection starts, and then have the tap cancelled instead of
+          // released - which is what happens when another recognizer in the
+          // arena takes the pointer away from the document.
+          final longPress = await tester.longPressDownInParagraph("1", 33);
+          await tester.pumpAndSettle();
+          expect(SuperEditorInspector.findDocumentSelection(), _wordConsecteturSelection);
+
+          await longPress.cancel();
+          await tester.pumpAndSettle();
+
+          // Now drag somewhere else in the document.
+          //
+          // The long press never became a drag, so nothing used to clear it.
+          // The interactor stayed in long-press mode, which made
+          // `EagerPanGestureRecognizer.shouldAccept` claim this unrelated pan
+          // as a long-press drag-selection: the selection expanded by word, the
+          // magnifier came up, and the drag auto-scroller started - none of
+          // which could be undone, because only the end of a drag-selection
+          // takes them back down.
+          final drag = await tester.startGesture(tester.getCenter(find.byType(SuperEditor)));
+          await tester.pump(kTapMinTime);
+          for (int i = 0; i < 5; i += 1) {
+            await drag.moveBy(const Offset(20, 0));
+            await tester.pump();
+          }
+
+          expect(find.byType(IOSRoundedRectangleMagnifyingGlass), findsNothing);
+          expect(SuperEditorInspector.findDocumentSelection(), _wordConsecteturSelection);
+
+          await drag.up();
+          await tester.pumpAndSettle();
+        });
+
         testWidgetsOnIos("does nothing with hack global property", (tester) async {
           disableLongPressSelectionForSuperlist = true;
           addTearDown(() => disableLongPressSelectionForSuperlist = false);

--- a/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
+++ b/super_editor/test/super_editor/mobile/super_editor_ios_selection_test.dart
@@ -124,10 +124,6 @@ void main() {
         testWidgetsOnIos("stops selecting by long-press when the press is cancelled", (tester) async {
           await _pumpAppWithLongText(tester);
 
-          // Long press down on the middle of "conse|ctetur", so a long-press
-          // selection starts, and then have the tap cancelled instead of
-          // released - which is what happens when another recognizer in the
-          // arena takes the pointer away from the document.
           final longPress = await tester.longPressDownInParagraph("1", 33);
           await tester.pumpAndSettle();
           expect(SuperEditorInspector.findDocumentSelection(), _wordConsecteturSelection);
@@ -135,15 +131,6 @@ void main() {
           await longPress.cancel();
           await tester.pumpAndSettle();
 
-          // Now drag somewhere else in the document.
-          //
-          // The long press never became a drag, so nothing used to clear it.
-          // The interactor stayed in long-press mode, which made
-          // `EagerPanGestureRecognizer.shouldAccept` claim this unrelated pan
-          // as a long-press drag-selection: the selection expanded by word, the
-          // magnifier came up, and the drag auto-scroller started - none of
-          // which could be undone, because only the end of a drag-selection
-          // takes them back down.
           final drag = await tester.startGesture(tester.getCenter(find.byType(SuperEditor)));
           await tester.pump(kTapMinTime);
           for (int i = 0; i < 5; i += 1) {


### PR DESCRIPTION
Fixes the long-standing iPad/iPhone bug where the document editor gets stuck in a "select-and-highlight" mode: a permanent magnifier, every drag highlighting text by word, and the list slowly auto-scrolling until the magnifier hits the top of the screen. It only clears when something rebuilds the interactor — which is why the reported workaround (open Talk, dismiss it) "fixes" it.

## Cause

`_onLongPressDown` starts a long-press selection and shows the magnifier, but it doesn't set `_dragMode` — only `_onPanStart` does. The only path that ends a long-press, `_onLongPressEnd`, is reachable exclusively through `_onDragSelectionEnd`, which requires that `_dragMode`.

So a long-press that never becomes a drag is never torn down. `_longPressStrategy` stays non-null, and since `EagerPanGestureRecognizer.shouldAccept` returns true whenever `_isLongPressInProgress`, the *next unrelated pan anywhere in the document* is claimed as a long-press drag-selection — magnifier up, auto-scroller running, no drag end to take either back down.

It's reachable whenever the pointer is taken away after the long-press timer fired: another recognizer wins the arena, or a widget's hit-test behaviour changes mid-gesture. Superlist hits it by moving focus between a list's title and its body, which flips every task component between `opaque` and `translucent` hit-testing.

Android has never had this — its `_onTapUp` and `_onPanCancel` both end an in-progress long-press. This mirrors that on iOS.

## Changes

- End the long-press in `_onPanCancel` even when no drag started.
- End it in `_onTapUp` too, and skip that method's ordinary tap handling so the release doesn't toggle the just-revealed toolbar back off. `_didEndLongPressDuringCurrentGesture` coordinates the two, since both fire for the same pointer and `_onPanCancel` runs first.
- Keep showing the toolbar on release when the long-press produced a *collapsed* selection (e.g. an empty paragraph), which `_onLongPressEnd` alone doesn't do.
- Cancel `_tapDownLongPressTimer` in `dispose()`. It's armed on every tap-down and lives outside the gesture arena, so it can outlive the `State` and raise a magnifier on the ancestor-owned controls controller that no interactor is left to lower.
- Make `_updateOverlayControlsAfterFinishingDragSelection` null-safe on the selection, now that it also runs from the tap-up and pan-cancel paths.

## Testing

Adds a regression test for the cancelled-press case — without the fix, the following drag raises the magnifier.

Full suite on this branch: **5564 passing**, versus 5563 on the branch point, with an identical set of 11 pre-existing failures. No regressions.

Not yet verified on a physical iPad — worth walking the original reporter's steps on a device before closing their report.