### PR TITLE
ci: fix CI — pin Flutter to our fork, and fix the 3 bugs that surfaced

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,40 @@
+name: Set up Flutter
+description: >
+  Installs the Flutter revision the Superlist app ships, so a green run means
+  super_editor compiles against the SDK it is actually consumed with.
+
+inputs:
+  revision:
+    description: Revision of superlistapp/flutter to install.
+    required: false
+    default: "3b60946182d204e4f0a9f50ffb91818ec07d2624"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore the SDK from the cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/superlist-flutter
+        key: superlist-flutter-${{ runner.os }}-${{ runner.arch }}-${{ inputs.revision }}
+
+    - name: Fetch the SDK
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Blobless clone: keeps the commit and tag graph that `flutter --version`
+        # needs, without paying for every blob in Flutter's history.
+        git clone --filter=blob:none https://github.com/superlistapp/flutter.git \
+          "${{ runner.tool_cache }}/superlist-flutter"
+        git -C "${{ runner.tool_cache }}/superlist-flutter" \
+          checkout --detach "${{ inputs.revision }}"
+
+    - name: Put the SDK on PATH
+      shell: bash
+      run: echo "${{ runner.tool_cache }}/superlist-flutter/bin" >> "$GITHUB_PATH"
+
+    - name: Report the SDK in use
+      shell: bash
+      run: flutter --version

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -35,6 +35,32 @@ runs:
       shell: bash
       run: echo "${{ runner.tool_cache }}/superlist-flutter/bin" >> "$GITHUB_PATH"
 
+    - name: Verify the SDK is at the pinned revision
+      shell: bash
+      env:
+        SDK: ${{ runner.tool_cache }}/superlist-flutter
+        REVISION: ${{ inputs.revision }}
+        # Commits and trees are local in a blobless clone, so resolving a revision
+        # never needs the network. Fail fast instead of attempting a doomed fetch
+        # when the revision genuinely isn't there.
+        GIT_NO_LAZY_FETCH: "1"
+      run: |
+        set -euo pipefail
+
+        if ! pinned="$(git -C "$SDK" rev-parse --verify --quiet "$REVISION^{commit}")"; then
+          echo "::error::Revision $REVISION is not in the Flutter SDK at $SDK."
+          exit 1
+        fi
+
+        checked_out="$(git -C "$SDK" rev-parse HEAD)"
+        if [ "$checked_out" != "$pinned" ]; then
+          echo "::error::Flutter SDK is at $checked_out, but this action pins $pinned." \
+            "A cache entry saved under this key with different contents is the likely cause."
+          exit 1
+        fi
+
+        echo "Flutter SDK verified at $checked_out"
+
     - name: Report the SDK in use
       shell: bash
       run: flutter --version

--- a/.github/workflows/build_clones.yaml
+++ b/.github/workflows/build_clones.yaml
@@ -12,10 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -34,10 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -56,10 +50,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -78,10 +69,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -100,10 +88,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -122,10 +107,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -12,10 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -36,9 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -59,9 +54,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -82,10 +75,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -110,9 +100,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -132,9 +120,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -154,9 +140,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -175,10 +159,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -203,9 +184,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -223,9 +202,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -243,9 +220,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -263,9 +238,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -284,10 +257,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -312,9 +282,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -332,9 +300,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get
@@ -353,10 +319,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Setup Flutter environment
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: "master"
-          architecture: x64
+      - uses: ./.github/actions/setup-flutter
 
       # Download all the packages that the app uses
       - run: flutter pub get

--- a/super_editor/lib/src/core/document_layout.dart
+++ b/super_editor/lib/src/core/document_layout.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:super_editor/src/core/editor.dart';
+import 'package:super_editor/src/infrastructure/document_gestures.dart';
 
 import 'document.dart';
 import 'document_selection.dart';
@@ -110,7 +111,13 @@ abstract class DocumentLayout {
 }
 
 abstract class ScrollableDocumentLayout extends DocumentLayout {
-  void ensureVisible(DocumentPosition position);
+  /// Scrolls the minimum distance needed to reveal [position] within the viewport.
+  ///
+  /// [boundary] is space that's kept between [position] and the viewport's leading
+  /// and trailing edges. It costs scroll distance, not viewport size, so the document
+  /// still paints edge to edge. Callers that float content over the editor, e.g., a
+  /// mobile drag handle beneath the caret, pass the space they need.
+  void ensureVisible(DocumentPosition position, {AxisOffset boundary = AxisOffset.zero});
   void animateToBeginningOfDocument({required Duration duration, required Curve curve});
   void animateToEndOfDocument({required Duration duration, required Curve curve});
 }

--- a/super_editor/lib/src/default_editor/document_caret_overlay.dart
+++ b/super_editor/lib/src/default_editor/document_caret_overlay.dart
@@ -86,6 +86,11 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
       widget.composer.selectionNotifier.addListener(_onSelectionChange);
 
       _startOrStopBlinking();
+    } else if (widget.displayOnAllPlatforms != oldWidget.displayOnAllPlatforms ||
+        widget.platformOverride != oldWidget.platformOverride) {
+      // Whether we paint a caret just changed, and with it whether we have
+      // anything to blink.
+      _startOrStopBlinking();
     }
   }
 
@@ -123,9 +128,27 @@ class CaretDocumentOverlayState extends DocumentLayoutLayerState<CaretDocumentOv
     }
   }
 
+  /// Returns `true` if this overlay paints a caret on the current platform, or `false`
+  /// if it paints nothing.
+  ///
+  /// On mobile, `SuperEditor` paints the caret and the drag handles elsewhere, so this
+  /// overlay builds an empty box, which means it has no caret to blink.
+  bool get _paintsCaret {
+    if (widget.displayOnAllPlatforms) {
+      return true;
+    }
+
+    final platform = widget.platformOverride ?? defaultTargetPlatform;
+    return platform != TargetPlatform.android && platform != TargetPlatform.iOS;
+  }
+
   void _startOrStopBlinking() {
     // TODO: allow a configurable policy as to whether to show the caret at all when the selection is expanded: https://github.com/superlistapp/super_editor/issues/234
-    final wantsToBlink = widget.composer.selection != null;
+    //
+    // Only blink when this overlay actually paints a caret. Otherwise a `Ticker` runs
+    // for a caret that's never on screen, which forces full FPS rendering on mobile
+    // and prevents `pumpAndSettle()` from ever settling in tests.
+    final wantsToBlink = _paintsCaret && widget.composer.selection != null;
     if (wantsToBlink && _blinkController.isBlinking) {
       return;
     }

--- a/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_android.dart
@@ -667,8 +667,11 @@ class _AndroidDocumentTouchInteractorState extends State<AndroidDocumentTouchInt
 
     final layout = widget.getDocumentLayout();
     if (layout is ScrollableDocumentLayout) {
-      layout.ensureVisible(selection.base);
-      layout.ensureVisible(selection.extent);
+      // Keep the same distance from the viewport edges that the drag handle
+      // auto-scroller keeps, so that a caret revealed near an edge still has room
+      // for the handle that hangs off it.
+      layout.ensureVisible(selection.base, boundary: widget.dragAutoScrollBoundary);
+      layout.ensureVisible(selection.extent, boundary: widget.dragAutoScrollBoundary);
       return;
     }
 

--- a/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
+++ b/super_editor/lib/src/default_editor/document_gestures_touch_ios.dart
@@ -459,8 +459,11 @@ class _IosDocumentTouchInteractorState extends State<IosDocumentTouchInteractor>
 
     final layout = widget.getDocumentLayout();
     if (layout is ScrollableDocumentLayout) {
-      layout.ensureVisible(selection.base);
-      layout.ensureVisible(selection.extent);
+      // Keep the same distance from the viewport edges that the drag handle
+      // auto-scroller keeps, so that a caret revealed near an edge still has room
+      // for the handle that hangs off it.
+      layout.ensureVisible(selection.base, boundary: widget.dragAutoScrollBoundary);
+      layout.ensureVisible(selection.extent, boundary: widget.dragAutoScrollBoundary);
       return;
     }
 

--- a/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
+++ b/super_editor/lib/src/default_editor/layout_single_column/_layout.dart
@@ -7,6 +7,7 @@ import 'package:super_editor/src/core/document.dart';
 import 'package:super_editor/src/core/document_layout.dart';
 import 'package:super_editor/src/core/document_selection.dart';
 import 'package:super_editor/src/infrastructure/_logging.dart';
+import 'package:super_editor/src/infrastructure/document_gestures.dart';
 import 'package:super_editor/src/infrastructure/render_sliver_ext.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
@@ -887,7 +888,7 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
   }
 
   @override
-  void ensureVisible(DocumentPosition position) {
+  void ensureVisible(DocumentPosition position, {AxisOffset boundary = AxisOffset.zero}) {
     final component = getComponentByNodeId(position.nodeId);
 
     final scrollable = Scrollable.maybeOf(context);
@@ -911,6 +912,24 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
     final componentRect = component.getRectForPosition(position.nodePosition); // .translate(padding.left, padding.top);
     // print('CR $index $componentRect');
 
+    // Revealing a rect aligns that rect's edge with the viewport's edge. Growing the
+    // rect past the position therefore leaves that much space between the position and
+    // the edge, without shrinking the viewport. Each direction grows only on the side
+    // it reveals, so that a boundary never pushes the position away from the edge it's
+    // being revealed at.
+    final leadingRect = Rect.fromLTRB(
+      componentRect.left,
+      componentRect.top - boundary.leading,
+      componentRect.right,
+      componentRect.bottom,
+    );
+    final trailingRect = Rect.fromLTRB(
+      componentRect.left,
+      componentRect.top,
+      componentRect.right,
+      componentRect.bottom + boundary.trailing,
+    );
+
     {
       final viewport = RenderAbstractViewport.maybeOf(context.findRenderObject());
       if (viewport == null) return;
@@ -920,7 +939,7 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
           .getOffsetToRevealExt(
             target!,
             0.0,
-            rect: componentRect,
+            rect: leadingRect,
             esimationOnly: true,
           )
           .offset;
@@ -932,19 +951,19 @@ class _SingleColumnDocumentLayoutState extends State<SingleColumnDocumentLayout>
             .getOffsetToRevealExt(
               target,
               0.0,
-              rect: componentRect,
+              rect: leadingRect,
               esimationOnly: false,
             )
             .offset;
         scrollable.position.moveTo(offset);
       } else {
-        final maxOffset = viewport.getOffsetToRevealExt(target, 1.0, rect: componentRect).offset;
+        final maxOffset = viewport.getOffsetToRevealExt(target, 1.0, rect: trailingRect).offset;
         if (position.pixels < maxOffset) {
           final offset = viewport
               .getOffsetToRevealExt(
                 target,
                 1.0,
-                rect: componentRect,
+                rect: trailingRect,
                 esimationOnly: false,
               )
               .offset;

--- a/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
+++ b/super_editor/lib/src/super_reader/read_only_document_mouse_interactor.dart
@@ -161,9 +161,17 @@ class _ReadOnlyDocumentMouseInteractorState extends State<ReadOnlyDocumentMouseI
       onNextFrame((_) {
         readerGesturesLog.finer("Ensuring selection extent is visible because the doc selection changed");
 
-        final globalExtentRect = _getSelectionExtentAsGlobalRect();
-        if (globalExtentRect != null) {
-          widget.autoScroller.ensureGlobalRectIsVisible(globalExtentRect);
+        final layout = _docLayout;
+        if (layout is ScrollableDocumentLayout) {
+          final selection = widget.readerContext.composer.selection;
+          if (selection != null) {
+            layout.ensureVisible(selection.extent);
+          }
+        } else {
+          final globalExtentRect = _getSelectionExtentAsGlobalRect();
+          if (globalExtentRect != null) {
+            widget.autoScroller.ensureGlobalRectIsVisible(globalExtentRect);
+          }
         }
       });
     }


### PR DESCRIPTION
## Why

CI was dead. Every job installed Flutter from `master`, and master added `TextInputConnection.updateStyle`, which our `TextInputConnectionDecorator` doesn't forward. Nothing compiled: `test_mac`, `test_linux` and `test_windows` each reported `0 tests passed, 137 failed`, and the clone builds and package suites died the same way.

`master` is also the wrong target. The app builds against `superlistapp/flutter` @ `3b60946182` (3.39.0-1.0.pre-48), so a green run never told us the app would compile.

## What this PR does

**1. Installs the pinned SDK.** A composite action at `.github/actions/setup-flutter` clones `superlistapp/flutter` at that revision, so it's declared once instead of in 22 places. Blobless clone, cached on the revision. The action then asserts `git rev-parse HEAD` matches the pin and fails the job otherwise, so a stale cache entry or a bad clone can't quietly send us back to testing against the wrong SDK.

We could have added the missing `updateStyle` forwarder instead, but `TextInputStyle` doesn't exist in the SDK the app ships, so that override is a compile error there. It would turn CI green and break the app.

**2. Fixes the 11 tests that then failed.** They'd been invisible for as long as nothing compiled. Three separate bugs, all gaps left by the sliver layout work on this branch:

- **`read_only_document_mouse_interactor.dart`** — `SuperReader` measured the caret itself to decide where to scroll. The sliver layout hasn't built off-screen components, so it got `null` and never scrolled. Now goes through `ScrollableDocumentLayout.ensureVisible`, like `SuperEditor` already does. *(6 tests, `super_reader_scrolling_test.dart`)*

- **`document_caret_overlay.dart`** — the desktop caret overlay paints nothing on mobile, but still ran a blink `Ticker`. A live `Ticker` keeps a frame scheduled forever, so `pumpAndSettle()` never returned. Now it only blinks when it paints. *(3 tests, iOS/Android overlay controls)*

- **`_layout.dart` + both mobile touch interactors** — `ensureVisible` revealed the caret flush against the viewport edge, tucked behind the drag handle. It now takes a `boundary`, and mobile passes the 54px `dragAutoScrollBoundary` it used before the sliver rewrite. *(2 tests, `keeps caret visible when keyboard appears`)*

## Behaviour changes worth a look

- **macOS jobs now run native arm64.** `flutter-action` took `architecture: x64`; a git clone has no equivalent. `macos-latest` is Apple Silicon, so `test_mac` and the six clone builds were running under Rosetta and now aren't. All seven pass.
- **No caret `Ticker` on mobile.** The overlay was forcing full FPS rendering whenever a selection existed. The visible mobile caret is unaffected — it has its own controller.
- **`ensureVisible` gains an optional `boundary`,** defaulting to `AxisOffset.zero`, so desktop reveals exactly as before.

## Verification

Full `super_editor` suite on the pinned SDK: **5429 passed, 0 failed, 8 skipped.** For comparison: `0 / 137` on master, and `5418 / 11 / 8` with the SDK pin alone. All 25 CI checks green.

## Conflicts with #5

#5 adds an app-level `selectionExtentAutoScrollBoundary` and grows the same rects in the same `ensureVisible` hunk, via a widget field instead of a parameter. The two are complementary — whoever rebases second should keep both rather than pick one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmbVfx64j6wHEHUjLAWYQQ